### PR TITLE
fix: preserve edits and playback metadata, reject stale feeds, and resume Android refreshes

### DIFF
--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshCheckpoint.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshCheckpoint.java
@@ -29,8 +29,8 @@ final class SubscriptionRefreshCheckpoint {
         StringBuilder value = new StringBuilder();
         for (SubscriptionRefreshConfiguration.Feed feed : feeds) {
             for (String field : new String[] { feed.profileId, feed.type, feed.instanceUrl, feed.authorization }) {
-                String text = String.valueOf(field);
-                value.append(text.length()).append(':').append(text);
+                if (field == null) value.append("-1:");
+                else value.append(field.length()).append(':').append(field);
             }
             value.append(feed.channelIds.size()).append(':');
             for (String channelId : feed.channelIds) value.append(channelId.length()).append(':').append(channelId);
@@ -44,6 +44,9 @@ final class SubscriptionRefreshCheckpoint {
         Properties saved = new Properties();
         try (FileInputStream input = new FileInputStream(file)) {
             saved.load(input);
+        } catch (IllegalArgumentException error) {
+            // Malformed properties must not prevent every later retry from starting.
+            return checkpoint;
         }
         if (!configuration.equals(saved.getProperty("configuration"))) return checkpoint;
         try {

--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshCheckpoint.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshCheckpoint.java
@@ -1,0 +1,86 @@
+package org.opentubex.app;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+
+/** Resume a stopped periodic refresh without refetching its completed channels. */
+final class SubscriptionRefreshCheckpoint {
+    private final File file;
+    private final String configuration;
+    int nextIndex;
+    int completed;
+    int failed;
+    final Set<String> failedProfileIds = new LinkedHashSet<>();
+
+    private SubscriptionRefreshCheckpoint(File file, String configuration) {
+        this.file = file;
+        this.configuration = configuration;
+    }
+
+    static String configurationId(List<SubscriptionRefreshConfiguration.Feed> feeds) {
+        StringBuilder value = new StringBuilder();
+        for (SubscriptionRefreshConfiguration.Feed feed : feeds) {
+            for (String field : new String[] { feed.profileId, feed.type, feed.instanceUrl, feed.authorization }) {
+                String text = String.valueOf(field);
+                value.append(text.length()).append(':').append(text);
+            }
+            value.append(feed.channelIds.size()).append(':');
+            for (String channelId : feed.channelIds) value.append(channelId.length()).append(':').append(channelId);
+        }
+        return UUID.nameUUIDFromBytes(value.toString().getBytes(StandardCharsets.UTF_8)).toString();
+    }
+
+    static SubscriptionRefreshCheckpoint load(File file, String configuration, int channelCount) throws IOException {
+        SubscriptionRefreshCheckpoint checkpoint = new SubscriptionRefreshCheckpoint(file, configuration);
+        if (!file.exists()) return checkpoint;
+        Properties saved = new Properties();
+        try (FileInputStream input = new FileInputStream(file)) {
+            saved.load(input);
+        }
+        if (!configuration.equals(saved.getProperty("configuration"))) return checkpoint;
+        try {
+            int nextIndex = Integer.parseInt(saved.getProperty("nextIndex"));
+            int completed = Integer.parseInt(saved.getProperty("completed"));
+            int failed = Integer.parseInt(saved.getProperty("failed"));
+            if (nextIndex < 0 || nextIndex > channelCount || completed < 0 || failed < 0 || completed + failed != nextIndex) {
+                return checkpoint;
+            }
+            checkpoint.nextIndex = nextIndex;
+            checkpoint.completed = completed;
+            checkpoint.failed = failed;
+            for (String key : saved.stringPropertyNames()) {
+                if (key.startsWith("failedProfile.")) checkpoint.failedProfileIds.add(key.substring("failedProfile.".length()));
+            }
+        } catch (NumberFormatException ignored) {
+            // An incomplete checkpoint starts a fresh pass; cached results remain safe.
+        }
+        return checkpoint;
+    }
+
+    void save(int nextIndex, int completed, int failed, Set<String> failedProfileIds) throws IOException {
+        Properties saved = new Properties();
+        saved.setProperty("configuration", configuration);
+        saved.setProperty("nextIndex", String.valueOf(nextIndex));
+        saved.setProperty("completed", String.valueOf(completed));
+        saved.setProperty("failed", String.valueOf(failed));
+        for (String profileId : failedProfileIds) saved.setProperty("failedProfile." + profileId, "true");
+        File temporary = new File(file.getPath() + ".tmp");
+        try (FileOutputStream output = new FileOutputStream(temporary)) {
+            saved.store(output, null);
+            output.getFD().sync();
+        }
+        if (!temporary.renameTo(file)) throw new IOException("Unable to save subscription refresh progress");
+    }
+
+    void clear() throws IOException {
+        if (!file.delete() && file.exists()) throw new IOException("Unable to clear subscription refresh progress");
+    }
+}

--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshResultIndex.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshResultIndex.java
@@ -1,0 +1,43 @@
+package org.opentubex.app;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+/** Keeps response bodies on disk; only record IDs and slot paths stay in memory. */
+final class SubscriptionRefreshResultIndex {
+    interface IdReader {
+        String read(File file) throws IOException;
+    }
+
+    private final TreeMap<String, File> filesById = new TreeMap<>();
+    private final Map<File, String> idsByFile = new HashMap<>();
+
+    SubscriptionRefreshResultIndex(File directory, IdReader readId) throws IOException {
+        File[] files = directory.listFiles((dir, name) -> name.endsWith(".json"));
+        if (files != null) {
+            for (File file : files) put(file, readId.read(file));
+        }
+    }
+
+    void put(File file, String id) {
+        remove(file);
+        filesById.put(id, file);
+        idsByFile.put(file, id);
+    }
+
+    void remove(File file) {
+        String id = idsByFile.remove(file);
+        if (id != null) filesById.remove(id);
+    }
+
+    File first() {
+        return filesById.isEmpty() ? null : filesById.firstEntry().getValue();
+    }
+
+    File get(String id) {
+        return filesById.get(id);
+    }
+}

--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshResultStore.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshResultStore.java
@@ -14,6 +14,8 @@ import java.util.UUID;
 
 final class SubscriptionRefreshResultStore {
     private static final String DIRECTORY_NAME = "subscription-refresh-results";
+    private static File indexedDirectory;
+    private static SubscriptionRefreshResultIndex index;
 
     private SubscriptionRefreshResultStore() {}
 
@@ -60,30 +62,25 @@ final class SubscriptionRefreshResultStore {
         String slot = profileId + "\n" + feedType + "\nfailure";
         String slotName = UUID.nameUUIDFromBytes(slot.getBytes(StandardCharsets.UTF_8)).toString();
         File failure = new File(directory(context), slotName + ".json");
-        if (failure.exists()) failure.delete();
+        if (failure.delete() && index != null && failure.getParentFile().equals(indexedDirectory)) {
+            index.remove(failure);
+        }
     }
 
     static synchronized JSONObject readNext(Context context) throws IOException, JSONException {
-        File[] files = directory(context).listFiles((dir, name) -> name.endsWith(".json"));
-        if (files == null || files.length == 0) return null;
-        JSONObject next = null;
-        for (File file : files) {
-            JSONObject result = read(file);
-            if (next == null || result.getString("id").compareTo(next.getString("id")) < 0) {
-                next = result;
-            }
-        }
-        return next;
+        File file = index(context).first();
+        return file == null ? null : read(file);
     }
 
     static synchronized boolean acknowledge(Context context, String id) throws IOException, JSONException {
         if (id == null) return false;
-        File[] files = directory(context).listFiles((dir, name) -> name.endsWith(".json"));
-        if (files == null) return false;
-        for (File file : files) {
-            if (id.equals(read(file).optString("id"))) return file.delete();
-        }
-        // A newer result may have replaced the slot after the renderer read it.
+        SubscriptionRefreshResultIndex pending = index(context);
+        File file = pending.get(id);
+        // Replacing a slot removes its old ID, so an old acknowledgement cannot
+        // delete the replacement. All writes and acknowledgements hold this lock.
+        if (file == null) return true;
+        if (!file.delete() && file.exists()) return false;
+        pending.remove(file);
         return true;
     }
 
@@ -98,21 +95,41 @@ final class SubscriptionRefreshResultStore {
     }
 
     private static void write(Context context, JSONObject result, String slot) throws IOException, JSONException {
+        File directory = directory(context);
+        SubscriptionRefreshResultIndex pending = directory.equals(indexedDirectory) ? index : null;
         String id = result.getString("id");
         String slotName = UUID.nameUUIDFromBytes(slot.getBytes(StandardCharsets.UTF_8)).toString();
-        File target = new File(directory(context), slotName + ".json");
-        File temporary = new File(directory(context), id + ".tmp");
+        File target = new File(directory, slotName + ".json");
+        File temporary = new File(directory, id + ".tmp");
         byte[] bytes = result.toString().getBytes(StandardCharsets.UTF_8);
         try (FileOutputStream output = new FileOutputStream(temporary)) {
             output.write(bytes);
             output.getFD().sync();
         }
         if (!temporary.renameTo(target)) {
-            if (!target.delete() || !temporary.renameTo(target)) {
+            boolean removed = target.delete();
+            if (removed && pending != null) pending.remove(target);
+            if (!removed || !temporary.renameTo(target)) {
                 temporary.delete();
                 throw new IOException("Unable to commit pending refresh result");
             }
         }
+        if (pending != null) pending.put(target, id);
+    }
+
+    private static SubscriptionRefreshResultIndex index(Context context) throws IOException {
+        File directory = directory(context);
+        if (index == null || !directory.equals(indexedDirectory)) {
+            index = new SubscriptionRefreshResultIndex(directory, file -> {
+                try {
+                    return read(file).getString("id");
+                } catch (JSONException error) {
+                    throw new IOException("Invalid pending refresh result", error);
+                }
+            });
+            indexedDirectory = directory;
+        }
+        return index;
     }
 
     private static String createId() {

--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshWorker.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshWorker.java
@@ -2,6 +2,7 @@ package org.opentubex.app;
 
 import android.app.NotificationManager;
 import android.content.Context;
+import android.os.SystemClock;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -16,6 +17,7 @@ import androidx.work.WorkerParameters;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.io.File;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -28,6 +30,7 @@ public final class SubscriptionRefreshWorker extends Worker {
     private static final String UNIQUE_WORK_NAME = "subscription-refresh";
     private static final String TOKEN_INPUT = "token";
     static final String FEED_TYPE_INPUT = "feedType";
+    private static final long MAXIMUM_BATCH_MILLIS = 5 * 60 * 1000;
     private static final SubscriptionRefreshState STATE = new SubscriptionRefreshState();
 
     @FunctionalInterface
@@ -161,6 +164,16 @@ public final class SubscriptionRefreshWorker extends Worker {
             new SubscriptionRefreshNotificationProgress();
         NotificationManager notifications = context.getSystemService(NotificationManager.class);
         try {
+            List<String> orderedChannelIds = new ArrayList<>(channelIds);
+            SubscriptionRefreshCheckpoint checkpoint = SubscriptionRefreshCheckpoint.load(
+                new File(context.getFilesDir(), "subscription-refresh-" + feedType + ".properties"),
+                SubscriptionRefreshCheckpoint.configurationId(feeds),
+                orderedChannelIds.size()
+            );
+            completed = checkpoint.completed;
+            failed = checkpoint.failed;
+            failedProfileIds.addAll(checkpoint.failedProfileIds);
+            long batchStartedAt = SystemClock.elapsedRealtime();
             // A periodic job may recreate the process while the app is closed, where
             // Android does not allow starting WorkManager's foreground service. Keep
             // the durable work owned by JobScheduler and make its progress visible
@@ -172,15 +185,20 @@ public final class SubscriptionRefreshWorker extends Worker {
                     token,
                     feed.title,
                     feed.cancelLabel,
-                    0
+                    channelIds.isEmpty() ? 100 : (int) Math.round(checkpoint.nextIndex * 100.0 / channelIds.size())
                 )
             );
 
             int total = channelIds.size();
-            for (String channelId : channelIds) {
-                if (SubscriptionRefreshCoordinator.isCancelled(token) || isStopped()) {
+            for (int index = checkpoint.nextIndex; index < orderedChannelIds.size(); index++) {
+                if (SubscriptionRefreshCoordinator.isCancelled(token)) {
+                    checkpoint.clear();
                     return Result.success();
                 }
+                if (isStopped() || SystemClock.elapsedRealtime() - batchStartedAt >= MAXIMUM_BATCH_MILLIS) {
+                    return Result.retry();
+                }
+                String channelId = orderedChannelIds.get(index);
                 List<String> profileIds = targetProfileIds(feeds, channelId);
                 try {
                     JSONObject payload = SubscriptionRefreshHttpClient.fetch(feed, channelId);
@@ -225,6 +243,7 @@ public final class SubscriptionRefreshWorker extends Worker {
                     );
                 }
 
+                checkpoint.save(index + 1, completed, failed, failedProfileIds);
                 int progress = total == 0 ? 100 : (int) Math.round((completed + failed) * 100.0 / total);
                 if (notificationProgress.advanceTo(progress)) {
                     notifications.notify(
@@ -240,10 +259,13 @@ public final class SubscriptionRefreshWorker extends Worker {
                 }
             }
 
-            if (SubscriptionRefreshCoordinator.isCancelled(token) || isStopped()) {
+            if (SubscriptionRefreshCoordinator.isCancelled(token)) {
+                checkpoint.clear();
                 return Result.success();
             }
+            if (isStopped()) return Result.retry();
             if (failed > 0 && completed == 0 && !channelIds.isEmpty()) {
+                checkpoint.clear();
                 return Result.retry();
             }
 
@@ -276,7 +298,9 @@ public final class SubscriptionRefreshWorker extends Worker {
                     );
                 }
             );
-            return completionFailedProfileIds.isEmpty() ? Result.success() : Result.retry();
+            if (!completionFailedProfileIds.isEmpty()) return Result.retry();
+            checkpoint.clear();
+            return Result.success();
         } catch (Exception error) {
             List<String> profileIds = new ArrayList<>();
             for (SubscriptionRefreshConfiguration.Feed profileFeed : feeds) {

--- a/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshCheckpointTest.java
+++ b/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshCheckpointTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -48,6 +50,28 @@ public class SubscriptionRefreshCheckpointTest {
         assertEquals(Set.of("profile-with-failure"), resumed.failedProfileIds);
         assertEquals(0, SubscriptionRefreshCheckpoint.load(file, "second", 10).nextIndex);
         assertEquals(0, SubscriptionRefreshCheckpoint.load(file, "first", 2).nextIndex);
+    }
+
+    @Test
+    public void nullAuthorizationDiffersFromLiteralNull() {
+        SubscriptionRefreshConfiguration.Feed anonymous = feed("https://first.test", List.of("one"));
+        SubscriptionRefreshConfiguration.Feed authorized = new SubscriptionRefreshConfiguration.Feed(
+            "profile", "videos", 900_000, List.of("one"), "https://first.test", "null", "Refresh", "Cancel"
+        );
+        assertNotEquals(
+            SubscriptionRefreshCheckpoint.configurationId(List.of(anonymous)),
+            SubscriptionRefreshCheckpoint.configurationId(List.of(authorized))
+        );
+    }
+
+    @Test
+    public void malformedPropertiesStartAFreshPassAndCanBeReplaced() throws Exception {
+        File file = new File(temporary.newFolder(), "progress.properties");
+        Files.write(file.toPath(), "bad=\\u12G4\n".getBytes(StandardCharsets.UTF_8));
+        SubscriptionRefreshCheckpoint checkpoint = SubscriptionRefreshCheckpoint.load(file, "configuration", 10);
+        assertEquals(0, checkpoint.nextIndex);
+        checkpoint.save(1, 1, 0, Set.of());
+        assertEquals(1, SubscriptionRefreshCheckpoint.load(file, "configuration", 10).nextIndex);
     }
 
     @Test

--- a/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshCheckpointTest.java
+++ b/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshCheckpointTest.java
@@ -1,0 +1,69 @@
+package org.opentubex.app;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class SubscriptionRefreshCheckpointTest {
+    @Rule public TemporaryFolder temporary = new TemporaryFolder();
+
+    @Test
+    public void interruptedPassesEventuallyReachEveryChannelWithoutRestartingAtTheFirst() throws Exception {
+        File file = new File(temporary.newFolder(), "progress.properties");
+        List<Integer> visited = new ArrayList<>();
+        for (int batch = 0; batch < 9; batch++) {
+            SubscriptionRefreshCheckpoint checkpoint = SubscriptionRefreshCheckpoint.load(file, "configuration", 900);
+            int completed = checkpoint.completed;
+            for (int index = checkpoint.nextIndex; index < (batch + 1) * 100; index++) {
+                visited.add(index);
+                checkpoint.save(index + 1, ++completed, 0, Set.of());
+            }
+            // Recreating the checkpoint above simulates process loss between batches.
+        }
+        assertEquals(900, visited.size());
+        for (int index = 0; index < 900; index++) assertEquals(index, visited.get(index).intValue());
+        SubscriptionRefreshCheckpoint completed = SubscriptionRefreshCheckpoint.load(file, "configuration", 900);
+        assertEquals(900, completed.nextIndex);
+        completed.clear();
+        assertEquals(0, SubscriptionRefreshCheckpoint.load(file, "configuration", 900).nextIndex);
+    }
+
+    @Test
+    public void failureStateSurvivesRestartsButChangedConfigurationStartsANewPass() throws Exception {
+        File file = new File(temporary.newFolder(), "progress.properties");
+        SubscriptionRefreshCheckpoint checkpoint = SubscriptionRefreshCheckpoint.load(file, "first", 10);
+        checkpoint.save(3, 2, 1, Set.of("profile-with-failure"));
+        SubscriptionRefreshCheckpoint resumed = SubscriptionRefreshCheckpoint.load(file, "first", 10);
+        assertEquals(3, resumed.nextIndex);
+        assertEquals(2, resumed.completed);
+        assertEquals(1, resumed.failed);
+        assertEquals(Set.of("profile-with-failure"), resumed.failedProfileIds);
+        assertEquals(0, SubscriptionRefreshCheckpoint.load(file, "second", 10).nextIndex);
+        assertEquals(0, SubscriptionRefreshCheckpoint.load(file, "first", 2).nextIndex);
+    }
+
+    @Test
+    public void changingProviderOrProfileMembershipInvalidatesProgress() {
+        SubscriptionRefreshConfiguration.Feed first = feed("https://first.test", List.of("one", "two"));
+        assertNotEquals(
+            SubscriptionRefreshCheckpoint.configurationId(List.of(first)),
+            SubscriptionRefreshCheckpoint.configurationId(List.of(feed("https://second.test", List.of("one", "two"))))
+        );
+        assertNotEquals(
+            SubscriptionRefreshCheckpoint.configurationId(List.of(first)),
+            SubscriptionRefreshCheckpoint.configurationId(List.of(feed("https://first.test", List.of("two", "one"))))
+        );
+    }
+
+    private static SubscriptionRefreshConfiguration.Feed feed(String instance, List<String> channels) {
+        return new SubscriptionRefreshConfiguration.Feed("profile", "videos", 900_000, channels, instance, null, "Refresh", "Cancel");
+    }
+}

--- a/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshResultIndexTest.java
+++ b/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshResultIndexTest.java
@@ -1,0 +1,62 @@
+package org.opentubex.app;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class SubscriptionRefreshResultIndexTest {
+    @Rule public TemporaryFolder temporary = new TemporaryFolder();
+
+    @Test
+    public void drainingLargeBacklogsReadsBodiesOnlyOnceToIndexAndOnceToConsume() throws Exception {
+        File directory = temporary.newFolder();
+        for (int i = 0; i < 900; i++) {
+            Files.write(new File(directory, "slot-" + i + ".json").toPath(), String.format("%013d", i).getBytes(StandardCharsets.UTF_8));
+        }
+        AtomicInteger reads = new AtomicInteger();
+        SubscriptionRefreshResultIndex.IdReader readId = file -> {
+            reads.incrementAndGet();
+            return new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+        };
+        SubscriptionRefreshResultIndex index = new SubscriptionRefreshResultIndex(directory, readId);
+        for (int i = 0; i < 900; i++) {
+            File file = index.first();
+            String id = readId.read(file);
+            assertEquals(String.format("%013d", i), id);
+            assertEquals(file, index.get(id));
+            assertTrue(file.delete());
+            index.remove(file);
+        }
+        assertNull(index.first());
+        assertEquals(1800, reads.get());
+    }
+
+    @Test
+    public void oldAcknowledgementsCannotDeleteReplacedSlotsAndRestartKeepsOrder() throws Exception {
+        File directory = temporary.newFolder();
+        File slot = new File(directory, "slot.json");
+        File other = new File(directory, "other.json");
+        Files.write(slot.toPath(), "001".getBytes(StandardCharsets.UTF_8));
+        Files.write(other.toPath(), "002".getBytes(StandardCharsets.UTF_8));
+        SubscriptionRefreshResultIndex index = new SubscriptionRefreshResultIndex(directory, file -> new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8));
+        Files.write(slot.toPath(), "003".getBytes(StandardCharsets.UTF_8));
+        index.put(slot, "003");
+        assertNull(index.get("001"));
+        assertEquals(other, index.first());
+        assertEquals(slot, index.get("003"));
+
+        SubscriptionRefreshResultIndex restarted = new SubscriptionRefreshResultIndex(directory, file -> new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8));
+        assertEquals(other, restarted.first());
+        assertNull(restarted.get("001"));
+        assertEquals(slot, restarted.get("003"));
+    }
+}

--- a/e2e/tests/offline/persistence-regressions.spec.mjs
+++ b/e2e/tests/offline/persistence-regressions.spec.mjs
@@ -1,0 +1,191 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { test, expect, goToSettingsSection, latestSettings } from '../../helpers/app.mjs'
+import { decryptSyncDocument, encryptSyncDocument } from '../../../src/renderer/helpers/sync-server-privacy.js'
+
+test('encrypted subscription retries retain concurrent remote edits', async ({ page }) => {
+  const key = Buffer.alloc(32, 7).toString('base64')
+  const salt = Buffer.alloc(16, 8).toString('base64')
+  const channel = id => ({ id, name: id, avatar: 'https://example.test/avatar.png' })
+  let remote = [channel('base'), channel('removed-remotely')]
+  let revision = 1
+  let conflicts = 0
+  await page.route('https://sync.example.test/**', async route => {
+    const request = route.request()
+    const pathname = new URL(request.url()).pathname
+    let response
+    if (pathname === '/v1/encrypted_sync') {
+      response = { collections: [{ collection: 'subscriptions' }] }
+    } else if (pathname === '/v1/encrypted_sync/subscriptions' && request.method() === 'GET') {
+      response = { revision, payload: await encryptSyncDocument(remote, key, salt) }
+    } else if (pathname === '/v1/encrypted_sync/subscriptions' && request.method() === 'PUT') {
+      const body = request.postDataJSON()
+      if (conflicts === 0) {
+        remote = [channel('base'), channel('added-remotely')]
+        revision++
+        conflicts++
+        await route.fulfill({ status: 409, json: { error: 'Revision conflict' } })
+        return
+      }
+      expect(body.revision).toBe(revision)
+      remote = await decryptSyncDocument(body.payload, key)
+      revision++
+      response = { revision }
+    } else {
+      throw new Error(`Unexpected sync request: ${request.method()} ${pathname}`)
+    }
+    await route.fulfill({ json: response })
+  })
+
+  await page.evaluate(async ({ key, salt }) => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    await store.dispatch('updateProfile', {
+      _id: 'allChannels',
+      name: 'All Channels',
+      subscriptions: [
+        { id: 'base', name: 'Base' },
+        { id: 'removed-remotely', name: 'Removed remotely' },
+        { id: 'added-locally', name: 'Added locally' },
+      ],
+    })
+    for (const [setting, value] of Object.entries({
+      SyncServerEnabled: true,
+      SyncServerAutoSync: false,
+      SyncServerUrl: 'https://sync.example.test',
+      SyncServerToken: 'fixture-token',
+      SyncServerPrivacyMode: 'enhanced',
+      SyncServerPrivacyKey: key,
+      SyncServerPrivacySalt: salt,
+      SyncServerSyncSubscriptions: true,
+      SyncServerSyncProfiles: false,
+      SyncServerSyncHistory: false,
+      SyncServerSyncPlaylists: false,
+      SyncServerSyncSessions: false,
+      SyncServerSyncSettings: false,
+      SyncServerSnapshot: JSON.stringify({ subscriptions: ['base', 'removed-remotely'] }),
+    })) store.commit(`set${setting}`, value)
+    await store.dispatch('syncWithSyncServer')
+    await store.dispatch('syncWithSyncServer')
+  }, { key, salt })
+
+  expect(conflicts).toBe(1)
+  expect(remote.map(entry => entry.id).sort()).toEqual(['added-locally', 'added-remotely', 'base'])
+  expect(await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    return store.state.profiles.profileList.find(profile => profile._id === 'allChannels')
+      .subscriptions.map(entry => entry.id).sort()
+  })).toEqual(['added-locally', 'added-remotely', 'base'])
+})
+
+for (const [setting, launcher, attribute] of [
+  ['quickSettings', 'Customize quick settings', 'data-setting-id'],
+  ['navigationItems', 'Customize navigation', 'data-navigation-item-id'],
+]) {
+  test(`${setting} retains consecutive removals before persistence finishes`, async ({ app, page }) => {
+    const appearance = await goToSettingsSection(page, 'appearance')
+    await appearance.getByRole('button', { name: launcher }).click()
+    const rows = page.locator(`[${attribute}]`)
+    const initial = await rows.evaluateAll((elements, attribute) => elements.map(element => element.getAttribute(attribute)), attribute)
+    expect(initial.length).toBeGreaterThan(2)
+    // One renderer task guarantees that both real click handlers run before
+    // either asynchronous datastore write can update the store.
+    await rows.evaluateAll(elements => {
+      elements[0].querySelector('button[aria-label^="Remove "]').click()
+      elements[1].querySelector('button[aria-label^="Remove "]').click()
+    })
+    await expect.poll(async () => latestSettings(await readFile(path.join(app.userDataDir, 'settings.db'), 'utf8'))[setting]).toEqual(initial.slice(2))
+    await expect(rows).toHaveCount(initial.length - 2)
+    await app.relaunch()
+    expect(latestSettings(await readFile(path.join(app.userDataDir, 'settings.db'), 'utf8'))[setting]).toEqual(initial.slice(2))
+  })
+}
+
+for (const [feed, action, cache, entriesKey, storedKey, idKey] of [
+  ['videos', 'updateSubscriptionVideosCacheByChannel', 'videoCache', 'videos', 'videos', 'videoId'],
+  ['shorts', 'updateSubscriptionShortsCacheByChannel', 'shortsCache', 'videos', 'shorts', 'videoId'],
+  ['live', 'updateSubscriptionLiveCacheByChannel', 'liveCache', 'videos', 'liveStreams', 'videoId'],
+  ['posts', 'updateSubscriptionPostsCacheByChannel', 'postsCache', 'posts', 'communityPosts', 'postId'],
+]) {
+  test(`${feed} cache rejects stale results including overlapping writes`, async ({ app, page }) => {
+    const result = await page.evaluate(async ({ action, cache, entriesKey, idKey }) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const save = (time, ids) => store.dispatch(action, {
+        channelId: 'audit-channel',
+        timestamp: new Date(time),
+        [entriesKey]: ids.map(id => ({ [idKey]: id })),
+      })
+      await save(2000, ['old', 'new'])
+      await save(1000, ['old'])
+      const afterStale = store.state.subscriptionCache[cache]['audit-channel'][entriesKey].map(entry => entry[idKey])
+      await Promise.all([save(4000, ['newest']), save(3000, ['older-overlap'])])
+      return { afterStale, final: store.state.subscriptionCache[cache]['audit-channel'] }
+    }, { action, cache, entriesKey, idKey })
+    expect(result.afterStale).toEqual(['old', 'new'])
+    expect(result.final[entriesKey].map(entry => entry[idKey])).toEqual(['newest'])
+    const records = (await readFile(path.join(app.userDataDir, 'subscription-cache.db'), 'utf8'))
+      .trim().split('\n').map(line => JSON.parse(line))
+    const persisted = records.filter(record => record._id === 'audit-channel').at(-1)
+    expect(persisted[storedKey].map(entry => entry[idKey])).toEqual(['newest'])
+    expect(new Date(persisted[`${storedKey}Timestamp`]).getTime()).toBe(4000)
+  })
+}
+
+test('Shorts metadata enrichment cannot replace a concurrent feed refresh', async ({ app, page }) => {
+  const result = await page.evaluate(async () => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    const save = (timestamp, videos) => store.dispatch('updateSubscriptionShortsCacheByChannel', {
+      channelId: 'audit-channel', timestamp: new Date(timestamp), videos,
+    })
+    await save(1000, [{ videoId: 'old', title: 'Old title' }])
+    await Promise.all([
+      save(2000, [{ videoId: 'new', title: 'New title' }]),
+      store.dispatch('updateSubscriptionShortsCacheWithChannelPageShorts', {
+        channelId: 'audit-channel', videos: [{ videoId: 'old', title: 'Updated title' }],
+      }),
+    ])
+    return store.state.subscriptionCache.shortsCache['audit-channel'].videos
+  })
+  expect(result.map(video => video.videoId)).toEqual(['new'])
+  const records = (await readFile(path.join(app.userDataDir, 'subscription-cache.db'), 'utf8'))
+    .trim().split('\n').map(line => JSON.parse(line))
+  const persisted = records.filter(record => record._id === 'audit-channel').at(-1)
+  expect(persisted.shorts.map(video => video.videoId)).toEqual(['new'])
+  expect(new Date(persisted.shortsTimestamp).getTime()).toBe(2000)
+})
+
+test('persistent playback cache preserves thumbnails and duration after restart', async ({ app, page }) => {
+  const source = {
+    manifestMimeType: 'application/dash+xml',
+    manifestSrc: 'data:application/dash+xml;charset=UTF-8,fixture',
+    legacyFormats: [],
+    title: 'Fixture',
+    isLive: false,
+    captions: [],
+    captionTranslations: [],
+    subtitlesIncluded: true,
+    duration: 123,
+    storyboardSrc: 'data:text/vtt;charset=utf-8,WEBVTT',
+  }
+  expect(await page.evaluate(source => window.ftElectron.ytDlpPlaybackCacheSet(
+    'abcdefghijk', 'fixture-cache-key', Date.now() + 3600000, source
+  ), source)).toBe(true)
+  const { page: reopened } = await app.relaunch()
+  const result = await reopened.evaluate(() => window.ftElectron.ytDlpPlaybackCacheGet('abcdefghijk', 'fixture-cache-key'))
+  expect(result.source.storyboardSrc).toBe(source.storyboardSrc)
+  expect(result.source.duration).toBe(source.duration)
+})
+
+test('stale refresh completion cannot rewind feed refresh timing', async ({ page }) => {
+  const result = await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    const latest = Math.max(Date.now(), store.getters.getSubscriptionFeedLastRefreshTimestamp) + 1000
+    for (const timestamp of [latest, latest - 1000]) {
+      window.dispatchEvent(new CustomEvent('opentubex-subscription-refresh-completed', {
+        detail: { tab: 'videos', profileId: store.getters.getActiveProfile._id, timestamp },
+      }))
+    }
+    return { actual: store.getters.getSubscriptionFeedLastRefreshTimestamp, expected: latest }
+  })
+  expect(result.actual).toBe(result.expected)
+})

--- a/e2e/tests/offline/persistence-regressions.spec.mjs
+++ b/e2e/tests/offline/persistence-regressions.spec.mjs
@@ -189,3 +189,115 @@ test('stale refresh completion cannot rewind feed refresh timing', async ({ page
   })
   expect(result.actual).toBe(result.expected)
 })
+
+for (const mode of ['all', 'video', 'post']) {
+  test(`marking ${mode} seen does not mutate a newer refresh after a rejected write`, async ({ app, page }) => {
+    const result = await page.evaluate(async mode => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const isPost = mode === 'post'
+      const key = isPost ? 'posts' : 'videos'
+      const idKey = isPost ? 'postId' : 'videoId'
+      const action = isPost ? 'updateSubscriptionPostsCacheByChannel' : 'updateSubscriptionVideosCacheByChannel'
+      const save = (timestamp, ids) => store.dispatch(action, {
+        channelId: 'audit-seen',
+        timestamp: new Date(timestamp),
+        [key]: ids.map(id => ({ [idKey]: id, isNewInSubscriptionFeed: true })),
+      })
+      await save(1000, ['existing'])
+      const refresh = save(2000, ['existing', 'new'])
+      const seen = mode === 'all'
+        ? store.dispatch('markSubscriptionEntriesAsSeen', { tab: 'videos', channelIds: ['audit-seen'] })
+        : store.dispatch(isPost ? 'markSubscriptionPostAsSeen' : 'markSubscriptionVideoAsSeen', 'existing')
+      await Promise.all([refresh, seen])
+      return store.state.subscriptionCache[isPost ? 'postsCache' : 'videoCache']['audit-seen'][key]
+    }, mode)
+    expect(result.map(entry => entry.isNewInSubscriptionFeed)).toEqual([true, true])
+    const records = (await readFile(path.join(app.userDataDir, 'subscription-cache.db'), 'utf8'))
+      .trim().split('\n').map(line => JSON.parse(line))
+    const persisted = records.filter(record => record._id === 'audit-seen').at(-1)
+    expect(persisted[mode === 'post' ? 'communityPosts' : 'videos']).toEqual(result)
+  })
+}
+
+test('failed Home re-addition redirects when removal was already persisted', async ({ app, page }) => {
+  await page.locator('.sideNav .navOption[title="Home"]').click()
+  await expect.poll(() => page.evaluate(() => document.querySelector('#app').__vue_app__.config.globalProperties.$store.getters.getActiveTab.route.path)).toBe('/home')
+  const appearance = await goToSettingsSection(page, 'appearance')
+  await appearance.getByRole('button', { name: 'Customize navigation' }).click()
+  await app.electronApp.evaluate(({ ipcMain }) => {
+    const original = ipcMain._invokeHandlers.get('db-settings')
+    let writes = 0
+    ipcMain.removeHandler('db-settings')
+    ipcMain.handle('db-settings', async (event, request) => {
+      if (request.action !== 2 || request.data._id !== 'navigationItems') return original(event, request)
+      if (++writes === 2) throw new Error('Fixture disk failure')
+      const result = await original(event, request)
+      await new Promise(resolve => { globalThis.releaseNavigationWrite = resolve })
+      return result
+    })
+  })
+  await page.locator('[data-navigation-item-id="home"]').getByRole('button', { name: 'Remove Home' }).click()
+  await expect.poll(() => app.electronApp.evaluate(() => typeof globalThis.releaseNavigationWrite)).toBe('function')
+  await page.getByRole('button', { name: 'Add item', exact: true }).click()
+  await page.getByRole('menuitem', { name: 'Home', exact: true }).click()
+  await expect(page.locator('[data-navigation-item-id="home"]')).toHaveCount(1)
+  await app.electronApp.evaluate(() => globalThis.releaseNavigationWrite())
+  await expect.poll(() => page.evaluate(() => document.querySelector('#app').__vue_app__.config.globalProperties.$store.getters.getNavigationItems.includes('home'))).toBe(false)
+  await expect.poll(() => page.evaluate(() => document.querySelector('#app').__vue_app__.config.globalProperties.$route.path)).not.toBe('/home')
+})
+
+test('queued bulk seen writes and their final mutation retain the original snapshot', async ({ app, page }) => {
+  await page.evaluate(async () => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    for (let i = 0; i < 9; i++) {
+      await store.dispatch('updateSubscriptionVideosCacheByChannel', {
+        channelId: `audit-bulk-${i}`,
+        timestamp: new Date(1000),
+        videos: [{ videoId: 'old', isNewInSubscriptionFeed: true }],
+      })
+    }
+  })
+  await app.electronApp.evaluate(({ ipcMain }) => {
+    const original = ipcMain._invokeHandlers.get('db-subscription-cache')
+    let seenRequests = 0
+    globalThis.blockedSeenWrites = []
+    globalThis.finishedSeenWrites = 0
+    ipcMain.removeHandler('db-subscription-cache')
+    ipcMain.handle('db-subscription-cache', async (event, request) => {
+      const seen = request.data?.channelId?.startsWith('audit-bulk-') && request.data.entries?.every(entry => entry.isNewInSubscriptionFeed === false)
+      if (seen && ++seenRequests <= 8) {
+        await new Promise(resolve => globalThis.blockedSeenWrites.push(resolve))
+      }
+      const result = await original(event, request)
+      if (seen) globalThis.finishedSeenWrites++
+      return result
+    })
+  })
+  await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    window.bulkSeenWrite = store.dispatch('markSubscriptionEntriesAsSeen', {
+      tab: 'videos', channelIds: Array.from({ length: 9 }, (_, i) => `audit-bulk-${i}`),
+    })
+  })
+  await expect.poll(() => app.electronApp.evaluate(() => globalThis.blockedSeenWrites.length)).toBe(8)
+  const refresh = id => page.evaluate(id => document.querySelector('#app').__vue_app__.config.globalProperties.$store.dispatch('updateSubscriptionVideosCacheByChannel', {
+    channelId: `audit-bulk-${id}`,
+    timestamp: new Date(2000),
+    videos: [{ videoId: 'new', isNewInSubscriptionFeed: true }],
+  }), id)
+  // The ninth write has not started; it must not borrow the new timestamp.
+  await refresh(8)
+  await app.electronApp.evaluate(() => globalThis.blockedSeenWrites.shift()())
+  await expect.poll(() => app.electronApp.evaluate(() => globalThis.finishedSeenWrites)).toBeGreaterThan(0)
+  // The first write has finished, but the final bulk mutation is still pending.
+  await refresh(0)
+  await app.electronApp.evaluate(() => globalThis.blockedSeenWrites.splice(0).forEach(resolve => resolve()))
+  await page.evaluate(() => window.bulkSeenWrite)
+  const records = (await readFile(path.join(app.userDataDir, 'subscription-cache.db'), 'utf8'))
+    .trim().split('\n').map(line => JSON.parse(line))
+  for (const id of [0, 8]) {
+    const expected = [{ videoId: 'new', isNewInSubscriptionFeed: true }]
+    expect(records.filter(record => record._id === `audit-bulk-${id}`).at(-1).videos).toEqual(expected)
+    expect(await page.evaluate(id => document.querySelector('#app').__vue_app__.config.globalProperties.$store.state.subscriptionCache.videoCache[`audit-bulk-${id}`].videos, id)).toEqual(expected)
+  }
+})

--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -258,7 +258,7 @@ test.describe('new subscriptions feed', () => {
       window.__unsubscribeMarkSeen()
       return window.__markSeenMutations
     })).toEqual([[
-      { tab: 'videos', channelId: CHANNEL_ID }
+      { tab: 'videos', channelId: CHANNEL_ID, timestamp: expect.any(Date) }
     ]])
   })
 
@@ -608,10 +608,10 @@ test.describe('new feed settings and seen state', () => {
       window.__unsubscribeMarkSeen()
       return window.__markSeenMutations
     })).toEqual([[
-      { tab: 'videos', channelId: CHANNEL_ID },
-      { tab: 'shorts', channelId: CHANNEL_ID },
-      { tab: 'live', channelId: CHANNEL_ID },
-      { tab: 'posts', channelId: CHANNEL_ID }
+      { tab: 'videos', channelId: CHANNEL_ID, timestamp: expect.any(Date) },
+      { tab: 'shorts', channelId: CHANNEL_ID, timestamp: expect.any(Date) },
+      { tab: 'live', channelId: CHANNEL_ID, timestamp: expect.any(Date) },
+      { tab: 'posts', channelId: CHANNEL_ID, timestamp: expect.any(Date) }
     ]])
     await expect(markAllAsSeen).toHaveCount(0)
 

--- a/src/datastores/handlers/base.js
+++ b/src/datastores/handlers/base.js
@@ -659,76 +659,89 @@ class SearchHistory {
 }
 
 class SubscriptionCache {
+  static pendingUpdates = new Map()
+
+  static queueUpdate(channelId, field, operation) {
+    const key = JSON.stringify([channelId, field])
+    const previous = this.pendingUpdates.get(key) ?? Promise.resolve()
+    const update = previous.catch(() => {}).then(operation)
+    this.pendingUpdates.set(key, update)
+    return update.finally(() => {
+      if (this.pendingUpdates.get(key) === update) this.pendingUpdates.delete(key)
+    })
+  }
+
+  static updateFeed(channelId, entries, timestamp, field) {
+    return this.queueUpdate(channelId, field, async () => {
+      const timestampField = `${field}Timestamp`
+      const current = await db.subscriptionCache.findOneAsync({ _id: channelId })
+      if (new Date(current?.[timestampField]).getTime() > new Date(timestamp).getTime()) return false
+
+      await db.subscriptionCache.updateAsync(
+        { _id: channelId },
+        { $set: { [field]: entries, [timestampField]: timestamp } },
+        { upsert: true }
+      )
+      return true
+    })
+  }
+
   static find() {
     return db.subscriptionCache.findAsync({})
   }
 
   static updateVideosByChannelId(channelId, entries, timestamp) {
-    return db.subscriptionCache.updateAsync(
-      { _id: channelId },
-      { $set: { videos: entries, videosTimestamp: timestamp } },
-      { upsert: true }
-    )
+    return SubscriptionCache.updateFeed(channelId, entries, timestamp, 'videos')
   }
 
   static updateLiveStreamsByChannelId(channelId, entries, timestamp) {
-    return db.subscriptionCache.updateAsync(
-      { _id: channelId },
-      { $set: { liveStreams: entries, liveStreamsTimestamp: timestamp } },
-      { upsert: true }
-    )
+    return SubscriptionCache.updateFeed(channelId, entries, timestamp, 'liveStreams')
   }
 
   static updateShortsByChannelId(channelId, entries, timestamp) {
-    return db.subscriptionCache.updateAsync(
-      { _id: channelId },
-      { $set: { shorts: entries, shortsTimestamp: timestamp } },
-      { upsert: true }
-    )
+    return SubscriptionCache.updateFeed(channelId, entries, timestamp, 'shorts')
   }
 
-  static async updateShortsWithChannelPageShortsByChannelId(channelId, entries) {
-    const doc = await db.subscriptionCache.findOneAsync({ _id: channelId }, { shorts: 1 })
+  static updateShortsWithChannelPageShortsByChannelId(channelId, entries) {
+    return SubscriptionCache.queueUpdate(channelId, 'shorts', async () => {
+      const doc = await db.subscriptionCache.findOneAsync({ _id: channelId }, { shorts: 1 })
 
-    if (!Array.isArray(doc?.shorts)) {
-      return
-    }
+      if (!Array.isArray(doc?.shorts)) {
+        return
+      }
 
-    let hasUpdates = false
+      let hasUpdates = false
 
-    doc.shorts.forEach(cachedVideo => {
-      const channelVideo = entries.find(short => cachedVideo.videoId === short.videoId)
-      if (!channelVideo) { return }
+      doc.shorts.forEach(cachedVideo => {
+        const channelVideo = entries.find(short => cachedVideo.videoId === short.videoId)
+        if (!channelVideo) { return }
 
-      hasUpdates = true
+        hasUpdates = true
 
-      // authorId probably never changes, so we don't need to update that
-      cachedVideo.title = channelVideo.title
-      cachedVideo.author = channelVideo.author
+        // authorId probably never changes, so we don't need to update that
+        cachedVideo.title = channelVideo.title
+        cachedVideo.author = channelVideo.author
 
-      // as the channel shorts page only has compact view counts for numbers above 1000 e.g. 12k
-      // and the RSS feeds include an exact value, we only want to overwrite it when the number is larger than the cached value
-      // 12345 vs 12000 => 12345
-      // 12345 vs 15000 => 15000
-      if (channelVideo.viewCount > cachedVideo.viewCount) {
-        cachedVideo.viewCount = channelVideo.viewCount
+        // as the channel shorts page only has compact view counts for numbers above 1000 e.g. 12k
+        // and the RSS feeds include an exact value, we only want to overwrite it when the number is larger than the cached value
+        // 12345 vs 12000 => 12345
+        // 12345 vs 15000 => 15000
+        if (channelVideo.viewCount > cachedVideo.viewCount) {
+          cachedVideo.viewCount = channelVideo.viewCount
+        }
+      })
+
+      if (hasUpdates) {
+        await db.subscriptionCache.updateAsync(
+          { _id: channelId },
+          { $set: { shorts: doc.shorts } }
+        )
       }
     })
-
-    if (hasUpdates) {
-      await db.subscriptionCache.updateAsync(
-        { _id: channelId },
-        { $set: { shorts: doc.shorts } }
-      )
-    }
   }
 
   static updateCommunityPostsByChannelId(channelId, entries, timestamp) {
-    return db.subscriptionCache.updateAsync(
-      { _id: channelId },
-      { $set: { communityPosts: entries, communityPostsTimestamp: timestamp } },
-      { upsert: true }
-    )
+    return SubscriptionCache.updateFeed(channelId, entries, timestamp, 'communityPosts')
   }
 
   static deleteMultipleChannels(channelIds) {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -5117,7 +5117,7 @@ function runApp() {
           return await baseHandlers.subscriptionCache.find()
 
         case DBActions.SUBSCRIPTION_CACHE.UPDATE_VIDEOS_BY_CHANNEL:
-          await baseHandlers.subscriptionCache.updateVideosByChannelId(data.channelId, data.entries, data.timestamp)
+          if (!await baseHandlers.subscriptionCache.updateVideosByChannelId(data.channelId, data.entries, data.timestamp)) return false
           syncOtherWindows(
             IpcChannels.SYNC_SUBSCRIPTION_CACHE,
             event,
@@ -5126,7 +5126,7 @@ function runApp() {
           return null
 
         case DBActions.SUBSCRIPTION_CACHE.UPDATE_LIVE_STREAMS_BY_CHANNEL:
-          await baseHandlers.subscriptionCache.updateLiveStreamsByChannelId(data.channelId, data.entries, data.timestamp)
+          if (!await baseHandlers.subscriptionCache.updateLiveStreamsByChannelId(data.channelId, data.entries, data.timestamp)) return false
           syncOtherWindows(
             IpcChannels.SYNC_SUBSCRIPTION_CACHE,
             event,
@@ -5135,7 +5135,7 @@ function runApp() {
           return null
 
         case DBActions.SUBSCRIPTION_CACHE.UPDATE_SHORTS_BY_CHANNEL:
-          await baseHandlers.subscriptionCache.updateShortsByChannelId(data.channelId, data.entries, data.timestamp)
+          if (!await baseHandlers.subscriptionCache.updateShortsByChannelId(data.channelId, data.entries, data.timestamp)) return false
           syncOtherWindows(
             IpcChannels.SYNC_SUBSCRIPTION_CACHE,
             event,
@@ -5153,7 +5153,7 @@ function runApp() {
           return null
 
         case DBActions.SUBSCRIPTION_CACHE.UPDATE_COMMUNITY_POSTS_BY_CHANNEL:
-          await baseHandlers.subscriptionCache.updateCommunityPostsByChannelId(data.channelId, data.entries, data.timestamp)
+          if (!await baseHandlers.subscriptionCache.updateCommunityPostsByChannelId(data.channelId, data.entries, data.timestamp)) return false
           syncOtherWindows(
             IpcChannels.SYNC_SUBSCRIPTION_CACHE,
             event,

--- a/src/main/ytDlpPlaybackCache.js
+++ b/src/main/ytDlpPlaybackCache.js
@@ -110,6 +110,11 @@ function isValidEntry(entry) {
     (hasDashManifest || hasHlsManifest || hasLegacyFormatsOnly) &&
     Array.isArray(legacyFormats) &&
     hasValidCaptions &&
+    (source.storyboardSrc == null || (
+      typeof source.storyboardSrc === 'string' &&
+      source.storyboardSrc.startsWith('data:text/vtt;')
+    )) &&
+    (source.duration == null || (Number.isFinite(source.duration) && source.duration > 0)) &&
     (source.subtitlesIncluded === undefined || typeof source.subtitlesIncluded === 'boolean') &&
     (source.title === null || typeof source.title === 'string')
 }
@@ -195,6 +200,8 @@ export async function handleYtDlpPlaybackCacheSet(event, videoId, cacheKey, expi
           captionTranslations: source.captionTranslations,
           subtitlesIncluded: source.subtitlesIncluded,
           title: source.title,
+          storyboardSrc: source.storyboardSrc,
+          duration: source.duration,
           isLive: source.isLive,
           version: source.version
         }

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -1992,7 +1992,12 @@ function handleSubscriptionRefreshCancelled(event) {
  */
 function handleSubscriptionRefreshCompleted(event) {
   const { tab, profileId, timestamp } = event.detail
-  if (!subscriptionAutoRefreshTabs.includes(tab) || typeof profileId !== 'string') {
+  if (
+    !subscriptionAutoRefreshTabs.includes(tab) ||
+    typeof profileId !== 'string' ||
+    !Number.isFinite(timestamp) ||
+    timestamp < getStoredSubscriptionTabLastRefreshTimestamp(profileId, tab)
+  ) {
     return
   }
 
@@ -2203,6 +2208,7 @@ async function reconcileAndroidSubscriptionRefreshChannelResult(result) {
   )
   const config = getAndroidSubscriptionCacheConfig(feedType)
   const previousCache = config.getCache()[result.channelId]
+  if (previousCache?.timestamp > timestamp) return
   const reconciledEntries = reconcileFetchedSubscriptionEntries(
     entries,
     previousCache?.[config.entriesKey],
@@ -2211,14 +2217,15 @@ async function reconcileAndroidSubscriptionRefreshChannelResult(result) {
     feedType === 'posts' ? undefined : store.getters.getHistoryCacheById
   )
 
-  await store.dispatch(config.action, {
+  const applied = await store.dispatch(config.action, {
     channelId: result.channelId,
     [config.entriesKey]: reconciledEntries,
     timestamp
   })
+  if (applied === false) return
 
   const committedTimestamp = config.getCache()[result.channelId]?.timestamp
-  if (!(committedTimestamp instanceof Date) || committedTimestamp.getTime() !== timestamp.getTime()) {
+  if (!(committedTimestamp instanceof Date) || committedTimestamp.getTime() < timestamp.getTime()) {
     throw new Error(`The ${feedType} cache write did not complete`)
   }
 }

--- a/src/renderer/components/NavigationCustomizer/NavigationCustomizer.vue
+++ b/src/renderer/components/NavigationCustomizer/NavigationCustomizer.vue
@@ -285,9 +285,9 @@ onBeforeUnmount(() => {
 
 async function updateItems(items) {
   const removedHome = navigationItems.value.includes('home') && !items.includes('home')
-  await store.dispatch('updateNavigationItems', items)
+  const saved = await store.dispatch('updateNavigationItems', items)
 
-  if (!removedHome) return
+  if (!saved || !removedHome || navigationItems.value.includes('home')) return
   if (process.env.IS_ELECTRON) {
     await store.dispatch('redirectHomeTabsToLandingPage')
   } else if (route.path === '/home') {

--- a/src/renderer/components/NavigationCustomizer/NavigationCustomizer.vue
+++ b/src/renderer/components/NavigationCustomizer/NavigationCustomizer.vue
@@ -284,10 +284,9 @@ onBeforeUnmount(() => {
 })
 
 async function updateItems(items) {
-  const removedHome = navigationItems.value.includes('home') && !items.includes('home')
-  const saved = await store.dispatch('updateNavigationItems', items)
+  await store.dispatch('updateNavigationItems', items)
 
-  if (!saved || !removedHome || navigationItems.value.includes('home')) return
+  if (store.getters.getNavigationItems.includes('home')) return
   if (process.env.IS_ELECTRON) {
     await store.dispatch('redirectHomeTabsToLandingPage')
   } else if (route.path === '/home') {

--- a/src/renderer/helpers/settingUpdateQueue.js
+++ b/src/renderer/helpers/settingUpdateQueue.js
@@ -30,3 +30,32 @@ export function createSettingUpdateQueue() {
     })
   }
 }
+
+/**
+ * Publishes list edits immediately so the next edit starts from the intended
+ * value. Failed writes restore the last persisted value, unless superseded.
+ */
+export function createOptimisticSettingUpdater() {
+  const runUpdate = createSettingUpdateQueue()
+  const pending = new Map()
+
+  return (settingId, value, { read, commit, persist }) => {
+    const saved = pending.get(settingId) ?? { value: read() }
+    const token = {}
+    saved.latest = token
+    pending.set(settingId, saved)
+    commit(value)
+
+    return runUpdate(settingId, async isLatest => {
+      try {
+        await persist(value)
+        saved.value = value
+      } catch (error) {
+        if (isLatest()) commit(saved.value)
+        throw error
+      }
+    }).finally(() => {
+      if (saved.latest === token) pending.delete(settingId)
+    })
+  }
+}

--- a/src/renderer/helpers/settingUpdateQueue.js
+++ b/src/renderer/helpers/settingUpdateQueue.js
@@ -40,22 +40,26 @@ export function createOptimisticSettingUpdater() {
   const pending = new Map()
 
   return (settingId, value, { read, commit, persist }) => {
-    const saved = pending.get(settingId) ?? { value: read() }
+    const currentValue = read()
+    const previous = pending.get(settingId)
+    const saved = previous && previous.optimisticValue === currentValue ? previous : { value: currentValue }
     const token = {}
     saved.latest = token
     pending.set(settingId, saved)
     commit(value)
+    const optimisticValue = read()
+    saved.optimisticValue = optimisticValue
 
     return runUpdate(settingId, async isLatest => {
       try {
         await persist(value)
         saved.value = value
       } catch (error) {
-        if (isLatest()) commit(saved.value)
+        if (isLatest() && read() === optimisticValue) commit(saved.value)
         throw error
       }
     }).finally(() => {
-      if (saved.latest === token) pending.delete(settingId)
+      if (pending.get(settingId) === saved && saved.latest === token) pending.delete(settingId)
     })
   }
 }

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -43,7 +43,7 @@ import { DEFAULT_HOME_SECTION_LAYOUT } from '../../helpers/homeSections.js'
 import { isSettingSyncableOnPlatform } from '../../helpers/platformSettings.js'
 import { CUSTOM_THEMES_SYNC_KEY } from '../../../customTheme.js'
 import { DEFAULT_QUICK_SETTINGS, normalizeQuickSettings } from '../../helpers/quickSettings.js'
-import { createSettingUpdateQueue } from '../../helpers/settingUpdateQueue.js'
+import { createOptimisticSettingUpdater, createSettingUpdateQueue } from '../../helpers/settingUpdateQueue.js'
 import { filterAvailableNavigationItems } from '../../../navigationAvailability.js'
 import {
   DEFAULT_NAVIGATION_ITEMS,
@@ -943,18 +943,34 @@ async function persistPlaylistBookmarks(commit, bookmarks) {
   }
 }
 
+const updateOptimisticSetting = createOptimisticSettingUpdater()
+
+function updateOrderedSetting(commit, settings, settingId, value) {
+  return updateOptimisticSetting(settingId, value, {
+    read: () => settings[settingId],
+    commit: nextValue => commit(defaultMutationId(settingId), nextValue),
+    persist: async nextValue => {
+      await DBSettingHandlers.upsert(settingId, nextValue)
+      await recordSettingSyncTimestamp(commit, settings, settingId)
+    },
+  }).then(() => true).catch(error => {
+    console.error(error)
+    return false
+  })
+}
+
 const customActions = {
   recordSyncSettingEdit: ({ commit, state }, settingId) => (
     recordSettingSyncTimestamp(commit, state, settingId)
   ),
-  updateQuickSettings: ({ commit, state }, value) => updateValidatedSetting(
+  updateQuickSettings: ({ commit, state }, value) => updateOrderedSetting(
     commit,
     state,
     'quickSettings',
     normalizeQuickSettings(value)
   ),
 
-  updateNavigationItems: ({ commit, state }, value) => updateValidatedSetting(
+  updateNavigationItems: ({ commit, state }, value) => updateOrderedSetting(
     commit,
     state,
     'navigationItems',

--- a/src/renderer/store/modules/subscription-cache.js
+++ b/src/renderer/store/modules/subscription-cache.js
@@ -152,7 +152,7 @@ const actions = {
     )
 
     try {
-      await DBSubscriptionCacheHandlers.updateVideosByChannelId(channelId, videos, timestamp)
+      if (await DBSubscriptionCacheHandlers.updateVideosByChannelId(channelId, videos, timestamp) === false) return false
       commit('updateVideoCacheByChannel', { channelId, entries: videos, timestamp })
     } catch (errMessage) {
       console.error(errMessage)
@@ -161,7 +161,7 @@ const actions = {
 
   async updateSubscriptionShortsCacheByChannel({ commit }, { channelId, videos, timestamp = new Date() }) {
     try {
-      await DBSubscriptionCacheHandlers.updateShortsByChannelId(channelId, videos, timestamp)
+      if (await DBSubscriptionCacheHandlers.updateShortsByChannelId(channelId, videos, timestamp) === false) return false
       commit('updateShortsCacheByChannel', { channelId, entries: videos, timestamp })
     } catch (errMessage) {
       console.error(errMessage)
@@ -188,7 +188,7 @@ const actions = {
     )
 
     try {
-      await DBSubscriptionCacheHandlers.updateLiveStreamsByChannelId(channelId, videos, timestamp)
+      if (await DBSubscriptionCacheHandlers.updateLiveStreamsByChannelId(channelId, videos, timestamp) === false) return false
       commit('updateLiveCacheByChannel', { channelId, entries: videos, timestamp })
     } catch (errMessage) {
       console.error(errMessage)
@@ -205,7 +205,7 @@ const actions = {
     )
 
     try {
-      await DBSubscriptionCacheHandlers.updateCommunityPostsByChannelId(channelId, posts, timestamp)
+      if (await DBSubscriptionCacheHandlers.updateCommunityPostsByChannelId(channelId, posts, timestamp) === false) return false
       commit('updatePostsCacheByChannel', { channelId, entries: posts, timestamp })
     } catch (errMessage) {
       console.error(errMessage)
@@ -418,6 +418,7 @@ const mutations = {
 
   updateVideoCacheByChannel(state, { channelId, entries, timestamp = new Date() }) {
     const existingObject = state.videoCache[channelId]
+    if (toDate(existingObject?.timestamp).getTime() > toDate(timestamp).getTime()) return
     const newObject = existingObject ?? { videos: null }
     if (entries != null) { newObject.videos = entries }
     newObject.timestamp = toDate(timestamp)
@@ -425,6 +426,7 @@ const mutations = {
   },
   updateShortsCacheByChannel(state, { channelId, entries, timestamp = new Date() }) {
     const existingObject = state.shortsCache[channelId]
+    if (toDate(existingObject?.timestamp).getTime() > toDate(timestamp).getTime()) return
     const newObject = existingObject ?? { videos: null }
     if (entries != null) { newObject.videos = entries }
     newObject.timestamp = toDate(timestamp)
@@ -458,6 +460,7 @@ const mutations = {
   },
   updateLiveCacheByChannel(state, { channelId, entries, timestamp = new Date() }) {
     const existingObject = state.liveCache[channelId]
+    if (toDate(existingObject?.timestamp).getTime() > toDate(timestamp).getTime()) return
     const newObject = existingObject ?? { videos: null }
     if (entries != null) { newObject.videos = entries }
     newObject.timestamp = toDate(timestamp)
@@ -465,6 +468,7 @@ const mutations = {
   },
   updatePostsCacheByChannel(state, { channelId, entries, timestamp = new Date() }) {
     const existingObject = state.postsCache[channelId]
+    if (toDate(existingObject?.timestamp).getTime() > toDate(timestamp).getTime()) return
     const newObject = existingObject ?? { posts: null }
     if (entries != null) { newObject.posts = entries }
     newObject.timestamp = toDate(timestamp)

--- a/src/renderer/store/modules/subscription-cache.js
+++ b/src/renderer/store/modules/subscription-cache.js
@@ -264,11 +264,12 @@ const actions = {
           ...entry,
           isNewInSubscriptionFeed: false
         }))
+        const timestamp = cacheEntry.timestamp
 
         writes.push(async () => {
           try {
-            await config.updateEntries(channelId, seenEntries, cacheEntry.timestamp)
-            return { tab: feedTab, channelId }
+            if (await config.updateEntries(channelId, seenEntries, timestamp) === false) return null
+            return { tab: feedTab, channelId, timestamp }
           } catch (errMessage) {
             console.error(errMessage)
             return null
@@ -313,11 +314,12 @@ const actions = {
         const seenEntries = cacheEntry.videos.map(video => video.videoId === videoId
           ? { ...video, isNewInSubscriptionFeed: false }
           : video)
+        const timestamp = cacheEntry.timestamp
 
         writes.push(async () => {
           try {
-            await updateEntries(channelId, seenEntries, cacheEntry.timestamp)
-            commit('markSubscriptionVideoAsSeenByChannel', { tab, channelId, videoId })
+            if (await updateEntries(channelId, seenEntries, timestamp) === false) return
+            commit('markSubscriptionVideoAsSeenByChannel', { tab, channelId, videoId, timestamp })
           } catch (errMessage) {
             console.error(errMessage)
           }
@@ -338,15 +340,17 @@ const actions = {
       const seenEntries = cacheEntry.posts.map(post => post.postId === postId
         ? { ...post, isNewInSubscriptionFeed: false }
         : post)
+      const timestamp = cacheEntry.timestamp
 
       writes.push(async () => {
         try {
-          await DBSubscriptionCacheHandlers.updateCommunityPostsByChannelId(
+          const applied = await DBSubscriptionCacheHandlers.updateCommunityPostsByChannelId(
             channelId,
             seenEntries,
-            cacheEntry.timestamp
+            timestamp
           )
-          commit('markSubscriptionPostAsSeenByChannel', { channelId, postId })
+          if (applied === false) return
+          commit('markSubscriptionPostAsSeenByChannel', { channelId, postId, timestamp })
         } catch (errMessage) {
           console.error(errMessage)
         }
@@ -377,7 +381,8 @@ const actions = {
 }
 
 const mutations = {
-  markSubscriptionPostAsSeenByChannel(state, { channelId, postId }) {
+  markSubscriptionPostAsSeenByChannel(state, { channelId, postId, timestamp }) {
+    if (toDate(state.postsCache[channelId]?.timestamp).getTime() !== toDate(timestamp).getTime()) return
     const entry = state.postsCache[channelId]?.posts?.find(post => post.postId === postId)
 
     if (entry) {
@@ -385,12 +390,13 @@ const mutations = {
     }
   },
 
-  markSubscriptionVideoAsSeenByChannel(state, { tab, channelId, videoId }) {
+  markSubscriptionVideoAsSeenByChannel(state, { tab, channelId, videoId, timestamp }) {
     const cacheEntry = tab === 'videos'
       ? state.videoCache[channelId]
       : tab === 'shorts'
         ? state.shortsCache[channelId]
         : state.liveCache[channelId]
+    if (toDate(cacheEntry?.timestamp).getTime() !== toDate(timestamp).getTime()) return
     const entry = cacheEntry?.videos?.find(video => video.videoId === videoId)
 
     if (entry) {
@@ -399,7 +405,7 @@ const mutations = {
   },
 
   markSubscriptionEntriesAsSeenInCache(state, cacheEntries) {
-    for (const { tab, channelId } of cacheEntries) {
+    for (const { tab, channelId, timestamp } of cacheEntries) {
       const cache = tab === 'videos'
         ? state.videoCache
         : tab === 'shorts'
@@ -408,6 +414,7 @@ const mutations = {
             ? state.liveCache
             : state.postsCache
       const cacheEntry = cache[channelId]
+      if (toDate(cacheEntry?.timestamp).getTime() !== toDate(timestamp).getTime()) continue
       const entries = tab === 'posts' ? cacheEntry?.posts : cacheEntry?.videos
 
       entries?.forEach(entry => {

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -385,7 +385,9 @@ async function runSync(context, { allowDataLoss = false } = {}) {
                 continue
               }
               retryDocument[collection] = remoteData
-              retryDocument.subscriptions = client.document.subscriptions
+              if (collection !== 'subscriptions') {
+                retryDocument.subscriptions = client.document.subscriptions
+              }
               const retryClient = new EncryptedSyncAdapter(retryDocument)
               if (collection === 'settings') {
                 next.settings = await syncSettings(retryClient, store, next.settings)

--- a/tests/unit/setting-update-queue.test.mjs
+++ b/tests/unit/setting-update-queue.test.mjs
@@ -64,6 +64,51 @@ test('a failed latest list edit restores the last successful write, not an obsol
   assert.deepEqual(value, ['second', 'third'])
 })
 
+test('a failed optimistic write cannot roll back a newer synchronized value', async () => {
+  const update = createOptimisticSettingUpdater()
+  const started = deferred()
+  const release = deferred()
+  let value = ['original']
+  const pending = update('items', ['local'], {
+    read: () => value,
+    commit: next => { value = next },
+    persist: async () => {
+      started.resolve()
+      await release.promise
+      throw new Error('Disk write failed')
+    },
+  })
+  const failure = assert.rejects(pending, /Disk write failed/)
+  await started.promise
+  value = ['synchronized']
+  release.resolve()
+  await failure
+  assert.deepEqual(value, ['synchronized'])
+})
+
+test('edits after synchronization use the synchronized rollback baseline', async () => {
+  const update = createOptimisticSettingUpdater()
+  const started = deferred()
+  const release = deferred()
+  let value = ['original']
+  const options = {
+    read: () => value,
+    commit: next => { value = next },
+    persist: async () => {
+      started.resolve()
+      await release.promise
+      throw new Error('Disk write failed')
+    },
+  }
+  const first = assert.rejects(update('items', ['first'], options), /Disk write failed/)
+  await started.promise
+  value = ['synchronized']
+  const second = assert.rejects(update('items', ['second'], options), /Disk write failed/)
+  release.resolve()
+  await Promise.all([first, second])
+  assert.deepEqual(value, ['synchronized'])
+})
+
 test('keeps an in-flight setting write from applying after a newer update', async () => {
   const runUpdate = createSettingUpdateQueue()
   const firstStarted = deferred()

--- a/tests/unit/setting-update-queue.test.mjs
+++ b/tests/unit/setting-update-queue.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { createSettingUpdateQueue } from '../../src/renderer/helpers/settingUpdateQueue.js'
+import { createOptimisticSettingUpdater, createSettingUpdateQueue } from '../../src/renderer/helpers/settingUpdateQueue.js'
 
 function deferred () {
   let resolvePromise
@@ -10,6 +10,59 @@ function deferred () {
   })
   return { promise, resolve: resolvePromise }
 }
+
+test('optimistic list edits compose before persistence and survive delayed earlier writes', async () => {
+  const update = createOptimisticSettingUpdater()
+  const started = deferred()
+  const release = deferred()
+  let value = ['first', 'second', 'third']
+  let persisted = value
+  const options = {
+    read: () => value,
+    commit: next => { value = next },
+    persist: async next => {
+      if (next.includes('second')) {
+        started.resolve()
+        await release.promise
+      }
+      persisted = next
+    },
+  }
+  const first = update('items', value.filter(id => id !== 'first'), options)
+  await started.promise
+  const second = update('items', value.filter(id => id !== 'second'), options)
+  assert.deepEqual(value, ['third'])
+  release.resolve()
+  await Promise.all([first, second])
+  assert.deepEqual(value, ['third'])
+  assert.deepEqual(persisted, ['third'])
+})
+
+test('a failed latest list edit restores the last successful write, not an obsolete optimistic value', async () => {
+  const update = createOptimisticSettingUpdater()
+  const started = deferred()
+  const release = deferred()
+  let value = ['first', 'second', 'third']
+  const options = {
+    read: () => value,
+    commit: next => { value = next },
+    persist: async next => {
+      if (next.length === 2) {
+        started.resolve()
+        await release.promise
+      } else {
+        throw new Error('Disk write failed')
+      }
+    },
+  }
+  const first = update('items', ['second', 'third'], options)
+  await started.promise
+  const second = update('items', ['third'], options)
+  const failure = assert.rejects(second, /Disk write failed/)
+  release.resolve()
+  await Promise.all([first, failure])
+  assert.deepEqual(value, ['second', 'third'])
+})
 
 test('keeps an in-flight setting write from applying after a newer update', async () => {
   const runUpdate = createSettingUpdateQueue()

--- a/tests/unit/subscription-cache-writes.test.mjs
+++ b/tests/unit/subscription-cache-writes.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import vm from 'node:vm'
+import Datastore from '@seald-io/nedb'
+
+// The handlers module imports the platform datastore singleton through webpack.
+// Run the actual cache class with an isolated real NeDB for each interleaving.
+const source = await readFile(new URL('../../src/datastores/handlers/base.js', import.meta.url), 'utf8')
+const start = source.indexOf('class SubscriptionCache {')
+const cacheSource = source.slice(start, source.indexOf('\nclass ', start + 1))
+
+for (const enrichmentFirst of [false, true]) {
+  test(`Shorts refresh preserves new entries when enrichment starts ${enrichmentFirst ? 'first' : 'second'}`, async () => {
+    const db = { subscriptionCache: new Datastore({ inMemoryOnly: true }) }
+    const Cache = vm.runInNewContext(`${cacheSource}\nSubscriptionCache`, { db })
+    await Cache.updateShortsByChannelId('channel', [{ videoId: 'old', title: 'Old title' }], new Date(1000))
+
+    const refresh = () => Cache.updateShortsByChannelId('channel', [
+      { videoId: 'old', title: 'Refreshed title' },
+      { videoId: 'new', title: 'New title' },
+    ], new Date(2000))
+    const enrich = () => Cache.updateShortsWithChannelPageShortsByChannelId('channel', [
+      { videoId: 'old', title: 'Enriched title', viewCount: 2000 },
+    ])
+    const first = enrichmentFirst ? enrich() : refresh()
+    // Let the first read enter NeDB's queue before starting the other writer.
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.all([first, enrichmentFirst ? refresh() : enrich()])
+
+    const result = await db.subscriptionCache.findOneAsync({ _id: 'channel' })
+    assert.deepEqual(result.shorts.map(video => video.videoId), ['old', 'new'])
+    assert.equal(new Date(result.shortsTimestamp).getTime(), 2000)
+    assert.equal(result.shorts[0].title, enrichmentFirst ? 'Refreshed title' : 'Enriched title')
+  })
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
An audit of changes since the latest stable release and older persistence code found cases where concurrent edits or delayed responses could lose data. This fixes those findings and lets interrupted Android subscription refreshes resume.

- Preserve remote subscription additions and deletions when encrypted sync retries a revision conflict.
- Apply Quick Settings and navigation edits immediately, serialize writes, and restore the last saved value if a write fails.
- Reject stale feed results and completion timestamps; serialize Shorts metadata enrichment with full refreshes.
- Index pending Android results instead of repeatedly parsing the backlog, and checkpoint background refresh progress between bounded batches.
- Keep storyboard thumbnails and duration in the persistent playback cache.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Keep concurrent subscription sync edits and preserve seekbar thumbnails and duration when reusing cached playback data.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. In Appearance, open the Quick Settings and navigation customizers. Remove two items quickly, then restart the app. Both removals should remain; reordering should persist too.
2. Sync subscriptions on two devices while making different additions and deletions. After both devices sync again, neither device should restore a removed subscription or lose the other device's addition.
3. On Android, enable closed-app subscription refresh for a large channel list. Interrupt the app process during background work, then allow background work to resume. Later channels should be reached instead of repeatedly starting at the first channel. A delayed result should not remove uploads found by a newer refresh.
4. Play a video with yt-dlp and seekbar thumbnails, restart while its cache entry is still valid, and open it again. Duration and thumbnail previews should remain available.

## Additional context
<!-- Add any other context about the pull request here. -->
Automated validation passed: 890 JavaScript unit tests, 41 Android JVM tests, and 15 Electron persistence regressions. Existing feed and refresh suites were also verified. Lint passed with one existing unrelated warning.

Verified on a physical Pixel 8 Pro running Android 16 with the final APK. A 905-record native backlog drained without overwriting newer feed entries or completion timestamps. A 20-channel WorkManager refresh resumed after process death following six completed channels, retained those result IDs, completed all channels, and removed its checkpoint. Rapid customization edits and all three stale seen-state write cases passed and persisted after restart. These checks used isolated synthetic data and HTTPS echo responses; scheduler timing was advanced to avoid the periodic wait. The original app data was restored and all 64 file checksums matched.

Implemented with GPT-6 Astra in Codex.
