### PR TITLE
fix: recover detached picture-in-picture state

### DIFF
--- a/e2e/tests/offline/picture-in-picture-reload.spec.mjs
+++ b/e2e/tests/offline/picture-in-picture-reload.spec.mjs
@@ -1,4 +1,4 @@
-import { test, expect } from '../../helpers/app.mjs'
+import { test, expect, setPlayerFullscreen } from '../../helpers/app.mjs'
 import { activeTab, openMockedVideo, waitForPlayback } from '../../helpers/player.mjs'
 import { mockPlayableWatchPage, watchViewHandle } from '../../helpers/watch.mjs'
 
@@ -32,6 +32,34 @@ function pictureInPictureActive(page) {
   return page.evaluate(() => document.pictureInPictureElement !== null)
 }
 
+async function makeDetachedPictureInPictureExitHang(page) {
+  await page.evaluate(() => {
+    const nativeExitPictureInPicture = document.exitPictureInPicture.bind(document)
+    document.exitPictureInPicture = () => {
+      if (document.pictureInPictureElement?.isConnected === false) {
+        return new Promise(resolve => { window.__resolveStalePipExit = resolve })
+      }
+      return nativeExitPictureInPicture()
+    }
+  })
+}
+
+async function createDetachedPictureInPictureOwner(video) {
+  await video.evaluate(async element => {
+    const owner = document.createElement('div')
+    owner.className = 'ftVideoPlayer'
+    owner.dataset.tabId = element.closest('.ftVideoPlayer').dataset.tabId
+    const orphan = document.createElement('video')
+    orphan.muted = true
+    orphan.src = element.currentSrc
+    owner.append(orphan)
+    document.body.append(owner)
+    await orphan.play()
+    await orphan.requestPictureInPicture()
+    owner.remove()
+  })
+}
+
 test('restores automatic Picture-in-Picture across a video reload', async ({ app, page }) => {
   await mockPlayableWatchPage(app, page)
   await setFocused(app, page, true)
@@ -48,17 +76,37 @@ test('restores automatic Picture-in-Picture across a video reload', async ({ app
   await expect.poll(() => pictureInPictureActive(page)).toBe(false)
 })
 
+test('clears a detached PiP owner when mounting a replacement player', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  await setFocused(app, page, true)
+  const video = await openMockedVideo(page)
+
+  await makeDetachedPictureInPictureExitHang(page)
+  await createDetachedPictureInPictureOwner(video)
+  await expect.poll(() => page.evaluate(() => document.pictureInPictureElement?.isConnected)).toBe(false)
+
+  const watchView = await watchViewHandle(page)
+  await watchView.evaluate(view => view.reloadView())
+  await expect.poll(() => pictureInPictureActive(page)).toBe(false)
+  await setPlayerFullscreen(page, true)
+  await setPlayerFullscreen(page, false)
+})
+
 test('restores user-opened Picture-in-Picture across a video reload', async ({ app, page }) => {
   await mockPlayableWatchPage(app, page)
   await setFocused(app, page, true)
   const video = await openMockedVideo(page)
 
+  await makeDetachedPictureInPictureExitHang(page)
   await video.evaluate(element => element.requestPictureInPicture())
   await expect.poll(() => pictureInPictureActive(page)).toBe(true)
 
   const watchView = await watchViewHandle(page)
   await watchView.evaluate(view => view.reloadView())
-  await expect.poll(() => pictureInPictureActive(page)).toBe(true)
+  const replacementVideo = await waitForPlayback(page)
+  await expect.poll(() => replacementVideo.evaluate(
+    element => document.pictureInPictureElement === element
+  )).toBe(true)
 
   await setMinimized(app, false)
   await page.waitForTimeout(1000)
@@ -88,4 +136,38 @@ test('does not transfer Picture-in-Picture from another tab during reload', asyn
   expect(await originalVideo.evaluate(
     element => document.pictureInPictureElement === element
   )).toBe(true)
+})
+
+test.describe('after default Picture-in-Picture startup', () => {
+  test.use({
+    seed: {
+      settings: {
+        autoPictureInPictureTriggers: ['minimize'],
+        defaultViewingMode: 'pip',
+        videoPlaybackEngine: 'built-in',
+        ytDlpPlaybackEngineDefaultMigration: true
+      }
+    }
+  })
+
+  test('recovers a detached owner after the startup request settles', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await setFocused(app, page, true)
+    const video = await openMockedVideo(page)
+    await expect.poll(() => video.evaluate(
+      element => document.pictureInPictureElement === element
+    )).toBe(true)
+
+    await makeDetachedPictureInPictureExitHang(page)
+    await page.evaluate(() => document.exitPictureInPicture())
+    await createDetachedPictureInPictureOwner(video)
+    await expect.poll(() => page.evaluate(
+      () => document.pictureInPictureElement?.isConnected
+    )).toBe(false)
+
+    await setFocused(app, page, false)
+    await expect.poll(() => pictureInPictureActive(page)).toBe(false)
+    await setPlayerFullscreen(page, true)
+    await setPlayerFullscreen(page, false)
+  })
 })

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1277,6 +1277,7 @@ export default defineComponent({
       tabId,
       isTabPresented,
       isCrossTabMiniPlayerPresented,
+      isPictureInPictureRestorePending: () => startInPip,
       initialState: props.autoPictureInPictureState,
     })
 

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useAutoPictureInPicture.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useAutoPictureInPicture.js
@@ -25,6 +25,7 @@ import {
  *   tabId?: string | null,
  *   isTabPresented?: import('vue').ComputedRef<boolean> | null,
  *   isCrossTabMiniPlayerPresented?: import('vue').Ref<boolean> | null,
+ *   isPictureInPictureRestorePending?: () => boolean,
  *   initialState?: {
  *     minimized?: boolean,
  *     focused?: boolean,
@@ -42,6 +43,7 @@ export function useAutoPictureInPicture({
   tabId = null,
   isTabPresented = null,
   isCrossTabMiniPlayerPresented = null,
+  isPictureInPictureRestorePending = () => false,
   initialState = null
 }) {
   const isActiveTab = computed(() => {
@@ -69,6 +71,8 @@ export function useAutoPictureInPicture({
   let removeMinimizedListener = null
   let removeFocusedListener = null
   let blurTriggerRecheckTimeout = null
+  let stalePictureInPictureRecovery = null
+  let autoPictureInPictureTornDown = false
   let wasAndroidPictureInPictureTarget = isAndroidPictureInPictureTarget.value
 
   function canAutoPipNow() {
@@ -125,6 +129,8 @@ export function useAutoPictureInPicture({
       ).catch(error => console.warn('Failed to configure Android auto Picture-in-Picture:', error))
       return
     }
+
+    if (recoverStalePictureInPicture()) return
 
     const ui = getUi()
     if (!ui) return
@@ -197,7 +203,58 @@ export function useAutoPictureInPicture({
     updateAutoPip()
   }
 
+  function recoverStalePictureInPicture() {
+    const pictureInPictureElement = document.pictureInPictureElement
+    const ownerTabId = pictureInPictureElement
+      ?.closest('.ftVideoPlayer')
+      ?.getAttribute('data-tab-id')
+    const ownerTabStillMounted = ownerTabId != null && [...document.querySelectorAll('.tabContent')]
+      .some(tabContent => tabContent.getAttribute('data-tab-id') === ownerTabId)
+
+    if (
+      isPictureInPictureRestorePending() ||
+      pictureInPictureElement?.isConnected !== false ||
+      (ownerTabId !== tabId && ownerTabStillMounted)
+    ) {
+      return false
+    }
+
+    const videoElement = video.value
+    if (
+      stalePictureInPictureRecovery ||
+      !videoElement ||
+      videoElement.readyState < HTMLMediaElement.HAVE_METADATA
+    ) {
+      return true
+    }
+
+    const keepPictureInPicture = shouldAutoPipNow()
+    let recoverySucceeded = false
+    markPictureInPictureRequested(state, true, { automatic: keepPictureInPicture })
+    stalePictureInPictureRecovery = (async () => {
+      await videoElement.requestPictureInPicture()
+      if (keepPictureInPicture && !autoPictureInPictureTornDown) return
+
+      markPictureInPictureRequested(state, false)
+      await document.exitPictureInPicture()
+    })()
+      .then(() => {
+        recoverySucceeded = true
+      })
+      .catch(error => {
+        markPictureInPictureRequestFailed(state)
+        console.warn('Failed to recover stale Picture-in-Picture:', error)
+      })
+      .finally(() => {
+        stalePictureInPictureRecovery = null
+        if (recoverySucceeded && !autoPictureInPictureTornDown) updateAutoPip()
+      })
+
+    return true
+  }
+
   function setupAutoPictureInPicture() {
+    autoPictureInPictureTornDown = false
     if (process.env.IS_CAPACITOR) {
       video.value?.addEventListener('play', updateAutoPip)
       video.value?.addEventListener('pause', updateAutoPip)
@@ -212,6 +269,7 @@ export function useAutoPictureInPicture({
       window.addEventListener('blur', refreshFocusState)
     }
     stopActiveTabWatch = watch(isActiveTab, updateAutoPip)
+    recoverStalePictureInPicture()
   }
 
   /**
@@ -250,6 +308,7 @@ export function useAutoPictureInPicture({
   }
 
   function teardownAutoPictureInPicture() {
+    autoPictureInPictureTornDown = true
     if (process.env.IS_CAPACITOR) {
       video.value?.removeEventListener('play', updateAutoPip)
       video.value?.removeEventListener('pause', updateAutoPip)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No public issue. Reproduced from a live app session.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Automatic Picture-in-Picture could leave Chromium pointing at a disconnected video after the player was replaced. The PiP control would remain stuck on "Exit Picture-in-Picture", and fullscreen would stop working.

When this state is detected, the replacement player now transfers PiP ownership to its connected video before exiting. Intentional PiP restoration and PiP owned by another mounted tab remain unchanged. The restore guard also follows the live one-shot restore state instead of retaining its initial value.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Picture-in-Picture no longer gets stuck after a video player is replaced.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Enable automatic Picture-in-Picture when the app loses focus.
2. Play a video, switch to another application so PiP opens, then return and reload the video player.
3. Repeat the focus change and return to the app.
4. Confirm the PiP control returns to "Enter Picture-in-Picture" after PiP closes and fullscreen still opens normally.

## Additional context
<!-- Add any other context about the pull request here. -->

Chromium can leave `document.pictureInPictureElement` pointing at a disconnected video. Calling `document.exitPictureInPicture()` directly can then remain pending, so recovery first moves PiP to the connected replacement video.
