### PR TITLE
feat(settings): add quick settings category icons

### DIFF
--- a/e2e/tests/offline/quick-settings.spec.mjs
+++ b/e2e/tests/offline/quick-settings.spec.mjs
@@ -47,6 +47,26 @@ test.describe('quick settings menu', () => {
     expect(Math.abs(gaps[0] - gaps[1])).toBeLessThanOrEqual(1)
   })
 
+  test('shows settings category icons before section names', async ({ page }) => {
+    await page.locator('.profileTrigger').click()
+    const menu = page.getByRole('dialog', { name: 'Quick settings' })
+    const expectedHeaders = [
+      ['Appearance', 'display'],
+      ['Playback', 'circle-play'],
+      ['Content', 'eye-slash'],
+      ['Language and region', 'globe'],
+      ['Proxy', 'flask'],
+    ]
+
+    for (const [label, icon] of expectedHeaders) {
+      const heading = menu.getByRole('heading', { name: label, exact: true })
+      await expect(heading.locator(`[data-icon="${icon}"]`)).toBeVisible()
+      expect(await heading.evaluate(element => [...element.children].map(child => (
+        child.classList.contains('menuSectionIcon') ? 'icon' : child.tagName.toLowerCase()
+      )))).toEqual(['icon', 'span'])
+    }
+  })
+
   test('stays inside a short viewport below horizontal tabs', async ({ app, page }) => {
     await app.electronApp.evaluate(({ BrowserWindow }) => {
       BrowserWindow.getAllWindows()[0]?.setBounds({ x: 0, y: 0, width: 1280, height: 720 })

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.css
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.css
@@ -214,14 +214,23 @@
 }
 
 .menuSection h3 {
+  align-items: center;
   color: var(--secondary-text-color);
+  display: flex;
   font-size: 12px;
   font-weight: 600;
+  gap: 6px;
   grid-column: 1 / -1;
   line-height: 1.2;
   margin-block: 0 10px;
   margin-inline: 0;
   text-transform: uppercase;
+}
+
+.menuSectionIcon {
+  block-size: 14px;
+  flex: 0 0 auto;
+  inline-size: 14px;
 }
 
 .quickSettingControl {

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
@@ -157,7 +157,14 @@
                 :key="`${section.id}-${sectionIndex}`"
                 class="menuSection"
               >
-                <h3>{{ section.label }}</h3>
+                <h3>
+                  <FtIcon
+                    class="menuSectionIcon"
+                    :icon="section.icon"
+                    aria-hidden="true"
+                  />
+                  <span>{{ section.label }}</span>
+                </h3>
                 <div
                   v-for="setting in section.settings"
                   :key="setting.id"
@@ -519,8 +526,8 @@ const showSettingsShortcut = computed(() => (
 
 const quickSettings = computed(() => store.getters.getQuickSettings)
 const quickSettingCatalog = computed(() => createQuickSettingCatalog(t, USING_ELECTRON))
-const quickSettingSectionLabels = computed(() => new Map(
-  createQuickSettingSections(t, USING_ELECTRON).map(section => [section.id, section.label])
+const quickSettingSectionDefinitions = computed(() => new Map(
+  createQuickSettingSections(t, USING_ELECTRON).map(section => [section.id, section])
 ))
 const orderedQuickSettingSections = computed(() => {
   const catalogById = new Map(quickSettingCatalog.value.map(setting => [setting.id, setting]))
@@ -534,11 +541,13 @@ const orderedQuickSettingSections = computed(() => {
   return visibleSettings.reduce((sections, setting) => {
     let section = sections.at(-1)
     if (section?.id !== setting.section) {
+      const sectionDefinition = quickSettingSectionDefinitions.value.get(setting.section)
       section = {
         id: setting.section,
         label: setting.id === 'useProxy'
           ? t('Settings.Proxy Settings.Proxy Settings')
-          : quickSettingSectionLabels.value.get(setting.section),
+          : sectionDefinition.label,
+        icon: sectionDefinition.icon,
         settings: [],
       }
       sections.push(section)

--- a/src/renderer/helpers/quickSettings.js
+++ b/src/renderer/helpers/quickSettings.js
@@ -76,13 +76,31 @@ export const QUICK_SETTING_DEFINITIONS = Object.freeze([
   ...BASIC_QUICK_SETTING_DEFINITIONS,
 ])
 
-const SECTION_LABEL_KEYS = Object.freeze({
-  appearance: 'Settings.Quick Settings.Appearance',
-  playback: 'Settings.Quick Settings.Playback',
-  content: 'Settings.Quick Settings.Content',
-  language: 'Settings.Quick Settings.Language and Region',
-  'add-ons': 'Settings.Categories.Add-ons',
-  advanced: 'Settings.Categories.Advanced',
+const SECTION_DEFINITIONS = Object.freeze({
+  appearance: Object.freeze({
+    labelKey: 'Settings.Quick Settings.Appearance',
+    icon: Object.freeze(['fas', 'display']),
+  }),
+  playback: Object.freeze({
+    labelKey: 'Settings.Quick Settings.Playback',
+    icon: Object.freeze(['fas', 'circle-play']),
+  }),
+  content: Object.freeze({
+    labelKey: 'Settings.Quick Settings.Content',
+    icon: Object.freeze(['fas', 'eye-slash']),
+  }),
+  language: Object.freeze({
+    labelKey: 'Settings.Quick Settings.Language and Region',
+    icon: Object.freeze(['fas', 'globe']),
+  }),
+  'add-ons': Object.freeze({
+    labelKey: 'Settings.Categories.Add-ons',
+    icon: Object.freeze(['fas', 'puzzle-piece']),
+  }),
+  advanced: Object.freeze({
+    labelKey: 'Settings.Categories.Advanced',
+    icon: Object.freeze(['fas', 'flask']),
+  }),
 })
 
 export function createQuickSettingCatalog(t, usingElectron) {
@@ -100,10 +118,12 @@ export function createQuickSettingSections(t, usingElectron) {
 
   for (const definition of createQuickSettingCatalog(t, usingElectron)) {
     if (!sections.has(definition.section)) {
+      const sectionDefinition = SECTION_DEFINITIONS[definition.section]
       sections.set(definition.section, {
         id: definition.section,
         // eslint-disable-next-line @intlify/vue-i18n/no-dynamic-keys
-        label: t(SECTION_LABEL_KEYS[definition.section]),
+        label: t(sectionDefinition.labelKey),
+        icon: sectionDefinition.icon,
         settings: [],
       })
     }

--- a/tests/unit/quick-settings.test.mjs
+++ b/tests/unit/quick-settings.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  createQuickSettingSections,
   DEFAULT_QUICK_SETTINGS,
   isQuickSettingPaired,
   normalizeQuickSettings,
@@ -30,6 +31,21 @@ test('gives every customizable setting an icon', () => {
   for (const setting of QUICK_SETTING_DEFINITIONS) {
     assert.equal(Array.isArray(setting.icon) && setting.icon.length, 2, setting.id)
   }
+})
+
+test('uses the settings category icons for quick setting sections', () => {
+  const sectionIcons = Object.fromEntries(
+    createQuickSettingSections(key => key, true).map(section => [section.id, section.icon])
+  )
+
+  assert.deepEqual(sectionIcons, {
+    appearance: ['fas', 'display'],
+    playback: ['fas', 'circle-play'],
+    content: ['fas', 'eye-slash'],
+    language: ['fas', 'globe'],
+    advanced: ['fas', 'flask'],
+    'add-ons': ['fas', 'puzzle-piece'],
+  })
 })
 
 test('pairs adjacent selects without leaving an odd select in a half-row', () => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Quick Settings category labels had no visual cues, which made the menu harder to scan. This adds an icon before every category heading and uses a globe for Language and region while preserving the existing grouping.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Quick Settings now shows an icon beside each category heading.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114451Z-quick-category-icons-dark-dark-60fda61274.png">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114451Z-quick-category-icons-light-light-e1725d4f9f.png">
  <img alt="Quick Settings with category heading icons and the default profile color" src="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114451Z-quick-category-icons-dark-dark-60fda61274.png">
</picture>
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Quick Settings and confirm that every visible category heading has an icon before its name.
2. Confirm that Language and region uses a globe icon.
3. Customize Quick Settings to add an Add-ons control and confirm its puzzle-piece heading icon appears.

## Additional context
<!-- Add any other context about your pull request here. -->
The category icons use the existing Material and Remix icon mappings.
