### PR TITLE
fix(player): prevent KDE Wayland auto PiP flicker

### DIFF
--- a/src/main/kdeWaylandWindowState.js
+++ b/src/main/kdeWaylandWindowState.js
@@ -12,6 +12,9 @@ const ACTIVE_WINDOW_REPORT_PATH = '/io/github/OpenTubeX/KWinActiveWindow'
 const ACTIVE_WINDOW_REPORT_INTERFACE = 'io.github.OpenTubeX.KWinActiveWindow'
 const ACTIVE_WINDOW_QUERY_TIMEOUT = 1_500
 const KDE_DESKTOP_POPUP_CLASS = /(?:^|\.)(?:krunner|plasmashell)$/i
+// Mapping PiP during KWin's source-window transition can expose one fully
+// painted frame before KWin starts the PiP opening animation.
+const KWIN_TRANSITION_SETTLE_DELAY = 250
 const WINDOW_SEARCH_TERM = 'OpenTubeX'
 
 /**
@@ -400,7 +403,7 @@ export function monitorKdeWaylandWindowState({
   onMinimizedState,
   releaseWindowIdentity = () => {},
   processId = process.pid,
-  detectionDelay = 100,
+  detectionDelay = KWIN_TRANSITION_SETTLE_DELAY,
   focusHandoffDelay = 100,
   pollInterval = 1_000,
 }) {

--- a/tests/unit/kde-wayland-window-state.test.mjs
+++ b/tests/unit/kde-wayland-window-state.test.mjs
@@ -197,6 +197,38 @@ test('does not mistake an ordinary focus change for minimize', () => {
   assert.equal(findNewlyMinimizedWindow(state, state, targetWindow()), null)
 })
 
+test('waits for the KWin transition before reporting a minimized window', async () => {
+  const browserWindow = new EventEmitter()
+  browserWindow.getBounds = () => targetWindow().bounds
+  browserWindow.getTitle = () => targetWindow().caption
+  browserWindow.isFocused = () => false
+  const minimizedStates = []
+  let stop
+  const reported = new Promise(resolve => {
+    stop = monitorKdeWaylandWindowState({
+      browserWindow,
+      backend: Promise.resolve({
+        queryWindow: async () => windowInfo({ minimized: true }),
+        queryWindows: async () => [windowInfo({ minimized: true })],
+        watchActiveWindow: () => ({ activeWindow: null, stop: () => {} }),
+      }),
+      onMinimizedState: minimized => {
+        minimizedStates.push(minimized)
+        resolve()
+      },
+      pollInterval: 60000,
+    })
+  })
+
+  browserWindow.emit('blur')
+  await new Promise(resolve => setTimeout(resolve, 200))
+  assert.deepEqual(minimizedStates, [])
+
+  await reported
+  stop()
+  assert.deepEqual(minimizedStates, [true])
+})
+
 test('keeps focus when a KDE desktop popup leaves the window active', async () => {
   const focusedStates = await focusedStatesAfterBlur({
     resourceClass: 'electron',

--- a/tests/unit/kde-wayland-window-state.test.mjs
+++ b/tests/unit/kde-wayland-window-state.test.mjs
@@ -203,6 +203,7 @@ test('waits for the KWin transition before reporting a minimized window', async 
   browserWindow.getTitle = () => targetWindow().caption
   browserWindow.isFocused = () => false
   const minimizedStates = []
+  let watcherStopped = false
   let stop
   const reported = new Promise(resolve => {
     stop = monitorKdeWaylandWindowState({
@@ -210,7 +211,10 @@ test('waits for the KWin transition before reporting a minimized window', async 
       backend: Promise.resolve({
         queryWindow: async () => windowInfo({ minimized: true }),
         queryWindows: async () => [windowInfo({ minimized: true })],
-        watchActiveWindow: () => ({ activeWindow: null, stop: () => {} }),
+        watchActiveWindow: () => ({
+          activeWindow: null,
+          stop: () => { watcherStopped = true },
+        }),
       }),
       onMinimizedState: minimized => {
         minimizedStates.push(minimized)
@@ -226,6 +230,7 @@ test('waits for the KWin transition before reporting a minimized window', async 
 
   await reported
   stop()
+  assert.equal(watcherStopped, true)
   assert.deepEqual(minimizedStates, [true])
 })
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #1109.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

On KDE Wayland, auto PiP could map its window while KWin was still animating the source window. This exposed a painted PiP frame before KWin began the PiP opening animation, causing a visible flicker when minimizing or switching away from the app.

Wait 250 ms for the KWin transition to settle before reporting the minimized window. A regression test covers the delayed production default.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Start the app in a KDE Plasma Wayland session and play a video.
2. Enable automatic PiP on minimize, then minimize and restore the app several times.
3. Confirm PiP opens once without flashing before its KWin animation and remains open.
4. Enable automatic PiP on app switch and repeat the check by switching to another app.

## Additional context
<!-- Add any other context about the pull request here. -->

A KWin lifecycle trace on the affected laptop showed PiP mapping about 107 ms after minimize while the `squash` effect was still active. The 250 ms delay was then verified on the same laptop without the flicker.
