### PR TITLE
feat(sync): add customization sync controls

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -4920,6 +4920,33 @@ test.describe('synced setting indicators', () => {
     await expect(localOnlyLabel.getByRole('button', { name: /syncing this setting/i })).toHaveCount(0)
   })
 
+  test('allows quick settings and navigation customization to be excluded independently', async ({ page }) => {
+    const appearance = await goToSettingsSection(page, 'appearance')
+    const quickSettings = appearance.locator('.settingButtonWithSync').filter({
+      hasText: 'Customize quick settings'
+    })
+    const navigation = appearance.locator('.settingButtonWithSync').filter({
+      hasText: 'Customize navigation'
+    })
+
+    await quickSettings.getByRole('button', { name: 'Stop syncing this setting' }).click()
+    await expect(quickSettings.getByRole('button', { name: 'Sync this setting' })).toBeVisible()
+    await expect(navigation.getByRole('button', { name: 'Stop syncing this setting' })).toBeVisible()
+
+    await navigation.getByRole('button', { name: 'Stop syncing this setting' }).click()
+    await expect(navigation.getByRole('button', { name: 'Sync this setting' })).toBeVisible()
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.state.settings.syncServerSettingsExcluded
+    })).toEqual(['quickSettings', 'navigationItems'])
+
+    await quickSettings.getByRole('button', { name: 'Sync this setting' }).click()
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.state.settings.syncServerSettingsExcluded
+    })).toEqual(['navigationItems'])
+  })
+
   test('spaces setting sync and help icons', async ({ page }) => {
     await goTo(page, 'settings')
 

--- a/src/renderer/components/NavigationCustomizer/NavigationCustomizer.vue
+++ b/src/renderer/components/NavigationCustomizer/NavigationCustomizer.vue
@@ -1,9 +1,12 @@
 <template>
-  <FtButton
-    :label="t('Settings.General Settings.Navigation.Customize Navigation')"
-    :icon="['fas', 'bars']"
-    @click="open = true"
-  />
+  <div class="settingButtonWithSync">
+    <FtButton
+      :label="t('Settings.General Settings.Navigation.Customize Navigation')"
+      :icon="['fas', 'bars']"
+      @click="open = true"
+    />
+    <FtSyncedSettingIndicator setting-key="navigationItems" />
+  </div>
 
   <FtSettingsSubpage
     :open="open"
@@ -178,6 +181,7 @@ import { useRoute, useRouter } from 'vue-router'
 
 import FtButton from '../FtButton/FtButton.vue'
 import FtSettingsSubpage from '../FtSettingsSubpage/FtSettingsSubpage.vue'
+import FtSyncedSettingIndicator from '../FtSyncedSettingIndicator/FtSyncedSettingIndicator.vue'
 
 import store from '../../store/index'
 import { clampOverlayScrollTop } from '../../helpers/overlayScrollbars'
@@ -357,6 +361,11 @@ function resetItems() {
 </script>
 
 <style scoped>
+.settingButtonWithSync {
+  align-items: center;
+  display: inline-flex;
+}
+
 .navigationActions {
   display: flex;
   flex-wrap: wrap;

--- a/src/renderer/components/QuickSettingsCustomizer/QuickSettingsCustomizer.vue
+++ b/src/renderer/components/QuickSettingsCustomizer/QuickSettingsCustomizer.vue
@@ -3,11 +3,14 @@
     :title="`${t('Settings.General Settings.Navigation.Navigation')} / ${t('Settings.Quick Settings.Quick Settings')}`"
   >
     <div class="customizerLaunchers">
-      <FtButton
-        :label="t('Settings.Quick Settings.Customize Quick Settings')"
-        :icon="['fas', 'sliders-h']"
-        @click="open = true"
-      />
+      <div class="settingButtonWithSync">
+        <FtButton
+          :label="t('Settings.Quick Settings.Customize Quick Settings')"
+          :icon="['fas', 'sliders-h']"
+          @click="open = true"
+        />
+        <FtSyncedSettingIndicator setting-key="quickSettings" />
+      </div>
       <NavigationCustomizer />
     </div>
   </FtSettingsSection>
@@ -166,6 +169,7 @@ import FtButton from '../FtButton/FtButton.vue'
 import FtInput from '../FtInput/FtInput.vue'
 import FtSettingsSection from '../FtSettingsSection/FtSettingsSection.vue'
 import FtSettingsSubpage from '../FtSettingsSubpage/FtSettingsSubpage.vue'
+import FtSyncedSettingIndicator from '../FtSyncedSettingIndicator/FtSyncedSettingIndicator.vue'
 import NavigationCustomizer from '../NavigationCustomizer/NavigationCustomizer.vue'
 
 import store from '../../store/index'
@@ -302,6 +306,11 @@ function resetQuickSettings() {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
+}
+
+.settingButtonWithSync {
+  align-items: center;
+  display: inline-flex;
 }
 
 .quickSettingsActions {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Quick settings and navigation customization were always included when settings sync was enabled. This adds an independent sync control beside each customization button, using the same control as the quick playback speed bar customization.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Quick settings and navigation customizations can now be excluded from account settings sync independently.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/ad07d88c-e1f8-48c2-bf8d-acb0b187776d">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/bbf320e0-6b71-428b-bd94-b226a3293661">
  <img alt="Quick settings sync disabled independently from navigation customization sync" src="https://github.com/user-attachments/assets/ad07d88c-e1f8-48c2-bf8d-acb0b187776d">
</picture>
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Connect to a sync account and enable settings sync.
2. Open Settings, then Appearance.
3. Click the link icon beside either customization button and confirm its linked state changes without changing the other icon.
4. Reload the app and confirm both choices persist.

## Additional context
<!-- Add any other context about the pull request here. -->

The controls are only shown while account settings sync is available, matching the existing per-setting sync behavior.
