### PR TITLE
feat(tabs): show sync device names in organizers

### DIFF
--- a/e2e/tests/network/sync-server.spec.mjs
+++ b/e2e/tests/network/sync-server.spec.mjs
@@ -326,10 +326,10 @@ test.describe('OpenTubeX sync server', () => {
           return
         }
         holdStaleSessionRequest = false
+        const response = await route.fetch()
         staleSessionRequestStarted()
         await staleSessionRequestPending
         try {
-          const response = await route.fetch()
           await route.fulfill({ response })
         } finally {
           staleSessionRequestFinished()
@@ -361,10 +361,18 @@ test.describe('OpenTubeX sync server', () => {
         headers.Authorization = latestSettings(
           await readFile(settingsPath, 'utf8')
         ).syncServerToken
+        await page.evaluate(() => {
+          const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+          store.commit('setSyncServerDeviceNames', { 'new-account': 'New account' })
+        })
       } finally {
         finishStaleSessionRequest()
       }
       await staleSessionRequestCompleted
+      await expect.poll(() => page.evaluate(() => {
+        const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+        return store.state.syncServer.syncServerDeviceNames
+      })).toEqual({ 'new-account': 'New account' })
       await expect(syncSection.getByText(`Connected as ${username}`)).toBeVisible()
       await expect(currentCard).toBeVisible()
 

--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -2207,19 +2207,19 @@ test.describe('tab organizer', () => {
     )
     let markDelayedResponseStarted
     let releaseDelayedResponse
-    let markExpiredSessionResponseStarted
-    let releaseExpiredSessionResponse
+    let markTokenReplacementResponseStarted
+    let releaseTokenReplacementResponse
     const delayedResponseStarted = new Promise(resolve => {
       markDelayedResponseStarted = resolve
     })
     const delayedResponseRelease = new Promise(resolve => {
       releaseDelayedResponse = resolve
     })
-    const expiredSessionResponseStarted = new Promise(resolve => {
-      markExpiredSessionResponseStarted = resolve
+    const tokenReplacementResponseStarted = new Promise(resolve => {
+      markTokenReplacementResponseStarted = resolve
     })
-    const expiredSessionResponseRelease = new Promise(resolve => {
-      releaseExpiredSessionResponse = resolve
+    const tokenReplacementResponseRelease = new Promise(resolve => {
+      releaseTokenReplacementResponse = resolve
     })
     let accountSessionRequests = 0
     let healthRequests = 0
@@ -2238,8 +2238,8 @@ test.describe('tab organizer', () => {
           markDelayedResponseStarted()
           await delayedResponseRelease
         } else if (requestNumber === 4) {
-          markExpiredSessionResponseStarted()
-          await expiredSessionResponseRelease
+          markTokenReplacementResponseStarted()
+          await tokenReplacementResponseRelease
         }
         await route.fulfill({
           status: 200,
@@ -2381,18 +2381,22 @@ test.describe('tab organizer', () => {
     await organizer.locator('.tabOrganizerHeader .iconButton').click()
     await expect(organizer).toBeHidden()
     await page.locator(sel.tabOrganizerButton).click()
-    await expiredSessionResponseStarted
+    await tokenReplacementResponseStarted
     await expect.poll(() => accountSessionRequests).toBe(4)
     await page.evaluate(async () => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
-      await store.dispatch('expireSyncServerSession')
+      await store.dispatch('replaceSyncServerToken', 'replacement-token')
     })
-    releaseExpiredSessionResponse()
+    releaseTokenReplacementResponse()
     await expect.poll(() => page.evaluate(() => window.__deviceNameRefreshCompletions)).toBe(4)
     await expect.poll(() => page.evaluate(() => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       return store.state.syncServer.syncServerDeviceNames
     })).toEqual({})
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.getters.getSyncServerToken
+    })).toBe('replacement-token')
   })
 
   test('clamps scroll after switching to a shorter synced session at fractional UI scale', async ({ page }) => {

--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -2207,11 +2207,19 @@ test.describe('tab organizer', () => {
     )
     let markDelayedResponseStarted
     let releaseDelayedResponse
+    let markExpiredSessionResponseStarted
+    let releaseExpiredSessionResponse
     const delayedResponseStarted = new Promise(resolve => {
       markDelayedResponseStarted = resolve
     })
     const delayedResponseRelease = new Promise(resolve => {
       releaseDelayedResponse = resolve
+    })
+    const expiredSessionResponseStarted = new Promise(resolve => {
+      markExpiredSessionResponseStarted = resolve
+    })
+    const expiredSessionResponseRelease = new Promise(resolve => {
+      releaseExpiredSessionResponse = resolve
     })
     let accountSessionRequests = 0
     let healthRequests = 0
@@ -2229,6 +2237,9 @@ test.describe('tab organizer', () => {
         if (requestNumber === 2) {
           markDelayedResponseStarted()
           await delayedResponseRelease
+        } else if (requestNumber === 4) {
+          markExpiredSessionResponseStarted()
+          await expiredSessionResponseRelease
         }
         await route.fulfill({
           status: 200,
@@ -2366,6 +2377,22 @@ test.describe('tab organizer', () => {
     await expect(renamedMobileTab).toHaveCount(0)
     await expect(desktopTab).toHaveAttribute('aria-selected', 'true')
     await expect(syncedSet).toContainText('Desktop synced tab')
+
+    await organizer.locator('.tabOrganizerHeader .iconButton').click()
+    await expect(organizer).toBeHidden()
+    await page.locator(sel.tabOrganizerButton).click()
+    await expiredSessionResponseStarted
+    await expect.poll(() => accountSessionRequests).toBe(4)
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('expireSyncServerSession')
+    })
+    releaseExpiredSessionResponse()
+    await expect.poll(() => page.evaluate(() => window.__deviceNameRefreshCompletions)).toBe(4)
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.state.syncServer.syncServerDeviceNames
+    })).toEqual({})
   })
 
   test('clamps scroll after switching to a shorter synced session at fractional UI scale', async ({ page }) => {

--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -1,4 +1,10 @@
+import { randomBytes } from 'node:crypto'
+
 import { test, expect, sel, goTo, goToSettingsSection } from '../../helpers/app.mjs'
+import {
+  encryptSyncServerDeviceInfo,
+  randomSyncServerDeviceId,
+} from '../../../src/renderer/helpers/sync-server-sessions.js'
 
 /**
  * Returns the box of an element that has stopped moving. Menus and submenus
@@ -2185,16 +2191,78 @@ test.describe('background tab shortcuts', () => {
 
 test.describe('tab organizer', () => {
   test('shows synced tab sets in device tabs and confirms deletion', async ({ page }) => {
-    await page.evaluate(() => {
+    const privacyKey = randomBytes(32).toString('base64')
+    const phoneDeviceId = randomSyncServerDeviceId()
+    const desktopDeviceId = randomSyncServerDeviceId()
+    const phoneDeviceInfo = {
+      name: 'Pixel 9',
+      platform: 'android',
+      architecture: 'arm64-v8a',
+      release: '16',
+    }
+    let encryptedPhoneInfo = await encryptSyncServerDeviceInfo(
+      phoneDeviceInfo,
+      privacyKey,
+      phoneDeviceId
+    )
+    let markDelayedResponseStarted
+    let releaseDelayedResponse
+    const delayedResponseStarted = new Promise(resolve => {
+      markDelayedResponseStarted = resolve
+    })
+    const delayedResponseRelease = new Promise(resolve => {
+      releaseDelayedResponse = resolve
+    })
+    let accountSessionRequests = 0
+    let healthRequests = 0
+    await page.route('https://sync.d3sox.me/**', async route => {
+      const pathname = new URL(route.request().url()).pathname
+      if (pathname === '/health') {
+        healthRequests++
+        await route.fulfill({
+          status: 200,
+          json: { capabilities: { account_sessions: 1 } },
+        })
+      } else if (pathname === '/v1/account/sessions') {
+        const requestNumber = ++accountSessionRequests
+        const responseEncryptedPhoneInfo = encryptedPhoneInfo
+        if (requestNumber === 2) {
+          markDelayedResponseStarted()
+          await delayedResponseRelease
+        }
+        await route.fulfill({
+          status: 200,
+          json: {
+            sessions: [{
+              device_id: phoneDeviceId,
+              encrypted_device_info: responseEncryptedPhoneInfo,
+            }],
+          },
+        })
+      } else {
+        await route.fulfill({ status: 500, body: 'Unexpected sync request' })
+      }
+    })
+
+    await page.evaluate(({ desktopDeviceId, phoneDeviceId, privacyKey }) => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       store.commit('setSyncServerEnabled', true)
       store.commit('setSyncServerToken', 'e2e-token')
+      store.commit('setSyncServerPrivacyKey', privacyKey)
       store.commit('setSyncServerPrivacyMode', 'enhanced')
       store.commit('setSyncServerSyncSessions', true)
       store.commit('setSyncServerSharedTabs', false)
+      window.__deviceNameRefreshCompletions = 0
+      store.subscribeAction({
+        after(action) {
+          if (action.type === 'refreshSyncServerDeviceNames') {
+            window.__deviceNameRefreshCompletions++
+          }
+        },
+      })
       store.commit('setSyncServerOtherDeviceSessions', [
         {
-          syncDeviceId: 'phone-e2e',
+          syncDeviceId: phoneDeviceId,
           syncPlatform: 'mobile',
           sessionId: 'mobile-session-e2e',
           tabs: [
@@ -2203,7 +2271,7 @@ test.describe('tab organizer', () => {
           ],
         },
         {
-          syncDeviceId: 'desktop-e2e',
+          syncDeviceId: desktopDeviceId,
           syncPlatform: 'desktop',
           sessionId: 'desktop-session-e2e',
           tabs: [
@@ -2221,15 +2289,18 @@ test.describe('tab organizer', () => {
         )
         return Promise.resolve(true)
       }]
-    })
+    }, { desktopDeviceId, phoneDeviceId, privacyKey })
 
     await page.locator(sel.tabOrganizerButton).click()
     const organizer = page.getByRole('dialog', { name: 'Tab Organizer' })
     const syncedSection = organizer.locator('.syncedTabsSection')
     const sessionTabs = syncedSection.getByRole('tablist', { name: 'Tabs from other devices' })
-    const mobileTab = sessionTabs.getByRole('tab', { name: 'Mobile · 2 tabs', exact: true })
+    const mobileTab = sessionTabs.getByRole('tab', { name: 'Pixel 9 · 2 tabs', exact: true })
     const desktopTab = sessionTabs.getByRole('tab', { name: 'Desktop · 1 tab', exact: true })
     const syncedSet = syncedSection.getByRole('tabpanel')
+    await expect.poll(() => accountSessionRequests).toBe(1)
+    await expect.poll(() => page.evaluate(() => window.__deviceNameRefreshCompletions)).toBe(1)
+    expect(healthRequests).toBe(0)
     await expect(syncedSection.getByRole('heading', { name: 'Tabs from other devices' })).toBeVisible()
     await expect(sessionTabs.getByRole('tab')).toHaveCount(2)
     await expect(mobileTab).toHaveAttribute('aria-selected', 'true')
@@ -2241,27 +2312,58 @@ test.describe('tab organizer', () => {
     await expect(syncedSet.locator('[data-icon="arrow-up-right-from-square"]')).toHaveCount(2)
     await expect(syncedSet).not.toContainText('Desktop synced tab')
 
-    await mobileTab.press('ArrowRight')
+    encryptedPhoneInfo = await encryptSyncServerDeviceInfo(
+      { ...phoneDeviceInfo, name: 'Stale phone' },
+      privacyKey,
+      phoneDeviceId
+    )
+    await organizer.locator('.tabOrganizerHeader .iconButton').click()
+    await expect(organizer).toBeHidden()
+    await page.locator(sel.tabOrganizerButton).click()
+    await delayedResponseStarted
+    await expect.poll(() => accountSessionRequests).toBe(2)
+
+    encryptedPhoneInfo = await encryptSyncServerDeviceInfo(
+      { ...phoneDeviceInfo, name: 'Travel phone' },
+      privacyKey,
+      phoneDeviceId
+    )
+    await organizer.locator('.tabOrganizerHeader .iconButton').click()
+    await expect(organizer).toBeHidden()
+    await page.locator(sel.tabOrganizerButton).click()
+    await expect.poll(() => accountSessionRequests).toBe(3)
+    await expect.poll(() => page.evaluate(() => window.__deviceNameRefreshCompletions)).toBe(2)
+    expect(healthRequests).toBe(0)
+    const renamedMobileTab = sessionTabs.getByRole('tab', {
+      name: 'Travel phone · 2 tabs',
+      exact: true,
+    })
+    await expect(renamedMobileTab).toBeVisible()
+    releaseDelayedResponse()
+    await expect.poll(() => page.evaluate(() => window.__deviceNameRefreshCompletions)).toBe(3)
+    await expect(renamedMobileTab).toBeVisible()
+
+    await renamedMobileTab.press('ArrowRight')
     await expect(desktopTab).toBeFocused()
     await expect(desktopTab).toHaveAttribute('aria-selected', 'true')
     await expect(syncedSet).toContainText('Desktop synced tab')
     await expect(syncedSet).not.toContainText('Synced watch tab')
 
     await desktopTab.press('Home')
-    await expect(mobileTab).toBeFocused()
+    await expect(renamedMobileTab).toBeFocused()
     await expect(syncedSet).toContainText('Synced watch tab')
 
-    const deleteSet = syncedSet.getByRole('button', { name: 'Delete: Mobile · 2 tabs' })
+    const deleteSet = syncedSet.getByRole('button', { name: 'Delete: Travel phone · 2 tabs' })
     await deleteSet.click()
     let confirmation = page.getByRole('dialog', { name: 'Delete' })
-    await expect(confirmation).toContainText('Mobile · 2 tabs')
+    await expect(confirmation).toContainText('Travel phone · 2 tabs')
     await confirmation.getByRole('button', { name: 'Cancel' }).click()
     await expect(syncedSet).toBeVisible()
 
     await deleteSet.click()
     confirmation = page.getByRole('dialog', { name: 'Delete' })
     await confirmation.getByRole('button', { name: 'Delete', exact: true }).click()
-    await expect(mobileTab).toHaveCount(0)
+    await expect(renamedMobileTab).toHaveCount(0)
     await expect(desktopTab).toHaveAttribute('aria-selected', 'true')
     await expect(syncedSet).toContainText('Desktop synced tab')
   })

--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -1,9 +1,14 @@
+import { randomBytes } from 'node:crypto'
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { test, expect, goTo, repoRoot, setWindowSize } from '../../helpers/app.mjs'
 import { findWatchComponent, openMockedVideo } from '../../helpers/player.mjs'
 import { mockPlayableWatchPage } from '../../helpers/watch.mjs'
+import {
+  encryptSyncServerDeviceInfo,
+  randomSyncServerDeviceId,
+} from '../../../src/renderer/helpers/sync-server-sessions.js'
 
 function historyEntry(videoId, title, timeWatched) {
   return {
@@ -128,7 +133,7 @@ test('fits synced-device tabs in the phone tab organizer', async ({ app, page })
       <div class="capacitorPhoneSyncedTabs" role="tabpanel">
         <article class="capacitorPhoneSyncedSession">
           <header class="capacitorPhoneSyncedSessionHeader">
-            <strong>Desktop · 2 tabs</strong>
+            <strong>A very long encrypted device name that must wrap · 2 tabs</strong>
             <button class="capacitorPhoneSyncedTabButton capacitorPhoneSyncedOpenAll"><span aria-hidden="true">↗</span><span>Open all tabs</span></button>
           </header>
           <div class="capacitorPhoneSyncedTabList">
@@ -169,18 +174,49 @@ test('fits synced-device tabs in the phone tab organizer', async ({ app, page })
 })
 
 test('restores and clamps the real phone tab organizer viewports', async ({ app, page }) => {
+  const privacyKey = randomBytes(32).toString('base64')
+  const desktopDeviceId = randomSyncServerDeviceId()
+  const encryptedDeviceInfo = await encryptSyncServerDeviceInfo({
+    name: 'Living room PC',
+    platform: 'linux',
+    architecture: 'x64',
+    release: '6.16.4-arch1-1',
+  }, privacyKey, desktopDeviceId)
+  let accountSessionRequests = 0
+  let healthRequests = 0
+  await page.route('https://sync.d3sox.me/**', async route => {
+    const pathname = new URL(route.request().url()).pathname
+    if (pathname === '/health') {
+      healthRequests++
+      await route.fulfill({ status: 200, json: { capabilities: { account_sessions: 1 } } })
+    } else if (pathname === '/v1/account/sessions') {
+      accountSessionRequests++
+      await route.fulfill({
+        status: 200,
+        json: {
+          sessions: [{
+            device_id: desktopDeviceId,
+            encrypted_device_info: encryptedDeviceInfo,
+          }],
+        },
+      })
+    } else {
+      await route.fulfill({ status: 500, body: 'Unexpected sync request' })
+    }
+  })
   await setWindowSize(app, page, { width: 375, height: 760 })
   await page.evaluate(() => window.ftElectron.setZoomFactor(0.95))
   await enablePhoneTabSwitcher(page)
-  await page.evaluate(async () => {
+  await page.evaluate(async ({ desktopDeviceId, privacyKey }) => {
     const store = document.querySelector('#app')._vnode.component.appContext.config.globalProperties.$store
     store.commit('setSyncServerEnabled', true)
     store.commit('setSyncServerToken', 'e2e-token')
+    store.commit('setSyncServerPrivacyKey', privacyKey)
     store.commit('setSyncServerPrivacyMode', 'enhanced')
     store.commit('setSyncServerSyncSessions', true)
     store.commit('setSyncServerSharedTabs', false)
     store.commit('setSyncServerOtherDeviceSessions', [{
-      syncDeviceId: 'desktop-e2e',
+      syncDeviceId: desktopDeviceId,
       syncPlatform: 'desktop',
       sessionId: 'session-e2e',
       tabs: Array.from({ length: 30 }, (_, index) => ({
@@ -192,9 +228,11 @@ test('restores and clamps the real phone tab organizer viewports', async ({ app,
     for (let index = 0; index < 30; index++) {
       await store.dispatch('createTab', { route: `/watch/local-${index}`, makeActive: false })
     }
-  })
+  }, { desktopDeviceId, privacyKey })
   await expect.poll(() => page.locator('.capacitorPhoneTabCount').textContent()).toBe('31')
   await page.locator('.capacitorPhoneTabSwitcherButton').click()
+  await expect.poll(() => accountSessionRequests).toBe(1)
+  expect(healthRequests).toBe(0)
 
   const openPanel = page.locator('#capacitor-phone-open-tabs-panel')
   await expect(openPanel).toHaveAttribute('data-overlayscrollbars-viewport')
@@ -204,6 +242,8 @@ test('restores and clamps the real phone tab organizer viewports', async ({ app,
   await page.getByRole('tab', { name: 'Tabs from other devices' }).click()
 
   const syncedPanel = page.locator('#capacitor-phone-synced-tabs-panel')
+  await expect(syncedPanel.locator('.capacitorPhoneSyncedSessionHeader strong'))
+    .toHaveText('Living room PC · 30 tabs')
   await expect(syncedPanel).toHaveAttribute('data-overlayscrollbars-viewport')
   await syncedPanel.evaluate(element => { element.scrollTop = 360 })
   await expect.poll(async () => (await phoneTabScrollState(page, '.capacitorPhoneSyncedTabsContent')).scrollTop)
@@ -229,18 +269,19 @@ test('restores and clamps the real phone tab organizer viewports', async ({ app,
   await expect.poll(async () => (await phoneTabScrollState(page, '.capacitorPhoneSyncedTabsContent')).scrollTop)
     .toBeCloseTo(360, 0)
   await syncedPanel.evaluate(element => { element.scrollTop = element.scrollHeight })
-  await page.evaluate(() => {
+  await page.evaluate(desktopDeviceId => {
     const store = document.querySelector('#app')._vnode.component.appContext.config.globalProperties.$store
+    store.commit('setSyncServerDeviceNames', { [desktopDeviceId]: 'Desk PC' })
     store.commit('setSyncServerOtherDeviceSessions', [{
-      syncDeviceId: 'desktop-e2e',
+      syncDeviceId: desktopDeviceId,
       syncPlatform: 'desktop',
       sessionId: 'session-e2e',
       tabs: [{ id: 'synced-0', title: 'Synced tab 0', url: '/watch/synced-0' }],
     }])
-  })
+  }, desktopDeviceId)
   await expect(page.locator('.capacitorPhoneSyncedTabTarget')).toHaveCount(1)
   await expect(syncedPanel.locator('.capacitorPhoneSyncedSessionHeader strong'))
-    .toHaveText('Desktop · 1 tab')
+    .toHaveText('Desk PC · 1 tab')
   await expect.poll(() => phoneTabScrollState(page, '.capacitorPhoneSyncedTabsContent')).toEqual({
     scrollTop: 0,
     maximum: 0,

--- a/src/renderer/components/SyncSettings/SyncAccountManagement.vue
+++ b/src/renderer/components/SyncSettings/SyncAccountManagement.vue
@@ -350,6 +350,7 @@ async function loadSessions(token = props.token) {
     if (!response || !Array.isArray(response.sessions)) throw new Error()
     emit('password-login-changed', response.password_login === true)
     const currentSystemInfo = await getCurrentSyncServerSystemInfo()
+    const deviceNames = {}
     sessions.value = await Promise.all(response.sessions.map(async session => {
       if (!session || typeof session.id !== 'string' ||
           !isValidSyncServerDeviceId(session.device_id) ||
@@ -399,8 +400,12 @@ async function loadSessions(token = props.token) {
         )
         await requestClient.updateAccountSession(session.id, session.encrypted_device_info)
       }
+      if (deviceInfoDecrypted || currentSystemInfoChanged) {
+        deviceNames[session.device_id] = deviceInfo.name
+      }
       return { ...session, deviceInfo }
     }))
+    store.commit('setSyncServerDeviceNames', deviceNames)
   } catch (requestError) {
     await handleRequestError(requestError, requestClient.token)
   } finally {

--- a/src/renderer/components/SyncSettings/SyncAccountManagement.vue
+++ b/src/renderer/components/SyncSettings/SyncAccountManagement.vue
@@ -405,7 +405,9 @@ async function loadSessions(token = props.token) {
       }
       return { ...session, deviceInfo }
     }))
-    store.commit('setSyncServerDeviceNames', deviceNames)
+    if (requestClient.token === store.getters.getSyncServerToken) {
+      store.commit('setSyncServerDeviceNames', deviceNames)
+    }
   } catch (requestError) {
     await handleRequestError(requestError, requestClient.token)
   } finally {

--- a/src/renderer/components/SyncSettings/SyncSettings.vue
+++ b/src/renderer/components/SyncSettings/SyncSettings.vue
@@ -834,7 +834,7 @@ async function changePassword() {
   try {
     const response = await client.changePassword(currentPassword.value, newPassword.value)
     if (!response || typeof response.jwt !== 'string' || !response.jwt) throw new Error()
-    await store.dispatch('updateSyncServerToken', response.jwt)
+    await store.dispatch('replaceSyncServerToken', response.jwt)
     resetPasswordPrompt()
     showToast({
       message: t('Settings.Sync Settings.Password Changed'),

--- a/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.vue
+++ b/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.vue
@@ -419,6 +419,11 @@ const {
 function openSwitcher() {
   activeView.value = 'open'
   open.value = true
+  if (showSyncedTabsView.value) {
+    store.dispatch('refreshSyncServerDeviceNames').catch(error => {
+      console.error('Failed to refresh sync device names:', error)
+    })
+  }
 }
 
 async function selectView(view, focus = false) {

--- a/src/renderer/components/TabOrganizer/TabOrganizer.vue
+++ b/src/renderer/components/TabOrganizer/TabOrganizer.vue
@@ -774,6 +774,11 @@ onBeforeMount(lockBodyScroll)
 onMounted(async () => {
   lastActiveElement = document.activeElement
   store.commit('addOpenPrompt', promptId)
+  if (showSyncedTabs.value) {
+    store.dispatch('refreshSyncServerDeviceNames').catch(error => {
+      console.error('Failed to refresh sync device names:', error)
+    })
+  }
   await window.ftElectron.tabs.setShortcutsBlocked(true).catch(error => {
     console.error('Failed to block shortcuts for the tab organizer:', error)
   })

--- a/src/renderer/helpers/sync-server-sessions.js
+++ b/src/renderer/helpers/sync-server-sessions.js
@@ -177,3 +177,30 @@ export async function decryptSyncServerDeviceInfo(payload, exportedKey, deviceId
     throw new Error('The encrypted sync device info is invalid')
   }
 }
+
+export async function loadSyncServerDeviceNames(client, exportedKey) {
+  const response = await client.getAccountSessions()
+  if (!response || !Array.isArray(response.sessions)) {
+    throw new Error('The sync server account sessions are invalid')
+  }
+
+  const entries = await Promise.all(response.sessions.map(async session => {
+    if (!isValidSyncServerDeviceId(session?.device_id) ||
+        typeof session.encrypted_device_info !== 'string') {
+      return null
+    }
+
+    try {
+      const deviceInfo = await decryptSyncServerDeviceInfo(
+        session.encrypted_device_info,
+        exportedKey,
+        session.device_id
+      )
+      return [session.device_id, deviceInfo.name]
+    } catch {
+      return null
+    }
+  }))
+
+  return Object.fromEntries(entries.filter(Boolean))
+}

--- a/src/renderer/helpers/sync-server.js
+++ b/src/renderer/helpers/sync-server.js
@@ -26,6 +26,7 @@ import {
 import { createSyncServerRequestHeaders } from './sync-server-request'
 import { isValidPlaylistBookmark, playlistBookmarkForSync } from './playlist-bookmarks'
 import { getOtherDeviceSessions, mergeSyncSessions } from './sync-sessions'
+import { isValidSyncServerDeviceId } from './sync-server-sessions'
 import { mergeSettingEntry } from './sync-settings-conflict'
 import { getCapacitorTabService } from '../tabs/CapacitorTabService'
 import { capacitorHttpFetch } from './api/capacitor-http'
@@ -1115,10 +1116,23 @@ function getSyncDeviceId() {
   }
 }
 
-export function getSavedOtherDeviceSessions(snapshot) {
+function getTabSessionDeviceIdentity(settings = {}) {
+  const legacyDeviceId = getSyncDeviceId()
+  const deviceId = isValidSyncServerDeviceId(settings.syncServerDeviceId)
+    ? settings.syncServerDeviceId
+    : legacyDeviceId
+  return {
+    deviceId,
+    legacyDeviceIds: deviceId === legacyDeviceId ? [] : [legacyDeviceId],
+  }
+}
+
+export function getSavedOtherDeviceSessions(snapshot, settings) {
+  const { deviceId, legacyDeviceIds } = getTabSessionDeviceIdentity(settings)
   return getOtherDeviceSessions(
     snapshot?.sessionsV2 ?? snapshot?.sessions,
-    getSyncDeviceId()
+    deviceId,
+    legacyDeviceIds
   )
 }
 
@@ -1143,13 +1157,15 @@ export async function syncSessions(client, store, previous = null) {
 
   const local = await tabs.getSyncSessions()
   const remote = await client.getSessions()
+  const { deviceId, legacyDeviceIds } = getTabSessionDeviceIdentity(store.state.settings)
   const merged = mergeSyncSessions({
     localSessions: local,
     remoteValue: remote,
     previousValue: previous,
-    deviceId: getSyncDeviceId(),
+    deviceId,
     platform: process.env.IS_CAPACITOR ? 'mobile' : 'desktop',
     preferredMode: store.state.settings.syncServerSharedTabs ? 'shared' : 'separate',
+    legacyDeviceIds,
   })
 
   if (!metadataEquals(local, merged.sessionsToApply) && merged.sessionsToApply.length > 0) {

--- a/src/renderer/helpers/sync-sessions.js
+++ b/src/renderer/helpers/sync-sessions.js
@@ -132,7 +132,20 @@ function claimLegacyDeviceSessions(document, deviceId, legacyDeviceIds) {
   for (const legacyDeviceId of legacyDeviceIds) {
     if (legacyDeviceId === deviceId || !claimed.devices[legacyDeviceId]) continue
 
-    claimed.devices[deviceId] ??= claimed.devices[legacyDeviceId]
+    const legacyDevice = claimed.devices[legacyDeviceId]
+    const currentDevice = claimed.devices[deviceId]
+    if (currentDevice) {
+      const currentSessionIds = new Set(
+        currentDevice.sessions.map(session => session?.sessionId)
+      )
+      for (const session of legacyDevice.sessions) {
+        if (currentSessionIds.has(session?.sessionId)) continue
+        currentDevice.sessions.push(session)
+        currentSessionIds.add(session?.sessionId)
+      }
+    } else {
+      claimed.devices[deviceId] = legacyDevice
+    }
     delete claimed.devices[legacyDeviceId]
     if (claimed.deletedSessions[legacyDeviceId]) {
       claimed.deletedSessions[deviceId] = Array.from(new Set([

--- a/src/renderer/helpers/sync-sessions.js
+++ b/src/renderer/helpers/sync-sessions.js
@@ -72,10 +72,11 @@ export function normalizeSyncSessionsDocument(value) {
   }
 }
 
-export function getOtherDeviceSessions(value, deviceId) {
+export function getOtherDeviceSessions(value, deviceId, legacyDeviceIds = []) {
   const document = normalizeSyncSessionsDocument(value)
+  const currentDeviceIds = new Set([deviceId, ...legacyDeviceIds])
   return Object.entries(document.devices)
-    .filter(([id]) => id !== deviceId)
+    .filter(([id]) => !currentDeviceIds.has(id))
     .flatMap(([id, device]) => device.sessions.map(session => ({
       ...clone(session),
       syncDeviceId: id,
@@ -117,10 +118,31 @@ export function shouldShowOtherDeviceSessions({
 
 export function formatDeviceSessionLabel(session, t) {
   const count = session.tabs.length
-  const platform = session.syncPlatform === 'mobile'
+  const fallbackName = session.syncPlatform === 'mobile'
     ? t('Settings.Sync Settings.Mobile Device')
     : t('Settings.Sync Settings.Desktop Device')
-  return `${platform} · ${t('Tab Organizer.Tab Count', { count }, count)}`
+  const name = typeof session.syncDeviceName === 'string' && session.syncDeviceName.trim()
+    ? session.syncDeviceName
+    : fallbackName
+  return `${name} · ${t('Tab Organizer.Tab Count', { count }, count)}`
+}
+
+function claimLegacyDeviceSessions(document, deviceId, legacyDeviceIds) {
+  const claimed = clone(document)
+  for (const legacyDeviceId of legacyDeviceIds) {
+    if (legacyDeviceId === deviceId || !claimed.devices[legacyDeviceId]) continue
+
+    claimed.devices[deviceId] ??= claimed.devices[legacyDeviceId]
+    delete claimed.devices[legacyDeviceId]
+    if (claimed.deletedSessions[legacyDeviceId]) {
+      claimed.deletedSessions[deviceId] = Array.from(new Set([
+        ...(claimed.deletedSessions[deviceId] ?? []),
+        ...claimed.deletedSessions[legacyDeviceId],
+      ]))
+      delete claimed.deletedSessions[legacyDeviceId]
+    }
+  }
+  return claimed
 }
 
 function claimLegacyDesktopSessions(document, deviceId, platform) {
@@ -162,18 +184,27 @@ export function mergeSyncSessions({
   deviceId,
   platform,
   preferredMode,
+  legacyDeviceIds = [],
 }) {
-  const remote = claimLegacyDesktopSessions(
-    normalizeSyncSessionsDocument(remoteValue),
+  const remote = claimLegacyDeviceSessions(
+    claimLegacyDesktopSessions(
+      normalizeSyncSessionsDocument(remoteValue),
+      deviceId,
+      platform
+    ),
     deviceId,
-    platform
+    legacyDeviceIds
   )
   const previous = previousValue === null
     ? null
-    : claimLegacyDesktopSessions(
-        normalizeSyncSessionsDocument(previousValue),
+    : claimLegacyDeviceSessions(
+        claimLegacyDesktopSessions(
+          normalizeSyncSessionsDocument(previousValue),
+          deviceId,
+          platform
+        ),
         deviceId,
-        platform
+        legacyDeviceIds
       )
   const localMode = preferredMode === 'shared' ? 'shared' : 'separate'
   const localModeChanged = previous !== null && previous.mode !== localMode

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -25,7 +25,10 @@ import {
   migrateLegacyPlaybackSpeedsToSettings,
   preparePrivacyKey,
 } from '../../helpers/sync-server-privacy'
-import { encryptSyncServerDeviceInfo } from '../../helpers/sync-server-sessions'
+import {
+  encryptSyncServerDeviceInfo,
+  loadSyncServerDeviceNames,
+} from '../../helpers/sync-server-sessions'
 import { mergePlaylistBookmarkConflict } from '../../helpers/playlist-bookmarks'
 import { getPreviousSyncSessions, removeSyncSession } from '../../helpers/sync-sessions'
 import {
@@ -51,6 +54,7 @@ const activeSyncClients = new Set()
 let autoSyncTimer = null
 let eventSyncTimer = null
 let lifecycleSyncStarted = false
+let deviceNameRefreshId = 0
 
 function trackSyncClient(client) {
   activeSyncClients.add(client)
@@ -71,6 +75,16 @@ function assertSyncEnabled(rootState, client) {
   }
 }
 
+async function tryLoadSyncServerDeviceNames(client, privacyKey) {
+  try {
+    return await loadSyncServerDeviceNames(client, privacyKey)
+  } catch (error) {
+    if (error instanceof SyncServerCancelledError || isSessionExpiredError(error)) throw error
+    console.warn('Failed to load encrypted sync device names:', error)
+    return null
+  }
+}
+
 const state = {
   syncServerStatus: 'idle',
   syncServerProgress: null,
@@ -79,6 +93,7 @@ const state = {
   syncServerHistorySupported: null,
   syncServerSessionExpired: false,
   syncServerOtherDeviceSessions: [],
+  syncServerDeviceNames: {},
 }
 
 const getters = {
@@ -87,7 +102,10 @@ const getters = {
   getSyncServerError: state => state.syncServerError,
   getSyncServerLastResult: state => state.syncServerLastResult,
   getSyncServerHistorySupported: state => state.syncServerHistorySupported,
-  getSyncServerOtherDeviceSessions: state => state.syncServerOtherDeviceSessions,
+  getSyncServerOtherDeviceSessions: state => state.syncServerOtherDeviceSessions.map(session => ({
+    ...session,
+    syncDeviceName: state.syncServerDeviceNames[session.syncDeviceId] ?? '',
+  })),
 }
 
 function parseSnapshot(value) {
@@ -492,7 +510,7 @@ const actions = {
           const snapshot = parseSnapshot(rootState.settings.syncServerSnapshot)
           snapshot.sessionsV2 = nextSessions
           await dispatch('updateSyncServerSnapshot', JSON.stringify(snapshot), { root: true })
-          commit('setSyncServerOtherDeviceSessions', getSavedOtherDeviceSessions(snapshot))
+          commit('setSyncServerOtherDeviceSessions', getSavedOtherDeviceSessions(snapshot, settings))
           commit('setSyncServerStatus', 'success')
           return true
         }
@@ -680,6 +698,7 @@ const actions = {
     commit('setSyncServerError', SYNC_SERVER_SESSION_EXPIRED_MESSAGE)
     commit('setSyncServerSessionExpired', true)
     commit('setSyncServerStatus', 'error')
+    commit('setSyncServerDeviceNames', {})
   },
 
   async disconnectSyncServer({ commit, dispatch }) {
@@ -698,6 +717,7 @@ const actions = {
     commit('setSyncServerStatus', 'idle')
     commit('setSyncServerSessionExpired', false)
     commit('setSyncServerOtherDeviceSessions', [])
+    commit('setSyncServerDeviceNames', {})
   },
 
   async deleteSyncServerAccount({ commit, dispatch, rootState }, password) {
@@ -772,7 +792,10 @@ const actions = {
 
     commit(
       'setSyncServerOtherDeviceSessions',
-      getSavedOtherDeviceSessions(parseSnapshot(rootState.settings.syncServerSnapshot))
+      getSavedOtherDeviceSessions(
+        parseSnapshot(rootState.settings.syncServerSnapshot),
+        rootState.settings
+      )
     )
 
     try {
@@ -834,6 +857,40 @@ const actions = {
     }, AUTO_SYNC_INTERVAL_MS)
   },
 
+  async refreshSyncServerDeviceNames({ commit, dispatch, rootState }) {
+    const refreshId = ++deviceNameRefreshId
+    const settings = rootState.settings
+    if (!settings.syncServerToken || !settings.syncServerPrivacyKey) {
+      commit('setSyncServerDeviceNames', {})
+      return
+    }
+
+    const client = trackSyncClient(new SyncServerClient(
+      settings.syncServerUrl,
+      settings.syncServerToken
+    ))
+    try {
+      const deviceNames = await tryLoadSyncServerDeviceNames(
+        client,
+        settings.syncServerPrivacyKey
+      )
+      assertSyncEnabled(rootState, client)
+      if (refreshId === deviceNameRefreshId && deviceNames !== null) {
+        commit('setSyncServerDeviceNames', deviceNames)
+      }
+    } catch (error) {
+      if (refreshId !== deviceNameRefreshId) return
+      if (error instanceof SyncServerCancelledError) return
+      if (isSessionExpiredError(error)) {
+        await dispatch('expireSyncServerSession')
+        return
+      }
+      throw error
+    } finally {
+      releaseSyncClient(client)
+    }
+  },
+
   restartSyncServerAutoSync({ dispatch }) {
     clearTimeout(autoSyncTimer)
     autoSyncTimer = null
@@ -879,6 +936,7 @@ const actions = {
       commit('setSyncServerError', '')
       commit('setSyncServerStatus', 'idle')
       commit('setSyncServerOtherDeviceSessions', [])
+      commit('setSyncServerDeviceNames', {})
       return
     }
     if (rootState.settings.syncServerToken) {
@@ -919,6 +977,9 @@ const mutations = {
   },
   setSyncServerOtherDeviceSessions(state, sessions) {
     state.syncServerOtherDeviceSessions = sessions
+  },
+  setSyncServerDeviceNames(state, deviceNames) {
+    state.syncServerDeviceNames = deviceNames
   },
 }
 

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -56,6 +56,11 @@ let eventSyncTimer = null
 let lifecycleSyncStarted = false
 let deviceNameRefreshId = 0
 
+function clearSyncServerDeviceNames(commit) {
+  deviceNameRefreshId++
+  commit('setSyncServerDeviceNames', {})
+}
+
 function trackSyncClient(client) {
   activeSyncClients.add(client)
   return client
@@ -698,7 +703,7 @@ const actions = {
     commit('setSyncServerError', SYNC_SERVER_SESSION_EXPIRED_MESSAGE)
     commit('setSyncServerSessionExpired', true)
     commit('setSyncServerStatus', 'error')
-    commit('setSyncServerDeviceNames', {})
+    clearSyncServerDeviceNames(commit)
   },
 
   async disconnectSyncServer({ commit, dispatch }) {
@@ -717,7 +722,7 @@ const actions = {
     commit('setSyncServerStatus', 'idle')
     commit('setSyncServerSessionExpired', false)
     commit('setSyncServerOtherDeviceSessions', [])
-    commit('setSyncServerDeviceNames', {})
+    clearSyncServerDeviceNames(commit)
   },
 
   async deleteSyncServerAccount({ commit, dispatch, rootState }, password) {
@@ -858,12 +863,12 @@ const actions = {
   },
 
   async refreshSyncServerDeviceNames({ commit, dispatch, rootState }) {
-    const refreshId = ++deviceNameRefreshId
     const settings = rootState.settings
     if (!settings.syncServerToken || !settings.syncServerPrivacyKey) {
-      commit('setSyncServerDeviceNames', {})
+      clearSyncServerDeviceNames(commit)
       return
     }
+    const refreshId = ++deviceNameRefreshId
 
     const client = trackSyncClient(new SyncServerClient(
       settings.syncServerUrl,
@@ -936,7 +941,7 @@ const actions = {
       commit('setSyncServerError', '')
       commit('setSyncServerStatus', 'idle')
       commit('setSyncServerOtherDeviceSessions', [])
-      commit('setSyncServerDeviceNames', {})
+      clearSyncServerDeviceNames(commit)
       return
     }
     if (rootState.settings.syncServerToken) {

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -561,7 +561,7 @@ const actions = {
     await dispatch('updateSyncServerPrivacyMode', 'enhanced', { root: true })
     await dispatch('updateSyncServerPrivacyKey', privacyKey, { root: true })
     await dispatch('updateSyncServerPrivacySalt', privacySalt, { root: true })
-    await dispatch('updateSyncServerToken', token, { root: true })
+    await dispatch('replaceSyncServerToken', token)
     commit('setSyncServerSessionExpired', false)
 
     if (deviceSystemInfo) {
@@ -673,7 +673,7 @@ const actions = {
       )
       await updateWhileEnabled('updateSyncServerPrivacyKey', privacyKey)
       await updateWhileEnabled('updateSyncServerPrivacySalt', privacySalt)
-      await updateWhileEnabled('updateSyncServerToken', token)
+      await updateWhileEnabled('replaceSyncServerToken', token)
       commit('setSyncServerSessionExpired', false)
 
       await dispatch('startSyncServerAutoSync')
@@ -681,7 +681,7 @@ const actions = {
     } catch (error) {
       if (error instanceof SyncServerCancelledError &&
           rootState.settings.syncServerToken !== previousToken) {
-        await dispatch('updateSyncServerToken', previousToken, { root: true })
+        await dispatch('replaceSyncServerToken', previousToken)
       }
       throw error
     } finally {
@@ -698,12 +698,11 @@ const actions = {
    */
   async expireSyncServerSession({ commit, dispatch }) {
     await dispatch('stopSyncServerAutoSync')
-    await dispatch('updateSyncServerToken', '', { root: true })
+    await dispatch('replaceSyncServerToken', '')
     commit('setSyncServerProgress', null)
     commit('setSyncServerError', SYNC_SERVER_SESSION_EXPIRED_MESSAGE)
     commit('setSyncServerSessionExpired', true)
     commit('setSyncServerStatus', 'error')
-    clearSyncServerDeviceNames(commit)
   },
 
   async disconnectSyncServer({ commit, dispatch }) {
@@ -714,7 +713,7 @@ const actions = {
     await dispatch('updateSyncServerPrivacyMode', 'unknown', { root: true })
     await dispatch('updateSyncServerPrivacyKey', '', { root: true })
     await dispatch('updateSyncServerPrivacySalt', '', { root: true })
-    await dispatch('updateSyncServerToken', '', { root: true })
+    await dispatch('replaceSyncServerToken', '')
     commit('setSyncServerError', '')
     commit('setSyncServerLastResult', null)
     commit('setSyncServerHistorySupported', null)
@@ -722,7 +721,6 @@ const actions = {
     commit('setSyncServerStatus', 'idle')
     commit('setSyncServerSessionExpired', false)
     commit('setSyncServerOtherDeviceSessions', [])
-    clearSyncServerDeviceNames(commit)
   },
 
   async deleteSyncServerAccount({ commit, dispatch, rootState }, password) {
@@ -894,6 +892,11 @@ const actions = {
     } finally {
       releaseSyncClient(client)
     }
+  },
+
+  async replaceSyncServerToken({ commit, dispatch }, token) {
+    clearSyncServerDeviceNames(commit)
+    await dispatch('updateSyncServerToken', token, { root: true })
   },
 
   restartSyncServerAutoSync({ dispatch }) {

--- a/tests/unit/sync-server-account-sessions.test.mjs
+++ b/tests/unit/sync-server-account-sessions.test.mjs
@@ -7,6 +7,7 @@ import {
   getCurrentSyncServerDeviceInfo,
   isValidSyncServerDeviceId,
   isValidSyncServerDeviceName,
+  loadSyncServerDeviceNames,
   randomSyncServerDeviceId,
   resolveSyncServerDeviceName,
 } from '../../src/renderer/helpers/sync-server-sessions.js'
@@ -71,6 +72,30 @@ test('encrypts device identification for one device and privacy key', async () =
     () => decryptSyncServerDeviceInfo(payload, key, otherDeviceId),
     /device info is invalid/
   )
+})
+
+test('loads valid device names from encrypted account-session metadata', async () => {
+  const key = bytesToBase64(crypto.getRandomValues(new Uint8Array(32)))
+  const laptopId = randomSyncServerDeviceId()
+  const phoneId = randomSyncServerDeviceId()
+  const encryptedLaptop = await encryptSyncServerDeviceInfo({
+    name: 'Travel laptop',
+    platform: 'linux',
+    architecture: 'x64',
+    release: '6.16.4-arch1-1',
+  }, key, laptopId)
+
+  const names = await loadSyncServerDeviceNames({
+    getAccountSessions: async () => ({
+      sessions: [
+        { device_id: laptopId, encrypted_device_info: encryptedLaptop },
+        { device_id: phoneId, encrypted_device_info: 'invalid ciphertext' },
+        { device_id: 'invalid-device-id', encrypted_device_info: encryptedLaptop },
+      ],
+    }),
+  }, key)
+
+  assert.deepEqual(names, { [laptopId]: 'Travel laptop' })
 })
 
 test('validates device names and rejects invalid encrypted device info', async () => {

--- a/tests/unit/sync-sessions.test.mjs
+++ b/tests/unit/sync-sessions.test.mjs
@@ -28,6 +28,40 @@ test('formats device session labels with localized tab plurals', () => {
 
   assert.equal(formatDeviceSessionLabel({ syncPlatform: 'desktop', tabs: [{}] }, t), 'Desktop · 1 tab')
   assert.equal(formatDeviceSessionLabel({ syncPlatform: 'mobile', tabs: [{}, {}] }, t), 'Mobile · 2 tabs')
+  assert.equal(formatDeviceSessionLabel({
+    syncDeviceName: 'Travel phone',
+    syncPlatform: 'mobile',
+    tabs: [{}, {}],
+  }, t), 'Travel phone · 2 tabs')
+})
+
+test('moves this device tab sets from its old local ID to its account-session ID', () => {
+  const local = session('local', 2)
+  const remote = session('remote', 1)
+  const result = mergeSyncSessions({
+    localSessions: [local],
+    remoteValue: {
+      version: 1,
+      mode: 'separate',
+      devices: {
+        'old-local-id': { platform: 'desktop', sessions: [local] },
+        'remote-account-id': { platform: 'mobile', sessions: [remote] },
+      },
+      shared: [],
+    },
+    deviceId: 'current-account-id',
+    legacyDeviceIds: ['old-local-id'],
+    platform: 'desktop',
+    preferredMode: 'separate',
+  })
+
+  assert.deepEqual(result.document.devices['current-account-id'].sessions, [local])
+  assert.equal(result.document.devices['old-local-id'], undefined)
+  assert.deepEqual(result.otherDeviceSessions, [{
+    ...remote,
+    syncDeviceId: 'remote-account-id',
+    syncPlatform: 'mobile',
+  }])
 })
 
 test('treats legacy session arrays as a separate desktop device', () => {

--- a/tests/unit/sync-sessions.test.mjs
+++ b/tests/unit/sync-sessions.test.mjs
@@ -64,6 +64,41 @@ test('moves this device tab sets from its old local ID to its account-session ID
   }])
 })
 
+test('merges legacy tab sets into an existing account-session device', () => {
+  const current = session('current', 3)
+  const duplicate = session('duplicate', 2)
+  const legacyOnly = session('legacy-only', 1)
+  const result = mergeSyncSessions({
+    localSessions: [current, duplicate],
+    remoteValue: {
+      version: 1,
+      mode: 'separate',
+      devices: {
+        'current-account-id': {
+          platform: 'desktop',
+          sessions: [current, duplicate],
+        },
+        'old-local-id': {
+          platform: 'desktop',
+          sessions: [session('duplicate', 1), legacyOnly],
+        },
+      },
+      shared: [],
+    },
+    deviceId: 'current-account-id',
+    legacyDeviceIds: ['old-local-id'],
+    platform: 'desktop',
+    preferredMode: 'separate',
+  })
+
+  assert.deepEqual(result.document.devices['current-account-id'].sessions, [
+    current,
+    duplicate,
+    legacyOnly,
+  ])
+  assert.equal(result.document.devices['old-local-id'], undefined)
+})
+
 test('treats legacy session arrays as a separate desktop device', () => {
   const document = normalizeSyncSessionsDocument([session('desktop', 1)])
   assert.equal(document.mode, 'separate')


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Synced tab sets currently identify their source only as Desktop or Mobile, which makes multiple devices hard to distinguish.

Use the encrypted device names already stored in account-session metadata and match them to tab sets by device ID. Desktop and mobile organizers show `<device name> · <tab count>`, with the existing Desktop or Mobile labels as fallbacks. Account-session metadata is requested once when an organizer with synced sets opens, without a separate capability request, and decrypted names remain in memory only. Reopening refreshes renamed devices, while a request-generation guard prevents older responses from restoring stale names.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Synced tab sets now show the name of their source device.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware <picture> with dark and light prefers-color-scheme sources and the dark image as its <img> fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through e2e/helpers/visual-fixtures.mjs. Before capturing, verify that every visible image has loaded successfully (complete === true and naturalWidth > 0).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to gh pr create or gh pr edit with --attach <path> so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat --attach <path> for each one. Read back the hosted URLs, replace the temporary references with the <picture> below, and update the pull request body without --attach:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION" regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION". Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Connect two devices to the same enhanced-privacy sync account and enable separate synced tabs.
2. Open the desktop tab organizer and the mobile tab switcher. Each remote tab set should show its device name and tab count.
3. Rename one device, then close and reopen the organizer on the other device. The new name should appear.
4. Remove or corrupt a device's encrypted metadata. Its tab set should fall back to Desktop or Mobile.

## Additional context
<!-- Add any other context about the pull request here. -->

This uses the existing encrypted account-session metadata and does not require sync-server changes. Decrypted names are not persisted or added to tab-sync documents.
