### PR TITLE
fix(android): keep PiP video aligned during resize

### DIFF
--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -1111,16 +1111,30 @@ test('isolates the owning video surface while Android Picture-in-Picture is acti
       const video = document.createElement('video')
       video.className = 'player'
       player.append(video)
-      document.querySelector('.routerView').append(player)
+      document.querySelector('.app > .routerView').append(player)
     }
     document.body.classList.add('androidPictureInPicture')
   })
 
   await expect(page.locator('.topNav')).toHaveCSS('visibility', 'hidden')
+  await expect(page.locator('.app > .routerView')).toHaveCSS('container-type', 'normal')
   await expect(page.locator('.ftVideoPlayer').first()).toHaveCSS('visibility', 'hidden')
   const target = page.locator('[data-android-picture-in-picture-target]')
   await expect(target).toHaveCSS('visibility', 'visible')
   await expect(target.locator('> .player')).toHaveCSS('visibility', 'visible')
+  await expect(target.locator('> .player')).toHaveCSS('transition-property', 'none')
+  await expect.poll(() => target.evaluate(element => {
+    const fillsViewport = (bounds) => {
+      return Math.abs(bounds.top) <= 1 &&
+        Math.abs(bounds.right - window.innerWidth) <= 1 &&
+        Math.abs(bounds.bottom - window.innerHeight) <= 1 &&
+        Math.abs(bounds.left) <= 1
+    }
+    return {
+      target: fillsViewport(element.getBoundingClientRect()),
+      video: fillsViewport(element.querySelector(':scope > .player').getBoundingClientRect()),
+    }
+  })).toEqual({ target: true, video: true })
 
   // Vue replaces the class attribute when the player changes into its
   // cross-tab mini-player layout. PiP ownership must survive that update.

--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -1111,6 +1111,9 @@ test('isolates the owning video surface while Android Picture-in-Picture is acti
       const video = document.createElement('video')
       video.className = 'player'
       player.append(video)
+      const canvas = document.createElement('canvas')
+      canvas.className = 'vrCanvas'
+      player.append(canvas)
       document.querySelector('.app > .routerView').append(player)
     }
     document.body.classList.add('androidPictureInPicture')
@@ -1123,6 +1126,7 @@ test('isolates the owning video surface while Android Picture-in-Picture is acti
   await expect(target).toHaveCSS('visibility', 'visible')
   await expect(target.locator('> .player')).toHaveCSS('visibility', 'visible')
   await expect(target.locator('> .player')).toHaveCSS('transition-property', 'none')
+  await expect(target.locator('> .vrCanvas')).toHaveCSS('transition-property', 'none')
   await expect.poll(() => target.evaluate(element => {
     const fillsViewport = (bounds) => {
       return Math.abs(bounds.top) <= 1 &&

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -47,6 +47,13 @@
   visibility: hidden !important;
 }
 
+/* Chromium WebView treats an inline-size query container as the containing
+   block for fixed descendants. Drop that containment so the PiP player uses
+   the activity viewport instead of inheriting the route's top-nav offset. */
+:global(body.androidPictureInPicture .app > .routerView) {
+  container-type: normal;
+}
+
 .mobileLinkActionsBackdrop {
   position: fixed;
   z-index: 1200;
@@ -115,6 +122,7 @@
   block-size: 100% !important;
   border-radius: 0 !important;
   object-fit: contain !important;
+  transition: none !important;
 }
 
 :global(body.androidPictureInPicture .ftVideoPlayer[data-android-picture-in-picture-target] .shaka-controls-container),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No related issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

On affected Samsung tablets, Android picture-in-picture inherited the route container's top navigation offset. The video was misaligned, and resizing the PiP window from a corner could leave it black.

This removes route query containment while native Android PiP is active so the fixed player uses the activity viewport. It also disables video and canvas transitions during PiP resizing. The regression test now uses the real route wrapper and checks containment, transitions, and viewport coverage.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Android picture-in-picture video now stays aligned and visible while resizing on affected Samsung tablets.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware <picture> with dark and light prefers-color-scheme sources and the dark image as its <img> fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through e2e/helpers/visual-fixtures.mjs. Before capturing, verify that every visible image has loaded successfully (complete === true and naturalWidth > 0).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to gh pr create or gh pr edit with --attach <path> so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat --attach <path> for each one. Read back the hosted URLs, replace the temporary references with the <picture> below, and update the pull request body without --attach:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION" regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION". Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run the Android app on a tablet and start video playback.
2. Enter picture-in-picture mode. The video should fill and align with the PiP window without a top offset.
3. Resize the PiP window repeatedly from a corner. The video should remain visible and aligned throughout resizing.

## Additional context
<!-- Add any other context about the pull request here. -->

Verified on a Samsung SM-X920 running Android 14. The original reporter confirmed that corner resizing works after installing the fixed APK.
