### PR TITLE
fix(settings): match system themes to color schemes

### DIFF
--- a/e2e/tests/network/sync-server.spec.mjs
+++ b/e2e/tests/network/sync-server.spec.mjs
@@ -602,7 +602,12 @@ test.describe('OpenTubeX sync server', () => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       const themes = await window.ftElectron.replaceCustomThemes([customTheme])
       store.commit('setCustomThemes', themes)
-      await store.dispatch('updateSyncServerSnapshot', '')
+      const snapshot = JSON.parse(store.state.settings.syncServerSnapshot)
+      snapshot.settings.customThemes.value = themes
+      snapshot.settings.customThemes.updatedAt = 1
+      await store.dispatch('updateSyncServerSnapshot', JSON.stringify(snapshot))
+      await store.dispatch('updateBaseTheme', 'custom:synced-theme')
+      await store.dispatch('updateSystemDarkTheme', 'custom:synced-theme')
     }, theme)
     await syncNow()
     await expect.poll(async () => readFile(themePath, 'utf8').then(
@@ -612,6 +617,16 @@ test.describe('OpenTubeX sync server', () => {
     await expect.poll(async () => (
       latestSettings(await readFile(settingsPath, 'utf8')).baseTheme
     )).toBe(theme.basedOn)
+    await expect.poll(async () => {
+      const settings = latestSettings(await readFile(settingsPath, 'utf8'))
+      const snapshot = JSON.parse(settings.syncServerSnapshot).settings
+      return [settings.systemDarkTheme, snapshot.baseTheme.value, snapshot.systemDarkTheme.value]
+    }).toEqual(['dark', theme.basedOn, 'dark'])
+    await syncNow()
+    await expect.poll(async () => {
+      const settings = latestSettings(await readFile(settingsPath, 'utf8'))
+      return [settings.baseTheme, settings.systemDarkTheme]
+    }).toEqual([theme.basedOn, 'dark'])
   })
 
   test('migrates existing plaintext data before locking the account', async ({ app, page }, testInfo) => {

--- a/e2e/tests/network/sync-server.spec.mjs
+++ b/e2e/tests/network/sync-server.spec.mjs
@@ -540,6 +540,7 @@ test.describe('OpenTubeX sync server', () => {
 
     await page.evaluate(async customTheme => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateSyncServerSyncSessions', false)
       const themes = await window.ftElectron.saveCustomTheme(customTheme)
       store.commit('setCustomThemes', themes)
       await store.dispatch('updateSystemDarkTheme', `custom:${customTheme.id}`)

--- a/e2e/tests/network/sync-server.spec.mjs
+++ b/e2e/tests/network/sync-server.spec.mjs
@@ -542,6 +542,7 @@ test.describe('OpenTubeX sync server', () => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       const themes = await window.ftElectron.saveCustomTheme(customTheme)
       store.commit('setCustomThemes', themes)
+      await store.dispatch('updateSystemDarkTheme', `custom:${customTheme.id}`)
     }, theme)
 
     const syncSection = await goToSettingsSection(page, 'sync')
@@ -570,6 +571,7 @@ test.describe('OpenTubeX sync server', () => {
       await store.dispatch('setSyncServerAutoSync', false)
       const themes = await window.ftElectron.replaceCustomThemes([])
       store.commit('setCustomThemes', themes)
+      await store.dispatch('updateSystemDarkTheme', 'dark')
       await store.dispatch('updateSyncServerSnapshot', '')
     })
     await syncNow()
@@ -582,6 +584,10 @@ test.describe('OpenTubeX sync server', () => {
       name: theme.name,
       colors: { background: '#123456' },
     })
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.getters.getSystemDarkTheme
+    })).toBe('custom:synced-theme')
 
     await page.evaluate(async () => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store

--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -1,7 +1,15 @@
 import { readFile, readdir } from 'node:fs/promises'
 import path from 'node:path'
 
-import { test, expect, goTo, goToSettingsSection, sel } from '../../helpers/app.mjs'
+import {
+  test,
+  expect,
+  goTo,
+  goToSettingsSection,
+  openNewWindowFromTabBar,
+  sel,
+  waitForAppReady,
+} from '../../helpers/app.mjs'
 
 async function readSavedThemes (userDataDir) {
   const themeDirectory = path.join(userDataDir, 'themes')
@@ -223,19 +231,65 @@ test.describe('default appearance', () => {
     await expect(page.locator('.select').filter({ has: darkTheme }).locator('.select-icon')).toBeVisible()
 
     await lightTheme.click()
-    await page.locator(`#${await lightTheme.getAttribute('aria-controls')}`)
-      .getByRole('option', { name: 'Catppuccin Frappe', exact: true }).click()
-    await expect(page.locator('body')).toHaveClass(/catppuccinFrappe/)
+    const lightThemeOptions = page.locator(`#${await lightTheme.getAttribute('aria-controls')}`)
+    await expect(lightThemeOptions.getByRole('option', { name: 'Catppuccin Frappe', exact: true }))
+      .toHaveCount(0)
+    await expect(lightThemeOptions.getByRole('option', { name: 'Catppuccin Latte', exact: true }))
+      .toBeVisible()
+    await lightThemeOptions.getByRole('option', { name: 'Catppuccin Latte', exact: true }).click()
+    await expect(page.locator('body')).toHaveClass(/catppuccinLatte/)
 
     await darkTheme.click()
-    await page.locator(`#${await darkTheme.getAttribute('aria-controls')}`)
-      .getByRole('option', { name: 'Catppuccin Mocha', exact: true }).click()
+    const darkThemeOptions = page.locator(`#${await darkTheme.getAttribute('aria-controls')}`)
+    await expect(darkThemeOptions.getByRole('option', { name: 'Catppuccin Latte', exact: true }))
+      .toHaveCount(0)
+    await expect(darkThemeOptions.getByRole('option', { name: 'Catppuccin Mocha', exact: true }))
+      .toBeVisible()
+    await darkThemeOptions.getByRole('option', { name: 'Catppuccin Mocha', exact: true }).click()
     await page.emulateMedia({ colorScheme: 'dark' })
     await expect(page.locator('body')).toHaveClass(/catppuccinMocha/)
 
     ;({ page } = await app.relaunch())
     await page.emulateMedia({ colorScheme: 'dark' })
     await expect(page.locator('body')).toHaveClass(/catppuccinMocha/)
+  })
+
+  test('repairs a reclassified system theme in every open window', async ({ app, page }) => {
+    await page.emulateMedia({ colorScheme: 'light' })
+    await goToSettingsSection(page, 'theme')
+    await page.getByRole('button', { name: 'Create custom theme' }).click()
+    await page.getByRole('textbox', { name: 'Theme name' }).fill('Paper')
+    await page.getByRole('button', { name: 'Save and apply' }).click()
+
+    const baseTheme = page.getByRole('combobox', { name: 'Base Theme' })
+    await baseTheme.click()
+    await page.locator(`#${await baseTheme.getAttribute('aria-controls')}`)
+      .getByRole('option', { name: /System default/i }).click()
+    const lightTheme = page.getByRole('combobox', { name: 'Light theme' })
+    await lightTheme.click()
+    await page.locator(`#${await lightTheme.getAttribute('aria-controls')}`)
+      .getByRole('option', { name: 'Paper', exact: true }).click()
+    await page.locator('.settingsCloseButton').click()
+
+    const secondWindow = await openNewWindowFromTabBar(app, page)
+    await waitForAppReady(secondWindow)
+    await secondWindow.emulateMedia({ colorScheme: 'light' })
+    await expect(page.locator('body')).toHaveClass(/custom/)
+    await expect(secondWindow.locator('body')).toHaveClass(/custom/)
+
+    await goToSettingsSection(page, 'theme')
+    await page.getByRole('button', { name: 'Edit custom theme' }).click()
+    await page.locator('label.switch-label').filter({ hasText: 'Dark theme' }).click()
+    await page.getByRole('button', { name: 'Save and apply' }).click()
+
+    for (const openWindow of [page, secondWindow]) {
+      await expect.poll(() => openWindow.evaluate(() => {
+        const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+        return store.getters.getSystemLightTheme
+      })).toBe('light')
+      await expect(openWindow.locator('body')).toHaveClass(/light/)
+      await expect(openWindow.locator('body')).not.toHaveClass(/custom/)
+    }
   })
 
   test('keeps a changed theme marker clear of the previous select', async ({ page }) => {
@@ -755,6 +809,11 @@ test.describe('custom theme editor', () => {
     await expect(page.getByRole('combobox', { name: /Main colou?r theme/i })).toBeDisabled()
     await expect(page.getByRole('combobox', { name: /Secondary colou?r theme/i })).toBeDisabled()
 
+    await page.getByRole('button', { name: 'Edit custom theme' }).click()
+    await page.locator('label.switch-label').filter({ hasText: 'Dark theme' }).click()
+    await expect(darkTheme).toBeChecked()
+    await saveAndApplyButton.click()
+
     await page.getByRole('button', { name: 'Create custom theme' }).click()
     await expect(backgroundValue).toHaveText('#445566')
     await expect(page.getByRole('combobox', { name: 'Based on' })).toHaveText('Dark')
@@ -780,8 +839,10 @@ test.describe('custom theme editor', () => {
       .getByRole('option', { name: /System default/i }).click()
     const darkSystemTheme = page.getByRole('combobox', { name: 'Dark theme' })
     await darkSystemTheme.click()
-    await page.locator(`#${await darkSystemTheme.getAttribute('aria-controls')}`)
-      .getByRole('option', { name: 'Midnight', exact: true }).click()
+    const darkSystemThemeOptions = page.locator(`#${await darkSystemTheme.getAttribute('aria-controls')}`)
+    await expect(darkSystemThemeOptions.getByRole('option', { name: 'Paper', exact: true })).toHaveCount(0)
+    await expect(darkSystemThemeOptions.getByRole('option', { name: 'Midnight', exact: true })).toBeVisible()
+    await darkSystemThemeOptions.getByRole('option', { name: 'Midnight', exact: true }).click()
 
     await page.locator('.settingsCloseButton').click()
     await page.locator('.topNav .profileTrigger').click()
@@ -803,8 +864,9 @@ test.describe('custom theme editor', () => {
 
     const lightSystemTheme = page.getByRole('combobox', { name: 'Light theme' })
     await lightSystemTheme.click()
-    await page.locator(`#${await lightSystemTheme.getAttribute('aria-controls')}`)
-      .getByRole('option', { name: 'Paper', exact: true }).click()
+    const lightSystemThemeOptions = page.locator(`#${await lightSystemTheme.getAttribute('aria-controls')}`)
+    await expect(lightSystemThemeOptions.getByRole('option', { name: 'Midnight', exact: true })).toHaveCount(0)
+    await lightSystemThemeOptions.getByRole('option', { name: 'Paper', exact: true }).click()
     await expect(page.getByRole('button', { name: 'Edit custom theme' })).toBeVisible()
     await page.getByRole('button', { name: 'Edit custom theme' }).click()
     await setEditorColor('Page background', '#abcdef')
@@ -835,7 +897,7 @@ test.describe('custom theme editor', () => {
     ;({ page } = await app.relaunch())
     await expect(page.locator('body')).toHaveClass(/custom/)
     await expect(page.locator('body')).toHaveCSS('--bg-color', '#445566')
-    await expect(page.locator('body')).toHaveAttribute('data-custom-theme', 'light')
+    await expect(page.locator('body')).toHaveAttribute('data-custom-theme', 'dark')
 
     await goToSettingsSection(page, 'theme')
     await page.getByRole('button', { name: 'Edit custom theme' }).click()
@@ -860,8 +922,8 @@ test.describe('invalid appearance values', () => {
     seed: {
       settings: {
         baseTheme: 'missingTheme',
-        systemLightTheme: 'missingLightTheme',
-        systemDarkTheme: 'missingDarkTheme',
+        systemLightTheme: 'solarizedDark',
+        systemDarkTheme: 'solarizedLight',
         mainColor: 'missingMainColor',
         secColor: 'missingSecondaryColor'
       }

--- a/src/appearanceSettings.js
+++ b/src/appearanceSettings.js
@@ -2,6 +2,16 @@ import { DARK_BASE_THEMES, LIGHT_BASE_THEMES } from './constants.js'
 
 const BUILTIN_BASE_THEMES = new Set(['system', ...LIGHT_BASE_THEMES, ...DARK_BASE_THEMES])
 
+function getThemeClassification(value, customThemes = []) {
+  if (LIGHT_BASE_THEMES.includes(value)) return 'light'
+  if (DARK_BASE_THEMES.includes(value)) return 'dark'
+
+  const customTheme = customThemes.find(({ id }) => value === `custom:${id}`)
+  if (customTheme) return customTheme.isDark ? 'dark' : 'light'
+
+  return null
+}
+
 function resolveBaseTheme(value, fallback, customThemes = [], allowSystem = true) {
   if (!allowSystem && value === 'system') return fallback
   if (BUILTIN_BASE_THEMES.has(value) || customThemes.some(({ id }) => value === `custom:${id}`)) {
@@ -10,4 +20,22 @@ function resolveBaseTheme(value, fallback, customThemes = [], allowSystem = true
   return fallback
 }
 
-export { resolveBaseTheme }
+function resolveSystemTheme(value, classification, customThemes = []) {
+  return getThemeClassification(value, customThemes) === classification
+    ? value
+    : classification
+}
+
+function resolveSystemThemeSettings(settings, customThemes = []) {
+  return {
+    systemLightTheme: resolveSystemTheme(settings.systemLightTheme, 'light', customThemes),
+    systemDarkTheme: resolveSystemTheme(settings.systemDarkTheme, 'dark', customThemes),
+  }
+}
+
+export {
+  getThemeClassification,
+  resolveBaseTheme,
+  resolveSystemTheme,
+  resolveSystemThemeSettings,
+}

--- a/src/datastores/handlers/base.js
+++ b/src/datastores/handlers/base.js
@@ -1,4 +1,5 @@
 import * as db from '../index'
+import { updateSettingIfUnchanged } from '../settingRepair'
 import { PlaylistVideoAddResult } from '../../constants'
 import { hasReachedWatchedThreshold, migrateLegacyHistoryRecord } from '../../history'
 import { resolveSearchHistoryEntry } from '../../search-history'
@@ -67,6 +68,10 @@ class Settings {
 
   static upsert(_id, value) {
     return db.settings.updateAsync({ _id }, { _id, value }, { upsert: true })
+  }
+
+  static _updateIfUnchanged(_id, expectedValue, value) {
+    return updateSettingIfUnchanged(db.settings, _id, expectedValue, value)
   }
 
   static delete(_id) {

--- a/src/datastores/settingRepair.js
+++ b/src/datastores/settingRepair.js
@@ -1,0 +1,9 @@
+// Match and update in one datastore operation so repairs cannot replace a
+// selection written after the repair read its original value.
+export async function updateSettingIfUnchanged(datastore, key, expectedValue, value) {
+  const { numAffected } = await datastore.updateAsync(
+    { _id: key, value: expectedValue },
+    { $set: { value } }
+  )
+  return numAffected === 1
+}

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -478,9 +478,14 @@ function runApp() {
    * open renderer so its Settings UI remains accurate.
    * @param {string} settingKey
    * @param {unknown} value
+   * @param {unknown} [expectedValue] Only repair a value that has not changed.
    */
-  async function updateSettingFromMain(settingKey, value) {
-    await baseHandlers.settings.upsert(settingKey, value)
+  async function updateSettingFromMain(settingKey, value, expectedValue) {
+    if (expectedValue !== undefined) {
+      if (!await baseHandlers.settings._updateIfUnchanged(settingKey, expectedValue, value)) return
+    } else {
+      await baseHandlers.settings.upsert(settingKey, value)
+    }
     const syncPayload = {
       event: SyncEvents.GENERAL.UPSERT,
       data: { _id: settingKey, value }
@@ -504,7 +509,7 @@ function runApp() {
     const resolvedSettings = resolveSystemThemeSettings(currentSettings, themes)
 
     await Promise.all(Object.entries(resolvedSettings).map(([key, value]) => (
-      value === currentSettings[key] ? null : updateSettingFromMain(key, value)
+      value === currentSettings[key] ? null : updateSettingFromMain(key, value, currentSettings[key])
     )))
   }
 
@@ -4573,13 +4578,15 @@ function runApp() {
       if (systemLightTheme?.value === deletedThemeValue) {
         await updateSettingFromMain(
           'systemLightTheme',
-          resolveSystemTheme(deletedTheme.basedOn, 'light')
+          resolveSystemTheme(deletedTheme.basedOn, 'light'),
+          deletedThemeValue
         )
       }
       if (systemDarkTheme?.value === deletedThemeValue) {
         await updateSettingFromMain(
           'systemDarkTheme',
-          resolveSystemTheme(deletedTheme.basedOn, 'dark')
+          resolveSystemTheme(deletedTheme.basedOn, 'dark'),
+          deletedThemeValue
         )
       }
       if (baseTheme?.value === deletedThemeValue) {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -33,6 +33,7 @@ import {
   normalizeCustomTheme,
   normalizeCustomThemes,
 } from '../customTheme'
+import { resolveSystemTheme, resolveSystemThemeSettings } from '../appearanceSettings'
 import { applySyncServerUserAgent } from '../syncServerUserAgent'
 import * as baseHandlers from '../datastores/handlers/base'
 import { liveReminders } from '../datastores'
@@ -489,6 +490,22 @@ function runApp() {
         window.webContents.send(IpcChannels.SYNC_SETTINGS, syncPayload)
       }
     }
+  }
+
+  async function repairSystemThemeSettingsFromMain(themes) {
+    const [systemLightTheme, systemDarkTheme] = await Promise.all([
+      baseHandlers.settings._findOne('systemLightTheme'),
+      baseHandlers.settings._findOne('systemDarkTheme')
+    ])
+    const currentSettings = {
+      systemLightTheme: systemLightTheme?.value ?? 'light',
+      systemDarkTheme: systemDarkTheme?.value ?? 'dark',
+    }
+    const resolvedSettings = resolveSystemThemeSettings(currentSettings, themes)
+
+    await Promise.all(Object.entries(resolvedSettings).map(([key, value]) => (
+      value === currentSettings[key] ? null : updateSettingFromMain(key, value)
+    )))
   }
 
   /**
@@ -4527,6 +4544,7 @@ function runApp() {
     if (!isOpenTubeXUrl(event.senderFrame.url)) return
 
     const themes = await saveCustomTheme(theme)
+    await repairSystemThemeSettingsFromMain(themes)
     await publishCustomThemes(themes)
     return themes
   })
@@ -4535,6 +4553,7 @@ function runApp() {
     if (!isOpenTubeXUrl(event.senderFrame.url)) return
 
     const normalizedThemes = await replaceCustomThemes(themes)
+    await repairSystemThemeSettingsFromMain(normalizedThemes)
     await publishCustomThemes(normalizedThemes)
     return normalizedThemes
   })
@@ -4552,10 +4571,16 @@ function runApp() {
         baseHandlers.settings._findOne('systemDarkTheme')
       ])
       if (systemLightTheme?.value === deletedThemeValue) {
-        await updateSettingFromMain('systemLightTheme', deletedTheme.basedOn)
+        await updateSettingFromMain(
+          'systemLightTheme',
+          resolveSystemTheme(deletedTheme.basedOn, 'light')
+        )
       }
       if (systemDarkTheme?.value === deletedThemeValue) {
-        await updateSettingFromMain('systemDarkTheme', deletedTheme.basedOn)
+        await updateSettingFromMain(
+          'systemDarkTheme',
+          resolveSystemTheme(deletedTheme.basedOn, 'dark')
+        )
       }
       if (baseTheme?.value === deletedThemeValue) {
         await updateSettingFromMain('mainColor', deletedTheme.mainColor)
@@ -4564,6 +4589,7 @@ function runApp() {
         updateThemeSource(deletedTheme.basedOn)
       }
     }
+    await repairSystemThemeSettingsFromMain(themes)
     await publishCustomThemes(themes)
     return themes
   })

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -409,10 +409,11 @@ import {
   handleCustomThemeUpdated,
   loadCustomThemes,
 } from './helpers/customTheme'
+import { repairSystemThemeSettings } from './helpers/customThemeSync'
 
 import packageDetails from '../../package.json'
 import { MULTIPLE_TABS_CONFIRM_THRESHOLD, KeyboardShortcuts } from '../constants'
-import { resolveBaseTheme } from '../appearanceSettings'
+import { resolveBaseTheme, resolveSystemThemeSettings } from '../appearanceSettings'
 import { calculateColorLuminance, resolveColor } from './helpers/colors'
 import { matchesKeyboardShortcut } from './helpers/keyboardShortcuts'
 import { hasVisibleGamepadLayer, initializeGamepadNavigation } from './helpers/gamepadNavigation'
@@ -1204,8 +1205,9 @@ onMounted(async () => {
   } catch (error) {
     console.error('Failed to load custom theme:', error)
   }
-  removeCustomThemeListener = handleCustomThemeUpdated((themes) => {
+  removeCustomThemeListener = handleCustomThemeUpdated(async (themes) => {
     store.commit('setCustomThemes', themes)
+    await repairSystemThemeSettings(store, themes)
     updateTheme()
   })
   updateTheme()
@@ -2483,10 +2485,14 @@ function updateAppFont() {
 }
 
 async function sanitizeAppearanceSettings(customThemes) {
+  const systemThemes = resolveSystemThemeSettings({
+    systemLightTheme: store.getters.getSystemLightTheme,
+    systemDarkTheme: store.getters.getSystemDarkTheme,
+  }, customThemes)
   const settings = [
     ['BaseTheme', resolveBaseTheme(store.getters.getBaseTheme, 'system', customThemes)],
-    ['SystemLightTheme', resolveBaseTheme(store.getters.getSystemLightTheme, 'light', customThemes, false)],
-    ['SystemDarkTheme', resolveBaseTheme(store.getters.getSystemDarkTheme, 'dark', customThemes, false)],
+    ['SystemLightTheme', systemThemes.systemLightTheme],
+    ['SystemDarkTheme', systemThemes.systemDarkTheme],
     ['MainColor', resolveColor(store.getters.getMainColor, 'Red')],
     ['SecColor', resolveColor(store.getters.getSecColor, 'Blue')],
   ]

--- a/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
+++ b/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
@@ -158,6 +158,7 @@ import {
   hexColorToRgbComponents,
   normalizeCustomTheme,
 } from '../../../customTheme'
+import { getThemeClassification } from '../../../appearanceSettings'
 import {
   applyThemeToDocument,
   deleteCustomTheme,
@@ -462,9 +463,7 @@ function copyThemeSources() {
   themeSourceColors.value = sourceColors
   draft.colors = { ...sourceColors }
   draft.blurs = Object.fromEntries(CUSTOM_THEME_BLURS.map(([key]) => [key, 0]))
-  draft.isDark = !['light', 'pastelPink', 'catppuccinLatte', 'everforestLightHard',
-    'everforestLightMedium', 'everforestLightLow', 'gruvboxLight', 'solarizedLight']
-    .includes(draft.basedOn)
+  draft.isDark = getThemeClassification(draft.basedOn) !== 'light'
   previewing = true
   previewTheme()
 }

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -45,8 +45,8 @@
         :placeholder="t('Settings.Theme Settings.Light Theme')"
         :value="systemLightTheme"
         setting-key="systemLightTheme"
-        :select-names="systemVariantThemeNames"
-        :select-values="systemVariantThemeValues"
+        :select-names="systemLightThemeNames"
+        :select-values="systemLightThemeValues"
         :icon="['fas', 'sun']"
         @change="store.dispatch('updateSystemLightTheme', $event)"
       />
@@ -54,8 +54,8 @@
         :placeholder="t('Settings.Theme Settings.Dark Theme')"
         :value="systemDarkTheme"
         setting-key="systemDarkTheme"
-        :select-names="systemVariantThemeNames"
-        :select-values="systemVariantThemeValues"
+        :select-names="systemDarkThemeNames"
+        :select-values="systemDarkThemeValues"
         :icon="['fas', 'moon']"
         @change="store.dispatch('updateSystemDarkTheme', $event)"
       />
@@ -389,6 +389,7 @@ import CustomThemeEditor from './CustomThemeEditor/CustomThemeEditor.vue'
 import QuickSettingsCustomizer from './QuickSettingsCustomizer/QuickSettingsCustomizer.vue'
 
 import store from '../store/index'
+import { getThemeClassification } from '../../appearanceSettings'
 import { customThemeIdFromValue, customThemeValue, isCustomThemeValue } from '../../customTheme'
 
 import { colors } from '../helpers/colors'
@@ -503,8 +504,19 @@ const baseThemeNames = computed(() => [
   ...builtInBaseThemeNames.value,
   ...customThemes.value.map(({ name }) => name)
 ])
-const systemVariantThemeValues = computed(() => baseThemeValues.value.filter(value => value !== 'system'))
-const systemVariantThemeNames = computed(() => baseThemeNames.value.slice(1))
+function systemThemeOptions(classification) {
+  return baseThemeValues.value.flatMap((value, index) =>
+    getThemeClassification(value, customThemes.value) === classification
+      ? [{ name: baseThemeNames.value[index], value }]
+      : [])
+}
+
+const systemLightThemeOptions = computed(() => systemThemeOptions('light'))
+const systemLightThemeValues = computed(() => systemLightThemeOptions.value.map(({ value }) => value))
+const systemLightThemeNames = computed(() => systemLightThemeOptions.value.map(({ name }) => name))
+const systemDarkThemeOptions = computed(() => systemThemeOptions('dark'))
+const systemDarkThemeValues = computed(() => systemDarkThemeOptions.value.map(({ value }) => value))
+const systemDarkThemeNames = computed(() => systemDarkThemeOptions.value.map(({ name }) => name))
 
 const iconPackNames = computed(() => [
   t('Settings.Theme Settings.Icon Pack.Material Symbols'),

--- a/src/renderer/helpers/customThemeSync.js
+++ b/src/renderer/helpers/customThemeSync.js
@@ -1,6 +1,24 @@
 import { CUSTOM_THEMES_SYNC_KEY } from '../../customTheme.js'
+import { resolveSystemThemeSettings } from '../../appearanceSettings.js'
 
-export async function commitCustomThemesEdit({ commit, dispatch }, themes) {
+export async function repairSystemThemeSettings({ dispatch, getters, rootGetters }, themes) {
+  const settingsGetters = rootGetters ?? getters
+  const currentSettings = {
+    systemLightTheme: settingsGetters.getSystemLightTheme,
+    systemDarkTheme: settingsGetters.getSystemDarkTheme,
+  }
+  const resolvedSettings = resolveSystemThemeSettings(currentSettings, themes)
+
+  await Promise.all(Object.entries(resolvedSettings).map(([key, value]) => {
+    const currentValue = currentSettings[key]
+    const action = `update${key.charAt(0).toUpperCase()}${key.slice(1)}`
+    return value === currentValue ? null : dispatch(action, value)
+  }))
+}
+
+export async function commitCustomThemesEdit(context, themes) {
+  const { commit, dispatch } = context
   await dispatch('recordSyncSettingEdit', CUSTOM_THEMES_SYNC_KEY)
   commit('setCustomThemes', themes)
+  await repairSystemThemeSettings(context, themes)
 }

--- a/src/renderer/helpers/sync-server.js
+++ b/src/renderer/helpers/sync-server.js
@@ -28,7 +28,7 @@ import { createSyncServerRequestHeaders } from './sync-server-request'
 import { isValidPlaylistBookmark, playlistBookmarkForSync } from './playlist-bookmarks'
 import { getOtherDeviceSessions, mergeSyncSessions } from './sync-sessions'
 import { isValidSyncServerDeviceId } from './sync-server-sessions'
-import { mergeSettingEntry } from './sync-settings-conflict'
+import { mergeSettingEntry, resolveMergedThemeEntry } from './sync-settings-conflict'
 import { getCapacitorTabService } from '../tabs/CapacitorTabService'
 import { capacitorHttpFetch } from './api/capacitor-http'
 
@@ -1214,13 +1214,17 @@ export async function syncSettings(client, store, previous = {}) {
       now,
     })
 
+    entry = resolveMergedThemeEntry(
+      entry, store.state.utils.customThemes, local[CUSTOM_THEMES_SYNC_KEY], now
+    )
     merged[key] = entry
     if (key === 'defaultProfile' &&
         !store.state.profiles.profileList.some(profile => profile._id === entry.value)) {
       entry = { key, value: MAIN_PROFILE_ID, updatedAt: now }
       merged[key] = entry
     }
-    if (!metadataEquals(value, entry.value)) {
+    const currentValue = key === CUSTOM_THEMES_SYNC_KEY ? value : store.state.settings[key]
+    if (!metadataEquals(currentValue, entry.value)) {
       if (key === CUSTOM_THEMES_SYNC_KEY) {
         const previousThemes = store.state.utils.customThemes
         const themes = await replaceCustomThemes(entry.value)

--- a/src/renderer/helpers/sync-server.js
+++ b/src/renderer/helpers/sync-server.js
@@ -1195,10 +1195,12 @@ export async function syncSettings(client, store, previous = {}) {
     !Array.isArray(store.state.settings.syncServerSettingUpdatedAt)
     ? store.state.settings.syncServerSettingUpdatedAt
     : {}
-  const local = Object.fromEntries(getSyncableSettingKeys(store.state.settings).map(key => (
-    [key, deepCopy(store.state.settings[key])]
-  )))
-  local[CUSTOM_THEMES_SYNC_KEY] = normalizeCustomThemes(store.state.utils.customThemes)
+  const local = Object.fromEntries([
+    [CUSTOM_THEMES_SYNC_KEY, normalizeCustomThemes(store.state.utils.customThemes)],
+    ...getSyncableSettingKeys(store.state.settings).map(key => (
+      [key, deepCopy(store.state.settings[key])]
+    )),
+  ])
 
   for (const [key, value] of Object.entries(local)) {
     const old = previous[key]

--- a/src/renderer/helpers/sync-server.js
+++ b/src/renderer/helpers/sync-server.js
@@ -16,6 +16,7 @@ import {
 import { getSyncableSettingKeys } from '../store/modules/settings'
 import { deepCopy } from './utils'
 import { replaceCustomThemes } from './customTheme'
+import { repairSystemThemeSettings } from './customThemeSync'
 import { generateRandomUniqueId } from './playlists'
 import {
   getMergedProfileBackground,
@@ -1077,7 +1078,7 @@ function settingUpdater(key) {
   return `update${key.charAt(0).toUpperCase()}${key.slice(1)}`
 }
 
-async function repairDeletedCustomThemeReferences(store, previousThemes, themes) {
+async function repairCustomThemeReferences(store, previousThemes, themes) {
   const themeIds = new Set(themes.map(theme => theme.id))
   const previousById = new Map(previousThemes.map(theme => [theme.id, theme]))
   const fallbacks = {
@@ -1097,6 +1098,8 @@ async function repairDeletedCustomThemeReferences(store, previousThemes, themes)
     }
     await store.dispatch(settingUpdater(key), deletedTheme?.basedOn ?? defaultTheme)
   }
+
+  await repairSystemThemeSettings(store, themes)
 }
 
 const SYNC_DEVICE_ID_KEY = 'opentubex-sync-device-id'
@@ -1220,7 +1223,7 @@ export async function syncSettings(client, store, previous = {}) {
         const previousThemes = store.state.utils.customThemes
         const themes = await replaceCustomThemes(entry.value)
         store.commit('setCustomThemes', themes)
-        await repairDeletedCustomThemeReferences(store, previousThemes, themes)
+        await repairCustomThemeReferences(store, previousThemes, themes)
       } else {
         await store.dispatch(settingUpdater(key), deepCopy(entry.value))
       }

--- a/src/renderer/helpers/sync-settings-conflict.js
+++ b/src/renderer/helpers/sync-settings-conflict.js
@@ -1,4 +1,17 @@
 import { areJsonValuesEqual } from './jsonValues.js'
+import { resolveBaseTheme, resolveSystemTheme } from '../../appearanceSettings.js'
+import { customThemeIdFromValue } from '../../customTheme.js'
+
+export function resolveMergedThemeEntry(entry, themes, previousThemes, now) {
+  let value = entry.value
+  if (entry.key === 'baseTheme') {
+    const deletedTheme = previousThemes.find(theme => theme.id === customThemeIdFromValue(value))
+    value = resolveBaseTheme(value, resolveBaseTheme(deletedTheme?.basedOn, 'system'), themes)
+  } else if (entry.key === 'systemLightTheme' || entry.key === 'systemDarkTheme') {
+    value = resolveSystemTheme(value, entry.key === 'systemLightTheme' ? 'light' : 'dark', themes)
+  }
+  return value === entry.value ? entry : { ...entry, value, updatedAt: Math.max(now, entry.updatedAt) }
+}
 
 export function mergeSettingEntry({ key, value, old, remoteEntry, localUpdatedAt, now }) {
   const localChanged = old !== undefined && !areJsonValuesEqual(value, old.value)

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -26,7 +26,7 @@ import { DEFAULT_SEARCH_ENGINES_SETTING } from '../../../searchEngines'
 import { DEFAULT_SEGMENT_PREFETCH_LIMIT } from '../../helpers/player/segmentPrefetch'
 import { normalizeYouTubeCaptionLanguageCode } from '../../helpers/player/youtubeCaptionLanguages'
 import { currentIconPack, isIconPack, setIconPack } from '../../icons/iconPackState'
-import { resolveBaseTheme } from '../../../appearanceSettings.js'
+import { resolveBaseTheme, resolveSystemTheme } from '../../../appearanceSettings.js'
 import { resolveColor } from '../../helpers/colors.js'
 import { DEFAULT_APP_FONT, normalizeAppFont } from '../../helpers/appFont.js'
 import {
@@ -1032,14 +1032,14 @@ const customActions = {
     commit,
     state,
     'systemLightTheme',
-    resolveBaseTheme(value, 'light', rootGetters.getCustomThemes, false)
+    resolveSystemTheme(value, 'light', rootGetters.getCustomThemes)
   ),
 
   updateSystemDarkTheme: ({ commit, rootGetters, state }, value) => updateValidatedSetting(
     commit,
     state,
     'systemDarkTheme',
-    resolveBaseTheme(value, 'dark', rootGetters.getCustomThemes, false)
+    resolveSystemTheme(value, 'dark', rootGetters.getCustomThemes)
   ),
 
   updateMainColor: ({ commit, state }, value) => updateValidatedSetting(

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -130,7 +130,7 @@ function withSyncLock(callback) {
 }
 
 async function runSync(context, { allowDataLoss = false } = {}) {
-  const { commit, dispatch, rootState } = context
+  const { commit, dispatch, rootGetters, rootState } = context
   const settings = rootState.settings
   const networkClient = trackSyncClient(
     new SyncServerClient(settings.syncServerUrl, settings.syncServerToken)
@@ -140,7 +140,7 @@ async function runSync(context, { allowDataLoss = false } = {}) {
   const previous = parseSnapshot(settings.syncServerSnapshot)
   const next = { ...previous }
   const result = {}
-  const store = { state: rootState, commit, dispatch }
+  const store = { state: rootState, getters: rootGetters, commit, dispatch }
   const stages = [
     ...(settings.syncServerPrivacyMode === 'enhanced' ? ['download'] : []),
     ...(settings.syncServerSyncSubscriptions ? ['subscriptions'] : []),

--- a/tests/unit/appearance-settings.test.mjs
+++ b/tests/unit/appearance-settings.test.mjs
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 
-import { resolveBaseTheme } from '../../src/appearanceSettings.js'
+import {
+  getThemeClassification,
+  resolveBaseTheme,
+  resolveSystemTheme,
+} from '../../src/appearanceSettings.js'
 
 test('invalid appearance choices fall back to their defaults', () => {
   assert.equal(resolveBaseTheme('missing', 'system'), 'system')
@@ -12,4 +16,31 @@ test('invalid appearance choices fall back to their defaults', () => {
 test('built-in and available custom appearance choices are retained', () => {
   assert.equal(resolveBaseTheme('solarizedDark', 'system'), 'solarizedDark')
   assert.equal(resolveBaseTheme('custom:paper', 'system', [{ id: 'paper' }]), 'custom:paper')
+})
+
+test('themes are classified by their built-in or custom color scheme', () => {
+  const customThemes = [
+    { id: 'midnight', isDark: true },
+    { id: 'paper', isDark: false },
+  ]
+
+  assert.equal(getThemeClassification('solarizedLight'), 'light')
+  assert.equal(getThemeClassification('solarizedDark'), 'dark')
+  assert.equal(getThemeClassification('custom:paper', customThemes), 'light')
+  assert.equal(getThemeClassification('custom:midnight', customThemes), 'dark')
+  assert.equal(getThemeClassification('missing', customThemes), null)
+})
+
+test('system theme choices must match their color scheme', () => {
+  const customThemes = [
+    { id: 'midnight', isDark: true },
+    { id: 'paper', isDark: false },
+  ]
+
+  assert.equal(resolveSystemTheme('solarizedLight', 'light'), 'solarizedLight')
+  assert.equal(resolveSystemTheme('solarizedDark', 'light'), 'light')
+  assert.equal(resolveSystemTheme('custom:paper', 'light', customThemes), 'custom:paper')
+  assert.equal(resolveSystemTheme('custom:midnight', 'light', customThemes), 'light')
+  assert.equal(resolveSystemTheme('custom:midnight', 'dark', customThemes), 'custom:midnight')
+  assert.equal(resolveSystemTheme('custom:paper', 'dark', customThemes), 'dark')
 })

--- a/tests/unit/setting-repair.test.mjs
+++ b/tests/unit/setting-repair.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import Datastore from '@seald-io/nedb'
+import { updateSettingIfUnchanged } from '../../src/datastores/settingRepair.js'
+
+test('a stale theme repair preserves a newer stored selection', async () => {
+  const db = new Datastore()
+  await db.insertAsync({ _id: 'systemDarkTheme', value: 'custom:paper' })
+  const original = await db.findOneAsync({ _id: 'systemDarkTheme' })
+  await db.updateAsync({ _id: original._id }, { $set: { value: 'solarizedDark' } })
+
+  assert.equal(await updateSettingIfUnchanged(db, original._id, original.value, 'dark'), false)
+  assert.equal((await db.findOneAsync({ _id: original._id })).value, 'solarizedDark')
+})
+
+test('a theme repair updates its unchanged selection without inserting missing settings', async () => {
+  const db = new Datastore()
+  await db.insertAsync({ _id: 'systemLightTheme', value: 'dark' })
+  assert.equal(await updateSettingIfUnchanged(db, 'systemLightTheme', 'dark', 'light'), true)
+  assert.equal((await db.findOneAsync({ _id: 'systemLightTheme' })).value, 'light')
+  assert.equal(await updateSettingIfUnchanged(db, 'systemDarkTheme', 'light', 'dark'), false)
+  assert.equal(await db.countAsync({}), 1)
+})

--- a/tests/unit/sync-settings-conflict.test.mjs
+++ b/tests/unit/sync-settings-conflict.test.mjs
@@ -5,7 +5,32 @@ import {
   commitCustomThemesEdit,
   repairSystemThemeSettings,
 } from '../../src/renderer/helpers/customThemeSync.js'
-import { mergeSettingEntry } from '../../src/renderer/helpers/sync-settings-conflict.js'
+import { mergeSettingEntry, resolveMergedThemeEntry } from '../../src/renderer/helpers/sync-settings-conflict.js'
+
+test('normalizes newer theme selections against a winning collection deletion', () => {
+  const previousThemes = [{ id: 'removed', isDark: true, basedOn: 'solarizedDark' }]
+  for (const [key, fallback] of Object.entries({
+    baseTheme: 'solarizedDark', systemLightTheme: 'light', systemDarkTheme: 'dark',
+  })) {
+    const entry = mergeSettingEntry({
+      key, value: 'custom:removed', old: { key, value: fallback, updatedAt: 10 },
+      remoteEntry: { key, value: fallback, updatedAt: 30 }, localUpdatedAt: 40, now: 100,
+    })
+    assert.equal(entry.value, 'custom:removed')
+    assert.deepEqual(resolveMergedThemeEntry(entry, [], previousThemes, 100), {
+      key, value: fallback, updatedAt: 100,
+    })
+  }
+})
+
+test('retains valid merged selections and repairs classification changes', () => {
+  const themes = [{ id: 'paper', isDark: false }]
+  const entry = { key: 'systemLightTheme', value: 'custom:paper', updatedAt: 40 }
+  assert.equal(resolveMergedThemeEntry(entry, themes, [], 100), entry)
+  assert.deepEqual(resolveMergedThemeEntry({ ...entry, key: 'systemDarkTheme' }, themes, [], 100), {
+    key: 'systemDarkTheme', value: 'dark', updatedAt: 100,
+  })
+})
 
 test('uses the actual local edit time instead of the later sync time', () => {
   const entry = mergeSettingEntry({

--- a/tests/unit/sync-settings-conflict.test.mjs
+++ b/tests/unit/sync-settings-conflict.test.mjs
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { commitCustomThemesEdit } from '../../src/renderer/helpers/customThemeSync.js'
+import {
+  commitCustomThemesEdit,
+  repairSystemThemeSettings,
+} from '../../src/renderer/helpers/customThemeSync.js'
 import { mergeSettingEntry } from '../../src/renderer/helpers/sync-settings-conflict.js'
 
 test('uses the actual local edit time instead of the later sync time', () => {
@@ -61,12 +64,51 @@ test('records a custom-theme edit before publishing the new theme list', async (
   await commitCustomThemesEdit({
     dispatch: async (action, payload) => calls.push(['dispatch', action, payload]),
     commit: (mutation, payload) => calls.push(['commit', mutation, payload]),
+    rootGetters: {
+      getSystemLightTheme: 'light',
+      getSystemDarkTheme: 'dark',
+    },
   }, themes)
 
   assert.deepEqual(calls, [
     ['dispatch', 'recordSyncSettingEdit', 'customThemes'],
     ['commit', 'setCustomThemes', themes],
   ])
+})
+
+test('resets a system theme slot when a custom theme changes classification', async () => {
+  const calls = []
+  const themes = [{ id: 'theme-1', name: 'Test theme', isDark: true }]
+
+  await commitCustomThemesEdit({
+    dispatch: async (action, payload) => calls.push(['dispatch', action, payload]),
+    commit: (mutation, payload) => calls.push(['commit', mutation, payload]),
+    rootGetters: {
+      getSystemLightTheme: 'custom:theme-1',
+      getSystemDarkTheme: 'dark',
+    },
+  }, themes)
+
+  assert.deepEqual(calls, [
+    ['dispatch', 'recordSyncSettingEdit', 'customThemes'],
+    ['commit', 'setCustomThemes', themes],
+    ['dispatch', 'updateSystemLightTheme', 'light'],
+  ])
+})
+
+test('repairs system theme slots from a store after a cross-window update', async () => {
+  const calls = []
+  const themes = [{ id: 'theme-1', name: 'Test theme', isDark: true }]
+
+  await repairSystemThemeSettings({
+    dispatch: async (action, payload) => calls.push([action, payload]),
+    getters: {
+      getSystemLightTheme: 'custom:theme-1',
+      getSystemDarkTheme: 'dark',
+    },
+  }, themes)
+
+  assert.deepEqual(calls, [['updateSystemLightTheme', 'light']])
 })
 
 test('uses the custom-theme edit timestamp when resolving a conflict', () => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No related issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The System Light and System Dark selectors currently expose every theme, allowing a light operating-system mode to use a dark-classified theme and vice versa.

This change filters each selector by the existing built-in classification and the custom-theme isDark setting. It also repairs mismatched saved values after startup, synchronization, custom-theme edits, deletion, and cross-window updates.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
System light and dark theme settings now only offer themes that match the corresponding color scheme.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run the app in development mode and open Settings → Appearance.
2. Choose System default as the base theme.
3. Open Light theme and confirm that every listed built-in theme is light.
4. Open Dark theme and confirm that every listed built-in theme is dark.
5. Create one light and one dark custom theme, then confirm each appears only in its matching selector.

## Additional context
<!-- Add any other context about the pull request here. -->
