### PR TITLE
feat(tabs): manage synced tab sets on mobile

### DIFF
--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -301,6 +301,15 @@ test('shows remote tab sets as tabs and confirms deletion in the phone organizer
     maximum: 0,
     scrollbarUnusable: true,
   })
+  await page.evaluate(() => {
+    const store = document.querySelector('#app')._vnode.component.appContext.config.globalProperties.$store
+    store.commit('setSyncServerOtherDeviceSessions', store.getters.getSyncServerOtherDeviceSessions.slice(0, 1))
+  })
+  await syncedSet.getByRole('button', { name: 'Delete: Desktop · 1 tab' }).click()
+  await page.getByRole('dialog', { name: 'Delete' })
+    .getByRole('button', { name: 'Delete', exact: true }).click()
+  await expect(sessionTabs).toHaveCount(0)
+  await expect(organizer.locator('.capacitorPhoneTabTarget[aria-selected="true"]')).toBeFocused()
 })
 
 test('restores and clamps the real phone tab organizer viewports', async ({ app, page }) => {

--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -54,9 +54,9 @@ async function enablePhoneTabSwitcher(page) {
 
 async function phoneTabScrollState(page, contentSelector) {
   return await page.locator('.capacitorPhoneTabDialog').evaluate((dialog, selector) => {
-    const viewport = dialog.querySelector('[data-overlayscrollbars-viewport]')
     const content = dialog.querySelector(selector)
-    const scrollbar = dialog.querySelector('.os-scrollbar-vertical')
+    const viewport = content.closest('[data-overlayscrollbars-viewport]')
+    const scrollbar = viewport.querySelector(':scope > .os-scrollbar-vertical')
     const paddingBottom = Number.parseFloat(getComputedStyle(viewport).paddingBottom) || 0
     const maximum = Math.max(0, content.offsetTop + content.offsetHeight + paddingBottom - viewport.clientHeight)
     return {
@@ -130,17 +130,23 @@ test('fits synced-device tabs in the phone tab organizer', async ({ app, page })
         <button class="capacitorPhoneTabViewTab" role="tab" aria-selected="false">2 open tabs</button>
         <button class="capacitorPhoneTabViewTab" role="tab" aria-selected="true">Tabs from other devices</button>
       </div>
-      <div class="capacitorPhoneSyncedTabs" role="tabpanel">
-        <article class="capacitorPhoneSyncedSession">
-          <header class="capacitorPhoneSyncedSessionHeader">
-            <strong>A very long encrypted device name that must wrap · 2 tabs</strong>
-            <button class="capacitorPhoneSyncedTabButton capacitorPhoneSyncedOpenAll"><span aria-hidden="true">↗</span><span>Open all tabs</span></button>
-          </header>
-          <div class="capacitorPhoneSyncedTabList">
-            <button class="capacitorPhoneSyncedTabButton capacitorPhoneSyncedTabTarget"><span aria-hidden="true">↗</span><span>A very long channel tab title that must not overflow</span></button>
-            <button class="capacitorPhoneSyncedTabButton capacitorPhoneSyncedTabTarget"><span aria-hidden="true">↗</span><span>Watch later</span></button>
-          </div>
-        </article>
+      <div class="capacitorPhoneSyncedView" role="tabpanel">
+        <div class="capacitorPhoneSyncedSessionTabs" role="tablist" aria-label="Tabs from other devices">
+          <button class="capacitorPhoneSyncedSessionTab" role="tab" aria-selected="true"><span aria-hidden="true">▣</span><strong>A very long encrypted device name that must wrap · 2 tabs</strong></button>
+          <button class="capacitorPhoneSyncedSessionTab" role="tab" aria-selected="false"><span aria-hidden="true">▣</span><strong>Mobile · 1 tab</strong></button>
+        </div>
+        <div class="capacitorPhoneSyncedTabs">
+          <article class="capacitorPhoneSyncedSession" role="tabpanel">
+            <header class="capacitorPhoneSyncedSessionHeader">
+              <button class="capacitorPhoneSyncedTabButton capacitorPhoneSyncedOpenAll"><span aria-hidden="true">↗</span><span>Open all tabs</span></button>
+              <button class="capacitorPhoneSyncedTabButton capacitorPhoneSyncedDelete dangerButton" aria-label="Delete: Desktop · 2 tabs"><span aria-hidden="true">×</span></button>
+            </header>
+            <div class="capacitorPhoneSyncedTabList">
+              <button class="capacitorPhoneSyncedTabButton capacitorPhoneSyncedTabTarget"><span aria-hidden="true">↗</span><span>A very long channel tab title that must not overflow</span></button>
+              <button class="capacitorPhoneSyncedTabButton capacitorPhoneSyncedTabTarget"><span aria-hidden="true">↗</span><span>Watch later</span></button>
+            </div>
+          </article>
+        </div>
       </div>
     `
     document.body.append(dialog)
@@ -155,6 +161,18 @@ test('fits synced-device tabs in the phone tab organizer', async ({ app, page })
     buttons.map(button => button.getBoundingClientRect().height)
   ))
   expect(touchTargetHeights.every(height => height >= 48)).toBe(true)
+  const actionAlignment = await dialog.locator('.capacitorPhoneSyncedSessionHeader')
+    .evaluate(header => {
+      const headerBounds = header.getBoundingClientRect()
+      const openAllBounds = header.querySelector('.capacitorPhoneSyncedOpenAll').getBoundingClientRect()
+      const deleteBounds = header.querySelector('.capacitorPhoneSyncedDelete').getBoundingClientRect()
+      return {
+        openAllStartOffset: Math.abs(openAllBounds.left - headerBounds.left),
+        deleteEndOffset: Math.abs(deleteBounds.right - headerBounds.right),
+      }
+    })
+  expect(actionAlignment.openAllStartOffset).toBeLessThanOrEqual(1)
+  expect(actionAlignment.deleteEndOffset).toBeLessThanOrEqual(1)
   const activeIndicator = await dialog.getByRole('tab', { name: 'Tabs from other devices' })
     .evaluate(element => {
       const style = getComputedStyle(element)
@@ -171,6 +189,118 @@ test('fits synced-device tabs in the phone tab organizer', async ({ app, page })
     element.scrollWidth <= element.clientWidth + 1 &&
     element.scrollHeight <= element.clientHeight + 1
   ))).toBe(true)
+})
+
+test('shows remote tab sets as tabs and confirms deletion in the phone organizer', async ({ app, page }) => {
+  await setWindowSize(app, page, { width: 375, height: 760 })
+  await page.evaluate(() => window.ftElectron.setZoomFactor(0.95))
+  await enablePhoneTabSwitcher(page)
+  await page.evaluate(() => {
+    const store = document.querySelector('#app')._vnode.component.appContext.config.globalProperties.$store
+    store.commit('setSyncServerEnabled', true)
+    store.commit('setSyncServerToken', 'e2e-token')
+    store.commit('setSyncServerPrivacyMode', 'enhanced')
+    store.commit('setSyncServerSyncSessions', true)
+    store.commit('setSyncServerSharedTabs', false)
+    store.commit('setSyncServerOtherDeviceSessions', [
+      {
+        syncDeviceId: 'phone-e2e',
+        syncPlatform: 'mobile',
+        sessionId: 'mobile-session-e2e',
+        tabs: Array.from({ length: 30 }, (_, index) => ({
+          id: `mobile-${index}`,
+          title: `Mobile tab ${index}`,
+          url: `/watch/mobile-${index}`,
+        })),
+      },
+      {
+        syncDeviceId: 'desktop-e2e',
+        syncPlatform: 'desktop',
+        sessionId: 'desktop-session-e2e',
+        tabs: [{ id: 'desktop-subscriptions', title: 'Desktop subscriptions', url: '/subscriptions' }],
+      },
+      ...Array.from({ length: 7 }, (_, sessionIndex) => ({
+        syncDeviceId: `extra-desktop-${sessionIndex}`,
+        syncPlatform: 'desktop',
+        sessionId: `extra-session-${sessionIndex}`,
+        tabs: Array.from({ length: sessionIndex + 2 }, (_, tabIndex) => ({
+          id: `extra-${sessionIndex}-${tabIndex}`,
+          title: `Extra tab ${sessionIndex}-${tabIndex}`,
+          url: `/watch/extra-${sessionIndex}-${tabIndex}`,
+        })),
+      })),
+    ])
+    store._actions.deleteSyncServerSession = [session => {
+      store.commit(
+        'setSyncServerOtherDeviceSessions',
+        store.getters.getSyncServerOtherDeviceSessions.filter(candidate => (
+          candidate.syncDeviceId !== session.syncDeviceId ||
+          candidate.sessionId !== session.sessionId
+        ))
+      )
+      return Promise.resolve(true)
+    }]
+  })
+
+  await page.locator('.capacitorPhoneTabSwitcherButton').click()
+  const organizer = page.locator('.capacitorPhoneTabDialog')
+  await organizer.getByRole('tab', { name: 'Tabs from other devices' }).click()
+
+  const sessionTabs = organizer.locator('.capacitorPhoneSyncedSessionTabs')
+  const mobileTab = sessionTabs.getByRole('tab', { name: 'Mobile · 30 tabs', exact: true })
+  const desktopTab = sessionTabs.getByRole('tab', { name: 'Desktop · 1 tab', exact: true })
+  const syncedPanel = organizer.locator('.capacitorPhoneSyncedTabs')
+  const syncedSet = organizer.locator('.capacitorPhoneSyncedSession[role="tabpanel"]')
+  await expect(sessionTabs).toHaveAttribute('data-overlayscrollbars-viewport')
+  await expect(sessionTabs.getByRole('tab')).toHaveCount(9)
+  await expect.poll(() => sessionTabs.evaluate(element => ({
+    horizontallyScrollable: element.scrollWidth > element.clientWidth,
+    selectedSetVisible: document.querySelector('.capacitorPhoneSyncedTabs').clientHeight > 0,
+  }))).toEqual({ horizontallyScrollable: true, selectedSetVisible: true })
+  await expect(mobileTab).toHaveAttribute('aria-selected', 'true')
+  await expect(desktopTab).toHaveAttribute('aria-selected', 'false')
+  await expect(syncedSet).toContainText('Mobile tab 0')
+  await expect(syncedSet).not.toContainText('Desktop subscriptions')
+
+  await mobileTab.press('ArrowRight')
+  await expect(desktopTab).toBeFocused()
+  await expect(desktopTab).toHaveAttribute('aria-selected', 'true')
+  await expect(syncedSet).toContainText('Desktop subscriptions')
+  await expect(syncedSet).not.toContainText('Mobile tab 0')
+
+  await desktopTab.press('Home')
+  await expect(mobileTab).toBeFocused()
+  await expect(mobileTab).toHaveAttribute('aria-selected', 'true')
+  await syncedPanel.evaluate(element => { element.scrollTop = element.scrollHeight })
+  await expect.poll(async () => (
+    await phoneTabScrollState(page, '.capacitorPhoneSyncedTabsContent')
+  ).scrollTop).toBeGreaterThan(0)
+
+  const deleteSet = syncedSet.getByRole('button', { name: 'Delete: Mobile · 30 tabs' })
+  await deleteSet.click()
+  let confirmation = page.getByRole('dialog', { name: 'Delete' })
+  await expect(confirmation).toContainText('Mobile · 30 tabs')
+  await expect(organizer).toHaveAttribute('inert', '')
+  await expect.poll(async () => ({
+    confirmation: Number.parseInt(await confirmation.evaluate(element => getComputedStyle(element.closest('.prompt')).zIndex)),
+    organizer: Number.parseInt(await organizer.evaluate(element => getComputedStyle(element.closest('.capacitorPhoneTabOverlay')).zIndex)),
+  })).toEqual({ confirmation: 1200, organizer: 1100 })
+  await confirmation.getByRole('button', { name: 'Cancel' }).click()
+  await expect(organizer).not.toHaveAttribute('inert')
+  await expect(syncedSet).toBeVisible()
+
+  await deleteSet.click()
+  confirmation = page.getByRole('dialog', { name: 'Delete' })
+  await confirmation.getByRole('button', { name: 'Delete', exact: true }).click()
+  await expect(mobileTab).toHaveCount(0)
+  await expect(desktopTab).toBeFocused()
+  await expect(desktopTab).toHaveAttribute('aria-selected', 'true')
+  await expect(syncedSet).toContainText('Desktop subscriptions')
+  await expect.poll(() => phoneTabScrollState(page, '.capacitorPhoneSyncedTabsContent')).toEqual({
+    scrollTop: 0,
+    maximum: 0,
+    scrollbarUnusable: true,
+  })
 })
 
 test('restores and clamps the real phone tab organizer viewports', async ({ app, page }) => {
@@ -215,16 +345,24 @@ test('restores and clamps the real phone tab organizer viewports', async ({ app,
     store.commit('setSyncServerPrivacyMode', 'enhanced')
     store.commit('setSyncServerSyncSessions', true)
     store.commit('setSyncServerSharedTabs', false)
-    store.commit('setSyncServerOtherDeviceSessions', [{
-      syncDeviceId: desktopDeviceId,
-      syncPlatform: 'desktop',
-      sessionId: 'session-e2e',
-      tabs: Array.from({ length: 30 }, (_, index) => ({
-        id: `synced-${index}`,
-        title: `Synced tab ${index}`,
-        url: `/watch/synced-${index}`,
-      })),
-    }])
+    store.commit('setSyncServerOtherDeviceSessions', [
+      {
+        syncDeviceId: desktopDeviceId,
+        syncPlatform: 'desktop',
+        sessionId: 'long-session-e2e',
+        tabs: Array.from({ length: 30 }, (_, index) => ({
+          id: `synced-${index}`,
+          title: `Synced tab ${index}`,
+          url: `/watch/synced-${index}`,
+        })),
+      },
+      {
+        syncDeviceId: desktopDeviceId,
+        syncPlatform: 'desktop',
+        sessionId: 'short-session-e2e',
+        tabs: [{ id: 'short-synced', title: 'Short synced tab', url: '/subscriptions' }],
+      },
+    ])
     for (let index = 0; index < 30; index++) {
       await store.dispatch('createTab', { route: `/watch/local-${index}`, makeActive: false })
     }
@@ -241,9 +379,9 @@ test('restores and clamps the real phone tab organizer viewports', async ({ app,
     .toBeCloseTo(240, 0)
   await page.getByRole('tab', { name: 'Tabs from other devices' }).click()
 
-  const syncedPanel = page.locator('#capacitor-phone-synced-tabs-panel')
-  await expect(syncedPanel.locator('.capacitorPhoneSyncedSessionHeader strong'))
-    .toHaveText('Living room PC · 30 tabs')
+  const syncedPanel = page.locator('.capacitorPhoneSyncedTabs')
+  await expect(page.getByRole('tab', { name: 'Living room PC · 30 tabs', exact: true }))
+    .toHaveAttribute('aria-selected', 'true')
   await expect(syncedPanel).toHaveAttribute('data-overlayscrollbars-viewport')
   await syncedPanel.evaluate(element => { element.scrollTop = 360 })
   await expect.poll(async () => (await phoneTabScrollState(page, '.capacitorPhoneSyncedTabsContent')).scrollTop)
@@ -272,15 +410,10 @@ test('restores and clamps the real phone tab organizer viewports', async ({ app,
   await page.evaluate(desktopDeviceId => {
     const store = document.querySelector('#app')._vnode.component.appContext.config.globalProperties.$store
     store.commit('setSyncServerDeviceNames', { [desktopDeviceId]: 'Desk PC' })
-    store.commit('setSyncServerOtherDeviceSessions', [{
-      syncDeviceId: desktopDeviceId,
-      syncPlatform: 'desktop',
-      sessionId: 'session-e2e',
-      tabs: [{ id: 'synced-0', title: 'Synced tab 0', url: '/watch/synced-0' }],
-    }])
   }, desktopDeviceId)
+  await page.getByRole('tab', { name: 'Desk PC · 1 tab', exact: true }).click()
   await expect(page.locator('.capacitorPhoneSyncedTabTarget')).toHaveCount(1)
-  await expect(syncedPanel.locator('.capacitorPhoneSyncedSessionHeader strong'))
+  await expect(page.locator('.capacitorPhoneSyncedSessionTab[aria-selected="true"]'))
     .toHaveText('Desk PC · 1 tab')
   await expect.poll(() => phoneTabScrollState(page, '.capacitorPhoneSyncedTabsContent')).toEqual({
     scrollTop: 0,

--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -131,9 +131,11 @@ test('fits synced-device tabs in the phone tab organizer', async ({ app, page })
         <button class="capacitorPhoneTabViewTab" role="tab" aria-selected="true">Tabs from other devices</button>
       </div>
       <div class="capacitorPhoneSyncedView" role="tabpanel">
-        <div class="capacitorPhoneSyncedSessionTabs" role="tablist" aria-label="Tabs from other devices">
-          <button class="capacitorPhoneSyncedSessionTab" role="tab" aria-selected="true"><span aria-hidden="true">▣</span><strong>A very long encrypted device name that must wrap · 2 tabs</strong></button>
-          <button class="capacitorPhoneSyncedSessionTab" role="tab" aria-selected="false"><span aria-hidden="true">▣</span><strong>Mobile · 1 tab</strong></button>
+        <div class="capacitorPhoneSyncedSessionTabs">
+          <div class="capacitorPhoneSyncedSessionTabsInner" role="tablist" aria-label="Tabs from other devices">
+            <button class="capacitorPhoneSyncedSessionTab" role="tab" aria-selected="true"><span aria-hidden="true">▣</span><strong>A very long encrypted device name that must wrap · 2 tabs</strong></button>
+            <button class="capacitorPhoneSyncedSessionTab" role="tab" aria-selected="false"><span aria-hidden="true">▣</span><strong>Mobile · 1 tab</strong></button>
+          </div>
         </div>
         <div class="capacitorPhoneSyncedTabs">
           <article class="capacitorPhoneSyncedSession" role="tabpanel">
@@ -252,6 +254,10 @@ test('shows remote tab sets as tabs and confirms deletion in the phone organizer
   const syncedPanel = organizer.locator('.capacitorPhoneSyncedTabs')
   const syncedSet = organizer.locator('.capacitorPhoneSyncedSession[role="tabpanel"]')
   await expect(sessionTabs).toHaveAttribute('data-overlayscrollbars-viewport')
+  const sessionTablist = sessionTabs.getByRole('tablist', { name: 'Tabs from other devices' })
+  await expect(sessionTablist).toHaveCount(1)
+  await expect(sessionTablist.locator(':scope > *')).toHaveCount(9)
+  await expect(sessionTablist.locator(':scope > [role="tab"]')).toHaveCount(9)
   await expect(sessionTabs.getByRole('tab')).toHaveCount(9)
   await expect.poll(() => sessionTabs.evaluate(element => ({
     horizontallyScrollable: element.scrollWidth > element.clientWidth,

--- a/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.css
+++ b/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.css
@@ -379,10 +379,7 @@
 }
 
 .capacitorPhoneSyncedSessionTabs {
-  display: flex;
   flex: 0 0 auto;
-  flex-wrap: nowrap;
-  gap: 4px;
   max-inline-size: 100%;
   min-inline-size: 0;
   padding-inline: 8px;
@@ -390,6 +387,12 @@
   border-block-end: 1px solid var(--border-color);
   overflow: auto hidden;
   overscroll-behavior-inline: contain;
+}
+
+.capacitorPhoneSyncedSessionTabsInner {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 4px;
 }
 
 .capacitorPhoneSyncedSessionTab {

--- a/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.css
+++ b/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.css
@@ -28,6 +28,7 @@
 .capacitorPhoneTabDragHandle :deep(.ft-icon),
 .capacitorPhoneTabClose :deep(.ft-icon),
 .capacitorPhoneTabFab :deep(.ft-icon),
+.capacitorPhoneSyncedSessionTab :deep(.ft-icon),
 .capacitorPhoneSyncedTabButton :deep(.ft-icon) {
   display: block;
   inline-size: 1em;
@@ -370,19 +371,74 @@
   flex: 1 1 auto;
 }
 
+.capacitorPhoneSyncedView {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-block-size: 0;
+}
+
+.capacitorPhoneSyncedSessionTabs {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: nowrap;
+  gap: 4px;
+  max-inline-size: 100%;
+  min-inline-size: 0;
+  padding-inline: 8px;
+  background-color: var(--card-bg-color);
+  border-block-end: 1px solid var(--border-color);
+  overflow: auto hidden;
+  overscroll-behavior-inline: contain;
+}
+
+.capacitorPhoneSyncedSessionTab {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+  min-inline-size: 0;
+  min-block-size: 48px;
+  padding-block: 8px 5px;
+  padding-inline: 10px;
+  color: var(--secondary-text-color);
+  background-color: transparent;
+  border: 0;
+  border-block-end: 3px solid transparent;
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.25;
+  text-align: start;
+  touch-action: manipulation;
+}
+
+.capacitorPhoneSyncedSessionTab strong {
+  min-inline-size: 0;
+  overflow-wrap: anywhere;
+}
+
+.capacitorPhoneSyncedSessionTab[aria-selected='true'] {
+  color: var(--primary-text-color);
+  border-block-end-color: var(--primary-color);
+}
+
+.capacitorPhoneSyncedSessionTab:is(:hover, :active) {
+  background-color: var(--side-nav-hover-color);
+}
+
+.capacitorPhoneSyncedSessionTab:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: -4px;
+}
+
 .capacitorPhoneSyncedTabs {
   min-block-size: 0;
   padding-block: 8px 24px;
   padding-inline: 8px;
   overflow-y: auto;
   overscroll-behavior: contain;
-}
-
-.capacitorPhoneSyncedTabsEmpty {
-  margin-block: 32px;
-  margin-inline: 16px;
-  color: var(--secondary-text-color);
-  text-align: center;
 }
 
 .capacitorPhoneSyncedSession {
@@ -398,12 +454,6 @@
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-}
-
-.capacitorPhoneSyncedSessionHeader strong {
-  min-inline-size: 0;
-  overflow-wrap: anywhere;
-  font-size: 15px;
 }
 
 .capacitorPhoneSyncedTabButton {
@@ -437,6 +487,17 @@
   flex: 0 0 auto;
 }
 
+.capacitorPhoneSyncedDelete {
+  grid-template-columns: 1fr;
+  flex: 0 0 48px;
+  inline-size: 48px;
+  padding: 0;
+}
+
+.dangerButton {
+  color: var(--error-color, #d84f4f);
+}
+
 .capacitorPhoneSyncedTabList {
   display: grid;
   gap: 4px;
@@ -454,6 +515,10 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+:global(.prompt:has(.capacitorPhoneDeletePrompt)) {
+  z-index: 1200;
 }
 
 .capacitorPhoneTabFab:is(:hover, :active) {

--- a/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.vue
+++ b/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.vue
@@ -225,31 +225,35 @@
               <div
                 v-overlay-scrollbars
                 class="capacitorPhoneSyncedSessionTabs"
-                role="tablist"
-                :aria-label="t('Settings.Sync Settings.Tabs From Other Devices')"
               >
-                <button
-                  v-for="(session, index) in otherDeviceSessions"
-                  :id="syncedSessionTabId(index)"
-                  :key="`${session.syncDeviceId}:${session.sessionId}`"
-                  type="button"
-                  class="capacitorPhoneSyncedSessionTab"
-                  role="tab"
-                  :aria-controls="syncedSessionPanelId"
-                  :aria-selected="activeOtherDeviceSessionKey === otherDeviceSessionKey(session)"
-                  :tabindex="activeOtherDeviceSessionKey === otherDeviceSessionKey(session) ? 0 : -1"
-                  @click="selectOtherDeviceSession(session)"
-                  @keydown.left.prevent="selectOtherDeviceSessionAt(index - 1, true)"
-                  @keydown.right.prevent="selectOtherDeviceSessionAt(index + 1, true)"
-                  @keydown.home.prevent="selectOtherDeviceSessionAt(0, true)"
-                  @keydown.end.prevent="selectOtherDeviceSessionAt(otherDeviceSessions.length - 1, true)"
+                <div
+                  class="capacitorPhoneSyncedSessionTabsInner"
+                  role="tablist"
+                  :aria-label="t('Settings.Sync Settings.Tabs From Other Devices')"
                 >
-                  <FtIcon
-                    :icon="session.syncPlatform === 'mobile' ? ['fas', 'layer-group'] : ['fas', 'display']"
-                    aria-hidden="true"
-                  />
-                  <strong>{{ formatDeviceSessionLabel(session, t) }}</strong>
-                </button>
+                  <button
+                    v-for="(session, index) in otherDeviceSessions"
+                    :id="syncedSessionTabId(index)"
+                    :key="`${session.syncDeviceId}:${session.sessionId}`"
+                    type="button"
+                    class="capacitorPhoneSyncedSessionTab"
+                    role="tab"
+                    :aria-controls="syncedSessionPanelId"
+                    :aria-selected="activeOtherDeviceSessionKey === otherDeviceSessionKey(session)"
+                    :tabindex="activeOtherDeviceSessionKey === otherDeviceSessionKey(session) ? 0 : -1"
+                    @click="selectOtherDeviceSession(session)"
+                    @keydown.left.prevent="selectOtherDeviceSessionAt(index - 1, true)"
+                    @keydown.right.prevent="selectOtherDeviceSessionAt(index + 1, true)"
+                    @keydown.home.prevent="selectOtherDeviceSessionAt(0, true)"
+                    @keydown.end.prevent="selectOtherDeviceSessionAt(otherDeviceSessions.length - 1, true)"
+                  >
+                    <FtIcon
+                      :icon="session.syncPlatform === 'mobile' ? ['fas', 'layer-group'] : ['fas', 'display']"
+                      aria-hidden="true"
+                    />
+                    <strong>{{ formatDeviceSessionLabel(session, t) }}</strong>
+                  </button>
+                </div>
               </div>
               <div
                 ref="syncedTabsScrollRef"

--- a/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.vue
+++ b/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.vue
@@ -43,6 +43,7 @@
             role="dialog"
             aria-modal="true"
             aria-labelledby="capacitor-phone-tab-dialog-title"
+            :inert="sessionToDelete !== null"
           >
             <header class="capacitorPhoneTabHeader">
               <div class="capacitorPhoneTabHeading">
@@ -217,57 +218,98 @@
             <div
               v-else
               id="capacitor-phone-synced-tabs-panel"
-              ref="syncedTabsScrollRef"
-              v-overlay-scrollbars
-              class="capacitorPhoneSyncedTabs"
+              class="capacitorPhoneSyncedView"
               role="tabpanel"
               aria-labelledby="capacitor-phone-synced-tabs-tab"
             >
               <div
-                ref="syncedTabsContentRef"
-                class="capacitorPhoneSyncedTabsContent"
+                v-overlay-scrollbars
+                class="capacitorPhoneSyncedSessionTabs"
+                role="tablist"
+                :aria-label="t('Settings.Sync Settings.Tabs From Other Devices')"
               >
-                <p
-                  v-if="otherDeviceSessions.length === 0"
-                  class="capacitorPhoneSyncedTabsEmpty"
-                >
-                  {{ t('Tab Organizer.Open Tab Count', { count: 0 }, 0) }}
-                </p>
-                <article
-                  v-for="session in otherDeviceSessions"
+                <button
+                  v-for="(session, index) in otherDeviceSessions"
+                  :id="syncedSessionTabId(index)"
                   :key="`${session.syncDeviceId}:${session.sessionId}`"
-                  class="capacitorPhoneSyncedSession"
+                  type="button"
+                  class="capacitorPhoneSyncedSessionTab"
+                  role="tab"
+                  :aria-controls="syncedSessionPanelId"
+                  :aria-selected="activeOtherDeviceSessionKey === otherDeviceSessionKey(session)"
+                  :tabindex="activeOtherDeviceSessionKey === otherDeviceSessionKey(session) ? 0 : -1"
+                  @click="selectOtherDeviceSession(session)"
+                  @keydown.left.prevent="selectOtherDeviceSessionAt(index - 1, true)"
+                  @keydown.right.prevent="selectOtherDeviceSessionAt(index + 1, true)"
+                  @keydown.home.prevent="selectOtherDeviceSessionAt(0, true)"
+                  @keydown.end.prevent="selectOtherDeviceSessionAt(otherDeviceSessions.length - 1, true)"
                 >
-                  <header class="capacitorPhoneSyncedSessionHeader">
-                    <strong>{{ formatDeviceSessionLabel(session, t) }}</strong>
-                    <button
-                      type="button"
-                      class="capacitorPhoneSyncedTabButton capacitorPhoneSyncedOpenAll"
-                      @click="openOtherDeviceSession(session)"
-                    >
-                      <FtIcon
-                        :icon="['fas', 'folder-open']"
-                        aria-hidden="true"
-                      />
-                      {{ t('Settings.Sync Settings.Open All Tabs') }}
-                    </button>
-                  </header>
-                  <div class="capacitorPhoneSyncedTabList">
-                    <button
-                      v-for="tab in session.tabs"
-                      :key="tab.id"
-                      type="button"
-                      class="capacitorPhoneSyncedTabButton capacitorPhoneSyncedTabTarget"
-                      @click="openOtherDeviceSession({ ...session, tabs: [tab] })"
-                    >
-                      <FtIcon
-                        :icon="['fas', 'arrow-up-right-from-square']"
-                        aria-hidden="true"
-                      />
-                      <span dir="auto">{{ tab.title || tab.url }}</span>
-                    </button>
-                  </div>
-                </article>
+                  <FtIcon
+                    :icon="session.syncPlatform === 'mobile' ? ['fas', 'layer-group'] : ['fas', 'display']"
+                    aria-hidden="true"
+                  />
+                  <strong>{{ formatDeviceSessionLabel(session, t) }}</strong>
+                </button>
+              </div>
+              <div
+                ref="syncedTabsScrollRef"
+                v-overlay-scrollbars
+                class="capacitorPhoneSyncedTabs"
+              >
+                <div
+                  ref="syncedTabsContentRef"
+                  class="capacitorPhoneSyncedTabsContent"
+                >
+                  <article
+                    v-if="activeOtherDeviceSession"
+                    :id="syncedSessionPanelId"
+                    :key="activeOtherDeviceSessionKey"
+                    class="capacitorPhoneSyncedSession"
+                    role="tabpanel"
+                    :aria-labelledby="activeOtherDeviceSessionTabId"
+                  >
+                    <header class="capacitorPhoneSyncedSessionHeader">
+                      <button
+                        type="button"
+                        class="capacitorPhoneSyncedTabButton capacitorPhoneSyncedOpenAll"
+                        @click="openOtherDeviceSession(activeOtherDeviceSession)"
+                      >
+                        <FtIcon
+                          :icon="['fas', 'folder-open']"
+                          aria-hidden="true"
+                        />
+                        {{ t('Settings.Sync Settings.Open All Tabs') }}
+                      </button>
+                      <button
+                        type="button"
+                        class="capacitorPhoneSyncedTabButton capacitorPhoneSyncedDelete dangerButton"
+                        :aria-label="`${t('Delete')}: ${formatDeviceSessionLabel(activeOtherDeviceSession, t)}`"
+                        :title="t('Delete')"
+                        @click="sessionToDelete = activeOtherDeviceSession"
+                      >
+                        <FtIcon
+                          :icon="['fas', 'trash']"
+                          aria-hidden="true"
+                        />
+                      </button>
+                    </header>
+                    <div class="capacitorPhoneSyncedTabList">
+                      <button
+                        v-for="tab in activeOtherDeviceSession.tabs"
+                        :key="tab.id"
+                        type="button"
+                        class="capacitorPhoneSyncedTabButton capacitorPhoneSyncedTabTarget"
+                        @click="openOtherDeviceSession({ ...activeOtherDeviceSession, tabs: [tab] })"
+                      >
+                        <FtIcon
+                          :icon="['fas', 'arrow-up-right-from-square']"
+                          aria-hidden="true"
+                        />
+                        <span dir="auto">{{ tab.title || tab.url }}</span>
+                      </button>
+                    </div>
+                  </article>
+                </div>
               </div>
             </div>
             <button
@@ -301,6 +343,17 @@
         </div>
       </Transition>
     </Teleport>
+    <FtPrompt
+      v-if="sessionToDelete"
+      card-class="capacitorPhoneDeletePrompt"
+      :label="t('Delete')"
+      :extra-labels="[formatDeviceSessionLabel(sessionToDelete, t)]"
+      :option-names="[t('Delete'), t('Cancel')]"
+      :option-values="['delete', 'cancel']"
+      is-first-option-destructive
+      autosize
+      @click="handleDeleteSessionPrompt"
+    />
   </div>
 </template>
 
@@ -313,8 +366,10 @@ import store from '../../store/index'
 import { shouldCloseSwipedTab } from '../../helpers/capacitorTabSwipe'
 import { clampOverlayScrollTop, restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
 import { formatDeviceSessionLabel, shouldShowOtherDeviceSessions } from '../../helpers/sync-sessions'
+import { showToast } from '../../helpers/utils'
 import { getCapacitorTabService } from '../../tabs/CapacitorTabService'
 import { getTabAvatarUrl, getTabPageIcon } from '../../tabs/tabPreview'
+import FtPrompt from '../FtPrompt/FtPrompt.vue'
 import FtRetryImage from '../FtRetryImage.vue'
 import { lockBodyScroll, unlockBodyScroll } from '../FtPrompt/scrollLock'
 import CapacitorTabActionsMenu from './CapacitorTabActionsMenu.vue'
@@ -331,6 +386,10 @@ const { t } = useI18n()
 const open = ref(false)
 const activeView = ref('open')
 const promptId = useId()
+const syncedSessionIdPrefix = `capacitor-phone-synced-session-${useId().replaceAll(':', '')}`
+const syncedSessionPanelId = `${syncedSessionIdPrefix}-panel`
+const selectedOtherDeviceSessionKey = ref(null)
+const sessionToDelete = ref(null)
 const triggerRef = useTemplateRef('triggerRef')
 const dialogRef = useTemplateRef('dialogRef')
 const openTabsScrollRef = useTemplateRef('openTabsScrollRef')
@@ -345,6 +404,20 @@ const syncConnected = computed(() => store.getters.getSyncServerToken !== '')
 const syncSessionsEnabled = computed(() => store.getters.getSyncServerSyncSessions)
 const sharedTabsEnabled = computed(() => store.getters.getSyncServerSharedTabs)
 const otherDeviceSessions = computed(() => store.getters.getSyncServerOtherDeviceSessions)
+const activeOtherDeviceSession = computed(() => (
+  otherDeviceSessions.value.find(session => (
+    otherDeviceSessionKey(session) === selectedOtherDeviceSessionKey.value
+  )) ?? otherDeviceSessions.value[0] ?? null
+))
+const activeOtherDeviceSessionKey = computed(() => (
+  activeOtherDeviceSession.value ? otherDeviceSessionKey(activeOtherDeviceSession.value) : null
+))
+const activeOtherDeviceSessionTabId = computed(() => {
+  const activeIndex = otherDeviceSessions.value.findIndex(session => (
+    otherDeviceSessionKey(session) === activeOtherDeviceSessionKey.value
+  ))
+  return syncedSessionTabId(Math.max(0, activeIndex))
+})
 const showSyncedTabsView = computed(() => shouldShowOtherDeviceSessions({
   syncEnabled: syncEnabled.value,
   syncConnected: syncConnected.value,
@@ -495,8 +568,56 @@ async function activateTab(tabId) {
   await activateTabAction(tabId)
 }
 
+function otherDeviceSessionKey(session) {
+  return `${session.syncDeviceId}:${session.sessionId}`
+}
+
+function syncedSessionTabId(index) {
+  return `${syncedSessionIdPrefix}-tab-${index}`
+}
+
+async function selectOtherDeviceSession(session, focus = false) {
+  selectedOtherDeviceSessionKey.value = otherDeviceSessionKey(session)
+  await nextTick()
+  clampActiveContentScroll()
+  if (!focus) return
+
+  const index = otherDeviceSessions.value.findIndex(candidate => (
+    otherDeviceSessionKey(candidate) === selectedOtherDeviceSessionKey.value
+  ))
+  dialogRef.value?.querySelector(`#${syncedSessionTabId(index)}`)?.focus({ preventScroll: true })
+}
+
+function selectOtherDeviceSessionAt(index, focus = false) {
+  const sessions = otherDeviceSessions.value
+  if (sessions.length === 0) return
+  const wrappedIndex = (index + sessions.length) % sessions.length
+  selectOtherDeviceSession(sessions[wrappedIndex], focus)
+}
+
 async function openOtherDeviceSession(session) {
   if (await store.dispatch('openSyncServerSession', session)) closeSwitcher()
+}
+
+async function handleDeleteSessionPrompt(option) {
+  const session = sessionToDelete.value
+  sessionToDelete.value = null
+  if (option !== 'delete' || !session) return
+
+  try {
+    if (!await store.dispatch('deleteSyncServerSession', session)) return
+    await nextTick()
+    if (activeView.value === 'synced') {
+      dialogRef.value
+        ?.querySelector(`#${activeOtherDeviceSessionTabId.value}`)
+        ?.focus({ preventScroll: true })
+    }
+  } catch (error) {
+    showToast({
+      message: t('Settings.Sync Settings.Sync failed', { error: error.message }),
+      icon: ['fas', 'circle-exclamation'],
+    })
+  }
 }
 
 function swipeStyle(tabId) {

--- a/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.vue
+++ b/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.vue
@@ -611,6 +611,8 @@ async function handleDeleteSessionPrompt(option) {
       dialogRef.value
         ?.querySelector(`#${activeOtherDeviceSessionTabId.value}`)
         ?.focus({ preventScroll: true })
+    } else {
+      focusActiveTab()
     }
   } catch (error) {
     showToast({


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The desktop tab organizer lets people switch between synced tab sets from other devices and delete a set, but the mobile organizer only listed the remote tabs. This adds a scrollable device-tab strip to the mobile organizer, shows one remote set at a time, and adds the same confirmed deletion flow with keyboard and focus handling.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Synced tab sets can now be switched between and deleted from the mobile tab organizer.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/0f8f59da-9ed2-41ec-9445-f9230fe21eae">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/d16b3fc3-1ecf-4a9e-abc9-9486b1977dd4">
  <img alt="Mobile tab organizer showing synced tab sets from other devices" src="https://github.com/user-attachments/assets/0f8f59da-9ed2-41ec-9445-f9230fe21eae">
</picture>

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run the app in the phone layout with session sync enabled and at least two tab sets from other devices.
2. Open the tab organizer and select "Tabs from other devices." Each device set should appear as a tab, with one set's tabs visible at a time.
3. Switch device tabs with touch or the arrow, Home, and End keys. The selected set should remain visible and focused.
4. Delete a device set, cancel once, then confirm it. Cancel should preserve the set; confirmation should remove it and focus the next available set.
5. Repeat with enough device sets and tabs to overflow both directions. The device tabs should scroll horizontally, the tab list should scroll vertically, and removing or switching to a shorter set should leave no empty stale scroll area.

## Additional context
<!-- Add any other context about the pull request here. -->

The mobile confirmation temporarily makes the organizer inert so only one modal remains available to keyboard and assistive-technology users.
