### PR TITLE
fix(player): save scroll and tab mini-player positions independently

### DIFF
--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -1466,6 +1466,59 @@ test.describe('scroll mini player', () => {
       }
     })
 
+    test('remembers separate mini player positions for scrolling and tab switches', async ({ app, page }) => {
+      await openDemoVideo({ app, page })
+      let player = page.locator('.ftVideoPlayer')
+      const videoTab = page.locator('.tabBar .tab').first()
+      const readPosition = () => player.evaluate(element => ({
+        left: Number.parseFloat(element.style.left),
+        top: Number.parseFloat(element.style.top)
+      }))
+      const dragTo = async (left, top) => {
+        const position = await readPosition()
+        await player.locator('.scrollMiniDragHandle').dispatchEvent('pointerdown', {
+          button: 0, clientX: 0, clientY: 0, pointerId: 1
+        })
+        await page.evaluate(({ dx, dy }) => {
+          for (const type of ['pointermove', 'pointerup']) {
+            window.dispatchEvent(new PointerEvent(type, {
+              clientX: dx, clientY: dy, pointerId: 1
+            }))
+          }
+        }, { dx: left - position.left, dy: top - position.top })
+        await expect.poll(async () => Math.abs((await readPosition()).top - top)).toBeLessThan(1)
+      }
+
+      await scrollBelowPlayer(player)
+      await expect(player).toHaveClass(/scrollMiniPlayer/)
+      await expect(player).not.toHaveClass(/scrollMiniPlayerAnimating/)
+      await dragTo(16, 160)
+      const scrollPosition = await readPosition()
+
+      await page.locator('.tabBar .newTabButton').click()
+      await expect(player.getByRole('button', { name: 'Hide mini player' })).toBeVisible()
+      await expect.poll(readPosition).not.toEqual(scrollPosition)
+      await dragTo(16, 260)
+      const tabPosition = await readPosition()
+
+      await videoTab.click()
+      await expect.poll(readPosition).toEqual(scrollPosition)
+      await page.locator('.tabBar .tab').nth(1).click()
+      await expect.poll(readPosition).toEqual(tabPosition)
+
+      // Both positions must survive restarting the app, not just remain in memory.
+      await videoTab.click()
+      await page.getByRole('link', { name: 'Go to Subscriptions', exact: true }).click()
+      await expect(page).toHaveURL(/#\/subscriptions$/)
+      ;({ page } = await app.relaunch())
+      await openDemoVideo({ app, page })
+      player = page.locator('.ftVideoPlayer')
+      await scrollBelowPlayer(player)
+      await expect.poll(readPosition).toEqual(scrollPosition)
+      await page.locator('.tabBar .newTabButton').click()
+      await expect.poll(readPosition).toEqual(tabPosition)
+    })
+
     test('keeps the most recently left video visible across tabs', async ({ app, page, attachScreenshot }) => {
       const video = await openDemoVideo({ app, page })
       const playbackTimeBeforeSwitch = await video.evaluate(element => element.currentTime)

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
@@ -444,8 +444,11 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
 
     if (persist) {
       // Drag and bounce frames can be interrupted, so only remember settled positions.
-      setSavedScrollMiniPlayerRect(clamped)
-      store.dispatch('updateScrollMiniPlayerSavedRect', serializeScrollMiniPlayerSavedRect(clamped))
+      setSavedScrollMiniPlayerRect(clamped, isActiveTab.value ? 'scroll' : 'tab')
+      store.dispatch(
+        isActiveTab.value ? 'updateScrollMiniPlayerSavedRect' : 'updateCrossTabMiniPlayerSavedRect',
+        serializeScrollMiniPlayerSavedRect(clamped)
+      )
     }
   }
 
@@ -519,13 +522,6 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     const sequence = ++scrollMiniLayoutAnimationSequence
     scrollMiniPlayerAnimating.value = true
     animateScrollMiniPlayerLayout(previousRect, true, sequence)
-  }
-
-  function loadScrollMiniPlayerSavedRectFromSettings() {
-    const savedRect = parseScrollMiniPlayerSavedRect(store.getters.getScrollMiniPlayerSavedRect)
-    if (savedRect) {
-      setSavedScrollMiniPlayerRect(savedRect)
-    }
   }
 
   function syncScrollMiniPlayerState() {
@@ -647,18 +643,9 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     const animationSequence = scrollMiniLayoutAnimationSequence
     scrollMiniPlayerAnimating.value = previousRect !== null
 
-    const savedRect = getSavedScrollMiniPlayerRect()
     scrollMiniPlayerActive.value = true
     updateScrollMiniVideoAspectRatio()
-    applyScrollMiniPlayerRect(
-      savedRect
-        // The window may have changed size since the rect was saved, so replay
-        // it against the edges it was docked to rather than its old coordinates.
-        ? reanchorScrollMiniPlayerRect(savedRect, scrollMiniVideoAspectRatio.value)
-        : getDefaultScrollMiniPlayerRect(scrollMiniVideoAspectRatio.value),
-      false,
-      true
-    )
+    restoreScrollMiniPlayerPosition()
     syncScrollMiniPlayerState()
 
     if (scrollMiniPlayPauseHiddenByTimer) {
@@ -675,6 +662,18 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     if (previousRect) {
       animateScrollMiniPlayerLayout(previousRect, true, animationSequence)
     }
+  }
+
+  function restoreScrollMiniPlayerPosition() {
+    const savedRect = getSavedScrollMiniPlayerRect(isActiveTab.value ? 'scroll' : 'tab')
+    applyScrollMiniPlayerRect(
+      savedRect
+        // Restore against the saved edges, since the viewport may have resized.
+        ? reanchorScrollMiniPlayerRect(savedRect, scrollMiniVideoAspectRatio.value)
+        : getDefaultScrollMiniPlayerRect(scrollMiniVideoAspectRatio.value),
+      false,
+      true
+    )
   }
 
   /** @param {boolean} [animate] */
@@ -1109,6 +1108,17 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
   })
 
   watch(isActiveTab, (active) => {
+    if (scrollMiniPlayerActive.value) {
+      // A tab switch can change modes without deactivating the mini player.
+      // Cancel unfinished gestures so they cannot overwrite the new mode's position.
+      cancelScrollMiniPlayerBounce()
+      cancelScrollMiniPlayerLayoutAnimation()
+      endScrollMiniPointerSession()
+      scrollMiniPlayerStashedSide.value = null
+      scrollMiniPlayerRestoreRect = null
+      restoreScrollMiniPlayerPosition()
+    }
+
     if (active) {
       scrollMiniPlayerDismissed.value = false
       markCrossTabMiniPlayerActive(crossTabMiniPlayerCandidate)
@@ -1121,7 +1131,12 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
 
   watch(
     () => store.getters.getScrollMiniPlayerSavedRect,
-    loadScrollMiniPlayerSavedRectFromSettings,
+    value => setSavedScrollMiniPlayerRect(parseScrollMiniPlayerSavedRect(value), 'scroll'),
+    { immediate: true }
+  )
+  watch(
+    () => store.getters.getCrossTabMiniPlayerSavedRect,
+    value => setSavedScrollMiniPlayerRect(parseScrollMiniPlayerSavedRect(value), 'tab'),
     { immediate: true }
   )
 

--- a/src/renderer/helpers/scrollMiniPlayer.js
+++ b/src/renderer/helpers/scrollMiniPlayer.js
@@ -37,21 +37,24 @@ export function getScrollMiniInlineLayoutHeight(container, lastKnownHeight = 0) 
 
 /** @typedef {{ left: number, top: number, width: number, height: number, dock: 'left' | 'right', verticalDock?: 'top' | 'bottom', verticalOffset?: number }} ScrollMiniPlayerRect */
 
-/** @type {ScrollMiniPlayerRect | null} */
-let savedScrollMiniPlayerRect = null
+/** @type {Record<'scroll' | 'tab', ScrollMiniPlayerRect | null>} */
+const savedScrollMiniPlayerRects = { scroll: null, tab: null }
 
 /**
  * @returns {ScrollMiniPlayerRect | null}
+ * @param {'scroll' | 'tab'} mode
  */
-export function getSavedScrollMiniPlayerRect() {
+export function getSavedScrollMiniPlayerRect(mode) {
+  const savedScrollMiniPlayerRect = savedScrollMiniPlayerRects[mode]
   return savedScrollMiniPlayerRect ? { ...savedScrollMiniPlayerRect } : null
 }
 
 /**
  * @param {ScrollMiniPlayerRect | null} rect
+ * @param {'scroll' | 'tab'} mode
  */
-export function setSavedScrollMiniPlayerRect(rect) {
-  savedScrollMiniPlayerRect = rect ? { ...rect } : null
+export function setSavedScrollMiniPlayerRect(rect, mode) {
+  savedScrollMiniPlayerRects[mode] = rect ? { ...rect } : null
 }
 
 /**

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -221,6 +221,7 @@ const state = {
   scrollMiniPlayerEnabled: true,
   scrollMiniPlayerOnAllTabs: false,
   scrollMiniPlayerSavedRect: '',
+  crossTabMiniPlayerSavedRect: '',
   scrollbarThumbWidth: DEFAULT_SCROLLBAR_THUMB_WIDTH,
   scrollSpeed: DEFAULT_SCROLL_SPEED,
   avoidTranslation: 'disabled',
@@ -800,6 +801,7 @@ export const NON_SYNCABLE_SETTINGS = new Set([
   'checkForUpdates',
   // Window coordinates are only valid for the display they were saved on.
   'scrollMiniPlayerSavedRect',
+  'crossTabMiniPlayerSavedRect',
   // These choices describe one physical device, not the user's account.
   'androidAutoPictureInPicture',
   'capacitorLayoutMode',

--- a/tests/unit/scroll-mini-player-insets.test.mjs
+++ b/tests/unit/scroll-mini-player-insets.test.mjs
@@ -8,6 +8,8 @@ import {
   clampScrollMiniPlayerRect,
   parseScrollMiniPlayerSavedRect,
   serializeScrollMiniPlayerSavedRect,
+  getSavedScrollMiniPlayerRect,
+  setSavedScrollMiniPlayerRect,
   getScrollMiniVerticalAnchor,
   getScrollMiniPlayerStashSide,
   getStashedScrollMiniPlayerRect,
@@ -184,6 +186,18 @@ const SAVED_RECT = {
   verticalDock: 'bottom',
   verticalOffset: 96
 }
+
+test('scroll and tab-switch positions do not overwrite each other', () => {
+  const tabRect = { ...SAVED_RECT, top: 200 }
+  setSavedScrollMiniPlayerRect(SAVED_RECT, 'scroll')
+  setSavedScrollMiniPlayerRect(tabRect, 'tab')
+  assert.deepEqual(getSavedScrollMiniPlayerRect('scroll'), SAVED_RECT)
+  assert.deepEqual(getSavedScrollMiniPlayerRect('tab'), tabRect)
+  setSavedScrollMiniPlayerRect(null, 'tab')
+  assert.equal(getSavedScrollMiniPlayerRect('tab'), null)
+  assert.deepEqual(getSavedScrollMiniPlayerRect('scroll'), SAVED_RECT)
+  setSavedScrollMiniPlayerRect(null, 'scroll')
+})
 
 test('parsing a saved rect round-trips it without consulting the viewport', () => {
   const saved = serializeScrollMiniPlayerSavedRect(SAVED_RECT)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

The scroll-down and tab-switch mini players shared one saved position, so moving either changed where the other appeared. Each mode now saves and restores its own position, including after restarting the app.

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Requested directly; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Keep the existing saved rectangle for scroll-down mode and store the tab-switch rectangle separately. Restore the appropriate position when switching modes, cancelling unfinished gestures first.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Scroll-down and tab-switch mini players now remember their positions independently.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Enable the mini player on all tabs, play a video, scroll below the player, and drag it to a recognizable position.
2. Switch to another tab and move the mini player somewhere else. Switch back and forth; each mode should restore its own position.
3. Restart the app and repeat both triggers. Both saved positions should remain.
4. Repeat with UI Scale set to 125%.

## Additional context
<!-- Add any other context about the pull request here. -->

Implemented and reviewed with GPT-6 in the Codex desktop app.
