### PR TITLE
fix(android): prevent stuck subscription refresh progress

### DIFF
--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshNotificationProgress.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshNotificationProgress.java
@@ -1,0 +1,15 @@
+package org.opentubex.app;
+
+final class SubscriptionRefreshNotificationProgress {
+    private int progress;
+
+    boolean advanceTo(int nextProgress) {
+        if (progress == nextProgress) return false;
+        progress = nextProgress;
+        return true;
+    }
+
+    void reset() {
+        progress = 0;
+    }
+}

--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshState.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshState.java
@@ -21,6 +21,7 @@ final class SubscriptionRefreshState {
     private String title;
     private String cancelLabel;
     private int progress;
+    private int notifiedProgress;
     private CountDownLatch completion = new CountDownLatch(0);
 
     synchronized void begin(String nextToken, String nextTitle, String nextCancelLabel) {
@@ -29,6 +30,7 @@ final class SubscriptionRefreshState {
         title = nextTitle;
         cancelLabel = nextCancelLabel;
         progress = 0;
+        notifiedProgress = 0;
         completion = new CountDownLatch(1);
     }
 
@@ -40,6 +42,12 @@ final class SubscriptionRefreshState {
 
     synchronized Snapshot snapshot(String expectedToken) {
         if (!isCurrent(expectedToken)) return null;
+        return new Snapshot(token, title, cancelLabel, progress);
+    }
+
+    synchronized Snapshot takeNotificationSnapshot(String expectedToken) {
+        if (!isCurrent(expectedToken) || progress == notifiedProgress) return null;
+        notifiedProgress = progress;
         return new Snapshot(token, title, cancelLabel, progress);
     }
 
@@ -58,6 +66,7 @@ final class SubscriptionRefreshState {
         title = null;
         cancelLabel = null;
         progress = 0;
+        notifiedProgress = 0;
         completion.countDown();
         return true;
     }

--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshState.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshState.java
@@ -21,7 +21,8 @@ final class SubscriptionRefreshState {
     private String title;
     private String cancelLabel;
     private int progress;
-    private int notifiedProgress;
+    private final SubscriptionRefreshNotificationProgress notificationProgress =
+        new SubscriptionRefreshNotificationProgress();
     private CountDownLatch completion = new CountDownLatch(0);
 
     synchronized void begin(String nextToken, String nextTitle, String nextCancelLabel) {
@@ -30,7 +31,7 @@ final class SubscriptionRefreshState {
         title = nextTitle;
         cancelLabel = nextCancelLabel;
         progress = 0;
-        notifiedProgress = 0;
+        notificationProgress.reset();
         completion = new CountDownLatch(1);
     }
 
@@ -46,8 +47,7 @@ final class SubscriptionRefreshState {
     }
 
     synchronized Snapshot takeNotificationSnapshot(String expectedToken) {
-        if (!isCurrent(expectedToken) || progress == notifiedProgress) return null;
-        notifiedProgress = progress;
+        if (!isCurrent(expectedToken) || !notificationProgress.advanceTo(progress)) return null;
         return new Snapshot(token, title, cancelLabel, progress);
     }
 
@@ -66,7 +66,7 @@ final class SubscriptionRefreshState {
         title = null;
         cancelLabel = null;
         progress = 0;
-        notifiedProgress = 0;
+        notificationProgress.reset();
         completion.countDown();
         return true;
     }

--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshWorker.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshWorker.java
@@ -157,6 +157,8 @@ public final class SubscriptionRefreshWorker extends Worker {
         int completed = 0;
         int failed = 0;
         Set<String> failedProfileIds = new LinkedHashSet<>();
+        SubscriptionRefreshNotificationProgress notificationProgress =
+            new SubscriptionRefreshNotificationProgress();
         NotificationManager notifications = context.getSystemService(NotificationManager.class);
         try {
             // A periodic job may recreate the process while the app is closed, where
@@ -224,16 +226,18 @@ public final class SubscriptionRefreshWorker extends Worker {
                 }
 
                 int progress = total == 0 ? 100 : (int) Math.round((completed + failed) * 100.0 / total);
-                notifications.notify(
-                    SubscriptionRefreshNotification.NOTIFICATION_ID,
-                    SubscriptionRefreshNotification.build(
-                        context,
-                        token,
-                        feed.title,
-                        feed.cancelLabel,
-                        progress
-                    )
-                );
+                if (notificationProgress.advanceTo(progress)) {
+                    notifications.notify(
+                        SubscriptionRefreshNotification.NOTIFICATION_ID,
+                        SubscriptionRefreshNotification.build(
+                            context,
+                            token,
+                            feed.title,
+                            feed.cancelLabel,
+                            progress
+                        )
+                    );
+                }
             }
 
             if (SubscriptionRefreshCoordinator.isCancelled(token) || isStopped()) {

--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshWorker.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshWorker.java
@@ -59,8 +59,8 @@ public final class SubscriptionRefreshWorker extends Worker {
 
     static boolean update(Context context, String token, int progress) {
         if (!STATE.update(token, progress)) return false;
-        SubscriptionRefreshState.Snapshot snapshot = STATE.snapshot(token);
-        if (snapshot == null) return false;
+        SubscriptionRefreshState.Snapshot snapshot = STATE.takeNotificationSnapshot(token);
+        if (snapshot == null) return true;
         context.getSystemService(NotificationManager.class).notify(
             SubscriptionRefreshNotification.NOTIFICATION_ID,
             SubscriptionRefreshNotification.build(

--- a/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshStateTest.java
+++ b/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshStateTest.java
@@ -44,4 +44,22 @@ public class SubscriptionRefreshStateTest {
         assertEquals("Refreshing shorts", state.snapshot("second").title);
         assertEquals("Cancel", state.snapshot("second").cancelLabel);
     }
+
+    @Test
+    public void coalescesNotificationUpdatesForLargeProfiles() {
+        SubscriptionRefreshState state = new SubscriptionRefreshState();
+        state.begin("refresh", "Refreshing videos", "Cancel");
+        int notificationUpdates = 0;
+
+        for (int completed = 1; completed <= 900; completed++) {
+            int progress = (int) Math.round(completed * 100.0 / 900);
+            assertTrue(state.update("refresh", progress));
+            if (state.takeNotificationSnapshot("refresh") != null) {
+                notificationUpdates++;
+            }
+        }
+
+        assertEquals(100, notificationUpdates);
+        assertEquals(100, state.snapshot("refresh").progress);
+    }
 }

--- a/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshWorkerTargetsTest.java
+++ b/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshWorkerTargetsTest.java
@@ -53,6 +53,20 @@ public class SubscriptionRefreshWorkerTargetsTest {
         assertEquals(List.of("second"), failedProfileIds);
     }
 
+    @Test
+    public void scheduledRefreshCoalescesNotificationUpdatesForLargeProfiles() {
+        SubscriptionRefreshNotificationProgress progress =
+            new SubscriptionRefreshNotificationProgress();
+        int notificationUpdates = 0;
+
+        for (int completed = 1; completed <= 900; completed++) {
+            int percentage = (int) Math.round(completed * 100.0 / 900);
+            if (progress.advanceTo(percentage)) notificationUpdates++;
+        }
+
+        assertEquals(100, notificationUpdates);
+    }
+
     private static SubscriptionRefreshConfiguration.Feed feed(
         String profileId,
         List<String> channelIds


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No related issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Large Android subscription lists posted a native progress notification after every refreshed channel. With about 900 subscriptions, many posts represented the same rounded percentage and exceeded Android's notification enqueue-rate limit. Android then dropped updates, which could leave the visible refresh progress stuck after leaving or locking the app even though the refresh continued.

Track the last posted percentage and notify Android only when the rounded value changes. Internal progress still records every channel, while a 900-channel refresh now produces at most 100 notification updates.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run the Android app with a profile containing several hundred subscriptions.
2. Let an automatic subscription refresh start, leave the app, and lock and unlock the device twice.
3. Confirm that the subscription refresh notification continues advancing and disappears when the refresh completes.

## Additional context
<!-- Add any other context about the pull request here. -->

An API 35 emulator run used 900 subscriptions and exercised foreground lock/unlock, Home, a second lock under forced idle, and unlock. Before this change, Android logged that it was shedding OpenTubeX notifications because the package exceeded the enqueue-rate limit. The same scenario produced no shed notification updates with coalescing enabled.
