### PR TITLE
fix(ci): require stable performance regressions

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -128,7 +128,9 @@ Actions summary show the comparison, and the raw samples are uploaded as
 `performance-results.json`.
 
 The workflow fails when the candidate crosses a metric's absolute limit from
-below or exceeds both its relative limit and minimum delta. Elapsed metrics
+below or exceeds both its relative limit and minimum delta. The candidate's
+lower quartile must clear the threshold against the base's upper quartile, so
+an overlapping distribution cannot fail from a median flip. Elapsed metrics
 allow 15%, longest-frame metrics 20%, renderer heap growth 50%, and packed code
 size 5%. Each metric's minimum delta lives in `e2e/performance/report.mjs`. A
 trusted follow-up workflow updates the comment so pull requests from forks

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -128,9 +128,10 @@ Actions summary show the comparison, and the raw samples are uploaded as
 `performance-results.json`.
 
 The workflow fails when the candidate crosses a metric's absolute limit from
-below or exceeds both its relative limit and minimum delta. The candidate's
-lower quartile must clear the threshold against the base's upper quartile, so
-an overlapping distribution cannot fail from a median flip. Elapsed metrics
+below or exceeds both its relative limit and minimum delta. Absolute gates
+require the candidate's lower quartile to clear the limit. Relative gates
+require it to clear the threshold against the base's upper quartile, so an
+overlapping distribution cannot fail from a median flip. Elapsed metrics
 allow 15%, longest-frame metrics 20%, renderer heap growth 50%, and packed code
 size 5%. Each metric's minimum delta lives in `e2e/performance/report.mjs`. A
 trusted follow-up workflow updates the comment so pull requests from forks

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -127,11 +127,12 @@ compares the median of seven samples. A single pull-request comment and the
 Actions summary show the comparison, and the raw samples are uploaded as
 `performance-results.json`.
 
-The workflow fails when the candidate crosses a metric's absolute limit from
-below or exceeds both its relative limit and minimum delta. Absolute gates
-require the candidate's lower quartile to clear the limit. Relative gates
-require it to clear the threshold against the base's upper quartile, so an
-overlapping distribution cannot fail from a median flip. Elapsed metrics
+An absolute gate fails when the base median is below the limit, the candidate's
+lower quartile reaches the limit, and the median increase exceeds the configured
+absolute minimum delta. A relative gate fails when the candidate's lower
+quartile clears the threshold against the base's upper quartile and the
+interquartile increase exceeds the configured minimum delta. This prevents an
+overlapping distribution from failing because of a median flip. Elapsed metrics
 allow 15%, longest-frame metrics 20%, renderer heap growth 50%, and packed code
 size 5%. Each metric's minimum delta lives in `e2e/performance/report.mjs`. A
 trusted follow-up workflow updates the comment so pull requests from forks

--- a/e2e/performance/report.mjs
+++ b/e2e/performance/report.mjs
@@ -195,7 +195,7 @@ export function comparePerformanceSamples(samples) {
       Math.max(baseUpperQuartile, definition.relativeBaselineFloor ?? Number.MIN_VALUE)
     const gated = definition.gate !== false
     const crossesAbsoluteLimit = gated && definition.absoluteLimit !== undefined &&
-      baseUpperQuartile < definition.absoluteLimit &&
+      baseMedian < definition.absoluteLimit &&
       candidateLowerQuartile >= definition.absoluteLimit &&
       interquartileDelta > (definition.absoluteMinimumDelta ?? 0)
     const relativeRegression = gated && definition.relativeLimit !== undefined &&

--- a/e2e/performance/report.mjs
+++ b/e2e/performance/report.mjs
@@ -197,7 +197,7 @@ export function comparePerformanceSamples(samples) {
     const crossesAbsoluteLimit = gated && definition.absoluteLimit !== undefined &&
       baseMedian < definition.absoluteLimit &&
       candidateLowerQuartile >= definition.absoluteLimit &&
-      interquartileDelta > (definition.absoluteMinimumDelta ?? 0)
+      delta > (definition.absoluteMinimumDelta ?? 0)
     const relativeRegression = gated && definition.relativeLimit !== undefined &&
       interquartileThresholdRatio > definition.relativeLimit &&
       interquartileDelta > definition.minimumDelta

--- a/e2e/performance/report.mjs
+++ b/e2e/performance/report.mjs
@@ -159,6 +159,15 @@ function median(values) {
   return (sorted[midpoint - 1] + sorted[midpoint]) / 2
 }
 
+function percentile(values, percentile) {
+  const sorted = [...values].sort((left, right) => left - right)
+  const position = (sorted.length - 1) * percentile
+  const lowerIndex = Math.floor(position)
+  const upperIndex = Math.ceil(position)
+  const weight = position - lowerIndex
+  return sorted[lowerIndex] + (sorted[upperIndex] - sorted[lowerIndex]) * weight
+}
+
 function metricValue(definition, value) {
   return `${value.toFixed(1)} ${definition.unit}`
 }
@@ -176,17 +185,22 @@ export function comparePerformanceSamples(samples) {
     const baseMedian = median(baseValues)
     const candidateMedian = median(candidateValues)
     const delta = candidateMedian - baseMedian
+    const baseUpperQuartile = percentile(baseValues, 0.75)
+    const candidateLowerQuartile = percentile(candidateValues, 0.25)
+    const interquartileDelta = candidateLowerQuartile - baseUpperQuartile
     const ratio = baseMedian === 0
       ? (candidateMedian === 0 ? 1 : Number.POSITIVE_INFINITY)
       : candidateMedian / baseMedian
-    const thresholdRatio = candidateMedian /
-      Math.max(baseMedian, definition.relativeBaselineFloor ?? Number.MIN_VALUE)
+    const interquartileThresholdRatio = candidateLowerQuartile /
+      Math.max(baseUpperQuartile, definition.relativeBaselineFloor ?? Number.MIN_VALUE)
     const gated = definition.gate !== false
     const crossesAbsoluteLimit = gated && definition.absoluteLimit !== undefined &&
-      baseMedian < definition.absoluteLimit && candidateMedian >= definition.absoluteLimit &&
-      delta > (definition.absoluteMinimumDelta ?? 0)
+      baseUpperQuartile < definition.absoluteLimit &&
+      candidateLowerQuartile >= definition.absoluteLimit &&
+      interquartileDelta > (definition.absoluteMinimumDelta ?? 0)
     const relativeRegression = gated && definition.relativeLimit !== undefined &&
-      thresholdRatio > definition.relativeLimit && delta > definition.minimumDelta
+      interquartileThresholdRatio > definition.relativeLimit &&
+      interquartileDelta > definition.minimumDelta
 
     if (crossesAbsoluteLimit) {
       failures.push(
@@ -209,6 +223,10 @@ export function comparePerformanceSamples(samples) {
       candidateMedian,
       delta,
       ratio,
+      baseUpperQuartile,
+      candidateLowerQuartile,
+      interquartileDelta,
+      interquartileThresholdRatio,
       crossesAbsoluteLimit,
       relativeRegression,
       passed: !crossesAbsoluteLimit && !relativeRegression

--- a/tests/unit/performance-report.test.mjs
+++ b/tests/unit/performance-report.test.mjs
@@ -103,18 +103,18 @@ test('reports a consistent regression despite sample spread', () => {
   ))
 })
 
-test('reports a stable absolute crossing when the base upper quartile reaches the limit', () => {
+test('reports a stable absolute crossing despite a noisy base upper quartile', () => {
   const comparison = comparePerformanceSamples(samplesForMetric(
-    'firstSwitchElapsedMs',
-    [230, 235, 240, 245, 250, 255, 260],
-    [255, 260, 265, 270, 275, 280, 285]
+    'startupLongestFrameMs',
+    [450, 475, 490, 495, 500, 525, 550],
+    [600, 605, 610, 615, 620, 625, 630]
   ))
 
   const metric = comparison.metrics.find(
-    metric => metric.key === 'firstSwitchElapsedMs'
+    metric => metric.key === 'startupLongestFrameMs'
   )
   assert.equal(metric.passed, false)
   assert.ok(comparison.failures.some(
-    failure => /First subscription switch elapsed is 270\.0 ms/.test(failure)
+    failure => /Startup: renderer longest frame is 615\.0 ms/.test(failure)
   ))
 })

--- a/tests/unit/performance-report.test.mjs
+++ b/tests/unit/performance-report.test.mjs
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { comparePerformanceSamples } from '../../e2e/performance/report.mjs'
+
+function sample (overrides = {}) {
+  return {
+    startupElectronConnectedMs: 500,
+    startupWindowCreatedMs: 600,
+    startupRouteCommittedMs: 700,
+    startupInteractiveMs: 800,
+    startupLongestFrameMs: 50,
+    subscribedChannelsNavigationElapsedMs: 120,
+    subscribedChannelsNavigationLongestFrameMs: 40,
+    channelSearchElapsedMs: 60,
+    channelSearchLongestFrameMs: 30,
+    firstSwitchElapsedMs: 100,
+    firstSwitchLongestFrameMs: 50,
+    repeatedSwitchElapsedMs: 80,
+    repeatedSwitchLongestFrameMs: 40,
+    largeFeedScrollLongestFrameMs: 20,
+    navigationHeapGrowthMiB: 6.5,
+    playbackStartElapsedMs: 1000,
+    playbackStartLongestFrameMs: 50,
+    packedCodeSizeKiB: 4000,
+    ...overrides
+  }
+}
+
+function samplesForMetric (key, baseValues, candidateValues) {
+  return {
+    base: baseValues.map(value => sample({ [key]: value })),
+    candidate: candidateValues.map(value => sample({ [key]: value }))
+  }
+}
+
+const recoveredFlakes = [
+  {
+    key: 'subscribedChannelsNavigationElapsedMs',
+    label: 'large route navigation elapsed',
+    base: [103.8, 116.2, 148.9, 104.6, 114.9, 142.9, 120.5],
+    candidate: [123.4, 152.5, 125.1, 122.4, 152, 149.7, 155.9]
+  },
+  {
+    key: 'subscribedChannelsNavigationLongestFrameMs',
+    label: 'large route navigation longest frame',
+    base: [66.7, 83.3, 99.9, 66.7, 66.7, 66.6, 83.3],
+    candidate: [83.3, 50, 66.7, 100, 100, 100, 100]
+  },
+  {
+    key: 'firstSwitchElapsedMs',
+    label: 'first subscription switch elapsed',
+    base: [176.1, 173.3, 184.5, 247.8, 178.6, 186.8, 187.9],
+    candidate: [268.6, 186.5, 191.5, 262.3, 255.2, 269.3, 190.7]
+  },
+  {
+    key: 'firstSwitchLongestFrameMs',
+    label: 'first subscription switch longest frame',
+    base: [116.7, 116.7, 116.5, 183.3, 116.7, 116.6, 116.7],
+    candidate: [200, 116.7, 116.6, 200, 183.4, 200, 116.7]
+  },
+  {
+    key: 'repeatedSwitchElapsedMs',
+    label: 'repeated subscription switch elapsed',
+    base: [89.1, 100.8, 96.5, 100.4, 91.9, 99.7, 116.6],
+    candidate: [155.5, 132.3, 167.6, 116, 96.4, 99.7, 163.4]
+  },
+  {
+    key: 'repeatedSwitchLongestFrameMs',
+    label: 'repeated subscription switch longest frame',
+    base: [33.3, 34.1, 33.3, 33.8, 33.3, 33.3, 50],
+    candidate: [66.6, 66.6, 83.4, 50, 33.4, 33.3, 83.4]
+  }
+]
+
+for (const flake of recoveredFlakes) {
+  test(`ignores recovered ${flake.label} flake`, () => {
+    const comparison = comparePerformanceSamples(samplesForMetric(
+      flake.key,
+      flake.base,
+      flake.candidate
+    ))
+
+    const metric = comparison.metrics.find(metric => metric.key === flake.key)
+    assert.equal(metric.passed, true)
+    assert.deepEqual(comparison.failures, [])
+  })
+}
+
+test('reports a consistent regression despite sample spread', () => {
+  const comparison = comparePerformanceSamples(samplesForMetric(
+    'repeatedSwitchElapsedMs',
+    [90, 95, 100, 105, 110, 98, 102],
+    [140, 145, 150, 155, 160, 148, 152]
+  ))
+
+  const metric = comparison.metrics.find(
+    metric => metric.key === 'repeatedSwitchElapsedMs'
+  )
+  assert.equal(metric.passed, false)
+  assert.ok(comparison.failures.some(
+    failure => /Repeated subscription switch elapsed regressed/.test(failure)
+  ))
+})

--- a/tests/unit/performance-report.test.mjs
+++ b/tests/unit/performance-report.test.mjs
@@ -102,3 +102,19 @@ test('reports a consistent regression despite sample spread', () => {
     failure => /Repeated subscription switch elapsed regressed/.test(failure)
   ))
 })
+
+test('reports a stable absolute crossing when the base upper quartile reaches the limit', () => {
+  const comparison = comparePerformanceSamples(samplesForMetric(
+    'firstSwitchElapsedMs',
+    [230, 235, 240, 245, 250, 255, 260],
+    [255, 260, 265, 270, 275, 280, 285]
+  ))
+
+  const metric = comparison.metrics.find(
+    metric => metric.key === 'firstSwitchElapsedMs'
+  )
+  assert.equal(metric.passed, false)
+  assert.ok(comparison.failures.some(
+    failure => /First subscription switch elapsed is 270\.0 ms/.test(failure)
+  ))
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No related issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Performance comparison runs sometimes reported regressions that disappeared when the workflow was retried. Their base and candidate sample distributions overlapped heavily, but a noisy median crossed the existing threshold.

Require the candidate's lower quartile to clear the threshold against the base's upper quartile. This preserves the existing practical limits while only failing for a repeatable distribution-wide slowdown. Regression fixtures cover every active flaky metric found in recovered workflow artifacts and a consistent slowdown that must still fail.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

Not applicable. This changes only the pull-request performance gate and has no dev-mode UI behavior.

## Additional context
<!-- Add any other context about the pull request here. -->

The investigation covered 23 failed attempts across 21 pull-request workflow runs that later succeeded. Two old failures had already been addressed by the renderer heap measurement change. Replaying every remaining failed artifact through this comparison rule produced no false regressions.
