### PR TITLE
fix(android): hide shortcut actions without a keyboard

### DIFF
--- a/android/app/src/main/java/org/opentubex/app/AndroidUiPlugin.java
+++ b/android/app/src/main/java/org/opentubex/app/AndroidUiPlugin.java
@@ -5,12 +5,13 @@ import android.app.PictureInPictureParams;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
-import android.content.res.Configuration;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
+import android.hardware.input.InputManager;
 import android.os.Build;
 import android.provider.Settings;
 import android.util.Rational;
+import android.view.InputDevice;
 
 import androidx.annotation.RequiresApi;
 
@@ -140,9 +141,26 @@ public class AndroidUiPlugin extends Plugin {
     }
 
     public boolean hasHardwareKeyboard() {
-        Configuration configuration = getContext().getResources().getConfiguration();
-        return configuration.keyboard != Configuration.KEYBOARD_NOKEYS &&
-            configuration.hardKeyboardHidden != Configuration.HARDKEYBOARDHIDDEN_YES;
+        InputManager inputManager = (InputManager) getContext()
+            .getSystemService(Context.INPUT_SERVICE);
+        for (int deviceId : inputManager.getInputDeviceIds()) {
+            InputDevice device = inputManager.getInputDevice(deviceId);
+            if (isHardwareKeyboardDevice(device)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static boolean isHardwareKeyboardDevice(InputDevice device) {
+        return device != null && isHardwareKeyboardDevice(
+            device.isVirtual(),
+            device.getKeyboardType()
+        );
+    }
+
+    static boolean isHardwareKeyboardDevice(boolean virtual, int keyboardType) {
+        return !virtual && keyboardType == InputDevice.KEYBOARD_TYPE_ALPHABETIC;
     }
 
     public void enterAutomaticPictureInPictureIfEnabled() {

--- a/android/app/src/main/java/org/opentubex/app/MainActivity.java
+++ b/android/app/src/main/java/org/opentubex/app/MainActivity.java
@@ -1,6 +1,7 @@
 package org.opentubex.app;
 
 import android.content.res.Configuration;
+import android.hardware.input.InputManager;
 import android.os.Bundle;
 
 import androidx.activity.OnBackPressedCallback;
@@ -9,6 +10,25 @@ import com.getcapacitor.BridgeActivity;
 import com.getcapacitor.PluginHandle;
 
 public class MainActivity extends BridgeActivity {
+    private InputManager inputManager;
+    private final InputManager.InputDeviceListener inputDeviceListener =
+        new InputManager.InputDeviceListener() {
+            @Override
+            public void onInputDeviceAdded(int deviceId) {
+                notifyHardwareKeyboardState();
+            }
+
+            @Override
+            public void onInputDeviceRemoved(int deviceId) {
+                notifyHardwareKeyboardState();
+            }
+
+            @Override
+            public void onInputDeviceChanged(int deviceId) {
+                notifyHardwareKeyboardState();
+            }
+        };
+
     @Override
     public void onStart() {
         super.onStart();
@@ -36,6 +56,8 @@ public class MainActivity extends BridgeActivity {
         getBridge().getWebView().removeJavascriptInterface("androidBridge");
         getBridge().setWebViewClient(new OpenTubeXWebViewClient(getBridge()));
         OpenTubeXNotificationChannels.createAll(this);
+        inputManager = (InputManager) getSystemService(INPUT_SERVICE);
+        inputManager.registerInputDeviceListener(inputDeviceListener, null);
 
         getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
             @Override
@@ -43,6 +65,12 @@ public class MainActivity extends BridgeActivity {
                 getBridge().triggerWindowJSEvent("opentubex:android-back");
             }
         });
+    }
+
+    @Override
+    public void onDestroy() {
+        inputManager.unregisterInputDeviceListener(inputDeviceListener);
+        super.onDestroy();
     }
 
     @Override
@@ -71,6 +99,10 @@ public class MainActivity extends BridgeActivity {
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
 
+        notifyHardwareKeyboardState();
+    }
+
+    private void notifyHardwareKeyboardState() {
         PluginHandle handle = getBridge().getPlugin("AndroidUi");
         if (handle != null && handle.getInstance() instanceof AndroidUiPlugin) {
             boolean attached = ((AndroidUiPlugin) handle.getInstance()).hasHardwareKeyboard();

--- a/android/app/src/test/java/org/opentubex/app/AndroidUiPluginTest.java
+++ b/android/app/src/test/java/org/opentubex/app/AndroidUiPluginTest.java
@@ -1,0 +1,27 @@
+package org.opentubex.app;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.view.InputDevice;
+
+import org.junit.Test;
+
+public class AndroidUiPluginTest {
+    @Test
+    public void onlyNonVirtualAlphabeticDevicesCountAsHardwareKeyboards() {
+        assertFalse(AndroidUiPlugin.isHardwareKeyboardDevice(null));
+        assertFalse(AndroidUiPlugin.isHardwareKeyboardDevice(
+            true,
+            InputDevice.KEYBOARD_TYPE_ALPHABETIC
+        ));
+        assertFalse(AndroidUiPlugin.isHardwareKeyboardDevice(
+            false,
+            InputDevice.KEYBOARD_TYPE_NON_ALPHABETIC
+        ));
+        assertTrue(AndroidUiPlugin.isHardwareKeyboardDevice(
+            false,
+            InputDevice.KEYBOARD_TYPE_ALPHABETIC
+        ));
+    }
+}

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -1314,6 +1314,35 @@ test.describe('settings', () => {
     await expect(page.locator('.settingsContent > [data-section="playback"]')).toBeVisible()
   })
 
+  test('closes an open shortcut prompt when Android reports keyboard disconnection', async ({ page }) => {
+    // Electron removes the Android-only handler from its bundle. Exercise the
+    // source handler against the running store and Settings UI instead.
+    const appSource = await readFile(new URL('../../../src/renderer/App.vue', import.meta.url), 'utf8')
+    const handlerSource = appSource.match(/function handleHardwareKeyboardChange\(event\) \{[\s\S]*?\n\}/)?.[0]
+    expect(handlerSource).toBeTruthy()
+    const reportKeyboardState = attached => page.evaluate(`(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const hardwareKeyboardAttached = { value: ${!attached} }
+      ${handlerSource}
+      handleHardwareKeyboardChange({ attached: ${attached} })
+      return hardwareKeyboardAttached.value
+    })()`)
+
+    await goTo(page, 'settings')
+    await page.getByRole('button', { name: 'Show Keyboard Shortcuts' }).click()
+    await expect(page.locator('.shortcutColumns')).toBeVisible()
+
+    expect(await reportKeyboardState(true)).toBe(true)
+    await expect(page.locator('.shortcutColumns')).toBeVisible()
+
+    expect(await reportKeyboardState(false)).toBe(false)
+    await expect(page.locator('.shortcutColumns')).toHaveCount(0)
+    await expect(page.locator('.settingsWindow')).toBeVisible()
+
+    expect(await reportKeyboardState(true)).toBe(true)
+    await expect(page.locator('.shortcutColumns')).toHaveCount(0)
+  })
+
   test('reopens Keyboard Shortcuts when its shortcut is pressed during closing', async ({ page }) => {
     await goTo(page, 'settings')
     await page.getByRole('button', { name: 'Show Keyboard Shortcuts' }).click()

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -82,6 +82,7 @@
       <KeepAlive>
         <SettingsWindow
           v-if="settingsWindowOpen"
+          :hardware-keyboard-attached="hardwareKeyboardAttached"
           :search-target="settingsSearchTarget"
           @search-target-opened="clearSettingsSearchTarget"
         />
@@ -2646,6 +2647,7 @@ const commandPaletteCommands = computed(() => createCommandPaletteRegistry({
   store,
   isElectron,
   isCapacitor,
+  hardwareKeyboardAttached: hardwareKeyboardAttached.value,
   navigate: navigateFromCommandPalette,
   openSettingsSection,
   openSettingsSearchResult,

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -2769,6 +2769,9 @@ function handleAndroidPictureInPictureChange(event) {
 
 function handleHardwareKeyboardChange(event) {
   hardwareKeyboardAttached.value = event.attached === true
+  if (!hardwareKeyboardAttached.value) {
+    store.dispatch('hideKeyboardShortcutPrompt')
+  }
 }
 
 function openSettingsView(view) {

--- a/src/renderer/helpers/commandPalette.js
+++ b/src/renderer/helpers/commandPalette.js
@@ -1,6 +1,16 @@
 export const OPEN_COMMAND_PALETTE_EVENT = 'opentubex:open-command-palette'
 
 /**
+ * Keeps keyboard-specific commands available on desktop and on Android when
+ * Android reports a physical keyboard.
+ * @param {{isCapacitor: boolean, hardwareKeyboardAttached: boolean}} context
+ * @returns {boolean}
+ */
+export function shouldShowKeyboardShortcutCommand({ isCapacitor, hardwareKeyboardAttached }) {
+  return !isCapacitor || hardwareKeyboardAttached
+}
+
+/**
  * Normalizes command text without losing words written in non-Latin scripts.
  * @param {string} value
  * @param {string} locale

--- a/src/renderer/helpers/commandPaletteRegistry.js
+++ b/src/renderer/helpers/commandPaletteRegistry.js
@@ -8,6 +8,7 @@ import { isMostPopularAvailable, isTrendingAvailable } from '../../navigationAva
 import { getTabAvatarUrl, getTabPageIcon } from '../tabs/tabPreview'
 import { switchActiveProfile, translateProfileName } from './profileSwitching'
 import { getFirstCharacter } from './strings'
+import { shouldShowKeyboardShortcutCommand } from './commandPalette'
 
 const SETTINGS_SECTIONS = [
   ['general', 'Settings.General Settings.General Settings', 'Settings.Categories.General Description', ['preferences', 'options']],
@@ -53,6 +54,7 @@ export function createCommandPaletteRegistry(context) {
     store,
     isElectron,
     isCapacitor,
+    hardwareKeyboardAttached,
     navigate,
     openSettingsSection,
     openSettingsSearchResult,
@@ -88,13 +90,16 @@ export function createCommandPaletteRegistry(context) {
   const appShortcuts = configuredShortcuts.APP.GENERAL
   const videoShortcuts = configuredShortcuts.VIDEO_PLAYER
 
-  commands.push(
-    command('app.shortcuts', t('KeyboardShortcutPrompt.Show Keyboard Shortcuts'), groups.app, {
+  if (shouldShowKeyboardShortcutCommand({ isCapacitor, hardwareKeyboardAttached })) {
+    commands.push(command('app.shortcuts', t('KeyboardShortcutPrompt.Show Keyboard Shortcuts'), groups.app, {
       aliases: ['hotkeys', 'key bindings'],
       icon: ['fas', 'keyboard'],
       shortcut: appShortcuts.SHOW_SHORTCUTS,
       run: showKeyboardShortcuts,
-    }),
+    }))
+  }
+
+  commands.push(
     command('app.find', t('KeyboardShortcutPrompt.Find in Page'), groups.app, {
       aliases: ['search page', 'text'],
       icon: ['fas', 'magnifying-glass'],

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -136,7 +136,7 @@
       </label>
       <div class="settingsHeaderActions">
         <button
-          v-if="USING_ELECTRON && !isStandaloneViewOpen"
+          v-if="showKeyboardShortcutAction && !isStandaloneViewOpen"
           type="button"
           class="settingsHeaderButton"
           :aria-label="t('KeyboardShortcutPrompt.Show Keyboard Shortcuts')"
@@ -410,11 +410,18 @@ const DEFAULT_WIDTH = 1280
 const DEFAULT_HEIGHT = 820
 const RESIZE_DIRECTIONS = ['n', 'ne', 'e', 'se', 's', 'sw', 'w', 'nw']
 const props = defineProps({
+  hardwareKeyboardAttached: {
+    type: Boolean,
+    default: false
+  },
   searchTarget: {
     type: Object,
     default: null
   }
 })
+const showKeyboardShortcutAction = computed(() => (
+  USING_ELECTRON || (IS_CAPACITOR && props.hardwareKeyboardAttached)
+))
 const emit = defineEmits(['search-target-opened'])
 const LEGACY_SETTINGS_SECTION_MAP = {
   theme: 'appearance',

--- a/tests/unit/command-palette.test.mjs
+++ b/tests/unit/command-palette.test.mjs
@@ -6,6 +6,7 @@ import {
   highlightCommandText,
   keyboardEventInitFromShortcut,
   normalizeCommandText,
+  shouldShowKeyboardShortcutCommand,
 } from '../../src/renderer/helpers/commandPalette.js'
 
 const commands = [
@@ -102,6 +103,21 @@ test('keeps direct actions ahead of settings search results', () => {
       .map(command => command.id),
     ['action', 'setting']
   )
+})
+
+test('hides the keyboard shortcuts command on Android without a hardware keyboard', () => {
+  assert.equal(shouldShowKeyboardShortcutCommand({
+    isCapacitor: true,
+    hardwareKeyboardAttached: false,
+  }), false)
+  assert.equal(shouldShowKeyboardShortcutCommand({
+    isCapacitor: true,
+    hardwareKeyboardAttached: true,
+  }), true)
+  assert.equal(shouldShowKeyboardShortcutCommand({
+    isCapacitor: false,
+    hardwareKeyboardAttached: false,
+  }), true)
 })
 
 test('converts configured shortcuts into keyboard event data', () => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #854.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Android exposed keyboard-shortcut actions even when no physical keyboard was connected, and the command palette could keep showing its shortcut entry after a keyboard was disconnected.

Detect physical alphabetic input devices directly, listen for input-device changes, and use the resulting state for both Settings and the command palette. Desktop behavior is unchanged.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Android now shows keyboard-shortcut actions only while a physical keyboard is connected.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run the Android app without a hardware keyboard and open Settings. The keyboard-shortcuts action should be absent from the header.
2. Open the command palette. “Show keyboard shortcuts,” shortcut badges, and the keyboard-navigation footer should be absent.
3. Connect a physical keyboard (or configure the emulator to expose one). The Settings action and command-palette shortcut UI should appear.
4. Disconnect the keyboard while the command palette is open. The shortcut command and keyboard-only decorations should disappear immediately.

## Additional context
<!-- Add any other context about the pull request here. -->

The connect and disconnect flows were validated on an Android API 35 emulator.
