### PR TITLE
fix(android): repair progress, refreshes, and player overlays

### DIFF
--- a/android/app/src/main/java/org/opentubex/app/AndroidMediaSessionService.java
+++ b/android/app/src/main/java/org/opentubex/app/AndroidMediaSessionService.java
@@ -1,8 +1,6 @@
 package org.opentubex.app;
 
 import android.app.Notification;
-import android.app.NotificationChannel;
-import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
@@ -40,7 +38,7 @@ public class AndroidMediaSessionService extends Service {
     static final String EXTRA_STATE = "state";
 
     private static final String ACTION_CONTROL_PREFIX = "org.opentubex.app.media.CONTROL.";
-    private static final String CHANNEL_ID = "media-playback";
+    private static final String CHANNEL_ID = OpenTubeXNotificationChannels.MEDIA_PLAYBACK_ID;
     private static final int NOTIFICATION_ID = 0x4d454449;
     private static final double DEFAULT_SEEK_SECONDS = 10;
     private static final int MAX_ARTWORK_REDIRECTS = 5;
@@ -66,7 +64,7 @@ public class AndroidMediaSessionService extends Service {
     @Override
     public void onCreate() {
         super.onCreate();
-        createNotificationChannel();
+        OpenTubeXNotificationChannels.createAll(this);
         mediaSession = new MediaSession(this, "OpenTubeX");
         mediaSession.setFlags(
             MediaSession.FLAG_HANDLES_MEDIA_BUTTONS |
@@ -515,17 +513,6 @@ public class AndroidMediaSessionService extends Service {
     private long secondsToMillis(double seconds) {
         if (!Double.isFinite(seconds) || seconds <= 0) return 0;
         return (long) Math.min(Long.MAX_VALUE, seconds * 1000);
-    }
-
-    private void createNotificationChannel() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return;
-        NotificationChannel channel = new NotificationChannel(
-            CHANNEL_ID,
-            getString(R.string.media_notification_channel),
-            NotificationManager.IMPORTANCE_LOW
-        );
-        channel.setDescription(getString(R.string.media_notification_channel_description));
-        getSystemService(NotificationManager.class).createNotificationChannel(channel);
     }
 
     private void stopPlaybackService() {

--- a/android/app/src/main/java/org/opentubex/app/MainActivity.java
+++ b/android/app/src/main/java/org/opentubex/app/MainActivity.java
@@ -34,6 +34,7 @@ public class MainActivity extends BridgeActivity {
         // exposing native plugins to untrusted subframes.
         getBridge().getWebView().removeJavascriptInterface("androidBridge");
         getBridge().setWebViewClient(new OpenTubeXWebViewClient(getBridge()));
+        OpenTubeXNotificationChannels.createAll(this);
 
         getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
             @Override

--- a/android/app/src/main/java/org/opentubex/app/OpenTubeXNotificationChannels.java
+++ b/android/app/src/main/java/org/opentubex/app/OpenTubeXNotificationChannels.java
@@ -1,0 +1,91 @@
+package org.opentubex.app;
+
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.os.Build;
+
+import java.util.ArrayList;
+import java.util.List;
+
+final class OpenTubeXNotificationChannels {
+    static final String MEDIA_PLAYBACK_ID = "media-playback";
+    static final String SUBSCRIPTION_REFRESH_ID = "subscription-refresh";
+    static final String LIVE_REMINDERS_ID = "live-reminders";
+    private static final String OBSOLETE_LOCAL_NOTIFICATIONS_DEFAULT_ID = "default";
+
+    static final class ChannelSpec {
+        final String id;
+        final int nameResource;
+        final int descriptionResource;
+        final int importance;
+        final boolean showBadge;
+
+        ChannelSpec(
+            String id,
+            int nameResource,
+            int descriptionResource,
+            int importance,
+            boolean showBadge
+        ) {
+            this.id = id;
+            this.nameResource = nameResource;
+            this.descriptionResource = descriptionResource;
+            this.importance = importance;
+            this.showBadge = showBadge;
+        }
+    }
+
+    private OpenTubeXNotificationChannels() {}
+
+    static ChannelSpec[] specifications() {
+        return new ChannelSpec[] {
+            // AndroidMediaSessionService owns the media playback notification.
+            new ChannelSpec(
+                MEDIA_PLAYBACK_ID,
+                R.string.notification_channel_media_playback_name,
+                R.string.notification_channel_media_playback_description,
+                NotificationManager.IMPORTANCE_LOW,
+                false
+            ),
+            // SubscriptionRefreshWorker owns foreground and scheduled progress.
+            new ChannelSpec(
+                SUBSCRIPTION_REFRESH_ID,
+                R.string.notification_channel_subscription_refresh_name,
+                R.string.notification_channel_subscription_refresh_description,
+                NotificationManager.IMPORTANCE_LOW,
+                false
+            ),
+            // Capacitor LocalNotifications owns scheduled live reminders.
+            new ChannelSpec(
+                LIVE_REMINDERS_ID,
+                R.string.notification_channel_live_reminders_name,
+                R.string.notification_channel_live_reminders_description,
+                NotificationManager.IMPORTANCE_HIGH,
+                true
+            ),
+        };
+    }
+
+    static void createAll(Context context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return;
+
+        List<NotificationChannel> channels = new ArrayList<>();
+        for (ChannelSpec specification : specifications()) {
+            NotificationChannel channel = new NotificationChannel(
+                specification.id,
+                context.getString(specification.nameResource),
+                specification.importance
+            );
+            channel.setDescription(context.getString(specification.descriptionResource));
+            channel.setShowBadge(specification.showBadge);
+            channels.add(channel);
+        }
+        NotificationManager manager = context.getSystemService(NotificationManager.class);
+        manager.createNotificationChannels(channels);
+        // Capacitor creates a generic fallback channel when its plugin loads.
+        // Every notification in this app has a purpose-specific channel, and
+        // live-reminders is the defined replacement for the old fallback.
+        manager.deleteNotificationChannel(OBSOLETE_LOCAL_NOTIFICATIONS_DEFAULT_ID);
+    }
+}

--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshNotification.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshNotification.java
@@ -1,7 +1,6 @@
 package org.opentubex.app;
 
 import android.app.Notification;
-import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
@@ -14,24 +13,13 @@ import androidx.annotation.RequiresApi;
 import androidx.work.ForegroundInfo;
 
 final class SubscriptionRefreshNotification {
-    static final String CHANNEL_ID = "subscription-refresh";
+    static final String CHANNEL_ID = OpenTubeXNotificationChannels.SUBSCRIPTION_REFRESH_ID;
     static final int NOTIFICATION_ID = 0x53554253;
 
     private SubscriptionRefreshNotification() {}
 
-    static void createChannel(Context context) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return;
-
-        NotificationChannel channel = new NotificationChannel(
-            CHANNEL_ID,
-            context.getString(R.string.app_name),
-            NotificationManager.IMPORTANCE_LOW
-        );
-        context.getSystemService(NotificationManager.class).createNotificationChannel(channel);
-    }
-
     static Notification build(Context context, String token, String title, String cancelLabel, int progress) {
-        createChannel(context);
+        OpenTubeXNotificationChannels.createAll(context);
         Notification.Builder builder = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
             ? new Notification.Builder(context, CHANNEL_ID)
             : new Notification.Builder(context);

--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshRequestDiagnostic.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshRequestDiagnostic.java
@@ -1,0 +1,136 @@
+package org.opentubex.app;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Locale;
+
+final class SubscriptionRefreshRequestDiagnostic {
+    final String category;
+    final String backend;
+    final String lifecycle;
+    final String failure;
+    final String code;
+    final String message;
+
+    private SubscriptionRefreshRequestDiagnostic(
+        String category,
+        String backend,
+        String failure,
+        String code,
+        String message
+    ) {
+        this.category = category;
+        this.backend = backend;
+        this.lifecycle = "background";
+        this.failure = failure;
+        this.code = code;
+        this.message = message;
+    }
+
+    static SubscriptionRefreshRequestDiagnostic create(String feedType, Throwable error) {
+        return create(feedType, "Invidious API", error);
+    }
+
+    static SubscriptionRefreshRequestDiagnostic create(
+        String feedType,
+        String backend,
+        Throwable error
+    ) {
+        Throwable cause = deepestCause(error);
+        return new SubscriptionRefreshRequestDiagnostic(
+            category(feedType),
+            backend,
+            classify(cause),
+            cause.getClass().getSimpleName(),
+            sanitize(cause.getMessage())
+        );
+    }
+
+    JSONObject toJson() throws JSONException {
+        return new JSONObject()
+            .put("category", category)
+            .put("backend", backend)
+            .put("lifecycle", lifecycle)
+            .put("failure", failure)
+            .put("code", code)
+            .put("message", message);
+    }
+
+    @Override
+    public String toString() {
+        return "request=" + category +
+            "; backend=" + backend +
+            "; lifecycle=" + lifecycle +
+            "; failure=" + failure +
+            "; code=" + code +
+            "; message=" + message;
+    }
+
+    private static Throwable deepestCause(Throwable error) {
+        Throwable cause = error;
+        while (cause.getCause() != null && cause.getCause() != cause) cause = cause.getCause();
+        return cause;
+    }
+
+    private static String category(String feedType) {
+        switch (feedType) {
+            case "shorts":
+                return "subscription Shorts";
+            case "live":
+                return "subscription live streams";
+            case "posts":
+                return "subscription posts";
+            default:
+                return "subscription videos";
+        }
+    }
+
+    private static String classify(Throwable error) {
+        String signature = (error.getClass().getName() + " " + error.getMessage())
+            .toLowerCase(Locale.ROOT);
+        if (signature.matches(".*(cancel|interrupt|aborted).*")) return "cancellation";
+        if (signature.matches(
+            ".*(foregroundservicestartnotallowed|backgroundservicestartnotallowed|" +
+                "(foreground|background) service.*(not allowed|restrict)|" +
+                "background execution.*(not allowed|restrict)).*"
+        )) return "background restriction";
+        if (signature.matches(".*\\bhttp\\s+\\d{3}\\b.*")) return "http";
+        if (signature.matches(".*(ssl|tls|certificate|certpath|handshake).*")) return "tls";
+        if (signature.matches(".*(json|parse|parsing|unexpected token).*")) return "parsing";
+        if (signature.matches(
+            ".*(unknownhost|gai|addrinfo|eai_|dns|network|socket|timeout|timed out|connect).*"
+        )) {
+            return "network";
+        }
+        return "api";
+    }
+
+    private static String sanitize(String rawMessage) {
+        String message = rawMessage == null ? "No error message" : rawMessage;
+        message = message.replaceAll("(?i)(https?://[^/\\s?#]+)[^\\s)]*", "$1");
+        message = message.replaceAll(
+            "(?i)authorization\\s*:\\s*(?:bearer\\s+)?[^\\s,;]+",
+            "Authorization: <redacted>"
+        );
+        message = message.replaceAll(
+            "(?i)\\b(bearer|basic)\\s+[A-Za-z0-9._~+/=-]+",
+            "$1 <redacted>"
+        );
+        message = message.replaceAll(
+            "(?i)\\b(?:cookie|set-cookie)\\s*:\\s*[^\\r\\n]*",
+            "Cookie: <redacted>"
+        );
+        message = message.replaceAll(
+            "(?i)\\b(access[_-]?token|refresh[_-]?token|id[_-]?token|token|" +
+                "api[_-]?key|client[_-]?secret|password|secret)[\"']?\\s*[:=]\\s*" +
+                "(?:\"[^\"]*\"|'[^']*'|[^\\s,;&}]+)",
+            "$1=<redacted>"
+        );
+        message = message.replaceAll(
+            "(?i)\\brequest\\s+body\\s*[:=]\\s*[^\\r\\n]*",
+            "request body=<redacted>"
+        );
+        return message.substring(0, Math.min(500, message.length()));
+    }
+}

--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshRequestDiagnostic.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshRequestDiagnostic.java
@@ -6,6 +6,9 @@ import org.json.JSONObject;
 import java.util.Locale;
 
 final class SubscriptionRefreshRequestDiagnostic {
+    private static final int MAX_MESSAGE_LENGTH = 500;
+    private static final String TRUNCATION_MARKER = "<truncated>";
+
     final String category;
     final String backend;
     final String lifecycle;
@@ -38,12 +41,14 @@ final class SubscriptionRefreshRequestDiagnostic {
         Throwable error
     ) {
         Throwable cause = deepestCause(error);
+        String rawMessage = normalizedMessage(cause.getMessage());
+        String message = boundedMessage(rawMessage);
         return new SubscriptionRefreshRequestDiagnostic(
             category(feedType),
             backend,
-            classify(cause),
+            classify(cause, boundedClassificationMessage(rawMessage)),
             cause.getClass().getSimpleName(),
-            sanitize(cause.getMessage())
+            sanitize(message)
         );
     }
 
@@ -86,8 +91,35 @@ final class SubscriptionRefreshRequestDiagnostic {
         }
     }
 
-    private static String classify(Throwable error) {
-        String signature = (error.getClass().getName() + " " + error.getMessage())
+    private static String normalizedMessage(String rawMessage) {
+        return rawMessage == null ? "No error message" : rawMessage;
+    }
+
+    private static String boundedMessage(String message) {
+        if (message.length() <= MAX_MESSAGE_LENGTH) return message;
+        if (
+            Character.isWhitespace(message.charAt(MAX_MESSAGE_LENGTH - 1)) ||
+            Character.isWhitespace(message.charAt(MAX_MESSAGE_LENGTH))
+        ) {
+            return message.substring(0, MAX_MESSAGE_LENGTH);
+        }
+
+        int prefixLength = MAX_MESSAGE_LENGTH - TRUNCATION_MARKER.length();
+        while (prefixLength > 0 && !Character.isWhitespace(message.charAt(prefixLength - 1))) {
+            prefixLength--;
+        }
+        return message.substring(0, prefixLength) + TRUNCATION_MARKER;
+    }
+
+    private static String boundedClassificationMessage(String message) {
+        if (message.length() <= MAX_MESSAGE_LENGTH) return message;
+        int headLength = (MAX_MESSAGE_LENGTH - 1) / 2;
+        return message.substring(0, headLength) + " " +
+            message.substring(message.length() - (MAX_MESSAGE_LENGTH - headLength - 1));
+    }
+
+    private static String classify(Throwable error, String message) {
+        String signature = (error.getClass().getName() + " " + message)
             .toLowerCase(Locale.ROOT);
         if (signature.matches(".*(cancel|interrupt|aborted).*")) return "cancellation";
         if (signature.matches(
@@ -106,14 +138,13 @@ final class SubscriptionRefreshRequestDiagnostic {
         return "api";
     }
 
-    private static String sanitize(String rawMessage) {
-        String message = rawMessage == null ? "No error message" : rawMessage;
+    private static String sanitize(String message) {
         message = message.replaceAll(
             "(?i)(https?://)(?:[^/@\\s?#]+@)?([^/\\s?#]+)[^\\s)]*",
             "$1$2"
         );
         message = message.replaceAll(
-            "(?i)authorization\\s*:\\s*(?:bearer\\s+)?[^\\s,;]+",
+            "(?i)\\bauthorization\\s*:\\s*[^\\r\\n]*",
             "Authorization: <redacted>"
         );
         message = message.replaceAll(
@@ -134,6 +165,6 @@ final class SubscriptionRefreshRequestDiagnostic {
             "(?i)\\brequest\\s+body\\s*[:=]\\s*[^\\r\\n]*",
             "request body=<redacted>"
         );
-        return message.substring(0, Math.min(500, message.length()));
+        return message.substring(0, Math.min(MAX_MESSAGE_LENGTH, message.length()));
     }
 }

--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshRequestDiagnostic.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshRequestDiagnostic.java
@@ -108,7 +108,10 @@ final class SubscriptionRefreshRequestDiagnostic {
 
     private static String sanitize(String rawMessage) {
         String message = rawMessage == null ? "No error message" : rawMessage;
-        message = message.replaceAll("(?i)(https?://[^/\\s?#]+)[^\\s)]*", "$1");
+        message = message.replaceAll(
+            "(?i)(https?://)(?:[^/@\\s?#]+@)?([^/\\s?#]+)[^\\s)]*",
+            "$1$2"
+        );
         message = message.replaceAll(
             "(?i)authorization\\s*:\\s*(?:bearer\\s+)?[^\\s,;]+",
             "Authorization: <redacted>"

--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshResultStore.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshResultStore.java
@@ -44,6 +44,25 @@ final class SubscriptionRefreshResultStore {
         );
     }
 
+    static synchronized void writeFailure(
+        Context context,
+        String profileId,
+        String feedType,
+        SubscriptionRefreshRequestDiagnostic diagnostic,
+        long timestamp
+    ) throws IOException, JSONException {
+        JSONObject result = baseResult("failure", profileId, feedType, timestamp)
+            .put("diagnostic", diagnostic.toJson());
+        write(context, result, profileId + "\n" + feedType + "\nfailure");
+    }
+
+    static synchronized void clearFailure(Context context, String profileId, String feedType) {
+        String slot = profileId + "\n" + feedType + "\nfailure";
+        String slotName = UUID.nameUUIDFromBytes(slot.getBytes(StandardCharsets.UTF_8)).toString();
+        File failure = new File(directory(context), slotName + ".json");
+        if (failure.exists()) failure.delete();
+    }
+
     static synchronized JSONObject readNext(Context context) throws IOException, JSONException {
         File[] files = directory(context).listFiles((dir, name) -> name.endsWith(".json"));
         if (files == null || files.length == 0) return null;

--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshWorker.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshWorker.java
@@ -16,6 +16,7 @@ import androidx.work.WorkerParameters;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -149,6 +150,7 @@ public final class SubscriptionRefreshWorker extends Worker {
 
         int completed = 0;
         int failed = 0;
+        Set<String> failedProfileIds = new LinkedHashSet<>();
         NotificationManager notifications = context.getSystemService(NotificationManager.class);
         try {
             // A periodic job may recreate the process while the app is closed, where
@@ -171,33 +173,48 @@ public final class SubscriptionRefreshWorker extends Worker {
                 if (SubscriptionRefreshCoordinator.isCancelled(token) || isStopped()) {
                     return Result.success();
                 }
-                JSONObject payload = null;
+                List<String> profileIds = targetProfileIds(feeds, channelId);
                 try {
-                    payload = SubscriptionRefreshHttpClient.fetch(feed, channelId);
+                    JSONObject payload = SubscriptionRefreshHttpClient.fetch(feed, channelId);
+                    boolean storageFailed = false;
+                    long timestamp = System.currentTimeMillis();
+                    for (String profileId : profileIds) {
+                        try {
+                            SubscriptionRefreshResultStore.writeChannel(
+                                context,
+                                profileId,
+                                feedType,
+                                channelId,
+                                payload,
+                                timestamp
+                            );
+                        } catch (Exception error) {
+                            storageFailed = true;
+                            failedProfileIds.add(profileId);
+                            recordFailure(
+                                context,
+                                Collections.singletonList(profileId),
+                                feedType,
+                                "Android result store",
+                                error
+                            );
+                        }
+                    }
+                    if (storageFailed) {
+                        failed++;
+                    } else {
+                        completed++;
+                    }
                 } catch (Exception error) {
                     failed++;
+                    failedProfileIds.addAll(profileIds);
                     recordFailure(
                         context,
-                        targetProfileIds(feeds, channelId),
+                        profileIds,
                         feedType,
                         "Invidious API",
                         error
                     );
-                }
-
-                if (payload != null) {
-                    long timestamp = System.currentTimeMillis();
-                    for (String profileId : targetProfileIds(feeds, channelId)) {
-                        SubscriptionRefreshResultStore.writeChannel(
-                            context,
-                            profileId,
-                            feedType,
-                            channelId,
-                            payload,
-                            timestamp
-                        );
-                    }
-                    completed++;
                 }
 
                 int progress = total == 0 ? 100 : (int) Math.round((completed + failed) * 100.0 / total);
@@ -222,7 +239,7 @@ public final class SubscriptionRefreshWorker extends Worker {
 
             long completionTimestamp = System.currentTimeMillis();
             for (SubscriptionRefreshConfiguration.Feed profileFeed : feeds) {
-                if (failed == 0) {
+                if (!failedProfileIds.contains(profileFeed.profileId)) {
                     SubscriptionRefreshResultStore.clearFailure(
                         context,
                         profileFeed.profileId,

--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshWorker.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshWorker.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.BiConsumer;
 
 public final class SubscriptionRefreshWorker extends Worker {
     private static final String LOG_TAG = "OpenTubeXFetch";
@@ -28,6 +29,11 @@ public final class SubscriptionRefreshWorker extends Worker {
     private static final String TOKEN_INPUT = "token";
     static final String FEED_TYPE_INPUT = "feedType";
     private static final SubscriptionRefreshState STATE = new SubscriptionRefreshState();
+
+    @FunctionalInterface
+    interface ProfileCompletionWriter {
+        void write(SubscriptionRefreshConfiguration.Feed profileFeed) throws Exception;
+    }
 
     public SubscriptionRefreshWorker(@NonNull Context context, @NonNull WorkerParameters parameters) {
         super(context, parameters);
@@ -238,22 +244,36 @@ public final class SubscriptionRefreshWorker extends Worker {
             }
 
             long completionTimestamp = System.currentTimeMillis();
-            for (SubscriptionRefreshConfiguration.Feed profileFeed : feeds) {
-                if (!failedProfileIds.contains(profileFeed.profileId)) {
-                    SubscriptionRefreshResultStore.clearFailure(
+            Set<String> completionFailedProfileIds = new LinkedHashSet<>();
+            writeProfileCompletions(
+                feeds,
+                profileFeed -> {
+                    if (!failedProfileIds.contains(profileFeed.profileId)) {
+                        SubscriptionRefreshResultStore.clearFailure(
+                            context,
+                            profileFeed.profileId,
+                            feedType
+                        );
+                    }
+                    SubscriptionRefreshResultStore.writeCompletion(
                         context,
                         profileFeed.profileId,
-                        feedType
+                        feedType,
+                        completionTimestamp
+                    );
+                },
+                (profileFeed, error) -> {
+                    completionFailedProfileIds.add(profileFeed.profileId);
+                    recordFailure(
+                        context,
+                        Collections.singletonList(profileFeed.profileId),
+                        feedType,
+                        "Android result store",
+                        error
                     );
                 }
-                SubscriptionRefreshResultStore.writeCompletion(
-                    context,
-                    profileFeed.profileId,
-                    feedType,
-                    completionTimestamp
-                );
-            }
-            return Result.success();
+            );
+            return completionFailedProfileIds.isEmpty() ? Result.success() : Result.retry();
         } catch (Exception error) {
             List<String> profileIds = new ArrayList<>();
             for (SubscriptionRefreshConfiguration.Feed profileFeed : feeds) {
@@ -283,6 +303,20 @@ public final class SubscriptionRefreshWorker extends Worker {
             if (feed.channelIds.contains(channelId)) profileIds.add(feed.profileId);
         }
         return profileIds;
+    }
+
+    static void writeProfileCompletions(
+        List<SubscriptionRefreshConfiguration.Feed> feeds,
+        ProfileCompletionWriter writer,
+        BiConsumer<SubscriptionRefreshConfiguration.Feed, Exception> onFailure
+    ) {
+        for (SubscriptionRefreshConfiguration.Feed profileFeed : feeds) {
+            try {
+                writer.write(profileFeed);
+            } catch (Exception error) {
+                onFailure.accept(profileFeed, error);
+            }
+        }
     }
 
     private static void recordFailure(

--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshWorker.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshWorker.java
@@ -176,7 +176,7 @@ public final class SubscriptionRefreshWorker extends Worker {
                 List<String> profileIds = targetProfileIds(feeds, channelId);
                 try {
                     JSONObject payload = SubscriptionRefreshHttpClient.fetch(feed, channelId);
-                    boolean storageFailed = false;
+                    boolean stored = false;
                     long timestamp = System.currentTimeMillis();
                     for (String profileId : profileIds) {
                         try {
@@ -188,8 +188,8 @@ public final class SubscriptionRefreshWorker extends Worker {
                                 payload,
                                 timestamp
                             );
+                            stored = true;
                         } catch (Exception error) {
-                            storageFailed = true;
                             failedProfileIds.add(profileId);
                             recordFailure(
                                 context,
@@ -200,10 +200,10 @@ public final class SubscriptionRefreshWorker extends Worker {
                             );
                         }
                     }
-                    if (storageFailed) {
-                        failed++;
-                    } else {
+                    if (stored) {
                         completed++;
+                    } else {
+                        failed++;
                     }
                 } catch (Exception error) {
                     failed++;

--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshWorker.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshWorker.java
@@ -247,14 +247,13 @@ public final class SubscriptionRefreshWorker extends Worker {
             Set<String> completionFailedProfileIds = new LinkedHashSet<>();
             writeProfileCompletions(
                 feeds,
+                failedProfileIds,
                 profileFeed -> {
-                    if (!failedProfileIds.contains(profileFeed.profileId)) {
-                        SubscriptionRefreshResultStore.clearFailure(
-                            context,
-                            profileFeed.profileId,
-                            feedType
-                        );
-                    }
+                    SubscriptionRefreshResultStore.clearFailure(
+                        context,
+                        profileFeed.profileId,
+                        feedType
+                    );
                     SubscriptionRefreshResultStore.writeCompletion(
                         context,
                         profileFeed.profileId,
@@ -307,10 +306,12 @@ public final class SubscriptionRefreshWorker extends Worker {
 
     static void writeProfileCompletions(
         List<SubscriptionRefreshConfiguration.Feed> feeds,
+        Set<String> failedProfileIds,
         ProfileCompletionWriter writer,
         BiConsumer<SubscriptionRefreshConfiguration.Feed, Exception> onFailure
     ) {
         for (SubscriptionRefreshConfiguration.Feed profileFeed : feeds) {
+            if (failedProfileIds.contains(profileFeed.profileId)) continue;
             try {
                 writer.write(profileFeed);
             } catch (Exception error) {

--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshWorker.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshWorker.java
@@ -2,6 +2,7 @@ package org.opentubex.app;
 
 import android.app.NotificationManager;
 import android.content.Context;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
@@ -14,12 +15,14 @@ import androidx.work.WorkerParameters;
 
 import org.json.JSONObject;
 
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
 public final class SubscriptionRefreshWorker extends Worker {
+    private static final String LOG_TAG = "OpenTubeXFetch";
     private static final String UNIQUE_WORK_NAME = "subscription-refresh";
     private static final String TOKEN_INPUT = "token";
     static final String FEED_TYPE_INPUT = "feedType";
@@ -168,19 +171,33 @@ public final class SubscriptionRefreshWorker extends Worker {
                 if (SubscriptionRefreshCoordinator.isCancelled(token) || isStopped()) {
                     return Result.success();
                 }
+                JSONObject payload = null;
                 try {
-                    JSONObject payload = SubscriptionRefreshHttpClient.fetch(feed, channelId);
-                    SubscriptionRefreshResultStore.writeChannel(
-                        context,
-                        feed.profileId,
-                        feedType,
-                        channelId,
-                        payload,
-                        System.currentTimeMillis()
-                    );
-                    completed++;
+                    payload = SubscriptionRefreshHttpClient.fetch(feed, channelId);
                 } catch (Exception error) {
                     failed++;
+                    recordFailure(
+                        context,
+                        targetProfileIds(feeds, channelId),
+                        feedType,
+                        "Invidious API",
+                        error
+                    );
+                }
+
+                if (payload != null) {
+                    long timestamp = System.currentTimeMillis();
+                    for (String profileId : targetProfileIds(feeds, channelId)) {
+                        SubscriptionRefreshResultStore.writeChannel(
+                            context,
+                            profileId,
+                            feedType,
+                            channelId,
+                            payload,
+                            timestamp
+                        );
+                    }
+                    completed++;
                 }
 
                 int progress = total == 0 ? 100 : (int) Math.round((completed + failed) * 100.0 / total);
@@ -205,6 +222,13 @@ public final class SubscriptionRefreshWorker extends Worker {
 
             long completionTimestamp = System.currentTimeMillis();
             for (SubscriptionRefreshConfiguration.Feed profileFeed : feeds) {
+                if (failed == 0) {
+                    SubscriptionRefreshResultStore.clearFailure(
+                        context,
+                        profileFeed.profileId,
+                        feedType
+                    );
+                }
                 SubscriptionRefreshResultStore.writeCompletion(
                     context,
                     profileFeed.profileId,
@@ -214,10 +238,62 @@ public final class SubscriptionRefreshWorker extends Worker {
             }
             return Result.success();
         } catch (Exception error) {
+            List<String> profileIds = new ArrayList<>();
+            for (SubscriptionRefreshConfiguration.Feed profileFeed : feeds) {
+                profileIds.add(profileFeed.profileId);
+            }
+            recordFailure(
+                context,
+                profileIds,
+                feedType,
+                "Android background worker",
+                error
+            );
             return Result.retry();
         } finally {
             if (SubscriptionRefreshCoordinator.finish(token)) {
                 notifications.cancel(SubscriptionRefreshNotification.NOTIFICATION_ID);
+            }
+        }
+    }
+
+    static List<String> targetProfileIds(
+        List<SubscriptionRefreshConfiguration.Feed> feeds,
+        String channelId
+    ) {
+        List<String> profileIds = new ArrayList<>();
+        for (SubscriptionRefreshConfiguration.Feed feed : feeds) {
+            if (feed.channelIds.contains(channelId)) profileIds.add(feed.profileId);
+        }
+        return profileIds;
+    }
+
+    private static void recordFailure(
+        Context context,
+        List<String> profileIds,
+        String feedType,
+        String backend,
+        Throwable error
+    ) {
+        SubscriptionRefreshRequestDiagnostic diagnostic =
+            SubscriptionRefreshRequestDiagnostic.create(feedType, backend, error);
+        Log.w(LOG_TAG, diagnostic.toString());
+        long timestamp = System.currentTimeMillis();
+        for (String profileId : profileIds) {
+            try {
+                SubscriptionRefreshResultStore.writeFailure(
+                    context,
+                    profileId,
+                    feedType,
+                    diagnostic,
+                    timestamp
+                );
+            } catch (Exception storageError) {
+                Log.e(
+                    LOG_TAG,
+                    "Unable to persist a subscription request diagnostic: " +
+                        storageError.getClass().getSimpleName()
+                );
             }
         }
     }

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1,7 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
-    <string name="media_notification_channel">Medienwiedergabe</string>
-    <string name="media_notification_channel_description">Steuerung für die Audio- und Videowiedergabe</string>
+    <string name="notification_channel_media_playback_name">Medienwiedergabe</string>
+    <string name="notification_channel_media_playback_description">Wiedergabesteuerung während der Medienwiedergabe</string>
+    <string name="notification_channel_subscription_refresh_name">Abonnement-Aktualisierung</string>
+    <string name="notification_channel_subscription_refresh_description">Fortschritt von Abonnement-Aktualisierungen im Hintergrund</string>
+    <string name="notification_channel_live_reminders_name">Livestream-Erinnerungen</string>
+    <string name="notification_channel_live_reminders_description">Benachrichtigungen beim Start geplanter Livestreams</string>
     <string name="media_play">Wiedergeben</string>
     <string name="media_pause">Pausieren</string>
     <string name="media_stop">Beenden</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4,8 +4,12 @@
     <string name="title_activity_main">OpenTubeX</string>
     <string name="package_name">org.opentubex.app</string>
     <string name="custom_url_scheme">org.opentubex.app</string>
-    <string name="media_notification_channel">Media playback</string>
-    <string name="media_notification_channel_description">Controls for audio and video playback</string>
+    <string name="notification_channel_media_playback_name">Media playback</string>
+    <string name="notification_channel_media_playback_description">Playback controls while media is playing</string>
+    <string name="notification_channel_subscription_refresh_name">Subscription refresh</string>
+    <string name="notification_channel_subscription_refresh_description">Progress for subscription refreshes running in the background</string>
+    <string name="notification_channel_live_reminders_name">Live reminders</string>
+    <string name="notification_channel_live_reminders_description">Alerts when scheduled live streams begin</string>
     <string name="media_play">Play</string>
     <string name="media_pause">Pause</string>
     <string name="media_stop">Stop</string>

--- a/android/app/src/test/java/org/opentubex/app/OpenTubeXNotificationChannelsTest.java
+++ b/android/app/src/test/java/org/opentubex/app/OpenTubeXNotificationChannelsTest.java
@@ -1,0 +1,36 @@
+package org.opentubex.app;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.app.NotificationManager;
+
+import org.junit.Test;
+
+public class OpenTubeXNotificationChannelsTest {
+    @Test
+    public void distinctNotificationPurposesKeepStableChannelIds() {
+        OpenTubeXNotificationChannels.ChannelSpec[] channels =
+            OpenTubeXNotificationChannels.specifications();
+
+        assertArrayEquals(
+            new String[] { "media-playback", "subscription-refresh", "live-reminders" },
+            new String[] { channels[0].id, channels[1].id, channels[2].id }
+        );
+        assertEquals(NotificationManager.IMPORTANCE_LOW, channels[0].importance);
+        assertEquals(NotificationManager.IMPORTANCE_LOW, channels[1].importance);
+        assertEquals(NotificationManager.IMPORTANCE_HIGH, channels[2].importance);
+        assertEquals(R.string.notification_channel_media_playback_name, channels[0].nameResource);
+        assertEquals(R.string.notification_channel_subscription_refresh_name, channels[1].nameResource);
+        assertEquals(R.string.notification_channel_live_reminders_name, channels[2].nameResource);
+        for (OpenTubeXNotificationChannels.ChannelSpec channel : channels) {
+            assertNotEquals(0, channel.descriptionResource);
+        }
+        assertFalse(channels[0].showBadge);
+        assertFalse(channels[1].showBadge);
+        assertTrue(channels[2].showBadge);
+    }
+}

--- a/android/app/src/test/java/org/opentubex/app/OpenTubeXNotificationChannelsTest.java
+++ b/android/app/src/test/java/org/opentubex/app/OpenTubeXNotificationChannelsTest.java
@@ -3,7 +3,6 @@ package org.opentubex.app;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import android.app.NotificationManager;
@@ -16,6 +15,7 @@ public class OpenTubeXNotificationChannelsTest {
         OpenTubeXNotificationChannels.ChannelSpec[] channels =
             OpenTubeXNotificationChannels.specifications();
 
+        assertEquals(3, channels.length);
         assertArrayEquals(
             new String[] { "media-playback", "subscription-refresh", "live-reminders" },
             new String[] { channels[0].id, channels[1].id, channels[2].id }
@@ -26,9 +26,18 @@ public class OpenTubeXNotificationChannelsTest {
         assertEquals(R.string.notification_channel_media_playback_name, channels[0].nameResource);
         assertEquals(R.string.notification_channel_subscription_refresh_name, channels[1].nameResource);
         assertEquals(R.string.notification_channel_live_reminders_name, channels[2].nameResource);
-        for (OpenTubeXNotificationChannels.ChannelSpec channel : channels) {
-            assertNotEquals(0, channel.descriptionResource);
-        }
+        assertEquals(
+            R.string.notification_channel_media_playback_description,
+            channels[0].descriptionResource
+        );
+        assertEquals(
+            R.string.notification_channel_subscription_refresh_description,
+            channels[1].descriptionResource
+        );
+        assertEquals(
+            R.string.notification_channel_live_reminders_description,
+            channels[2].descriptionResource
+        );
         assertFalse(channels[0].showBadge);
         assertFalse(channels[1].showBadge);
         assertTrue(channels[2].showBadge);

--- a/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshRequestDiagnosticTest.java
+++ b/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshRequestDiagnosticTest.java
@@ -1,0 +1,93 @@
+package org.opentubex.app;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.net.UnknownHostException;
+
+import javax.net.ssl.SSLHandshakeException;
+
+import org.json.JSONException;
+import org.junit.Test;
+
+public class SubscriptionRefreshRequestDiagnosticTest {
+    @Test
+    public void classifiesBackgroundFetchFailures() {
+        assertEquals(
+            "network",
+            SubscriptionRefreshRequestDiagnostic.create("videos", new UnknownHostException("offline"))
+                .failure
+        );
+        assertEquals(
+            "network",
+            SubscriptionRefreshRequestDiagnostic.create(
+                "videos",
+                new Exception(
+                    "android_getaddrinfo failed: EAI_NODATA (No address associated with hostname)"
+                )
+            ).failure
+        );
+        assertEquals(
+            "tls",
+            SubscriptionRefreshRequestDiagnostic.create("live", new SSLHandshakeException("bad cert"))
+                .failure
+        );
+        assertEquals(
+            "parsing",
+            SubscriptionRefreshRequestDiagnostic.create("posts", new JSONException("bad json"))
+                .failure
+        );
+        SubscriptionRefreshRequestDiagnostic restricted =
+            SubscriptionRefreshRequestDiagnostic.create(
+                "videos",
+                "Android background worker",
+                new SecurityException("Foreground service start not allowed from the background")
+            );
+        assertEquals("background restriction", restricted.failure);
+        assertEquals("Android background worker", restricted.backend);
+    }
+
+    @Test
+    public void stripsPathsQueriesAndCredentialsFromDiagnostics() {
+        Exception error = new Exception(
+            "Request https://example.test/private?token=secret Authorization: Bearer secret-token"
+        );
+        SubscriptionRefreshRequestDiagnostic diagnostic =
+            SubscriptionRefreshRequestDiagnostic.create("shorts", error);
+
+        assertEquals("subscription Shorts", diagnostic.category);
+        assertEquals("Invidious API", diagnostic.backend);
+        assertEquals("background", diagnostic.lifecycle);
+        assertEquals(
+            "Request https://example.test Authorization: <redacted>",
+            diagnostic.message
+        );
+        assertFalse(diagnostic.toString().contains("secret"));
+    }
+
+    @Test
+    public void stripsCredentialFieldsCookiesAndRequestBodies() {
+        Exception error = new Exception(
+            "Cookie: SID=cookie-secret\n" +
+                "token=token-secret api_key=key-secret\n" +
+                "request body={\"password\":\"body-secret\"}"
+        );
+        SubscriptionRefreshRequestDiagnostic diagnostic =
+            SubscriptionRefreshRequestDiagnostic.create("videos", error);
+
+        for (String secret : new String[] {
+            "cookie-secret",
+            "token-secret",
+            "key-secret",
+            "body-secret",
+        }) {
+            assertFalse(diagnostic.message.contains(secret));
+        }
+        assertEquals(
+            "Cookie: <redacted>\n" +
+                "token=<redacted> api_key=<redacted>\n" +
+                "request body=<redacted>",
+            diagnostic.message
+        );
+    }
+}

--- a/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshRequestDiagnosticTest.java
+++ b/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshRequestDiagnosticTest.java
@@ -2,6 +2,7 @@ package org.opentubex.app;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.net.UnknownHostException;
 
@@ -37,6 +38,11 @@ public class SubscriptionRefreshRequestDiagnosticTest {
             SubscriptionRefreshRequestDiagnostic.create("posts", new JSONException("bad json"))
                 .failure
         );
+        assertEquals(
+            "http",
+            SubscriptionRefreshRequestDiagnostic.create("videos", new Exception("HTTP 503"))
+                .failure
+        );
         SubscriptionRefreshRequestDiagnostic restricted =
             SubscriptionRefreshRequestDiagnostic.create(
                 "videos",
@@ -69,7 +75,8 @@ public class SubscriptionRefreshRequestDiagnosticTest {
     @Test
     public void stripsCredentialFieldsCookiesAndRequestBodies() {
         Exception error = new Exception(
-            "Cookie: SID=cookie-secret\n" +
+            "Authorization: Basic basic-secret with spaces\n" +
+                "Cookie: SID=cookie-secret\n" +
                 "token=token-secret api_key=key-secret\n" +
                 "request body={\"password\":\"body-secret\"}"
         );
@@ -77,6 +84,7 @@ public class SubscriptionRefreshRequestDiagnosticTest {
             SubscriptionRefreshRequestDiagnostic.create("videos", error);
 
         for (String secret : new String[] {
+            "basic-secret",
             "cookie-secret",
             "token-secret",
             "key-secret",
@@ -85,10 +93,41 @@ public class SubscriptionRefreshRequestDiagnosticTest {
             assertFalse(diagnostic.message.contains(secret));
         }
         assertEquals(
-            "Cookie: <redacted>\n" +
+            "Authorization: <redacted>\n" +
+                "Cookie: <redacted>\n" +
                 "token=<redacted> api_key=<redacted>\n" +
                 "request body=<redacted>",
             diagnostic.message
         );
+    }
+
+    @Test
+    public void boundsMessagesBeforeClassifyingThem() {
+        String message = "x".repeat(600) + " timeout";
+        SubscriptionRefreshRequestDiagnostic diagnostic =
+            SubscriptionRefreshRequestDiagnostic.create("videos", new Exception(message));
+
+        assertEquals("network", diagnostic.failure);
+        assertTrue(diagnostic.message.length() <= 500);
+    }
+
+    @Test
+    public void redactsUrlCredentialsSplitByTheMessageLimit() {
+        String message = "x ".repeat(240) + "https://user:password@example.test/path";
+        SubscriptionRefreshRequestDiagnostic diagnostic =
+            SubscriptionRefreshRequestDiagnostic.create("videos", new Exception(message));
+
+        assertFalse(diagnostic.message.contains("user"));
+        assertFalse(diagnostic.message.contains("password"));
+        assertTrue(diagnostic.message.length() <= 500);
+    }
+
+    @Test
+    public void keepsClassificationSamplesSeparate() {
+        String message = "x".repeat(246) + "time" + "z" + "out" + "y".repeat(247);
+        SubscriptionRefreshRequestDiagnostic diagnostic =
+            SubscriptionRefreshRequestDiagnostic.create("videos", new Exception(message));
+
+        assertEquals("api", diagnostic.failure);
     }
 }

--- a/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshRequestDiagnosticTest.java
+++ b/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshRequestDiagnosticTest.java
@@ -50,7 +50,8 @@ public class SubscriptionRefreshRequestDiagnosticTest {
     @Test
     public void stripsPathsQueriesAndCredentialsFromDiagnostics() {
         Exception error = new Exception(
-            "Request https://example.test/private?token=secret Authorization: Bearer secret-token"
+            "Request https://user:password@example.test/private?token=secret " +
+                "Authorization: Bearer secret-token"
         );
         SubscriptionRefreshRequestDiagnostic diagnostic =
             SubscriptionRefreshRequestDiagnostic.create("shorts", error);

--- a/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshWorkerTargetsTest.java
+++ b/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshWorkerTargetsTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Test;
 
@@ -27,7 +28,7 @@ public class SubscriptionRefreshWorkerTargetsTest {
     }
 
     @Test
-    public void completionFailuresDoNotSkipLaterProfiles() {
+    public void failedProfilesAreSkippedAndCompletionFailuresDoNotSkipLaterProfiles() {
         List<SubscriptionRefreshConfiguration.Feed> feeds = List.of(
             feed("first", List.of("shared")),
             feed("second", List.of("shared")),
@@ -38,6 +39,7 @@ public class SubscriptionRefreshWorkerTargetsTest {
 
         SubscriptionRefreshWorker.writeProfileCompletions(
             feeds,
+            Set.of("first"),
             profileFeed -> {
                 attemptedProfileIds.add(profileFeed.profileId);
                 if (profileFeed.profileId.equals("second")) {
@@ -47,7 +49,7 @@ public class SubscriptionRefreshWorkerTargetsTest {
             (profileFeed, error) -> failedProfileIds.add(profileFeed.profileId)
         );
 
-        assertEquals(List.of("first", "second", "third"), attemptedProfileIds);
+        assertEquals(List.of("second", "third"), attemptedProfileIds);
         assertEquals(List.of("second"), failedProfileIds);
     }
 

--- a/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshWorkerTargetsTest.java
+++ b/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshWorkerTargetsTest.java
@@ -1,0 +1,42 @@
+package org.opentubex.app;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+
+public class SubscriptionRefreshWorkerTargetsTest {
+    @Test
+    public void fetchedChannelsAreStoredForEverySubscribedProfile() {
+        List<SubscriptionRefreshConfiguration.Feed> feeds = List.of(
+            feed("first", List.of("shared", "first-only")),
+            feed("second", List.of("shared", "second-only"))
+        );
+
+        assertEquals(
+            List.of("first", "second"),
+            SubscriptionRefreshWorker.targetProfileIds(feeds, "shared")
+        );
+        assertEquals(
+            List.of("second"),
+            SubscriptionRefreshWorker.targetProfileIds(feeds, "second-only")
+        );
+    }
+
+    private static SubscriptionRefreshConfiguration.Feed feed(
+        String profileId,
+        List<String> channelIds
+    ) {
+        return new SubscriptionRefreshConfiguration.Feed(
+            profileId,
+            "videos",
+            900_000,
+            channelIds,
+            "https://example.test",
+            null,
+            "Refreshing subscriptions",
+            "Cancel"
+        );
+    }
+}

--- a/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshWorkerTargetsTest.java
+++ b/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshWorkerTargetsTest.java
@@ -2,6 +2,8 @@ package org.opentubex.app;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
@@ -22,6 +24,31 @@ public class SubscriptionRefreshWorkerTargetsTest {
             List.of("second"),
             SubscriptionRefreshWorker.targetProfileIds(feeds, "second-only")
         );
+    }
+
+    @Test
+    public void completionFailuresDoNotSkipLaterProfiles() {
+        List<SubscriptionRefreshConfiguration.Feed> feeds = List.of(
+            feed("first", List.of("shared")),
+            feed("second", List.of("shared")),
+            feed("third", List.of("shared"))
+        );
+        List<String> attemptedProfileIds = new ArrayList<>();
+        List<String> failedProfileIds = new ArrayList<>();
+
+        SubscriptionRefreshWorker.writeProfileCompletions(
+            feeds,
+            profileFeed -> {
+                attemptedProfileIds.add(profileFeed.profileId);
+                if (profileFeed.profileId.equals("second")) {
+                    throw new IOException("Result store unavailable");
+                }
+            },
+            (profileFeed, error) -> failedProfileIds.add(profileFeed.profileId)
+        );
+
+        assertEquals(List.of("first", "second", "third"), attemptedProfileIds);
+        assertEquals(List.of("second"), failedProfileIds);
     }
 
     private static SubscriptionRefreshConfiguration.Feed feed(

--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -906,6 +906,13 @@ test.describe('global progress presentation', () => {
     await expect(progressToast).toContainText('Downloading yt-dlp and ffmpeg')
     await expect(progressToast.locator('.icon')).toHaveAttribute('data-icon', 'download')
     await expect(progressToast.locator('.progress-indicator')).toHaveAttribute('data-progress', '42')
+    const progressGeometry = await progressToast.locator('.embeddedProgressPath').evaluate(element => ({
+      dashLength: Number.parseFloat(element.style.strokeDasharray),
+      pathLength: element.getTotalLength(),
+      vectorEffect: getComputedStyle(element).vectorEffect,
+    }))
+    expect(progressGeometry.dashLength / progressGeometry.pathLength).toBeCloseTo(0.42, 2)
+    expect(progressGeometry.vectorEffect).toBe('none')
     await expect(page.locator('.app > .progressBar')).toHaveCount(0)
 
     await page.evaluate(() => {

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -3492,6 +3492,135 @@ test.describe('settings', () => {
     await expect(holder.locator('.toast', { hasText: 'Test toast' })).toBeVisible()
   })
 
+  test('honors the configured toast position on Android phones', async ({ app, page }) => {
+    const phoneSafeArea = { top: 24, bottom: 16 }
+    await setWindowSize(app, page, { width: 375, height: 700 })
+    await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="appearance"]').click()
+    await page.locator('.app').evaluate((element, safeArea) => {
+      document.documentElement.style.setProperty('--safe-area-inset-top', `${safeArea.top}px`)
+      document.documentElement.style.setProperty('--safe-area-inset-bottom', `${safeArea.bottom}px`)
+      element.classList.remove('topTabs', 'bottomTabs', 'verticalTabs', 'verticalTabsLeft', 'verticalTabsRight')
+      element.classList.add('capacitorTabs', 'capacitorPhoneLayout')
+    }, phoneSafeArea)
+
+    const positionSelect = page.locator('[data-section="appearance"] .select')
+      .filter({ hasText: 'Toast Position' })
+      .locator('select')
+    const holder = page.locator('.toast-holder')
+    const progressToast = page.getByTestId('progress-toast')
+
+    async function viewportSize () {
+      return page.evaluate(() => ({
+        width: document.documentElement.clientWidth,
+        height: document.documentElement.clientHeight
+      }))
+    }
+
+    async function preparePhoneEdge (edge) {
+      // Electron needs a non-horizontal tab position to match Capacitor's 29px
+      // base inset. Keep that desktop tab on the edge opposite the one under
+      // test so it cannot affect the toast's horizontal alignment.
+      await page.evaluate((tabBarPosition) => {
+        const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+        store.commit('setTabBarPosition', tabBarPosition)
+      }, edge === 'bottom' ? 'right' : 'left')
+      await expect(holder).not.toHaveClass(/horizontal-tabs/)
+      // Updating the desktop tab position also refreshes `.app`'s responsive
+      // classes. Reapply the Capacitor fixture after that update has landed.
+      await page.locator('.app').evaluate((element) => {
+        element.classList.remove('topTabs', 'bottomTabs', 'verticalTabs', 'verticalTabsLeft', 'verticalTabsRight')
+        element.classList.add('capacitorTabs', 'capacitorPhoneLayout')
+      })
+      await expect(page.locator('.app')).toHaveClass(/capacitorPhoneLayout/)
+      const progressBounds = await progressToast.count() === 1
+        ? await progressToast.boundingBox()
+        : null
+      const progressInset = progressBounds ? progressBounds.height + 10 : 0
+      const expectedOffset = 29 + progressInset
+      await expect.poll(() => holder.evaluate((element, { edge, expectedOffset }) => {
+        const style = getComputedStyle(element)
+        return Math.max(
+          Math.abs(Number.parseFloat(style.getPropertyValue(`--offset-${edge}`)) - expectedOffset),
+          Math.abs(Number.parseFloat(style.getPropertyValue(`--mobile-offset-${edge}`)) - expectedOffset)
+        )
+      }, { edge, expectedOffset })).toBeLessThan(0.01)
+      return progressInset
+    }
+
+    async function expectBottomLeftToast (message) {
+      await positionSelect.selectOption('bottom-left')
+      await expect(holder).toHaveClass(/position-bottom-left/)
+      const progressInset = await preparePhoneEdge('bottom')
+      await page.evaluate((text) => {
+        window.ftElectron.showToastOnAllTabs(text, 10000)
+      }, message)
+      const toast = page.locator('.toast', { hasText: message })
+      const row = page.locator('[data-sonner-toast]', { hasText: message })
+      await expect(toast).toBeVisible()
+      await expect(row).toHaveAttribute('data-mounted', 'true')
+      await page.waitForTimeout(400)
+      const [bounds, viewport] = await Promise.all([
+        toast.boundingBox(),
+        viewportSize()
+      ])
+      expect.soft(bounds.x).toBeLessThan(30)
+      expect.soft(viewport.height - bounds.y - bounds.height)
+        .toBeCloseTo(72 + phoneSafeArea.bottom + progressInset, 1)
+      if (await progressToast.count() === 1) {
+        const progressBounds = await progressToast.boundingBox()
+        expect(bounds.y + bounds.height).toBeLessThan(progressBounds.y)
+      }
+      await row.focus()
+      await page.keyboard.press('Escape')
+      await expect(toast).toHaveCount(0)
+    }
+
+    async function expectTopRightToast (message) {
+      await positionSelect.selectOption('top-right')
+      await expect(holder).toHaveClass(/position-top-right/)
+      const progressInset = await preparePhoneEdge('top')
+      await page.evaluate((text) => {
+        window.ftElectron.showToastOnAllTabs(text, 10000)
+      }, message)
+      const toast = page.locator('.toast', { hasText: message })
+      const row = page.locator('[data-sonner-toast]', { hasText: message })
+      await expect(toast).toBeVisible()
+      await expect(row).toHaveAttribute('data-mounted', 'true')
+      await page.waitForTimeout(400)
+      const [bounds, topNavBounds, viewport] = await Promise.all([
+        toast.boundingBox(),
+        page.locator('.topNav').boundingBox(),
+        viewportSize()
+      ])
+      expect.soft(bounds.x + bounds.width).toBeGreaterThan(viewport.width - 30)
+      expect.soft(bounds.y).toBeGreaterThanOrEqual(topNavBounds.y + topNavBounds.height + 12 + progressInset)
+      expect.soft(bounds.y).toBeLessThan(viewport.height / 2)
+      if (await progressToast.count() === 1) {
+        const progressBounds = await progressToast.boundingBox()
+        expect(bounds.y).toBeGreaterThan(progressBounds.y + progressBounds.height)
+      }
+      await row.focus()
+      await page.keyboard.press('Escape')
+      await expect(toast).toHaveCount(0)
+    }
+
+    await expectBottomLeftToast('Android phone bottom-left toast')
+    await expectTopRightToast('Android phone top-right toast')
+    await page.evaluate(() => window.ftElectron.setZoomFactor(1.25))
+    await expect.poll(() => page.evaluate(() => window.devicePixelRatio)).toBeCloseTo(1.25, 2)
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setProgressBarMessage', 'Phone progress toast')
+      store.commit('setProgressBarPercentage', 50)
+      store.commit('setShowProgressBar', true)
+    })
+    await expect(progressToast).toBeVisible()
+
+    await expectBottomLeftToast('Scaled Android phone bottom-left toast')
+    await expectTopRightToast('Scaled Android phone top-right toast')
+  })
+
   test('keeps top toasts below the Android tablet app header', async ({ app, page }) => {
     await setWindowSize(app, page, { width: 375, height: 700 })
     await goTo(page, 'settings')

--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { test, expect, goTo, repoRoot, setWindowSize } from '../../helpers/app.mjs'
-import { openMockedVideo } from '../../helpers/player.mjs'
+import { findWatchComponent, openMockedVideo } from '../../helpers/player.mjs'
 import { mockPlayableWatchPage } from '../../helpers/watch.mjs'
 
 function historyEntry(videoId, title, timeWatched) {
@@ -464,6 +464,301 @@ test('scopes Android fullscreen safe-area rules to the player UI', async ({ app,
   await expect(page.locator('.shortsFullscreenMetadataSide')).toHaveCSS('display', 'none')
   await expect(page.locator('.fullscreenCommentsOverlay')).toHaveCSS('top', '44px')
   await expect(page.locator('.fullscreenCommentsOverlay')).toHaveCSS('bottom', '32px')
+})
+
+test('keeps Android player notices and end cards clear of visible controls', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  await openMockedVideo(page)
+  await setWindowSize(app, page, { width: 800, height: 480 })
+  await page.evaluate(() => window.ftElectron.setZoomFactor(1.25))
+  await page.evaluate(async () => {
+    document.documentElement.style.setProperty('--safe-area-inset-bottom', '24px')
+    const app = document.querySelector('.app')
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    await store.dispatch('updateShowFullscreenActionsWhenPaused', true)
+    app.classList.add('capacitorTabs')
+  })
+  const watchComponent = await page.evaluateHandle(findWatchComponent)
+  await page.locator('.full-window-button').first().dispatchEvent('click')
+  await expect(page.locator('.ftVideoPlayer')).toHaveClass(/fullWindow/)
+  await page.evaluate(() => {
+    const player = document.querySelector('.ftVideoPlayer')
+    const controls = player.querySelector('.shaka-controls-container')
+    const seekBar = controls.querySelector('.shaka-seek-bar-container')
+    const actionDock = player.querySelector('.fullscreenActions')
+    const notice = document.createElement('div')
+    const noticeAction = document.createElement('button')
+    const annotations = document.createElement('div')
+    const endCard = document.createElement('button')
+
+    player.dir = 'rtl'
+    controls.setAttribute('shown', 'true')
+    window.__keepTestControlsShown = new MutationObserver(() => {
+      if (controls.getAttribute('shown') !== 'true') controls.setAttribute('shown', 'true')
+    })
+    window.__keepTestControlsShown.observe(controls, {
+      attributeFilter: ['shown'],
+      attributes: true,
+    })
+
+    notice.className = 'skippedSegmentsWrapper'
+    for (const { name } of actionDock.attributes) {
+      if (name.startsWith('data-v-')) {
+        notice.setAttribute(name, '')
+        noticeAction.setAttribute(name, '')
+      }
+    }
+    noticeAction.className = 'skippedSegment'
+    noticeAction.textContent = 'SponsorBlock action'
+    noticeAction.addEventListener('click', (event) => {
+      event.stopPropagation()
+      window.__sponsorBlockActionClicked = true
+    })
+    notice.append(noticeAction)
+
+    annotations.className = 'videoAnnotations'
+    Object.assign(annotations.style, {
+      position: 'absolute',
+      inset: '0',
+      zIndex: '2',
+      pointerEvents: 'none',
+    })
+    endCard.className = 'annotation'
+    endCard.textContent = 'End card'
+    Object.assign(endCard.style, {
+      position: 'absolute',
+      inlineSize: '220px',
+      blockSize: '180px',
+      pointerEvents: 'auto',
+    })
+    annotations.append(endCard)
+    player.append(notice, annotations)
+
+    const playerBounds = player.getBoundingClientRect()
+    const seekBounds = seekBar.getBoundingClientRect()
+    endCard.style.left = 'calc(50% - 110px)'
+    endCard.style.top = `${seekBounds.top - playerBounds.top - 90}px`
+  })
+
+  const player = page.locator('.ftVideoPlayer')
+  const controls = player.locator('.shaka-controls-container')
+  const bottomControls = controls.locator('.shaka-bottom-controls')
+  const seekBar = controls.locator('.shaka-seek-bar-container')
+  const actionDock = player.locator('.fullscreenActions')
+  const notice = player.locator('.skippedSegmentsWrapper')
+  const endCard = player.locator('.annotation')
+
+  const alignEndCardWithSeekBar = () => player.evaluate((element) => {
+    const playerBounds = element.getBoundingClientRect()
+    const seekBounds = element.querySelector('.shaka-seek-bar-container').getBoundingClientRect()
+    element.querySelector('.annotation').style.top = `${seekBounds.top - playerBounds.top - 90}px`
+  })
+  await expect(controls).toHaveAttribute('shown', 'true')
+  await expect(player).toHaveClass(/actionDockVisible/)
+  await expect(player).toHaveClass(/playerControlsShown/)
+
+  const verticalGap = () => player.evaluate((element) => {
+    const dockBounds = element.querySelector('.fullscreenActions').getBoundingClientRect()
+    const noticeBounds = element.querySelector('.skippedSegmentsWrapper').getBoundingClientRect()
+    return dockBounds.top - noticeBounds.bottom
+  })
+  const noticeBottom = () => player.evaluate((element) => {
+    const playerBounds = element.getBoundingClientRect()
+    const noticeBounds = element.querySelector('.skippedSegmentsWrapper').getBoundingClientRect()
+    return playerBounds.bottom - noticeBounds.bottom
+  })
+  const hitOwnership = () => player.evaluate((element) => {
+    const seekBar = element.querySelector('.shaka-seek-bar-container')
+    const endCard = element.querySelector('.annotation')
+    const seekBounds = seekBar.getBoundingClientRect()
+    const cardBounds = endCard.getBoundingClientRect()
+    const seekHit = document.elementFromPoint(
+      seekBounds.left + seekBounds.width / 2,
+      seekBounds.top + seekBounds.height / 2
+    )
+    const cardHit = document.elementFromPoint(
+      element.dir === 'rtl' ? cardBounds.right - 20 : cardBounds.left + 20,
+      cardBounds.top + 20
+    )
+
+    return {
+      cardOwnsClearArea: endCard.contains(cardHit),
+      controlsOwnSeekBar: seekBar.contains(seekHit),
+    }
+  })
+
+  await expect(actionDock).toHaveCSS('opacity', '1')
+  await expect(actionDock).toHaveCSS('pointer-events', 'auto')
+  await expect(notice).toHaveCSS('bottom', '164px')
+  await expect.poll(verticalGap).toBeGreaterThanOrEqual(8)
+  await expect.poll(() => player.evaluate((element) => {
+    const playerBounds = element.getBoundingClientRect()
+    const dockBounds = element.querySelector('.fullscreenActions').getBoundingClientRect()
+    return playerBounds.bottom - dockBounds.bottom
+  })).toBeCloseTo(106, 0)
+  const raisedNoticeBottom = await noticeBottom()
+
+  await expect(controls).toHaveCSS('z-index', 'auto')
+  await expect(bottomControls).toHaveCSS('z-index', '3')
+  const [seekBounds, cardBounds] = await Promise.all([
+    seekBar.boundingBox(),
+    endCard.boundingBox(),
+  ])
+  expect(seekBounds.y).toBeLessThan(cardBounds.y + cardBounds.height)
+  expect(seekBounds.y + seekBounds.height).toBeGreaterThan(cardBounds.y)
+  await expect.poll(async () => {
+    const ownership = await hitOwnership()
+    return {
+      cardOwnsClearArea: ownership.cardOwnsClearArea,
+      controlsOwnSeekBar: ownership.controlsOwnSeekBar,
+    }
+  }).toEqual({ cardOwnsClearArea: true, controlsOwnSeekBar: true })
+  await notice.getByRole('button', { name: 'SponsorBlock action' }).click()
+  await expect.poll(() => page.evaluate(() => window.__sponsorBlockActionClicked)).toBe(true)
+
+  await seekBar.evaluate((element) => {
+    window.__seekDragEvents = []
+    for (const type of ['pointerdown', 'pointermove', 'pointerup']) {
+      element.addEventListener(type, () => window.__seekDragEvents.push(type), {
+        capture: true,
+      })
+    }
+  })
+  const dragBounds = await seekBar.boundingBox()
+  await page.mouse.move(dragBounds.x + dragBounds.width / 2, dragBounds.y + dragBounds.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(dragBounds.x + dragBounds.width / 2 + 40, dragBounds.y + dragBounds.height / 2)
+  await page.mouse.up()
+  await expect.poll(() => page.evaluate(() => window.__seekDragEvents)).toEqual([
+    'pointermove',
+    'pointerdown',
+    'pointermove',
+    'pointerup',
+  ])
+
+  for (const { width, height, direction, zoom } of [
+    { width: 480, height: 800, direction: 'ltr', zoom: 1 },
+    { width: 1024, height: 768, direction: 'rtl', zoom: 1.25 },
+  ]) {
+    await page.evaluate((factor) => window.ftElectron.setZoomFactor(factor), zoom)
+    await setWindowSize(app, page, { width, height })
+    await player.evaluate((element, dir) => { element.dir = dir }, direction)
+    await alignEndCardWithSeekBar()
+    await expect.poll(verticalGap).toBeGreaterThanOrEqual(8)
+    await expect.poll(async () => {
+      const ownership = await hitOwnership()
+      return {
+        cardOwnsClearArea: ownership.cardOwnsClearArea,
+        controlsOwnSeekBar: ownership.controlsOwnSeekBar,
+      }
+    }).toEqual({ cardOwnsClearArea: true, controlsOwnSeekBar: true })
+  }
+
+  const moreOptions = player.getByRole('button', { name: 'More settings' })
+  const overflowMenu = player.locator('.shaka-overflow-menu')
+  await moreOptions.click()
+  const zoomMenuButton = overflowMenu.getByRole('button', { name: 'Zoom' })
+  await expect(controls).toHaveCSS('z-index', '9')
+  await endCard.evaluate((element) => {
+    const playerBounds = element.closest('.ftVideoPlayer').getBoundingClientRect()
+    const menuButtonBounds = document.querySelector('.shaka-overflow-menu .video-zoom-button')
+      .getBoundingClientRect()
+    element.style.left = `${menuButtonBounds.left - playerBounds.left}px`
+    element.style.top = `${menuButtonBounds.top - playerBounds.top}px`
+  })
+  await expect.poll(async () => zoomMenuButton.evaluate((element) => {
+    const bounds = element.getBoundingClientRect()
+    return element.contains(document.elementFromPoint(
+      bounds.left + bounds.width / 2,
+      bounds.top + bounds.height / 2
+    ))
+  })).toBe(true)
+  await zoomMenuButton.click()
+  await expect(player).toHaveClass(/isSubMenuOpened/)
+  await expect(actionDock).toHaveCSS('opacity', '0')
+  await expect(actionDock).toHaveCSS('pointer-events', 'none')
+  await expect.poll(noticeBottom).toBeLessThan(raisedNoticeBottom - 40)
+
+  await player.locator('.video-zoom-menu .shaka-back-to-overflow-button').click()
+  await expect(player).not.toHaveClass(/isSubMenuOpened/)
+  await expect(actionDock).toHaveCSS('opacity', '1')
+  await expect(actionDock).toHaveCSS('pointer-events', 'auto')
+  await expect.poll(verticalGap).toBeGreaterThanOrEqual(8)
+  await moreOptions.click()
+  await expect(overflowMenu).toBeHidden()
+  await alignEndCardWithSeekBar()
+
+  await player.locator('video').evaluate(element => element.pause())
+  await watchComponent.evaluate(async (component) => {
+    await component.proxy.$store.dispatch('updateShowPlayerControlsWhenPaused', false)
+    component.proxy.$refs.player.$.setupState.pausedInterfaceRevealed = false
+    await component.proxy.$nextTick()
+  })
+  await expect(player).toHaveClass(/playerPaused/)
+  await expect(player).not.toHaveClass(/playerControlsShown/)
+  await expect(bottomControls).toHaveCSS('z-index', '1')
+  await expect.poll(async () => {
+    const ownership = await hitOwnership()
+    return {
+      cardOwnsClearArea: ownership.cardOwnsClearArea,
+      controlsOwnSeekBar: ownership.controlsOwnSeekBar,
+    }
+  }).toEqual({ cardOwnsClearArea: true, controlsOwnSeekBar: false })
+  await watchComponent.evaluate(async (component) => {
+    await component.proxy.$store.dispatch('updateShowPlayerControlsWhenPaused', true)
+    await component.proxy.$nextTick()
+  })
+  await expect(player).toHaveClass(/playerControlsShown/)
+  await player.locator('video').evaluate(element => element.play())
+  await expect(player).not.toHaveClass(/playerPaused/)
+
+  await controls.evaluate(element => {
+    window.__keepTestControlsShown.disconnect()
+    element.removeAttribute('shown')
+  })
+  await expect(player).not.toHaveClass(/actionDockVisible/)
+  await expect(player).not.toHaveClass(/playerControlsShown/)
+  await expect(actionDock).toHaveCSS('opacity', '0')
+  await expect(bottomControls).toHaveCSS('z-index', '1')
+  await endCard.evaluate(element => { element.style.top = '100px' })
+  await endCard.click({ trial: true })
+
+  const dockFocusAction = actionDock.locator('.fullscreenShareAction > .iconButton')
+  await expect(dockFocusAction).toHaveCount(1)
+  await dockFocusAction.focus()
+  await expect(actionDock).toHaveCSS('opacity', '1')
+  await expect(player).toHaveClass(/actionDockVisible/)
+  await expect.poll(verticalGap).toBeGreaterThanOrEqual(8)
+  await dockFocusAction.evaluate(element => element.blur())
+  await expect(actionDock).toHaveCSS('opacity', '0')
+  await expect.poll(noticeBottom).toBeLessThan(raisedNoticeBottom - 40)
+
+  await watchComponent.evaluate(async (component) => {
+    component.proxy.$refs.player.$.setupState.fullWindowEnabled = false
+    await component.proxy.$nextTick()
+  })
+  await expect(player).not.toHaveClass(/fullWindow/)
+  await expect(notice).toHaveCSS('bottom', /.+/)
+  await expect.poll(noticeBottom).toBeLessThan(raisedNoticeBottom - 40)
+
+  await page.locator('.app').evaluate(element => element.classList.remove('capacitorTabs'))
+  await watchComponent.evaluate(async (component) => {
+    component.proxy.$refs.player.$.setupState.fullWindowEnabled = true
+    await component.proxy.$nextTick()
+  })
+  await expect(player).toHaveClass(/fullWindow/)
+  await controls.evaluate(element => element.setAttribute('shown', 'true'))
+  await expect(controls).toHaveCSS('z-index', '1')
+  await expect(bottomControls).toHaveCSS('z-index', '1')
+  await moreOptions.click()
+  await overflowMenu.getByRole('button', { name: 'Zoom' }).click()
+  await expect(player).toHaveClass(/isSubMenuOpened/)
+  await expect(actionDock).toHaveCSS('opacity', '1')
+  await expect(actionDock).toHaveCSS('pointer-events', 'auto')
+  await player.locator('.video-zoom-menu .shaka-back-to-overflow-button').click()
+  await moreOptions.click()
+  await endCard.click({ trial: true })
+  await watchComponent.dispose()
 })
 
 test('paid promotion badge follows the full-window title visibility', async ({ page }) => {

--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -1215,6 +1215,14 @@ test.describe('thumbnail watched progress', () => {
         window.ftElectron.setZoomFactor(scale)
       }, scenario)
       await expect(progress).toBeVisible()
+      await expect.poll(() => progress.evaluate(element => {
+        const viewBox = element.viewBox.baseVal
+        const style = getComputedStyle(element)
+        return Math.max(
+          Math.abs(viewBox.width - Number.parseFloat(style.width)),
+          Math.abs(viewBox.height - Number.parseFloat(style.height))
+        )
+      })).toBeLessThan(0.1)
 
       const geometry = await progressPath.evaluate(element => ({
         dashLength: Number.parseFloat(element.style.strokeDasharray),

--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -807,6 +807,10 @@ test.describe('thumbnail watched progress', () => {
     seed: {
       settings: { uiRoundness: 200 },
       history: [
+        {
+          ...historyEntry('00000000000', 'Unwatched video', Date.now() + 1000),
+          watchProgress: 0,
+        },
         historyEntry('aaaaaaaaaaa', 'Partially watched video', Date.now()),
         {
           ...historyEntry('bbbbbbbbbbb', 'Fully watched video', Date.now() - 1000),
@@ -817,6 +821,14 @@ test.describe('thumbnail watched progress', () => {
         },
       ]
     }
+  })
+
+  test('renders no progress fill at zero percent', async ({ page }) => {
+    await goTo(page, 'history')
+
+    const video = page.locator('.ft-list-item').filter({ hasText: 'Unwatched video' })
+    await expect(video).toBeVisible()
+    await expect(video.locator('.watchedProgressBar')).toHaveCount(0)
   })
 
   test('covers the complete curved thumbnail path at 100 percent', async ({ app, page }) => {
@@ -856,11 +868,13 @@ test.describe('thumbnail watched progress', () => {
         strokeDasharray: element.style.strokeDasharray,
         strokeLinecap: line.strokeLinecap,
         strokeWidth: line.strokeWidth,
+        vectorEffect: line.vectorEffect,
       }
     })
     expect(progressGeometry).toMatchObject({
       strokeLinecap: 'round',
       strokeWidth: '3px',
+      vectorEffect: 'none',
     })
     expect(progressGeometry.path).toContain('A 14.5 14.5')
     const [visibleLength, gapLength] = progressGeometry.strokeDasharray
@@ -880,6 +894,41 @@ test.describe('thumbnail watched progress', () => {
       document.body.dir = 'rtl'
     })
     await expect.poll(() => progressPath.getAttribute('d')).not.toBe(leftToRightPath)
+  })
+
+  test('keeps full progress aligned across Android screen shapes and UI scales', async ({ app, page }) => {
+    await goTo(page, 'history')
+    const progress = page.locator('.ft-list-item')
+      .filter({ hasText: 'Fully watched video' })
+      .locator('.watchedProgressBar')
+    const progressPath = progress.locator('.embeddedProgressPath')
+    const scenarios = [
+      { width: 375, height: 700, layout: 'capacitorPhoneLayout', direction: 'ltr', scale: 1 },
+      { width: 700, height: 375, layout: 'capacitorPhoneLayout', direction: 'rtl', scale: 1 },
+      { width: 768, height: 1024, layout: 'capacitorTabletLayout', direction: 'ltr', scale: 1 },
+      { width: 1024, height: 768, layout: 'capacitorTabletLayout', direction: 'rtl', scale: 0.95 },
+    ]
+
+    for (const scenario of scenarios) {
+      await setWindowSize(app, page, { width: scenario.width, height: scenario.height })
+      await page.evaluate(({ layout, direction, scale }) => {
+        const application = document.querySelector('.app')
+        application.classList.add('capacitorTabs')
+        application.classList.remove('capacitorPhoneLayout', 'capacitorTabletLayout')
+        application.classList.add(layout)
+        document.body.dir = direction
+        window.ftElectron.setZoomFactor(scale)
+      }, scenario)
+      await expect(progress).toBeVisible()
+
+      const geometry = await progressPath.evaluate(element => ({
+        dashLength: Number.parseFloat(element.style.strokeDasharray),
+        pathLength: element.getTotalLength(),
+        vectorEffect: getComputedStyle(element).vectorEffect,
+      }))
+      expect(geometry.dashLength).toBeCloseTo(geometry.pathLength, 1)
+      expect(geometry.vectorEffect).toBe('none')
+    }
   })
 })
 

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -2166,7 +2166,11 @@ async function reconcileAndroidSubscriptionRefreshResults() {
             timestamp: Number(result.timestamp) || Date.now()
           }
         })
-      } else if (result.kind === 'failure' && result.diagnostic) {
+      } else if (
+        result.kind === 'failure' &&
+        result.diagnostic &&
+        store.getters.profileById(result.profileId)
+      ) {
         const diagnostic = formatRequestDiagnostic(result.diagnostic)
         console.error(`Closed-app subscription refresh request failed: ${diagnostic}`)
         showApiErrorToast(t('Invidious API Error (Click to copy)'), diagnostic)

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -427,7 +427,7 @@ import {
   shouldUseProgressToast,
 } from './helpers/progressPresentation'
 import { fetchReleasePages, findUpdateReleases, formatReleaseChangelog } from './helpers/releaseUpdates'
-import { copyToClipboard, openExternalLink, openInternalPath, showToast } from './helpers/utils'
+import { copyToClipboard, openExternalLink, openInternalPath, showApiErrorToast, showToast } from './helpers/utils'
 import {
   exitAndroidApp,
   getAndroidHardwareKeyboardState,
@@ -456,6 +456,7 @@ import {
   processAndroidSubscriptionRefreshChannelResult
 } from './helpers/androidSubscriptionRefreshData'
 import { normalizeInvidiousSubscriptionFeed } from './helpers/api/invidious'
+import { formatRequestDiagnostic } from './helpers/api/requestDiagnostics'
 import { reconcileFetchedSubscriptionEntries } from './helpers/subscription-entries'
 import {
   cancelSubscriptionRefresh,
@@ -2165,6 +2166,10 @@ async function reconcileAndroidSubscriptionRefreshResults() {
             timestamp: Number(result.timestamp) || Date.now()
           }
         })
+      } else if (result.kind === 'failure' && result.diagnostic) {
+        const diagnostic = formatRequestDiagnostic(result.diagnostic)
+        console.error(`Closed-app subscription refresh request failed: ${diagnostic}`)
+        showApiErrorToast(t('Invidious API Error (Click to copy)'), diagnostic)
       }
 
       await acknowledgeAndroidSubscriptionRefreshResult(result.id)

--- a/src/renderer/components/FtEmbeddedProgress/FtEmbeddedProgress.vue
+++ b/src/renderer/components/FtEmbeddedProgress/FtEmbeddedProgress.vue
@@ -169,6 +169,5 @@ onBeforeUnmount(() => {
   stroke-linecap: round;
   stroke-linejoin: round;
   stroke-width: v-bind(lineWidth);
-  vector-effect: non-scaling-stroke;
 }
 </style>

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -676,27 +676,40 @@
   }
 }
 
-/* Phone toasts follow the mobile navigation instead of the desktop position
-   preference. Teleport puts the holder beside `.app`, hence the body query. */
-body:has(.app.capacitorPhoneLayout) .toast-holder[data-sonner-toaster] {
-  inset-block: auto calc(60px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)) + 12px);
-  /* stylelint-disable-next-line liberty/use-logical-spec */
-  right: auto;
-  /* stylelint-disable-next-line liberty/use-logical-spec */
-  left: 50%;
-  inline-size: calc(100vw - 24px);
-  max-inline-size: calc(100vw - 24px);
-  transform: translateX(-50%);
+/* Teleport puts the holders beside `.app`, hence the body queries. Bottom
+   positions stay above the phone navigation; top positions stay below the app
+   header. The shared position rules keep control of the horizontal edge. The
+   toaster offsets already include the regular 29px edge inset and any progress
+   toast clearance, so its rules add the remaining 43px of phone chrome space.
+   The progress holder's 5px padding needs the matching 67px holder inset. */
+/* stylelint-disable liberty/use-logical-spec -- overrides sonner's physical mobile insets */
+body:has(.app.capacitorPhoneLayout) .toast-holder.position-bottom-left[data-sonner-toaster],
+body:has(.app.capacitorPhoneLayout) .toast-holder.position-bottom-center[data-sonner-toaster],
+body:has(.app.capacitorPhoneLayout) .toast-holder.position-bottom-right[data-sonner-toaster] {
+  top: auto;
+  bottom: calc(var(--offset-bottom) + 43px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)));
+}
+/* stylelint-enable liberty/use-logical-spec */
+
+body:has(.app.capacitorPhoneLayout) .progress-toast-holder.position-bottom-left,
+body:has(.app.capacitorPhoneLayout) .progress-toast-holder.position-bottom-center,
+body:has(.app.capacitorPhoneLayout) .progress-toast-holder.position-bottom-right {
+  inset-block: auto calc(60px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)) + 7px);
 }
 
-body:has(.app.capacitorPhoneLayout) .toast-holder[data-sonner-toaster] [data-sonner-toast] {
-  justify-content: center;
+body:has(.app.capacitorPhoneLayout) .toast-holder.position-top-left[data-sonner-toaster],
+body:has(.app.capacitorPhoneLayout) .toast-holder.position-top-center[data-sonner-toaster],
+body:has(.app.capacitorPhoneLayout) .toast-holder.position-top-right[data-sonner-toaster] {
+  /* stylelint-disable liberty/use-logical-spec -- overrides sonner's physical mobile inset */
+  top: calc(var(--offset-top) + 43px + var(--safe-area-inset-top, env(safe-area-inset-top, 0px)));
+  bottom: auto;
+  /* stylelint-enable liberty/use-logical-spec */
 }
 
-body:has(.app.capacitorPhoneLayout) .progress-toast-holder {
-  inset-block: auto calc(60px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)) + 12px);
-  inset-inline: 0;
-  justify-content: center;
+body:has(.app.capacitorPhoneLayout) .progress-toast-holder.position-top-left,
+body:has(.app.capacitorPhoneLayout) .progress-toast-holder.position-top-center,
+body:has(.app.capacitorPhoneLayout) .progress-toast-holder.position-top-right {
+  inset-block: calc(var(--safe-area-inset-top, env(safe-area-inset-top, 0px)) + var(--top-nav-height, 60px) + 7px) auto;
 }
 
 /* Tablet tabs and the top navigation are both fixed app chrome on Android.

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -2509,7 +2509,46 @@ html[data-reduced-motion='reduce'] .musicVisualizerCanvas {
   z-index: 8;
 }
 
-:global(.capacitorTabs .ftVideoPlayer:is(:fullscreen, .fullWindow) .shaka-controls-container:has(
+:global(.capacitorTabs .ftVideoPlayer:is(:fullscreen, .fullWindow)) {
+  --mobile-fullscreen-actions-block-end: calc(
+    82px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))
+  );
+  --mobile-fullscreen-actions-block-size: 50px;
+  --mobile-fullscreen-overlay-gap: 8px;
+}
+
+:global(.capacitorTabs .ftVideoPlayer:is(:fullscreen, .fullWindow) > .fullscreenActions) {
+  inset-block-end: var(--mobile-fullscreen-actions-block-end);
+}
+
+:global(.capacitorTabs .ftVideoPlayer:is(:fullscreen, .fullWindow) > .fullscreenActions:focus-within) {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Keep SponsorBlock notices above the mobile action dock while it is visible. */
+:global(.capacitorTabs .ftVideoPlayer.actionDockVisible > .skippedSegmentsWrapper) {
+  bottom: calc(
+    var(--mobile-fullscreen-actions-block-end) +
+    var(--mobile-fullscreen-actions-block-size) +
+    var(--mobile-fullscreen-overlay-gap)
+  );
+}
+
+/* End cards keep their layer and remain tappable away from the controls. */
+:global(.capacitorTabs .ftVideoPlayer .shaka-controls-container) {
+  z-index: auto;
+}
+
+:global(.capacitorTabs .ftVideoPlayer.playerControlsShown :is(
+  .shaka-top-controls,
+  .shaka-bottom-controls,
+  .shaka-big-buttons-container
+)) {
+  z-index: 3;
+}
+
+:global(.capacitorTabs .ftVideoPlayer .shaka-controls-container:has(
   .shaka-overflow-menu:not(.shaka-hidden),
   .shaka-settings-menu:not(.shaka-hidden),
   .shaka-sub-menu:not(.shaka-hidden),

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -686,6 +686,9 @@ export default defineComponent({
     const isFullscreen = ref(false)
     const playerPaused = ref(true)
     const pausedInterfaceRevealed = ref(false)
+    const shakaControlsShown = ref(false)
+    const isSubMenuOpened = ref(false)
+    const actionDockFocused = ref(false)
     /** @type {number|null} */
     let pausedInterfaceRevealTimeout = null
 
@@ -693,7 +696,24 @@ export default defineComponent({
     const showVideoTitleWhenPaused = computed(() => store.getters.getShowVideoTitleWhenPaused)
     const showFullscreenActionsWhenPaused = computed(() => store.getters.getShowFullscreenActionsWhenPaused)
     const pausedInterfaceHideDelay = computed(() => store.getters.getPausedInterfaceHideDelay)
-
+    const playerControlsShown = computed(() => (
+      shakaControlsShown.value &&
+      (
+        !playerPaused.value ||
+        showPlayerControlsWhenPaused.value ||
+        pausedInterfaceRevealed.value ||
+        (!isFullscreen.value && !fullWindowEnabled.value)
+      )
+    ))
+    const actionDockVisible = computed(() => (
+      !isSubMenuOpened.value &&
+      (
+        actionDockFocused.value || (
+          (shakaControlsShown.value || props.shortsPlayer) &&
+          (!playerPaused.value || showFullscreenActionsWhenPaused.value || pausedInterfaceRevealed.value)
+        )
+      )
+    ))
     function clearPausedInterfaceReveal() {
       if (pausedInterfaceRevealTimeout !== null) {
         clearTimeout(pausedInterfaceRevealTimeout)
@@ -5031,6 +5051,12 @@ export default defineComponent({
       const controlsContainer = ui.getControls().getControlsContainer()
       observeFullscreenControlsVisibility(controlsContainer)
 
+      const controls = ui.getControls()
+      controls.removeEventListener('submenuopen', handleSubMenuOpen)
+      controls.removeEventListener('submenuclose', handleSubMenuClose)
+      controls.addEventListener('submenuopen', handleSubMenuOpen)
+      controls.addEventListener('submenuclose', handleSubMenuClose)
+
       controlsContainer.removeEventListener('wheel', handleControlsContainerWheel)
       controlsContainer.removeEventListener('click', handleControlsContainerClick, true)
       controlsContainer.removeEventListener('pointerdown', handleTemporaryPlaybackRatePointerDown, true)
@@ -5454,6 +5480,14 @@ export default defineComponent({
     let fullscreenControlsVisibilityObserver = null
     let androidStatusBarVisible = true
 
+    function handleSubMenuOpen() {
+      isSubMenuOpened.value = true
+    }
+
+    function handleSubMenuClose() {
+      isSubMenuOpened.value = false
+    }
+
     /** @type {number|null} */
     let controlPanelLayoutFrame = null
 
@@ -5593,6 +5627,7 @@ export default defineComponent({
       ) {
         controlsContainer.setAttribute('shown', 'true')
       }
+      shakaControlsShown.value = controlsContainer?.hasAttribute('shown') === true
       const visible = shouldShowAndroidStatusBar({
         active: isActiveTab.value,
         fullscreen: isNativeFullscreenActive(),
@@ -10784,6 +10819,10 @@ export default defineComponent({
         fullscreenControlsVisibilityObserver = null
       }
 
+      const controls = ui?.getControls()
+      controls?.removeEventListener('submenuopen', handleSubMenuOpen)
+      controls?.removeEventListener('submenuclose', handleSubMenuClose)
+
       if (!androidStatusBarVisible) {
         androidStatusBarVisible = true
         setAndroidStatusBarVisible(true).catch(() => {})
@@ -11078,6 +11117,10 @@ export default defineComponent({
       showPlayerControlsWhenPaused,
       showVideoTitleWhenPaused,
       showFullscreenActionsWhenPaused,
+      actionDockVisible,
+      actionDockFocused,
+      playerControlsShown,
+      isSubMenuOpened,
       presentationModeChanging,
       chapterThumbnails,
       closeChaptersOverlay,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -85,7 +85,10 @@
         pausedInterfaceRevealed,
         hidePlayerControlsWhenPaused: !showPlayerControlsWhenPaused,
         hideVideoTitleWhenPaused: !showVideoTitleWhenPaused,
-        hideFullscreenActionsWhenPaused: !showFullscreenActionsWhenPaused
+        hideFullscreenActionsWhenPaused: !showFullscreenActionsWhenPaused,
+        actionDockVisible,
+        playerControlsShown,
+        isSubMenuOpened
       }"
       :style="[
         captionCssVariables,
@@ -386,6 +389,8 @@
         @click.stop
         @dblclick.stop
         @pointerdown.stop
+        @focusin="actionDockFocused = true"
+        @focusout="actionDockFocused = $event.currentTarget.contains($event.relatedTarget)"
       >
         <button
           v-if="watchingPlaylist"

--- a/src/renderer/helpers/api/requestDiagnostics.js
+++ b/src/renderer/helpers/api/requestDiagnostics.js
@@ -25,7 +25,7 @@ function stripUrlDetails(value) {
 
 export function sanitizeRequestErrorMessage(error) {
   return stripUrlDetails(errorText(error))
-    .replaceAll(/authorization\s*:\s*(?:bearer\s+)?[^\s,;]+/gi, 'Authorization: <redacted>')
+    .replaceAll(/\bauthorization\s*:\s*[^\r\n]*/gi, 'Authorization: <redacted>')
     .replaceAll(/\b(bearer|basic)\s+[A-Za-z0-9._~+/=-]+/gi, '$1 <redacted>')
     .replaceAll(/\b(?:cookie|set-cookie)\s*:\s*[^\r\n]*/gi, 'Cookie: <redacted>')
     .replaceAll(

--- a/src/renderer/helpers/api/requestDiagnostics.js
+++ b/src/renderer/helpers/api/requestDiagnostics.js
@@ -1,0 +1,100 @@
+const RESUME_WINDOW_MS = 5000
+let lastVisibleAt = Number.NEGATIVE_INFINITY
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') lastVisibleAt = Date.now()
+  })
+}
+
+function errorText(error) {
+  if (typeof error === 'string') return error
+  if (typeof error?.message === 'string') return error.message
+  return String(error)
+}
+
+function stripUrlDetails(value) {
+  return value.replaceAll(/https?:\/\/[^\s)]+/gi, match => {
+    try {
+      return new URL(match).origin
+    } catch {
+      return '<url>'
+    }
+  })
+}
+
+export function sanitizeRequestErrorMessage(error) {
+  return stripUrlDetails(errorText(error))
+    .replaceAll(/authorization\s*:\s*(?:bearer\s+)?[^\s,;]+/gi, 'Authorization: <redacted>')
+    .replaceAll(/\b(bearer|basic)\s+[A-Za-z0-9._~+/=-]+/gi, '$1 <redacted>')
+    .replaceAll(/\b(?:cookie|set-cookie)\s*:\s*[^\r\n]*/gi, 'Cookie: <redacted>')
+    .replaceAll(
+      /\b(access[_-]?token|refresh[_-]?token|id[_-]?token|token|api[_-]?key|client[_-]?secret|password|secret)["']?\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s,;&}]+)/gi,
+      '$1=<redacted>'
+    )
+    .replaceAll(/\brequest\s+body\s*[:=]\s*[^\r\n]*/gi, 'request body=<redacted>')
+    .slice(0, 500)
+}
+
+export function classifyRequestFailure(error) {
+  const name = String(error?.name ?? '')
+  const code = String(error?.code ?? '')
+  const message = errorText(error)
+  const signature = `${name} ${code} ${message}`.toLowerCase()
+
+  if (name === 'AbortError' || /cancel|aborted|err_canceled/.test(signature)) return 'cancellation'
+  if (
+    /foregroundservicestartnotallowed|backgroundservicestartnotallowed|(?:foreground|background) service.*(?:not allowed|restrict)|background execution.*(?:not allowed|restrict)/.test(signature)
+  ) return 'background restriction'
+  if (
+    typeof error?.status === 'number' ||
+    /\bhttp\s+\d{3}\b|\bstatus(?: code)?[: ]+\d{3}\b/.test(signature)
+  ) return 'http'
+  if (/ssl|tls|certificate|certpath|handshake/.test(signature)) return 'tls'
+  if (error instanceof SyntaxError || /json|parse|parsing|unexpected token/.test(signature)) return 'parsing'
+  if (
+    /unknownhost|gai|addrinfo|eai_|dns|network|socket|timeout|timed out|connect|failed to fetch|load failed/.test(signature)
+  ) {
+    return 'network'
+  }
+  return 'api'
+}
+
+export function classifyRequestLifecycle(visibilityState, visibleAt, now = Date.now()) {
+  if (visibilityState === 'hidden') return 'background'
+  if (now - visibleAt <= RESUME_WINDOW_MS) return 'resume'
+  return 'foreground'
+}
+
+export function getRequestLifecycle() {
+  const visibilityState = typeof document === 'undefined' ? 'visible' : document.visibilityState
+  return classifyRequestLifecycle(visibilityState, lastVisibleAt)
+}
+
+export function buildRequestDiagnostic(error, { category, backend, lifecycle = getRequestLifecycle() }) {
+  const code = typeof error?.code === 'string' && error.code.length > 0
+    ? error.code
+    : typeof error?.name === 'string' && error.name !== 'Error'
+      ? error.name
+      : null
+
+  return {
+    category,
+    backend,
+    lifecycle,
+    failure: classifyRequestFailure(error),
+    ...(code === null ? {} : { code }),
+    message: sanitizeRequestErrorMessage(error),
+  }
+}
+
+export function formatRequestDiagnostic(diagnostic) {
+  return [
+    `request=${diagnostic.category}`,
+    `backend=${diagnostic.backend}`,
+    `lifecycle=${diagnostic.lifecycle}`,
+    `failure=${diagnostic.failure}`,
+    diagnostic.code ? `code=${diagnostic.code}` : null,
+    `message=${diagnostic.message}`,
+  ].filter(Boolean).join('; ')
+}

--- a/src/renderer/helpers/api/requestDiagnostics.js
+++ b/src/renderer/helpers/api/requestDiagnostics.js
@@ -47,7 +47,7 @@ export function classifyRequestFailure(error) {
     /foregroundservicestartnotallowed|backgroundservicestartnotallowed|(?:foreground|background) service.*(?:not allowed|restrict)|background execution.*(?:not allowed|restrict)/.test(signature)
   ) return 'background restriction'
   if (
-    typeof error?.status === 'number' ||
+    (Number.isInteger(error?.status) && error.status >= 100 && error.status <= 599) ||
     /\bhttp\s+\d{3}\b|\bstatus(?: code)?[: ]+\d{3}\b/.test(signature)
   ) return 'http'
   if (/ssl|tls|certificate|certpath|handshake/.test(signature)) return 'tls'

--- a/src/renderer/helpers/liveReminders.js
+++ b/src/renderer/helpers/liveReminders.js
@@ -3,7 +3,6 @@ import { LocalNotifications } from '@capacitor/local-notifications'
 const STORAGE_KEY = 'opentubex-capacitor-live-reminders'
 const CHANNEL_ID = 'live-reminders'
 const listeners = new Set()
-let channelReady = false
 
 export const supportsLiveReminders = Boolean(process.env.IS_ELECTRON || process.env.IS_CAPACITOR)
 
@@ -46,19 +45,6 @@ function emitUpdated(videoId, scheduled) {
   for (const listener of listeners) listener(videoId, scheduled)
 }
 
-async function ensureNotificationChannel() {
-  if (channelReady) return
-  await LocalNotifications.createChannel({
-    id: CHANNEL_ID,
-    name: 'Livestream reminders',
-    description: 'Notifications when scheduled livestreams begin',
-    importance: 4,
-    visibility: 1,
-    vibration: true,
-  })
-  channelReady = true
-}
-
 async function requestNotificationPermission() {
   let status = await LocalNotifications.checkPermissions()
   if (status.display !== 'granted') {
@@ -83,7 +69,6 @@ const capacitorLiveReminder = {
 
   async schedule(reminder) {
     if (!await requestNotificationPermission()) return false
-    await ensureNotificationChannel()
 
     const records = readCapacitorReminders()
     const notificationId = notificationIdForVideo(reminder.videoId, records)

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -36,6 +36,7 @@ import { extractAssignedJsonObject } from './assigned-json'
 import { getLocalPremiereState } from './premiere'
 import { shouldShowProgressStartToast } from './progressPresentation'
 import { isAndroidSubscriptionRefreshActive } from './androidSubscriptionRefresh'
+import { buildRequestDiagnostic, formatRequestDiagnostic } from './api/requestDiagnostics'
 
 const AUTO_REFRESH_TOAST_DURATION = 5000
 export const SUBSCRIPTION_REFRESH_CHANNEL_EVENT = 'opentubex-subscription-refresh-channel'
@@ -273,12 +274,14 @@ async function fetchSubscriptionsInBatches(channels, fetchChannel) {
  * @param {{ id: string, name?: string }} channel
  * @param {unknown} error
  * @param {string} title
+ * @param {{ category: string, backend: string }} context
  */
-export function showSubscriptionFetchError(channel, error, title) {
+export function showSubscriptionFetchError(channel, error, title, context) {
   const channelLabel = channel.name ? `${channel.name} (${channel.id})` : channel.id
-  const message = `${channelLabel}: ${error}`
+  const diagnostic = formatRequestDiagnostic(buildRequestDiagnostic(error, context))
+  const message = `${channelLabel}: ${diagnostic}`
 
-  console.error(`Failed to fetch subscription channel ${channelLabel}`, error)
+  console.error(`Failed to fetch subscription channel ${channelLabel}: ${diagnostic}`)
   showApiErrorToast(title, message)
 }
 
@@ -1027,7 +1030,10 @@ async function getChannelPostsLocal(channel, t, errorChannels) {
 
     return posts
   } catch (err) {
-    showSubscriptionFetchError(channel, err, t('Local API Error (Click to copy)'))
+    showSubscriptionFetchError(channel, err, t('Local API Error (Click to copy)'), {
+      category: 'subscription posts',
+      backend: 'local API'
+    })
 
     if (store.getters.getBackendPreference === 'local' && store.getters.getBackendFallback) {
       showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
@@ -1044,7 +1050,10 @@ async function getChannelPostsInvidious(channel, t, errorChannels) {
 
     return result.posts
   } catch (err) {
-    showSubscriptionFetchError(channel, err, t('Invidious API Error (Click to copy)'))
+    showSubscriptionFetchError(channel, err, t('Invidious API Error (Click to copy)'), {
+      category: 'subscription posts',
+      backend: 'Invidious API'
+    })
 
     if (
       process.env.SUPPORTS_LOCAL_API &&
@@ -1075,7 +1084,10 @@ async function getChannelVideosLocalScraper(channel, t, errorChannels, failedAtt
         : await enrichScrapedUpcomingPublicationDates(channel.id, result.videos)
     }
   } catch (err) {
-    showSubscriptionFetchError(channel, err, t('Local API Error (Click to copy)'))
+    showSubscriptionFetchError(channel, err, t('Local API Error (Click to copy)'), {
+      category: 'subscription videos',
+      backend: 'local API'
+    })
 
     switch (failedAttempts) {
       case 0:
@@ -1120,7 +1132,10 @@ async function getChannelVideosLocalRSS(channel, t, errorChannels, failedAttempt
 
     return await parseYouTubeRSSFeed(await response.text(), channel.id)
   } catch (error) {
-    showSubscriptionFetchError(channel, error, t('Local API Error (Click to copy)'))
+    showSubscriptionFetchError(channel, error, t('Local API Error (Click to copy)'), {
+      category: 'subscription videos',
+      backend: 'YouTube RSS'
+    })
 
     switch (failedAttempts) {
       case 0:
@@ -1153,7 +1168,10 @@ async function getChannelVideosInvidiousScraper(channel, t, errorChannels, faile
       videos: result.videos
     }
   } catch (err) {
-    showSubscriptionFetchError(channel, err, t('Invidious API Error (Click to copy)'))
+    showSubscriptionFetchError(channel, err, t('Invidious API Error (Click to copy)'), {
+      category: 'subscription videos',
+      backend: 'Invidious API'
+    })
 
     switch (failedAttempts) {
       case 0:
@@ -1194,7 +1212,10 @@ async function getChannelVideosInvidiousRSS(channel, t, errorChannels, failedAtt
 
     return await parseYouTubeRSSFeed(await response.text(), channel.id)
   } catch (error) {
-    showSubscriptionFetchError(channel, error, t('Invidious API Error (Click to copy)'))
+    showSubscriptionFetchError(channel, error, t('Invidious API Error (Click to copy)'), {
+      category: 'subscription videos',
+      backend: 'Invidious RSS'
+    })
 
     switch (failedAttempts) {
       case 0:
@@ -1245,7 +1266,10 @@ async function getChannelShortsLocal(channel, t, errorChannels, failedAttempts =
     result.videos.forEach(video => { video.isShort = true })
     return result
   } catch (error) {
-    showSubscriptionFetchError(channel, error, t('Local API Error (Click to copy)'))
+    showSubscriptionFetchError(channel, error, t('Local API Error (Click to copy)'), {
+      category: 'subscription Shorts',
+      backend: 'YouTube RSS'
+    })
 
     if (failedAttempts === 0 && store.getters.getBackendFallback) {
       showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
@@ -1290,7 +1314,10 @@ async function getChannelShortsInvidious(channel, t, errorChannels, failedAttemp
     result.videos.forEach(video => { video.isShort = true })
     return result
   } catch (error) {
-    showSubscriptionFetchError(channel, error, t('Invidious API Error (Click to copy)'))
+    showSubscriptionFetchError(channel, error, t('Invidious API Error (Click to copy)'), {
+      category: 'subscription Shorts',
+      backend: 'Invidious RSS'
+    })
 
     if (failedAttempts === 0 && process.env.SUPPORTS_LOCAL_API && store.getters.getBackendFallback) {
       showToast({ message: t('Falling back to Local API'), icon: ['fas', 'exchange-alt'] })
@@ -1312,7 +1339,10 @@ async function getChannelLiveLocal(channel, t, errorChannels, failedAttempts = 0
 
     return result
   } catch (err) {
-    showSubscriptionFetchError(channel, err, t('Local API Error (Click to copy)'))
+    showSubscriptionFetchError(channel, err, t('Local API Error (Click to copy)'), {
+      category: 'subscription live streams',
+      backend: 'local API'
+    })
 
     switch (failedAttempts) {
       case 0:
@@ -1357,7 +1387,10 @@ async function getChannelLiveLocalRSS(channel, t, errorChannels, failedAttempts 
 
     return await parseYouTubeRSSFeed(await response.text(), channel.id)
   } catch (error) {
-    showSubscriptionFetchError(channel, error, t('Local API Error (Click to copy)'))
+    showSubscriptionFetchError(channel, error, t('Local API Error (Click to copy)'), {
+      category: 'subscription live streams',
+      backend: 'YouTube RSS'
+    })
 
     switch (failedAttempts) {
       case 0:
@@ -1390,7 +1423,10 @@ async function getChannelLiveInvidious(channel, t, errorChannels, failedAttempts
       videos: result.videos
     }
   } catch (err) {
-    showSubscriptionFetchError(channel, err, t('Invidious API Error (Click to copy)'))
+    showSubscriptionFetchError(channel, err, t('Invidious API Error (Click to copy)'), {
+      category: 'subscription live streams',
+      backend: 'Invidious API'
+    })
 
     switch (failedAttempts) {
       case 0:
@@ -1431,7 +1467,10 @@ async function getChannelLiveInvidiousRSS(channel, t, errorChannels, failedAttem
 
     return await parseYouTubeRSSFeed(await response.text(), channel.id)
   } catch (error) {
-    showSubscriptionFetchError(channel, error, t('Invidious API Error (Click to copy)'))
+    showSubscriptionFetchError(channel, error, t('Invidious API Error (Click to copy)'), {
+      category: 'subscription live streams',
+      backend: 'Invidious RSS'
+    })
 
     switch (failedAttempts) {
       case 0:

--- a/tests/unit/request-diagnostics.test.mjs
+++ b/tests/unit/request-diagnostics.test.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  buildRequestDiagnostic,
+  classifyRequestFailure,
+  classifyRequestLifecycle,
+  sanitizeRequestErrorMessage,
+} from '../../src/renderer/helpers/api/requestDiagnostics.js'
+
+test('classifies request failures without exposing request secrets', () => {
+  const error = Object.assign(
+    new Error('Unable to resolve https://example.test/path?token=secret with Authorization: Bearer secret-token'),
+    { code: 'UnknownHostException' }
+  )
+
+  assert.deepEqual(buildRequestDiagnostic(error, {
+    category: 'subscription videos',
+    backend: 'local API',
+    lifecycle: 'resume',
+  }), {
+    category: 'subscription videos',
+    backend: 'local API',
+    lifecycle: 'resume',
+    failure: 'network',
+    code: 'UnknownHostException',
+    message: 'Unable to resolve https://example.test with Authorization: <redacted>',
+  })
+})
+
+test('distinguishes HTTP, TLS, parsing, cancellation, and API failures', () => {
+  assert.equal(classifyRequestFailure({ status: 503 }), 'http')
+  assert.equal(classifyRequestFailure({ code: 'SSLHandshakeException' }), 'tls')
+  assert.equal(classifyRequestFailure(new TypeError('Failed to fetch')), 'network')
+  assert.equal(classifyRequestFailure(new Error('android_getaddrinfo failed: EAI_NODATA')), 'network')
+  assert.equal(
+    classifyRequestFailure({ code: 'ForegroundServiceStartNotAllowedException' }),
+    'background restriction'
+  )
+  assert.equal(classifyRequestFailure(new SyntaxError('Unexpected token')), 'parsing')
+  assert.equal(classifyRequestFailure({ name: 'AbortError' }), 'cancellation')
+  assert.equal(classifyRequestFailure(new Error('API rejected the request')), 'api')
+})
+
+test('redacts credential fields, cookies, and request bodies', () => {
+  const sanitized = sanitizeRequestErrorMessage(new Error([
+    'Cookie: SID=cookie-secret',
+    'token=token-secret api_key=key-secret',
+    'request body={"password":"body-secret"}',
+  ].join('\n')))
+
+  for (const secret of ['cookie-secret', 'token-secret', 'key-secret', 'body-secret']) {
+    assert.equal(sanitized.includes(secret), false)
+  }
+  assert.match(sanitized, /Cookie: <redacted>/)
+  assert.match(sanitized, /token=<redacted>/)
+  assert.match(sanitized, /api_key=<redacted>/)
+  assert.match(sanitized, /request body=<redacted>/)
+})
+
+test('labels foreground, background, and recent resume requests', () => {
+  assert.equal(classifyRequestLifecycle('hidden', 0, 10000), 'background')
+  assert.equal(classifyRequestLifecycle('visible', 8000, 10000), 'resume')
+  assert.equal(classifyRequestLifecycle('visible', 0, 10000), 'foreground')
+})

--- a/tests/unit/request-diagnostics.test.mjs
+++ b/tests/unit/request-diagnostics.test.mjs
@@ -39,6 +39,7 @@ test('distinguishes HTTP, TLS, parsing, cancellation, and API failures', () => {
   )
   assert.equal(classifyRequestFailure(new SyntaxError('Unexpected token')), 'parsing')
   assert.equal(classifyRequestFailure({ name: 'AbortError' }), 'cancellation')
+  assert.equal(classifyRequestFailure({ status: 0 }), 'api')
   assert.equal(classifyRequestFailure(new Error('API rejected the request')), 'api')
 })
 

--- a/tests/unit/request-diagnostics.test.mjs
+++ b/tests/unit/request-diagnostics.test.mjs
@@ -57,6 +57,11 @@ test('redacts credential fields, cookies, and request bodies', () => {
   assert.match(sanitized, /token=<redacted>/)
   assert.match(sanitized, /api_key=<redacted>/)
   assert.match(sanitized, /request body=<redacted>/)
+
+  assert.equal(
+    sanitizeRequestErrorMessage(new Error('Authorization: Basic basic-secret with spaces')),
+    'Authorization: <redacted>'
+  )
 })
 
 test('labels foreground, background, and recent resume requests', () => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

closes #1097
closes #1099

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Android could render watched-progress fills from the center, retain unclear notification categories, and report background subscription failures without enough safe context to diagnose them. In the mobile fullscreen player, SponsorBlock notices could overlap the action dock and end cards could cover or intercept visible controls.

This change makes progress fill linearly from the inline start edge, gives the three stable Android notification channels one owner, and records redacted request diagnostics by request category, backend, lifecycle, and failure class. It also persists Android background-restriction failures and delivers subscription refresh results to every eligible profile.

SponsorBlock notices now move above the safe-area-aware action dock while it is visible. End cards remain below visible controls and menus without losing their own tap targets when the controls hide.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Correct Android progress fills, notification and refresh handling, and mobile player overlay placement.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware <picture> with dark and light prefers-color-scheme sources and the dark image as its <img> fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through e2e/helpers/visual-fixtures.mjs. Before capturing, verify that every visible image has loaded successfully (complete === true and naturalWidth > 0).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to gh pr create or gh pr edit with --attach <path> so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat --attach <path> for each one. Read back the hosted URLs, replace the temporary references with the <picture> below, and update the pull request body without --attach:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION" regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION". Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open pages containing unwatched, partly watched, and fully watched videos. Confirm their progress tracks show no fill at 0%, a proportional fill from the inline start edge at intermediate values, and a complete fill at 100%.
2. Repeat in a right-to-left locale, portrait and landscape orientations, phone and tablet widths, and a non-100% UI scale. The fill should remain aligned with the rounded track at every size.
3. Switch the global progress presentation setting between its notification and in-app bar options, then start a task that reports progress. Only the selected presentation should appear, and its fill should match the displayed percentage.
4. On Android, open the app notification settings. Confirm Media playback, Subscription refresh, and Live reminders appear once each and can be configured independently.
5. Enable background subscription refresh for multiple eligible profiles, let a refresh run while the app is backgrounded, and reopen each profile. Each profile should receive its own refresh result. Failure logs should identify the request category, backend, lifecycle, and failure class without query parameters, bodies, cookies, authorization data, or tokens.
6. In the Android fullscreen player, show the bottom-right action dock and trigger a SponsorBlock notice. The notice should sit above the dock, remain tappable, and return to its usual position when the dock hides or a submenu opens.
7. Show end-screen cards over the seek bar. The visible seek bar and buttons should remain above the cards and accept input. Areas of each card outside the controls should remain tappable, including after the controls hide.
8. Repeat the fullscreen checks in portrait and landscape, left-to-right and right-to-left layouts, phone and tablet widths, a display cutout or safe-area inset, and a non-100% UI scale. Desktop placement and layering should remain unchanged.

## Additional context
<!-- Add any other context about the pull request here. -->

The existing Android channel IDs remain unchanged so user-selected channel settings survive the update. The native media session added on the base branch uses the same centralized media-playback channel.
