### PR TITLE
fix(player): prevent KDE auto PiP flicker on app switch

### DIFF
--- a/src/main/kdeWaylandWindowState.js
+++ b/src/main/kdeWaylandWindowState.js
@@ -387,6 +387,7 @@ workspace.windowActivated.connect(reportActiveWindow)
  *   releaseWindowIdentity?: () => void,
  *   processId?: number,
  *   detectionDelay?: number,
+ *   focusHandoffDelay?: number,
  *   pollInterval?: number
  * }} options
  * @returns {() => void}
@@ -400,6 +401,7 @@ export function monitorKdeWaylandWindowState({
   releaseWindowIdentity = () => {},
   processId = process.pid,
   detectionDelay = 100,
+  focusHandoffDelay = 100,
   pollInterval = 1_000,
 }) {
   let baseline = []
@@ -407,11 +409,17 @@ export function monitorKdeWaylandWindowState({
   let minimized = false
   let minimizedUuid = null
   let windowUuid = null
+  let focusHandoffTimer = null
   let pollTimer = null
   let stopActiveWindowWatch = null
   let stopped = false
 
+  const clearFocusHandoff = () => {
+    if (focusHandoffTimer !== null) clearTimeout(focusHandoffTimer)
+    focusHandoffTimer = null
+  }
   const clearActiveWindowWatch = () => {
+    clearFocusHandoff()
     stopActiveWindowWatch?.()
     stopActiveWindowWatch = null
   }
@@ -485,10 +493,24 @@ export function monitorKdeWaylandWindowState({
     clearActiveWindowWatch()
     const reportActiveWindow = activeWindow => {
       if (stopped || browserWindow.isFocused()) return
+      clearFocusHandoff()
+      // KWin reports an empty active window between the two sides of some
+      // focus handoffs. Give the next activation time to arrive, but still
+      // report focus loss when no window becomes active, such as on desktop.
+      if (activeWindow === null || activeWindow.uuid === '') {
+        focusHandoffTimer = setTimeout(() => {
+          focusHandoffTimer = null
+          if (stopped || browserWindow.isFocused()) return
+
+          onFocusedState(false)
+          clearActiveWindowWatch()
+        }, focusHandoffDelay)
+        return
+      }
 
       const focused = isLogicallyFocused(activeWindow, targetUuid)
       onFocusedState(focused)
-      if (!focused && activeWindow !== null && activeWindow.uuid !== '') {
+      if (!focused) {
         clearActiveWindowWatch()
       }
     }

--- a/tests/unit/kde-wayland-window-state.test.mjs
+++ b/tests/unit/kde-wayland-window-state.test.mjs
@@ -273,6 +273,47 @@ test('reports an app switch made through a KDE shell popup', async () => {
   assert.deepEqual(focusedStates, [true, true, true, false])
 })
 
+test('does not report transient focus loss while KWin hands off to another app', async () => {
+  // Forwarding the empty report would produce false, true, false and make
+  // automatic PiP open, close, then reopen during the same app switch.
+  const focusedStates = await focusedStatesAfterBlur(
+    {
+      resourceClass: '',
+      skipTaskbar: false,
+      uuid: '',
+    },
+    {
+      activeWindowChanges: [
+        {
+          resourceClass: 'electron',
+          skipTaskbar: false,
+          uuid: 'window',
+        },
+        {
+          resourceClass: 'org.kde.konsole',
+          skipTaskbar: false,
+          uuid: 'konsole',
+        },
+      ],
+    }
+  )
+
+  assert.deepEqual(focusedStates, [true, false])
+})
+
+test('reports focus loss when KWin keeps the active window empty', async () => {
+  const focusedStates = await focusedStatesAfterBlur(
+    {
+      resourceClass: '',
+      skipTaskbar: false,
+      uuid: '',
+    },
+    { focusHandoffDelay: 0 }
+  )
+
+  assert.deepEqual(focusedStates, [false])
+})
+
 test('detects a single minimized window when no earlier KWin snapshot is available', () => {
   const current = [
     windowInfo({ uuid: 'one', minimized: true }),
@@ -382,7 +423,10 @@ function targetWindow () {
   }
 }
 
-async function focusedStatesAfterBlur (activeWindow, { activeWindowChanges = [] } = {}) {
+async function focusedStatesAfterBlur (
+  activeWindow,
+  { activeWindowChanges = [], focusHandoffDelay } = {}
+) {
   const browserWindow = new EventEmitter()
   browserWindow.getBounds = () => targetWindow().bounds
   browserWindow.getTitle = () => targetWindow().caption
@@ -406,6 +450,7 @@ async function focusedStatesAfterBlur (activeWindow, { activeWindowChanges = [] 
     browserWindow,
     backend,
     detectionDelay: 0,
+    focusHandoffDelay,
     onFocusedState: focused => focusedStates.push(focused),
     onMinimizedState: () => {},
   })

--- a/tests/unit/kde-wayland-window-state.test.mjs
+++ b/tests/unit/kde-wayland-window-state.test.mjs
@@ -295,6 +295,8 @@ test('does not report transient focus loss while KWin hands off to another app',
           uuid: 'konsole',
         },
       ],
+      focusHandoffDelay: 30,
+      settleDelay: 60,
     }
   )
 
@@ -425,7 +427,7 @@ function targetWindow () {
 
 async function focusedStatesAfterBlur (
   activeWindow,
-  { activeWindowChanges = [], focusHandoffDelay } = {}
+  { activeWindowChanges = [], focusHandoffDelay, settleDelay = 10 } = {}
 ) {
   const browserWindow = new EventEmitter()
   browserWindow.getBounds = () => targetWindow().bounds
@@ -462,7 +464,7 @@ async function focusedStatesAfterBlur (
     if (activeWindowListener !== null) activeWindowListener(activeWindow)
     await Promise.resolve()
   }
-  await new Promise(resolve => setTimeout(resolve, 10))
+  await new Promise(resolve => setTimeout(resolve, settleDelay))
   stop()
 
   return focusedStates


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
KWin can briefly report no active window while handing focus from OpenTubeX to another application. The KDE focus monitor treated that intermediate state as a real focus loss, so automatic Picture-in-Picture could open, close, and reopen during one app switch.

This delays empty active-window reports for 100 ms. A real KWin activation cancels the pending report, while a persistent empty state still triggers Picture-in-Picture when switching to the desktop.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. On KDE Plasma Wayland, enable automatic Picture-in-Picture when switching applications and play a video.
2. Switch directly to another application, then repeat through a Plasma launcher. Picture-in-Picture should open once without flashing or reopening.
3. Return to OpenTubeX, then show the desktop while the video plays. Picture-in-Picture should still open after a brief delay.

## Additional context
<!-- Add any other context about the pull request here. -->
