### PR TITLE
fix(android): restore About spacing and show the full themed nightly wrench

### DIFF
--- a/android/app/src/debug/res/drawable/ic_launcher_nightly_monochrome.xml
+++ b/android/app/src/debug/res/drawable/ic_launcher_nightly_monochrome.xml
@@ -26,10 +26,10 @@
             android:pathData="m445.062,324.666c3.9,1.775 8.602,4.916 12.287,7.274l-0.903,1.088c-4.194,-2.631 -7.787,-4.948 -11.384,-8.362z" />
     </group>
 
-    <!-- Nightly wrench -->
+    <!-- Nightly wrench, entirely inside the adaptive icon's central 66dp safe circle. -->
     <group
-        android:translateX="650"
-        android:translateY="640"
+        android:translateX="530"
+        android:translateY="575"
         android:scaleX="8"
         android:scaleY="8">
         <path

--- a/e2e/tests/offline/about.spec.mjs
+++ b/e2e/tests/offline/about.spec.mjs
@@ -1,5 +1,42 @@
 import { test, expect } from '../../helpers/app.mjs'
 
+test('about header keeps its spacing without desktop runtime details', async ({ page }) => {
+  await page.locator('.profileTrigger').click()
+  await page.getByRole('dialog', { name: 'Quick settings' }).getByRole('button', { name: 'About' }).click()
+  const aboutWindow = page.getByRole('dialog', { name: 'About' })
+  await expect(aboutWindow).toBeVisible()
+
+  for (const build of ['desktop', 'mobile release', 'mobile nightly']) {
+    if (build === 'mobile release') {
+      // Capacitor omits this Electron-only block from the shared About template.
+      await aboutWindow.locator('.runtimeVersions').evaluate(element => element.remove())
+      await aboutWindow.locator('.commit').evaluateAll(elements => elements.forEach(element => element.remove()))
+    } else if (build === 'mobile nightly') {
+      await aboutWindow.locator('.version').evaluate(element => {
+        element.textContent = 'v0.33.0-nightly-1201 Beta'
+        const commit = element.cloneNode(false)
+        commit.className = 'commit'
+        commit.textContent = 'Commit: e89ae75'
+        element.after(commit)
+      })
+    }
+
+    for (const scale of [1, 1.25]) {
+      await page.evaluate(value => window.ftElectron.setZoomFactor(value), scale)
+      for (const viewport of [{ width: 375, height: 800 }, { width: 800, height: 375 }]) {
+        await page.setViewportSize(viewport)
+        await expect.poll(() => aboutWindow.evaluate(element => {
+          const brand = element.querySelector('.brand')
+          const details = brand.lastElementChild.getBoundingClientRect()
+          const cards = element.querySelector('.about-chunks').getBoundingClientRect()
+          const expectedGap = Number.parseFloat(getComputedStyle(brand).fontSize) * 2
+          return Math.abs(cards.top - details.bottom - expectedGap)
+        }), { message: `${build}, ${viewport.width}px, ${scale * 100}% scale` }).toBeLessThanOrEqual(1)
+      }
+    }
+  }
+})
+
 test('about page shows the bundled runtime versions', async ({ app, page }) => {
   const expectedVersions = await app.electronApp.evaluate(() => ({
     Electron: process.versions.electron,

--- a/e2e/tests/offline/android-launcher-icon.spec.mjs
+++ b/e2e/tests/offline/android-launcher-icon.spec.mjs
@@ -1,0 +1,59 @@
+import { readFile } from 'node:fs/promises'
+import { test, expect } from '../../helpers/app.mjs'
+
+test('nightly themed launcher wrench stays inside the adaptive icon safe zone', async ({ page }, testInfo) => {
+  const xml = await readFile('android/app/src/debug/res/drawable/ic_launcher_nightly_monochrome.xml', 'utf8')
+  const result = await page.evaluate(source => {
+    const vector = new DOMParser().parseFromString(source, 'application/xml')
+    const attribute = (element, name) => element.getAttributeNS('http://schemas.android.com/apk/res/android', name)
+    const size = Number(attribute(vector.documentElement, 'viewportWidth'))
+    const canvas = document.createElement('canvas')
+    canvas.width = canvas.height = size
+    const context = canvas.getContext('2d')
+    const groups = [...vector.querySelectorAll('group')]
+    const draw = group => {
+      context.save()
+      context.translate(Number(attribute(group, 'translateX')), Number(attribute(group, 'translateY')))
+      context.scale(Number(attribute(group, 'scaleX')), Number(attribute(group, 'scaleY')))
+      for (const path of group.querySelectorAll('path')) {
+        context.fill(new Path2D(attribute(path, 'pathData')))
+      }
+      context.restore()
+    }
+
+    draw(groups.at(-1))
+    const pixels = context.getImageData(0, 0, size, size).data
+    // Android guarantees the central 66dp circle of the 108dp adaptive layer.
+    const safeRadius = size * 33 / 108
+    let visiblePixels = 0
+    let unsafePixels = 0
+    for (let y = 0; y < size; y++) {
+      for (let x = 0; x < size; x++) {
+        if (pixels[(y * size + x) * 4 + 3] > 127) {
+          visiblePixels++
+          if (Math.hypot(x + 0.5 - size / 2, y + 0.5 - size / 2) > safeRadius) unsafePixels++
+        }
+      }
+    }
+
+    context.clearRect(0, 0, size, size)
+    context.beginPath()
+    context.arc(size / 2, size / 2, size / 3, 0, Math.PI * 2)
+    context.clip()
+    context.fillStyle = '#302e43'
+    context.fillRect(0, 0, size, size)
+    context.fillStyle = '#c9c2ef'
+    groups.forEach(draw)
+    const preview = document.createElement('canvas')
+    preview.width = preview.height = 144
+    preview.getContext('2d').drawImage(canvas, size / 6, size / 6, size * 2 / 3, size * 2 / 3, 0, 0, 144, 144)
+    return { visiblePixels, unsafePixels, preview: preview.toDataURL() }
+  }, xml)
+
+  await testInfo.attach('themed-launcher-icon', {
+    body: Buffer.from(result.preview.split(',')[1], 'base64'),
+    contentType: 'image/png'
+  })
+  expect(result.visiblePixels).toBeGreaterThan(0)
+  expect(result.unsafePixels, 'wrench pixels outside the launcher safe zone').toBe(0)
+})

--- a/src/renderer/views/About/About.css
+++ b/src/renderer/views/About/About.css
@@ -6,6 +6,7 @@
 
 .brand {
   text-align: center;
+  margin-block-end: 2em;
 }
 
 .logo {
@@ -28,7 +29,7 @@
   flex-wrap: wrap;
   gap: 4px 16px;
   justify-content: center;
-  margin-block: 8px 2em;
+  margin-block: 8px 0;
   margin-inline: 0;
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #1114.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

On mobile, the About version/commit touched the first card, and circular themed launcher icons clipped the nightly wrench down to its head.

Move the About section spacing from the desktop-only runtime list to the shared header. Move the monochrome wrench inside Android's guaranteed visible area.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open About on a phone-sized viewport. Confirm there is space between the version/commit and the Source code card, in portrait and landscape. Also check at 125% UI scale.
2. Open desktop About and confirm the runtime versions and their spacing remain intact.
3. Install the nightly Android build and enable themed launcher icons. Confirm the entire wrench, including its handle, remains visible with a circular icon shape.

## Additional context
<!-- Add any other context about the pull request here. -->
Automated checks cover About spacing in portrait/landscape at 100% and 125% UI scale and the wrench's rendered pixels against Android's adaptive icon safe circle. Targeted E2E, lint, nightly branding tests, and 34 Android unit tests passed. Both regressions were reproduced before the fixes. The updated nightly APK was installed on the Pixel for testing.

Corrected themed icon under a circular launcher mask:

![Themed nightly icon with the full wrench visible](https://github.com/user-attachments/assets/e7cdaf50-8b41-4f3e-afaf-b6ea21a87b08)
