### PR TITLE
fix(subscriptions): show mobile labels and refresh timing

### DIFF
--- a/e2e/tests/offline/subscriptions-header-layout.spec.mjs
+++ b/e2e/tests/offline/subscriptions-header-layout.spec.mjs
@@ -1,4 +1,4 @@
-import { test, expect, goTo } from '../../helpers/app.mjs'
+import { test, expect, goTo, setWindowSize } from '../../helpers/app.mjs'
 
 const now = Date.now()
 const CHANNEL_ID = 'UCaaaaaaaaaaaaaaaaaaaaaa'
@@ -83,6 +83,75 @@ function headerBoxes (page) {
 }
 
 test.describe('subscriptions header layout', () => {
+  test('shows the New feed action and regular feed refresh status on mobile', async ({ app, page, attachScreenshot }) => {
+    await goTo(page, 'subscriptions')
+    await page.locator('[data-subscription-feed-tab="all"]').click()
+    await setWindowWidth(app, page, 375)
+
+    const markAllSeen = page.getByRole('button', { name: 'Mark all as seen' })
+    await expect(markAllSeen).toBeVisible()
+    await expect(markAllSeen.locator('xpath=..')).toHaveClass(/headerActions/)
+
+    const labelWidth = await markAllSeen.locator('.markAllSeenLabel').evaluate(element => {
+      return element.getBoundingClientRect().width
+    })
+    expect(labelWidth).toBeGreaterThan(40)
+
+    const sharesControlRow = await page.evaluate(() => {
+      const markRect = document.querySelector('.markAllSeenButton').getBoundingClientRect()
+      return ['.headerViewToggle', '.headerSortSelect'].some(selector => {
+        const rect = document.querySelector(selector).getBoundingClientRect()
+        return rect.top < markRect.bottom && rect.bottom > markRect.top
+      })
+    })
+    expect(sharesControlRow).toBe(true)
+    expect(await page.evaluate(() => {
+      const markRect = document.querySelector('.markAllSeenButton').getBoundingClientRect()
+      const refreshRect = document.querySelector('.refreshButton').getBoundingClientRect()
+      return refreshRect.top < markRect.bottom && refreshRect.bottom > markRect.top
+    })).toBe(true)
+    await expect(page.locator('.headerRefreshWidget .lastRefreshTimestamp')).toHaveCount(0)
+    await expect(page.locator('.headerRefreshWidget .nextAutoRefreshTimestamp')).toHaveCount(0)
+    await attachScreenshot('portrait mobile New feed action')
+
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setSubscriptionFeedAutoRefreshInterval', String(60 * 60 * 1000))
+      store.commit('setSubscriptionFeedNextAutoRefreshTimestamp', Date.now() + 60 * 60 * 1000)
+    })
+    await page.locator('[data-subscription-feed-tab="videos"]').click()
+
+    await expect(page.getByText(/Videos feed last updated:/)).toBeVisible()
+    await expect(page.getByText(/Next auto refresh:/)).toBeVisible()
+    expect(await page.evaluate(() => {
+      const markRect = document.querySelector('.markAllSeenButton').getBoundingClientRect()
+      const refreshRect = document.querySelector('.refreshButton').getBoundingClientRect()
+      return refreshRect.top < markRect.bottom && refreshRect.bottom > markRect.top
+    })).toBe(true)
+    await expect.poll(() => page.evaluate(() => {
+      return document.documentElement.scrollWidth - document.documentElement.clientWidth
+    })).toBeLessThanOrEqual(2)
+    await attachScreenshot('portrait mobile subscription refresh status')
+
+    await setWindowSize(app, page, { width: 640, height: 375 })
+    await expect(markAllSeen.locator('.markAllSeenLabel')).toBeVisible()
+    await expect(page.getByText(/Videos feed last updated:/)).toBeVisible()
+    await expect(page.getByText(/Next auto refresh:/)).toBeVisible()
+    await expect.poll(() => page.evaluate(() => {
+      return document.documentElement.scrollWidth - document.documentElement.clientWidth
+    })).toBeLessThanOrEqual(2)
+    await attachScreenshot('landscape mobile subscription refresh status')
+
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateBaseTheme', 'black')
+    })
+    await expect(page.locator('body')).toHaveCSS('background-color', 'rgb(0, 0, 0)')
+    await expect(markAllSeen.locator('.markAllSeenLabel')).toBeVisible()
+    await expect(page.getByText(/Next auto refresh:/)).toBeVisible()
+    await attachScreenshot('dark landscape mobile subscription refresh status')
+  })
+
   test('keeps the New feed sort control wide until its row needs to shrink', async ({ app, page, attachScreenshot }) => {
     await goTo(page, 'subscriptions')
     await page.locator('[data-subscription-feed-tab="all"]').click()
@@ -107,6 +176,7 @@ test.describe('subscriptions header layout', () => {
         viewToggle: toBox(document.querySelector('.headerViewToggle .iconButton')),
         select: toBox(select),
         label: toBox(document.querySelector('.headerSortSelect .select-label')),
+        markAllSeen: toBox(document.querySelector('.markAllSeenButton')),
         refresh: toBox(document.querySelector('.headerRefreshWidget .refreshButton')),
         selectedText: select.textContent.trim()
       }
@@ -116,7 +186,9 @@ test.describe('subscriptions header layout', () => {
     expect(layout.select.end - layout.select.start).toBeLessThan(roomySelectWidth)
     expect(layout.viewToggle.start).toBeGreaterThanOrEqual(layout.header.start)
     expect(layout.viewToggle.end).toBeLessThanOrEqual(layout.select.start)
-    expect(layout.select.end).toBeLessThanOrEqual(layout.refresh.start)
+    expect(layout.select.end).toBeLessThanOrEqual(layout.header.end)
+    expect(layout.markAllSeen.end).toBeLessThanOrEqual(layout.header.end)
+    expect(layout.refresh.start).toBeGreaterThanOrEqual(layout.header.start)
     expect(layout.refresh.end).toBeLessThanOrEqual(layout.header.end)
     expect(Math.abs(
       (layout.viewToggle.top + layout.viewToggle.bottom) / 2 -
@@ -124,7 +196,7 @@ test.describe('subscriptions header layout', () => {
     )).toBeLessThanOrEqual(1)
     expect(Math.abs(
       (layout.select.top + layout.select.bottom) / 2 -
-      (layout.refresh.top + layout.refresh.bottom) / 2
+      (layout.markAllSeen.top + layout.markAllSeen.bottom) / 2
     )).toBeLessThanOrEqual(1)
     expect(layout.label.top).toBeGreaterThanOrEqual(layout.select.top)
     expect(layout.label.bottom).toBeLessThanOrEqual(layout.select.bottom)
@@ -210,7 +282,6 @@ test.describe('subscriptions header layout', () => {
       }
     })
 
-    await setWindowWidth(app, page, 1120)
     const wideLayout = await readLayout()
     expect(wideLayout.actions.top).toBeLessThan(wideLayout.tabs.bottom)
     expect(wideLayout.tabs.top).toBeLessThan(wideLayout.actions.bottom)

--- a/src/renderer/components/FtRefreshWidget/FtRefreshWidget.scss
+++ b/src/renderer/components/FtRefreshWidget/FtRefreshWidget.scss
@@ -138,6 +138,12 @@
     border-inline-start: none;
   }
 
+  .floatingRefreshSection.embedded.subscriptionsHeaderRefreshWidget,
+  .floatingRefreshSection.embedded.subscriptionsHeaderRefreshWidget.sideNavOpen,
+  .floatingRefreshSection.embedded.subscriptionsHeaderRefreshWidget.hideLabelsSideBar {
+    display: contents;
+  }
+
   .floatingRefreshSection.embedded,
   .floatingRefreshSection.embedded.sideNavOpen,
   .floatingRefreshSection.embedded.hideLabelsSideBar {
@@ -145,7 +151,29 @@
     justify-content: space-between;
   }
 
-  .nextAutoRefreshTimestamp {
-    display: none;
+  .floatingRefreshSection.embedded.subscriptionsHeaderRefreshWidget > .lastRefreshTimestamp {
+    flex: 1 0 100%;
+    order: 1;
+    text-align: start;
+  }
+
+  .floatingRefreshSection.embedded.subscriptionsHeaderRefreshWidget .refreshActions {
+    flex: 1 1 150px;
+    min-inline-size: 0;
+    margin-inline-start: 0;
+    order: 2;
+  }
+
+  .floatingRefreshSection.embedded.subscriptionsHeaderRefreshWidget .refreshActions:not(:has(.nextAutoRefreshTimestamp)) {
+    flex: 0 0 auto;
+  }
+
+  .floatingRefreshSection.embedded.subscriptionsHeaderRefreshWidget .nextAutoRefreshTimestamp {
+    flex: 1 1 auto;
+    min-inline-size: 0;
+
+    .lastRefreshTimestamp {
+      text-align: start;
+    }
   }
 }

--- a/src/renderer/views/Subscriptions/Subscriptions.css
+++ b/src/renderer/views/Subscriptions/Subscriptions.css
@@ -373,7 +373,13 @@
   }
 
   .headerActions {
+    flex-wrap: wrap;
     gap: 6px;
+    inline-size: 100%;
+  }
+
+  .headerActions .headerSortSelect {
+    flex-basis: 0;
   }
 
   .headerSortSelect :deep(.select-text) {
@@ -392,15 +398,7 @@
 
   .markAllSeenButton {
     min-block-size: 36px;
-  }
-
-  .markAllSeenLabel {
-    position: absolute;
-    inline-size: 1px;
-    block-size: 1px;
-    overflow: hidden;
-    clip-path: inset(50%);
-    white-space: nowrap;
+    order: 2;
   }
 
   .newFeedTabs {

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -180,18 +180,6 @@
                   ><span>{{ $t("Global.New") }}</span></span>
                 </div>
               </FtFlexBox>
-              <button
-                v-if="currentTabHasNewContent"
-                class="markAllSeenButton"
-                type="button"
-                :disabled="markingSeenTab !== null || currentTabRefreshing"
-                @click="markAllAsSeen(currentTab)"
-              >
-                <FtIcon :icon="['fas', 'check']" />
-                <span class="markAllSeenLabel">
-                  {{ $t('Subscriptions.Mark All as Seen') }}
-                </span>
-              </button>
             </div>
             <div
               v-if="currentTabPanel !== null"
@@ -221,9 +209,21 @@
                 :icon="newFeedSortByIcon"
                 @change="updateNewFeedSortBy"
               />
+              <button
+                v-if="currentTabHasNewContent"
+                class="markAllSeenButton"
+                type="button"
+                :disabled="markingSeenTab !== null || currentTabRefreshing"
+                @click="markAllAsSeen(currentTab)"
+              >
+                <FtIcon :icon="['fas', 'check']" />
+                <span class="markAllSeenLabel">
+                  {{ $t('Subscriptions.Mark All as Seen') }}
+                </span>
+              </button>
               <FtRefreshWidget
                 embedded
-                class="headerRefreshWidget"
+                class="headerRefreshWidget subscriptionsHeaderRefreshWidget"
                 :disable-refresh="subscriptionFeedRefreshInProgress || currentTabPanel.isLoading || activeSubscriptionList.length === 0"
                 :last-refresh-timestamp="currentTabPanel.lastRefreshTimestamp"
                 :next-auto-refresh-timestamp="currentTabPanel.nextAutoRefreshTimestamp"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

On narrow screens, the subscription header reduced "Mark all as seen" to an unlabeled checkmark and let it occupy its own row. It also hid the last-refresh and next-auto-refresh timing from regular subscription feeds.

This keeps the action labeled and groups it with the other header actions. Regular Videos, Shorts, Live, and Posts feeds now retain both refresh timestamps on mobile, while the combined New feed remains free of refresh metadata. The responsive refresh layout is scoped to Subscriptions so Popular and Trending keep their existing mobile layout.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Subscription headers now keep "Mark all as seen" labeled and show refresh timing on mobile.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/33b7f17f-b940-4ee9-9a40-41fa86577332">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/196a03f3-b5cb-4461-90cf-2a8eb81ebf31">
  <img alt="Mobile subscription header with a labeled Mark all as seen action and refresh timing" src="https://github.com/user-attachments/assets/33b7f17f-b940-4ee9-9a40-41fa86577332">
</picture>

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Subscriptions in a window no wider than 680 px and select New. Confirm that "Mark all as seen" is visible beside the other header actions, without last-refresh or next-auto-refresh text.
2. Enable subscription auto-refresh and select Videos, Shorts, Live, or Posts. Confirm that the header shows both the last update and next auto-refresh time without horizontal overflow.
3. Repeat in landscape dimensions and in both light and dark themes.

## Additional context
<!-- Add any other context about the pull request here. -->

The final layout was also checked on a physical Pixel 8 Pro running Android 16.
