### PR TITLE
feat(settings): expand Quick Settings with 17 optional controls

### DIFF
--- a/e2e/tests/offline/dearrow-quick-settings.spec.mjs
+++ b/e2e/tests/offline/dearrow-quick-settings.spec.mjs
@@ -1,0 +1,107 @@
+import { test, expect, goTo } from '../../helpers/app.mjs'
+import { fulfillVisualFixture, expectImagesLoaded } from '../../helpers/visual-fixtures.mjs'
+
+const VIDEO_ID = 'eeeeeeeeeee'
+const ORIGINAL_TITLE = 'Original video title'
+const REPLACEMENT_TITLE = 'DeArrow video title'
+const THUMBNAIL_URL = `https://dearrow-thumb.ajay.app/api/v1/getThumbnail?videoID=${VIDEO_ID}&time=10`
+
+test.use({
+  seed: {
+    settings: {
+      quickSettings: ['useDeArrowTitles', 'useDeArrowThumbnails'],
+      useDeArrowTitles: false,
+      useDeArrowThumbnails: false,
+    },
+    history: [{
+      _id: VIDEO_ID,
+      videoId: VIDEO_ID,
+      title: ORIGINAL_TITLE,
+      author: 'Test Channel',
+      authorId: 'UC-test-channel-id',
+      published: 1_700_000_000_000,
+      timeWatched: 1_700_000_000_000,
+      lengthSeconds: 60,
+      viewCount: 1234,
+      isLive: false,
+      type: 'video',
+    }],
+  }
+})
+
+for (const cached of [false, true]) {
+  test(`DeArrow quick toggles update visible cards ${cached ? 'with' : 'without'} cached replacements`, async ({ page }) => {
+    let brandingRequests = 0
+    await page.route('https://sponsor.ajay.app/api/branding/*', async route => {
+      brandingRequests++
+      await route.fulfill({
+        json: {
+          [VIDEO_ID]: {
+            titles: [{ title: REPLACEMENT_TITLE, votes: 1 }],
+            thumbnails: [{ timestamp: 10, votes: 1 }],
+            videoDuration: 60,
+          }
+        }
+      })
+    })
+    await page.route('https://dearrow-thumb.ajay.app/**', route => fulfillVisualFixture(route, 'video-thumbnail'))
+    await page.route('https://i.ytimg.com/**', route => fulfillVisualFixture(route, 'video-thumbnail'))
+    if (cached) {
+      await page.evaluate(({ videoId, title, thumbnail }) => {
+        document.querySelector('#app').__vue_app__.config.globalProperties.$store.commit('addVideoToDeArrowCache', {
+          videoId, title, thumbnail, thumbnailTimestamp: 10, videoDuration: 60,
+        })
+      }, { videoId: VIDEO_ID, title: REPLACEMENT_TITLE, thumbnail: THUMBNAIL_URL })
+    }
+
+    await goTo(page, 'history')
+    const card = page.locator('.ft-list-video').first()
+    const title = card.locator('.title')
+    const thumbnail = card.locator('.thumbnailImage').first()
+    const originalThumbnail = await thumbnail.getAttribute('src')
+    await expect(title).toHaveText(ORIGINAL_TITLE)
+    const originalCard = await card.elementHandle()
+    await page.locator('.profileTrigger').click()
+    const menu = page.getByRole('dialog', { name: 'Quick settings' })
+    const titlesToggle = menu.locator('[data-setting-id="useDeArrowTitles"] label.switch-label')
+    const thumbnailsToggle = menu.locator('[data-setting-id="useDeArrowThumbnails"] label.switch-label')
+
+    await titlesToggle.click()
+    await expect(title).toHaveText(REPLACEMENT_TITLE)
+    await expect(thumbnail).toHaveAttribute('src', originalThumbnail)
+    await thumbnailsToggle.click()
+    await expect(thumbnail).toHaveAttribute('src', THUMBNAIL_URL)
+    await expectImagesLoaded(thumbnail)
+    await titlesToggle.click()
+    await expect(title).toHaveText(ORIGINAL_TITLE)
+    await expect(thumbnail).toHaveAttribute('src', THUMBNAIL_URL)
+    await thumbnailsToggle.click()
+    await expect(thumbnail).toHaveAttribute('src', originalThumbnail)
+    await expect(card.locator('.deArrowToggleButton')).toHaveCount(0)
+
+    await titlesToggle.click()
+    await thumbnailsToggle.click()
+    await menu.press('Escape')
+    await card.locator('.deArrowToggleButton').click()
+    await expect(title).toHaveText(ORIGINAL_TITLE)
+    await expect(thumbnail).toHaveAttribute('src', originalThumbnail)
+    await expect(card.locator('.deArrowToggleButton')).toHaveAttribute('title', /Show modified details/i)
+    await page.locator('.profileTrigger').click()
+    await titlesToggle.click()
+    await expect(title).toHaveText(ORIGINAL_TITLE)
+    await expect(thumbnail).toHaveAttribute('src', originalThumbnail)
+    await thumbnailsToggle.click()
+    await expect(card.locator('.deArrowToggleButton')).toHaveCount(0)
+    await titlesToggle.click()
+    await thumbnailsToggle.click()
+    await menu.press('Escape')
+    await expect(title).toHaveText(REPLACEMENT_TITLE)
+    await expect(thumbnail).toHaveAttribute('src', THUMBNAIL_URL)
+    await card.locator('.deArrowToggleButton').click()
+    await card.locator('.deArrowToggleButton').click()
+    await expect(title).toHaveText(REPLACEMENT_TITLE)
+    await expect(thumbnail).toHaveAttribute('src', THUMBNAIL_URL)
+    expect(await originalCard.evaluate(element => element.isConnected)).toBe(true)
+    expect(brandingRequests).toBe(cached ? 0 : 1)
+  })
+}

--- a/e2e/tests/offline/dearrow-quick-settings.spec.mjs
+++ b/e2e/tests/offline/dearrow-quick-settings.spec.mjs
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { test, expect, goTo } from '../../helpers/app.mjs'
 import { fulfillVisualFixture, expectImagesLoaded } from '../../helpers/visual-fixtures.mjs'
 
@@ -103,5 +104,84 @@ for (const cached of [false, true]) {
     await expect(thumbnail).toHaveAttribute('src', THUMBNAIL_URL)
     expect(await originalCard.evaluate(element => element.isConnected)).toBe(true)
     expect(brandingRequests).toBe(cached ? 0 : 1)
+  })
+}
+
+for (const pending of ['metadata', 'thumbnail']) {
+  test(`reused DeArrow cards load the new video with old ${pending} pending`, async ({ page }) => {
+    const nextVideoId = 'fffffffffff'
+    const nextTitle = 'Replacement video DeArrow title'
+    const nextThumbnail = `https://dearrow-thumb.ajay.app/api/v1/getThumbnail?videoID=${nextVideoId}&time=20`
+    const oldHash = createHash('sha256').update(VIDEO_ID).digest('hex').slice(0, 4)
+    let heldRoute
+    const branding = {
+      [VIDEO_ID]: {
+        titles: [{ title: REPLACEMENT_TITLE, votes: 1 }],
+        thumbnails: [{ timestamp: 10, votes: 1 }],
+        videoDuration: 60,
+      },
+      [nextVideoId]: {
+        titles: [{ title: nextTitle, votes: 1 }],
+        thumbnails: [{ timestamp: 20, votes: 1 }],
+        videoDuration: 60,
+      },
+    }
+    await page.route('https://sponsor.ajay.app/api/branding/*', async route => {
+      if (pending === 'metadata' && route.request().url().endsWith(oldHash)) {
+        heldRoute = route
+        return
+      }
+      await route.fulfill({ json: branding })
+    })
+    await page.route('https://dearrow-thumb.ajay.app/**', async route => {
+      if (pending === 'thumbnail' && route.request().url().includes(VIDEO_ID)) {
+        heldRoute = route
+        return
+      }
+      await fulfillVisualFixture(route, 'video-thumbnail')
+    })
+    await page.route('https://i.ytimg.com/**', route => fulfillVisualFixture(route, 'video-thumbnail'))
+    await goTo(page, 'history')
+    const card = page.locator('.ft-list-video').first()
+    await expect(card.locator('.title')).toHaveText(ORIGINAL_TITLE)
+    const originalCard = await card.elementHandle()
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateUseDeArrowTitles', true)
+      await store.dispatch('updateUseDeArrowThumbnails', true)
+    })
+    await expect.poll(() => Boolean(heldRoute)).toBe(true)
+    if (pending === 'thumbnail') {
+      await card.locator('.deArrowToggleButton').click()
+      await expect(card.locator('.title')).toHaveText(ORIGINAL_TITLE)
+    }
+    // Replace the data prop without remounting, as a stable playlistItemId does.
+    await page.evaluate(({ videoId }) => {
+      const find = vnode => {
+        if (vnode?.component?.type?.__name === 'FtListVideo') return vnode.component
+        const nested = vnode?.component?.subTree && find(vnode.component.subTree)
+        if (nested) return nested
+        for (const child of Array.isArray(vnode?.children) ? vnode.children : []) {
+          const match = find(child)
+          if (match) return match
+        }
+      }
+      const component = find(document.querySelector('#app').__vue_app__._container._vnode)
+      component.props.data = { ...component.props.data, videoId, title: 'Replacement original title' }
+    }, { videoId: nextVideoId })
+    await expect(card.locator('.title')).toHaveText(nextTitle)
+    await expect(card.locator('.thumbnailImage').first()).toHaveAttribute('src', nextThumbnail)
+    if (pending === 'metadata') {
+      await heldRoute.fulfill({ json: branding })
+    } else {
+      await fulfillVisualFixture(heldRoute, 'video-thumbnail')
+    }
+    await expect.poll(() => page.evaluate(videoId => {
+      const cache = document.querySelector('#app').__vue_app__.config.globalProperties.$store.getters.getDeArrowCache
+      return cache[videoId]?.thumbnail
+    }, VIDEO_ID)).toBe(pending === 'thumbnail' ? THUMBNAIL_URL : null)
+    await expect(card.locator('.title')).toHaveText(nextTitle)
+    await expect(card.locator('.thumbnailImage').first()).toHaveAttribute('src', nextThumbnail)
+    expect(await originalCard.evaluate(element => element.isConnected)).toBe(true)
   })
 }

--- a/e2e/tests/offline/quick-settings.spec.mjs
+++ b/e2e/tests/offline/quick-settings.spec.mjs
@@ -1,10 +1,179 @@
-import { test, expect, goToSettingsSection } from '../../helpers/app.mjs'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { test, expect, goToSettingsSection, latestSettings } from '../../helpers/app.mjs'
 import { DEFAULT_QUICK_SETTINGS } from '../../../src/renderer/helpers/quickSettings.js'
 
 const ALL_QUICK_SETTINGS = [
   ...DEFAULT_QUICK_SETTINGS,
   'useProxy',
 ]
+
+const ADDITIONAL_QUICK_SETTINGS = [
+  ['rememberHistory', 'Remember Watch History', 'Privacy'],
+  ['rememberSearchHistory', 'Remember Search History', 'Privacy'],
+  ['ambientMode', 'Ambient Mode', 'Appearance'],
+  ['autoplayVideos', 'Start Videos Automatically', 'Playback'],
+  ['autoplayPlaylists', 'Autoplay Playlist Videos', 'Playback'],
+  ['defaultPlayback', 'Default Playback Rate', 'Playback'],
+  ['scrollMiniPlayerEnabled', 'Keep a mini player on screen when scrolling down', 'Playback'],
+  ['defaultVideoFormat', 'Default Video Format', 'Playback'],
+  ['useDeArrowTitles', 'Use DeArrow Video Titles', 'Add-ons'],
+  ['useDeArrowThumbnails', 'Use DeArrow for thumbnails', 'Add-ons'],
+  ['hideLiveChat', 'Hide Live Chat', 'Content'],
+  ['hideLiveChatReplay', 'Hide Live Chat Replay', 'Content'],
+  ['showThumbnailPreviews', 'Show thumbnail previews', 'Content'],
+  ['hideSubscriptionsShorts', 'Hide Subscriptions Shorts', 'Content'],
+  ['blurThumbnails', 'Blur thumbnails', 'Content'],
+  ['enableCaptionTranslations', 'Enable Caption Translations', 'Language and region'],
+  ['enableCommentTranslations', 'Enable comment translations', 'Language and region'],
+]
+
+test.describe('additional quick settings', () => {
+  test.use({ seed: { settings: { quickSettings: [], uiScale: 125 } } })
+
+  test('adds all suggested controls, groups them, and persists changes across restart', async ({ app, page }, testInfo) => {
+    test.setTimeout(120_000)
+    const appearance = await goToSettingsSection(page, 'appearance')
+    await appearance.getByRole('button', { name: 'Customize quick settings' }).click()
+    await page.getByRole('button', { name: 'Add setting' }).click()
+    const search = page.getByPlaceholder('Search settings')
+    for (const [, label] of ADDITIONAL_QUICK_SETTINGS) {
+      await search.fill(label)
+      await page.locator('.settingPicker .optionWrapper').getByText(new RegExp(`^${label}$`, 'i')).click()
+    }
+    await search.press('Escape')
+    await page.locator('.settingsCloseButton').click()
+    await page.locator('.profileTrigger').click()
+    const menu = page.getByRole('dialog', { name: 'Quick settings' })
+    const expected = {}
+
+    for (const [id, label, section] of ADDITIONAL_QUICK_SETTINGS) {
+      const control = menu.locator(`[data-setting-id="${id}"]`)
+      await expect(control.locator('..').getByRole('heading'))
+        .toHaveText(section)
+      if (id === 'defaultPlayback') {
+        const slider = control.getByRole('slider')
+        await slider.press('ArrowRight')
+        expected[id] = 1.25
+        await expect(slider).toHaveValue('1.25')
+      } else if (id === 'defaultVideoFormat') {
+        await control.getByRole('combobox', { name: new RegExp(`^${label}$`, 'i') }).click()
+        await page.getByRole('option', { name: /^Audio Formats$/i }).click()
+        expected[id] = 'audio'
+      } else {
+        const toggle = control.getByRole('checkbox')
+        expected[id] = !await toggle.isChecked()
+        await control.locator('label.switch-label').click()
+        await expect(toggle).toBeChecked({ checked: expected[id] })
+      }
+      await expect(menu).toBeVisible()
+    }
+
+    const ids = ADDITIONAL_QUICK_SETTINGS.map(([id]) => id)
+    await expect.poll(async () => {
+      const saved = latestSettings(await readFile(path.join(app.userDataDir, 'settings.db'), 'utf8'))
+      return Object.fromEntries(['quickSettings', ...ids].map(id => [id, saved[id]]))
+    }).toEqual({ quickSettings: ids, ...expected })
+
+    ;({ page } = await app.relaunch())
+    await page.locator('.profileTrigger').click()
+    const reopened = page.getByRole('dialog', { name: 'Quick settings' })
+    await expect(reopened.getByRole('heading', { name: 'Privacy', exact: true })
+      .locator('[data-icon="lock"]')).toBeVisible()
+    await expect.poll(() => reopened.locator('.quickSettingControl').evaluateAll(controls => (
+      controls.map(control => control.dataset.settingId)
+    ))).toEqual(ids)
+    for (const [id, value] of Object.entries(expected)) {
+      const control = reopened.locator(`[data-setting-id="${id}"]`)
+      if (typeof value === 'boolean') {
+        await expect(control.getByRole('checkbox')).toBeChecked({ checked: value })
+      } else if (typeof value === 'number') {
+        await expect(control.getByRole('slider')).toHaveValue(String(value))
+      } else {
+        await expect(control.getByRole('combobox')).toContainText(/Audio Formats/i)
+      }
+    }
+    const bounds = await reopened.boundingBox()
+    const viewport = await page.evaluate(() => ({ width: innerWidth, height: innerHeight }))
+    expect(bounds.x).toBeGreaterThanOrEqual(0)
+    expect(bounds.x + bounds.width).toBeLessThanOrEqual(viewport.width)
+    expect(bounds.y + bounds.height).toBeLessThanOrEqual(viewport.height)
+    // Electron capturePage includes the entire window at non-100% zoom.
+    const screenshot = await app.electronApp.evaluate(async ({ BrowserWindow }) => (
+      (await BrowserWindow.getAllWindows()[0].webContents.capturePage()).toDataURL()
+    ))
+    await testInfo.attach('expanded quick settings catalog at 125 percent scale', {
+      body: Buffer.from(screenshot.split(',')[1], 'base64'),
+      contentType: 'image/png',
+    })
+  })
+})
+
+test.describe('quick playback speed', () => {
+  test.use({
+    seed: {
+      settings: {
+        quickSettings: ['defaultPlayback'],
+        videoPlaybackRateInterval: 0.1,
+        maxVideoPlaybackRate: 5,
+      }
+    }
+  })
+
+  test('uses the configured speed interval and maximum', async ({ page }) => {
+    await page.locator('.profileTrigger').click()
+    const slider = page.getByRole('dialog', { name: 'Quick settings' }).getByRole('slider')
+    await expect(slider).toHaveAttribute('min', '0.1')
+    await expect(slider).toHaveAttribute('max', '5')
+    await expect(slider).toHaveAttribute('step', '0.1')
+    await slider.press('Home')
+    await slider.press('ArrowRight')
+    await expect(slider).toHaveValue('0.2')
+    await slider.press('End')
+    await expect.poll(() => page.evaluate(() => (
+      document.querySelector('#app').__vue_app__.config.globalProperties.$store.getters.getDefaultPlayback
+    ))).toBe(5)
+  })
+})
+
+test.describe('quick thumbnail blur', () => {
+  test.use({ seed: { settings: { quickSettings: ['blurThumbnails'] } } })
+
+  test('reflects the quick toggle and reset in the full thumbnail selector', async ({ page }) => {
+    for (const preference of ['blur', 'middle']) {
+      const appearance = await goToSettingsSection(page, 'appearance')
+      const select = appearance.locator('.select').filter({
+        has: page.getByRole('combobox', { name: 'Thumbnail Preference' })
+      }).locator('select')
+      await select.selectOption(preference)
+      await expect(select).toHaveValue(preference)
+      await page.locator('.settingsCloseButton').click()
+      await page.locator('.profileTrigger').click()
+      const menu = page.getByRole('dialog', { name: 'Quick settings' })
+      const toggle = menu.getByRole('checkbox', { name: 'Blur thumbnails' })
+      const label = menu.locator('label.switch-label')
+
+      if (preference === 'middle') {
+        await label.click()
+        await expect(toggle).toBeChecked()
+      }
+      await label.click()
+      await expect(toggle).not.toBeChecked()
+      await label.click()
+      await expect(toggle).toBeChecked()
+      await menu.getByRole('button', { name: 'Reset this setting to its default' }).click()
+      await expect(toggle).not.toBeChecked()
+
+      await menu.getByRole('button', { name: 'All Settings' }).click()
+      const reopened = await goToSettingsSection(page, 'appearance')
+      const reopenedSelect = reopened.locator('.select').filter({
+        has: page.getByRole('combobox', { name: 'Thumbnail Preference' })
+      }).locator('select')
+      await expect(reopenedSelect).toHaveValue(preference === 'blur' ? '' : preference)
+    }
+  })
+})
 
 test.describe('quick settings menu', () => {
   test.use({ seed: { settings: { quickSettings: ALL_QUICK_SETTINGS } } })

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -594,8 +594,6 @@ let thumbnailPreviewLoader = null
 let thumbnailPreviewLoaderUrl = null
 let thumbnailPreviewTimer = null
 const deArrowTogglePinned = ref(false)
-const showDeArrowTitle = ref(false)
-const showDeArrowThumbnail = ref(false)
 const showCollaboratorsPrompt = ref(false)
 const isFetchingCollaborators = ref(false)
 const sponsorBlockFullVideoCategory = ref(null)
@@ -1519,6 +1517,9 @@ const useDeArrowTitles = computed(() => store.getters.getUseDeArrowTitles)
 /** @type {import('vue').ComputedRef<boolean>} */
 const useDeArrowThumbnails = computed(() => store.getters.getUseDeArrowThumbnails)
 
+const showDeArrowTitle = computed(() => useDeArrowTitles.value && !deArrowTogglePinned.value)
+const showDeArrowThumbnail = computed(() => useDeArrowThumbnails.value && !deArrowTogglePinned.value)
+
 const deArrowChangedContent = computed(() => {
   return (useDeArrowThumbnails.value && deArrowCache.value?.thumbnail) ||
       (useDeArrowTitles.value && deArrowCache.value?.title &&
@@ -1673,14 +1674,6 @@ function toggleDeArrow() {
   }
 
   deArrowTogglePinned.value = !deArrowTogglePinned.value
-
-  if (useDeArrowTitles.value) {
-    showDeArrowTitle.value = !showDeArrowTitle.value
-  }
-
-  if (useDeArrowThumbnails.value) {
-    showDeArrowThumbnail.value = !showDeArrowThumbnail.value
-  }
 }
 
 function markSubscriptionVideoAsSeen() {
@@ -2067,16 +2060,26 @@ function onDragStart(event) {
 watch(() => props.data, parseVideoData, { immediate: true })
 watch([locale, dateFormat, timeFormat], updateUploadedTime)
 
-showDeArrowTitle.value = useDeArrowTitles.value
-showDeArrowThumbnail.value = useDeArrowThumbnails.value
+watch([useDeArrowTitles, useDeArrowThumbnails], ([titles, thumbnails]) => {
+  if (!titles && !thumbnails) deArrowTogglePinned.value = false
+})
 
-if ((showDeArrowTitle.value || showDeArrowThumbnail.value) && !deArrowCache.value) {
-  fetchDeArrowData()
-}
+let fetchingDeArrowData = false
+watch([showDeArrowTitle, showDeArrowThumbnail], async ([titles, thumbnails]) => {
+  if (!titles && !thumbnails) return
 
-if (showDeArrowThumbnail.value && deArrowCache.value && deArrowCache.value.thumbnail == null) {
-  debounceGetDeArrowThumbnail()
-}
+  if (!deArrowCache.value) {
+    if (fetchingDeArrowData) return
+    fetchingDeArrowData = true
+    try {
+      await fetchDeArrowData()
+    } finally {
+      fetchingDeArrowData = false
+    }
+  } else if (thumbnails && deArrowCache.value.thumbnail == null) {
+    debounceGetDeArrowThumbnail()
+  }
+}, { immediate: true })
 
 watch(premiereTimestamp, schedulePremiereStartInvalidation, { immediate: true })
 watch([id, premiereTimestamp], syncLiveReminder, { immediate: true })

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -1626,13 +1626,12 @@ function handleChannelLinkClick(event) {
 }
 
 async function fetchDeArrowThumbnail() {
-  if (thumbnailPreference.value === 'hidden') { return }
+  if (thumbnailPreference.value === 'hidden' || !showDeArrowThumbnail.value || !deArrowCache.value) { return }
 
-  const videoId = id.value
-  const thumbnail = await deArrowThumbnail(videoId, deArrowCache.value.thumbnailTimestamp)
+  const deArrowCacheClone = deepCopy(deArrowCache.value)
+  const thumbnail = await deArrowThumbnail(deArrowCacheClone.videoId, deArrowCacheClone.thumbnailTimestamp)
 
   if (thumbnail) {
-    const deArrowCacheClone = deepCopy(deArrowCache.value)
     deArrowCacheClone.thumbnail = thumbnail
     store.commit('addThumbnailToDeArrowCache', deArrowCacheClone)
   }
@@ -1640,8 +1639,7 @@ async function fetchDeArrowThumbnail() {
 
 const debounceGetDeArrowThumbnail = debounce(fetchDeArrowThumbnail, 1000)
 
-async function fetchDeArrowData() {
-  const videoId = id.value
+async function fetchDeArrowData(videoId) {
   const cacheData = { videoId, title: null, videoDuration: null, thumbnail: null, thumbnailTimestamp: null }
 
   const data = await deArrowData(videoId)
@@ -1663,7 +1661,7 @@ async function fetchDeArrowData() {
   store.commit('addVideoToDeArrowCache', cacheData)
 
   // fetch dearrow thumbnails if enabled
-  if (showDeArrowThumbnail.value && deArrowCache.value?.thumbnail === null) {
+  if (id.value === videoId && showDeArrowThumbnail.value && deArrowCache.value?.thumbnail === null) {
     debounceGetDeArrowThumbnail()
   }
 }
@@ -2064,17 +2062,22 @@ watch([useDeArrowTitles, useDeArrowThumbnails], ([titles, thumbnails]) => {
   if (!titles && !thumbnails) deArrowTogglePinned.value = false
 })
 
-let fetchingDeArrowData = false
-watch([showDeArrowTitle, showDeArrowThumbnail], async ([titles, thumbnails]) => {
-  if (!titles && !thumbnails) return
+watch(id, () => {
+  deArrowTogglePinned.value = false
+  debounceGetDeArrowThumbnail.cancel()
+})
+
+const fetchingDeArrowData = new Set()
+watch([id, showDeArrowTitle, showDeArrowThumbnail], async ([videoId, titles, thumbnails]) => {
+  if (!videoId || (!titles && !thumbnails)) return
 
   if (!deArrowCache.value) {
-    if (fetchingDeArrowData) return
-    fetchingDeArrowData = true
+    if (fetchingDeArrowData.has(videoId)) return
+    fetchingDeArrowData.add(videoId)
     try {
-      await fetchDeArrowData()
+      await fetchDeArrowData(videoId)
     } finally {
-      fetchingDeArrowData = false
+      fetchingDeArrowData.delete(videoId)
     }
   } else if (thumbnails && deArrowCache.value.thumbnail == null) {
     debounceGetDeArrowThumbnail()
@@ -2093,6 +2096,7 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+  debounceGetDeArrowThumbnail.cancel()
   resetThumbnailPreview()
   clearPremiereStartTimer()
   removeLiveReminderUpdatedListener?.()

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
@@ -248,6 +248,17 @@
                     compact
                     @change="updateSetting('PlayNextVideo', $event)"
                   />
+                  <FtSlider
+                    v-else-if="setting.id === 'defaultPlayback'"
+                    :label="t('Settings.Player Settings.Default Playback Rate')"
+                    :default-value="store.getters.getDefaultPlayback"
+                    setting-key="defaultPlayback"
+                    :min-value="store.getters.getVideoPlaybackRateInterval"
+                    :max-value="store.getters.getMaxVideoPlaybackRate"
+                    :step="store.getters.getVideoPlaybackRateInterval"
+                    value-extension="x"
+                    @change="updateSetting('DefaultPlayback', $event)"
+                  />
                   <FtToggleSwitch
                     v-else-if="setting.id === 'enableSubtitlesByDefault'"
                     :label="t('Settings.Player Settings.Turn on Subtitles by Default')"

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -686,7 +686,10 @@ const blurThumbnails = computed(() => store.getters.getBlurThumbnails)
 
 /** @type {import('vue').ComputedRef<'' | 'start' | 'middle' | 'end' | 'hidden' | 'blur'>} */
 const thumbnailPreference = computed(() => {
-  return blurThumbnails.value ? 'blur' : store.getters.getThumbnailPreference
+  if (blurThumbnails.value) return 'blur'
+  // Quick settings can turn blurring off independently of the thumbnail style.
+  const preference = store.getters.getThumbnailPreference
+  return preference === 'blur' ? '' : preference
 })
 
 const thumbnailPreferenceChanged = computed(() => (

--- a/src/renderer/helpers/quickSettings.js
+++ b/src/renderer/helpers/quickSettings.js
@@ -4,6 +4,7 @@ const CORE_QUICK_SETTINGS = [
   ['uiScale', 'appearance', 'Settings.Theme Settings.UI Scale', { control: 'slider', electronOnly: true, icon: ['fas', 'sliders-h'] }],
   ['thumbnailSize', 'appearance', 'Settings.Theme Settings.Thumbnail Size', { control: 'slider', icon: ['fas', 'photo-film'] }],
   ['defaultQuality', 'playback', 'Settings.Player Settings.Default Quality.Default Quality', { control: 'select', icon: ['fas', 'photo-film'] }],
+  ['defaultPlayback', 'playback', 'Settings.Player Settings.Default Playback Rate', { control: 'slider', icon: ['fas', 'gauge-high'] }],
   ['playNextVideo', 'playback', 'Settings.Player Settings.Play Next Video', { control: 'toggle', icon: ['fas', 'step-forward'] }],
   ['enableSubtitlesByDefault', 'playback', 'Settings.Player Settings.Turn on Subtitles by Default', { control: 'toggle', icon: ['fas', 'closed-captioning'] }],
   ['listType', 'content', 'Settings.General Settings.Video View Type.Video View Type', { control: 'select', icon: ['fas', 'grip'] }],
@@ -16,6 +17,19 @@ const CORE_QUICK_SETTINGS = [
 ]
 
 export const BASIC_QUICK_SETTING_DEFINITIONS = Object.freeze([
+  {
+    id: 'defaultVideoFormat',
+    section: 'playback',
+    labelKey: 'Settings.Player Settings.Default Video Format.Default Video Format',
+    control: 'select',
+    values: ['dash', 'legacy', 'audio'],
+    optionLabelKeys: [
+      'Settings.Player Settings.Default Video Format.Dash Formats',
+      'Settings.Player Settings.Default Video Format.Legacy Formats',
+      'Settings.Player Settings.Default Video Format.Audio Formats',
+    ],
+    icon: ['fas', 'file-video'],
+  },
   {
     id: 'iconPack',
     section: 'appearance',
@@ -56,6 +70,21 @@ export const BASIC_QUICK_SETTING_DEFINITIONS = Object.freeze([
   ['showToastTimeoutIndicator', 'Settings.Theme Settings.Show Toast Timeout Indicator', 'appearance', ['fas', 'message']],
   ['useSponsorBlock', 'Settings.SponsorBlock Settings.Enable SponsorBlock', 'add-ons', ['fas', 'forward']],
   ['useReturnYouTubeDislikes', 'Settings.Return YouTube Dislike Settings.Enable Return YouTube Dislike', 'add-ons', ['fas', 'thumbs-down']],
+  ['rememberHistory', 'Settings.Privacy Settings.Remember History', 'privacy', ['fas', 'history']],
+  ['rememberSearchHistory', 'Settings.Privacy Settings.Remember Search History', 'privacy', ['fas', 'search']],
+  ['autoplayVideos', 'Settings.Player Settings.Autoplay Videos', 'playback', ['fas', 'play']],
+  ['autoplayPlaylists', 'Settings.Player Settings.Autoplay Playlists', 'playback', ['fas', 'list']],
+  ['useDeArrowTitles', 'Settings.SponsorBlock Settings.UseDeArrowTitles', 'add-ons', ['fas', 'pen']],
+  ['useDeArrowThumbnails', 'Settings.SponsorBlock Settings.UseDeArrowThumbnails', 'add-ons', ['fas', 'photo-film']],
+  ['scrollMiniPlayerEnabled', 'Settings.Player Settings.Scroll Mini Player.When Scrolling Down', 'playback', ['fas', 'compress']],
+  ['ambientMode', 'Global.Ambient Mode', 'appearance', ['fas', 'palette']],
+  ['hideLiveChat', 'Settings.Distraction Free Settings.Hide Live Chat', 'content', ['fas', 'comment']],
+  ['hideLiveChatReplay', 'Settings.Distraction Free Settings.Hide Live Chat Replay', 'content', ['fas', 'comment']],
+  ['showThumbnailPreviews', 'Settings.General Settings.Show Thumbnail Previews', 'content', ['fas', 'photo-film']],
+  ['enableCaptionTranslations', 'Settings.Player Settings.Caption Appearance.Enable Translations', 'language', ['fas', 'closed-captioning']],
+  ['enableCommentTranslations', 'Settings.General Settings.Comment Translation.Enable', 'language', ['fas', 'language']],
+  ['hideSubscriptionsShorts', 'Settings.Distraction Free Settings.Hide Subscriptions Shorts', 'content', ['fas', 'eye-slash']],
+  ['blurThumbnails', 'Settings.General Settings.Blur Thumbnails', 'content', ['fas', 'eye-slash']],
 ].map(definition => Object.freeze(Array.isArray(definition)
   ? {
       id: definition[0],
@@ -100,6 +129,10 @@ const SECTION_DEFINITIONS = Object.freeze({
   advanced: Object.freeze({
     labelKey: 'Settings.Categories.Advanced',
     icon: Object.freeze(['fas', 'flask']),
+  }),
+  privacy: Object.freeze({
+    labelKey: 'Settings.Privacy Settings.Privacy Settings',
+    icon: Object.freeze(['fas', 'lock']),
   }),
 })
 

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -219,6 +219,7 @@ Settings:
       Network: شبكة
       Disk: القرص
   General Settings:
+    Blur Thumbnails: تمويه الصور المصغرة
     Navigation:
       Navigation: التنقل
       Customize Navigation: تخصيص التنقل

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -231,6 +231,7 @@ Settings:
       Network: сетка
       Disk: дыск
   General Settings:
+    Blur Thumbnails: Размываць мініяцюры
     Navigation:
       Navigation: Навігацыя
       Customize Navigation: Наладзіць навігацыю

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -217,6 +217,7 @@ Settings:
       Network: мрежата
       Disk: диска
   General Settings:
+    Blur Thumbnails: Замъгляване на миниатюрите
     Navigation:
       Navigation: Навигация
       Customize Navigation: Персонализиране на навигацията

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -215,6 +215,7 @@ Settings:
       Network: "ar rouedad"
       Disk: "ar bladenn"
   General Settings:
+    Blur Thumbnails: Lakaat ar skeudennoùigoù da vezañ dispis
     Navigation:
       Navigation: Merdeiñ
       Customize Navigation: Personelaat ar merdeiñ

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -342,6 +342,7 @@ Settings:
       Disk: disc
   Return to Settings Menu: Torna al menú de configuració
   General Settings:
+    Blur Thumbnails: Difumina les miniatures
     Navigation:
       Navigation: Navegació
       Customize Navigation: Personalitza la navegació

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -215,6 +215,7 @@ Settings:
       Network: sítě
       Disk: disku
   General Settings:
+    Blur Thumbnails: Rozmazat miniatury
     Navigation:
       Navigation: Navigace
       Customize Navigation: Přizpůsobit navigaci

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -217,6 +217,7 @@ Settings:
       Network: rhwydwaith
       Disk: disg
   General Settings:
+    Blur Thumbnails: Niwlio mân-luniau
     Navigation:
       Navigation: Llywio
       Customize Navigation: Addasu'r llywio

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -226,6 +226,7 @@ Settings:
       Network: netværk
       Disk: diskplads
   General Settings:
+    Blur Thumbnails: Slør miniaturebilleder
     Navigation:
       Navigation: Navigation
       Customize Navigation: Tilpas navigation

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -219,6 +219,7 @@ Settings:
       Network: δικτύου
       Disk: δίσκου
   General Settings:
+    Blur Thumbnails: Θόλωση μικρογραφιών
     Navigation:
       Navigation: Πλοήγηση
       Customize Navigation: Προσαρμογή πλοήγησης

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -214,6 +214,7 @@ Settings:
       Network: network
       Disk: disk
   General Settings:
+    Blur Thumbnails: Blur thumbnails
     Navigation:
       Navigation: Navigation
       Customize Navigation: Customise navigation

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -235,6 +235,7 @@ Settings:
       Network: red
       Disk: disco
   General Settings:
+    Blur Thumbnails: Desenfocar miniaturas
     Navigation:
       Navigation: Navegación
       Customize Navigation: Personalizar navegación

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -243,6 +243,7 @@ Settings:
       Network: red
       Disk: disco
   General Settings:
+    Blur Thumbnails: Desenfocar miniaturas
     Navigation:
       Navigation: Navegación
       Customize Navigation: Personalizar navegación

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -217,6 +217,7 @@ Settings:
       Network: red
       Disk: disco
   General Settings:
+    Blur Thumbnails: Desenfocar miniaturas
     Navigation:
       Navigation: Navegación
       Customize Navigation: Personalizar navegación

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -215,6 +215,7 @@ Settings:
       Network: võrgu
       Disk: ketta
   General Settings:
+    Blur Thumbnails: Hägusta pisipildid
     Navigation:
       Navigation: Navigeerimine
       Customize Navigation: Kohanda navigeerimist

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -217,6 +217,7 @@ Settings:
       Network: sarea
       Disk: diskoa
   General Settings:
+    Blur Thumbnails: Lausotu koadro txikiak
     Navigation:
       Navigation: Nabigazioa
       Customize Navigation: Pertsonalizatu nabigazioa

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -232,6 +232,7 @@ Settings:
       Network: شبکه
       Disk: دیسک
   General Settings:
+    Blur Thumbnails: تار کردن تصاویر بندانگشتی
     Navigation:
       Navigation: پیمایش
       Customize Navigation: سفارشی‌سازی پیمایش

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -219,6 +219,7 @@ Settings:
       Network: verkko
       Disk: levytila
   General Settings:
+    Blur Thumbnails: Sumenna pikkukuvat
     Navigation:
       Navigation: Navigointi
       Customize Navigation: Mukauta navigointia

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -215,6 +215,7 @@ Settings:
       Network: le réseau
       Disk: le disque
   General Settings:
+    Blur Thumbnails: Flouter les miniatures
     Navigation:
       Navigation: Navigation
       Customize Navigation: Personnaliser la navigation

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -219,6 +219,7 @@ Settings:
       Network: rede
       Disk: disco
   General Settings:
+    Blur Thumbnails: Desenfocar miniaturas
     Navigation:
       Navigation: Navegación
       Customize Navigation: Personalizar a navegación

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -219,6 +219,7 @@ Settings:
       Network: רשת
       Disk: כונן
   General Settings:
+    Blur Thumbnails: טשטוש תמונות ממוזערות
     Navigation:
       Navigation: ניווט
       Customize Navigation: התאמה אישית של הניווט

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -217,6 +217,7 @@ Settings:
       Network: mreže
       Disk: diska
   General Settings:
+    Blur Thumbnails: Zamuti minijature
     Navigation:
       Navigation: Navigacija
       Customize Navigation: Prilagodi navigaciju

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -215,6 +215,7 @@ Settings:
       Network: hálózat
       Disk: lemez
   General Settings:
+    Blur Thumbnails: Bélyegképek elhomályosítása
     Navigation:
       Navigation: Navigáció
       Customize Navigation: Navigáció testreszabása

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -219,6 +219,7 @@ Settings:
       Network: jaringan
       Disk: disk
   General Settings:
+    Blur Thumbnails: Buramkan gambar mini
     Navigation:
       Navigation: Navigasi
       Customize Navigation: Sesuaikan navigasi

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -219,6 +219,7 @@ Settings:
       Network: nets
       Disk: disks
   General Settings:
+    Blur Thumbnails: Þoka smámyndir
     Navigation:
       Navigation: Leiðsögn
       Customize Navigation: Sérsníða leiðsögn

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -215,6 +215,7 @@ Settings:
       Network: rete
       Disk: disco
   General Settings:
+    Blur Thumbnails: Sfoca le miniature
     Navigation:
       Navigation: Navigazione
       Customize Navigation: Personalizza la navigazione

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -215,6 +215,7 @@ Settings:
       Network: ネットワーク
       Disk: ディスク
   General Settings:
+    Blur Thumbnails: サムネイルをぼかす
     Navigation:
       Navigation: ナビゲーション
       Customize Navigation: ナビゲーションをカスタマイズ

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -303,6 +303,7 @@ Settings:
       Disk: 디스크
   Return to Settings Menu: 설정 메뉴로 돌아가기
   General Settings:
+    Blur Thumbnails: 썸네일 흐리게 표시
     Navigation:
       Navigation: 탐색
       Customize Navigation: 탐색 맞춤 설정

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -328,6 +328,7 @@ Settings:
       Disk: disko
   Return to Settings Menu: Grįžti į nustatymų meniu
   General Settings:
+    Blur Thumbnails: Sulieti miniatiūras
     Navigation:
       Navigation: Naršymas
       Customize Navigation: Tinkinti naršymą

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -215,6 +215,7 @@ Settings:
       Network: nettverk
       Disk: disk
   General Settings:
+    Blur Thumbnails: Gjør miniatyrbilder uskarpe
     Navigation:
       Navigation: Navigasjon
       Customize Navigation: Tilpass navigasjon

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -219,6 +219,7 @@ Settings:
       Network: netwerk
       Disk: schijf
   General Settings:
+    Blur Thumbnails: Miniaturen vervagen
     Navigation:
       Navigation: Navigatie
       Customize Navigation: Navigatie aanpassen

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -270,6 +270,7 @@ Settings:
       Disk: disk
   Return to Settings Menu: Tilbake til innstillingsmenyen
   General Settings:
+    Blur Thumbnails: Gjer miniatyrbilete uskarpe
     Navigation:
       Navigation: Navigasjon
       Customize Navigation: Tilpass navigasjon

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -71,6 +71,7 @@ Settings:
     Advanced Description: Dostawcy, aplikacje zewnętrzne i sieć
     Alternative providers: Dostawcy filmów i metadanych
   General Settings:
+    Blur Thumbnails: Rozmyj miniatury
     Navigation:
       Navigation: Nawigacja
       Customize Navigation: Dostosuj nawigację

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -215,6 +215,7 @@ Settings:
       Network: rede
       Disk: disco
   General Settings:
+    Blur Thumbnails: Desfocar miniaturas
     Navigation:
       Navigation: Navegação
       Customize Navigation: Personalizar navegação

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -219,6 +219,7 @@ Settings:
       Network: rede
       Disk: disco
   General Settings:
+    Blur Thumbnails: Desfocar miniaturas
     Navigation:
       Navigation: Navegação
       Customize Navigation: Personalizar navegação

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -219,6 +219,7 @@ Settings:
       Network: rede
       Disk: disco
   General Settings:
+    Blur Thumbnails: Desfocar miniaturas
     Navigation:
       Navigation: Navegação
       Customize Navigation: Personalizar navegação

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -217,6 +217,7 @@ Settings:
       Network: rețea
       Disk: disc
   General Settings:
+    Blur Thumbnails: Estompează miniaturile
     Navigation:
       Navigation: Navigare
       Customize Navigation: Personalizează navigarea

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -194,6 +194,7 @@ Settings:
       Network: сеть
       Disk: диск
   General Settings:
+    Blur Thumbnails: Размывать миниатюры
     Navigation:
       Navigation: Навигация
       Customize Navigation: Настроить навигацию

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -215,6 +215,7 @@ Settings:
       Network: sieť
       Disk: disk
   General Settings:
+    Blur Thumbnails: Rozmazať miniatúry
     Navigation:
       Navigation: Navigácia
       Customize Navigation: Prispôsobiť navigáciu

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -335,6 +335,7 @@ Settings:
       Disk: disk
   Return to Settings Menu: Nazaj v meni z nastavitvami
   General Settings:
+    Blur Thumbnails: Zamegli sličice
     Navigation:
       Navigation: Krmarjenje
       Customize Navigation: Prilagodi krmarjenje

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -225,6 +225,7 @@ Settings:
       Network: мрежа
       Disk: диск
   General Settings:
+    Blur Thumbnails: Замагли сличице
     Navigation:
       Navigation: Навигација
       Customize Navigation: Прилагоди навигацију

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -217,6 +217,7 @@ Settings:
       Network: nätverk
       Disk: diskutrymme
   General Settings:
+    Blur Thumbnails: Gör miniatyrbilder suddiga
     Navigation:
       Navigation: Navigering
       Customize Navigation: Anpassa navigeringen

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -220,6 +220,7 @@ Settings:
       Network: பிணையம்
       Disk: வட்டு
   General Settings:
+    Blur Thumbnails: சிறுபடங்களை மங்கலாக்கு
     Navigation:
       Navigation: வழிசெலுத்தல்
       Customize Navigation: வழிசெலுத்தலைத் தனிப்பயனாக்கு

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -215,6 +215,7 @@ Settings:
       Network: ağ
       Disk: disk
   General Settings:
+    Blur Thumbnails: Küçük resimleri bulanıklaştır
     Navigation:
       Navigation: Gezinme
       Customize Navigation: Gezinmeyi özelleştir

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -219,6 +219,7 @@ Settings:
       Network: мережа
       Disk: диск
   General Settings:
+    Blur Thumbnails: Розмивати мініатюри
     Navigation:
       Navigation: Навігація
       Customize Navigation: Налаштувати навігацію

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -219,6 +219,7 @@ Settings:
       Network: mạng
       Disk: ổ đĩa
   General Settings:
+    Blur Thumbnails: Làm mờ hình thu nhỏ
     Navigation:
       Navigation: Điều hướng
       Customize Navigation: Tùy chỉnh điều hướng

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -215,6 +215,7 @@ Settings:
       Network: 网络
       Disk: 磁盘
   General Settings:
+    Blur Thumbnails: 模糊缩略图
     Navigation:
       Navigation: 导航
       Customize Navigation: 自定义导航

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -215,6 +215,7 @@ Settings:
       Network: 網路
       Disk: 磁碟
   General Settings:
+    Blur Thumbnails: 模糊縮圖
     Navigation:
       Navigation: 導覽
       Customize Navigation: 自訂導覽

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -302,6 +302,7 @@ Settings:
     Advanced Description: Anbieter, externe Anwendungen und Netzwerk
     Alternative providers: Video- und Metadatenanbieter
   General Settings:
+    Blur Thumbnails: Vorschaubilder weichzeichnen
     General Settings: Allgemein
     Navigation:
       Navigation: Navigation

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -477,6 +477,7 @@ Settings:
   The app needs to restart for changes to take effect. Restart and apply change?: The
     app needs to restart for changes to take effect. Restart and apply change?
   General Settings:
+    Blur Thumbnails: Blur thumbnails
     General Settings: General
     Navigation:
       Navigation: Navigation

--- a/tests/unit/quick-settings.test.mjs
+++ b/tests/unit/quick-settings.test.mjs
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 import test from 'node:test'
+import { load } from 'js-yaml'
 
 import {
   createQuickSettingSections,
@@ -27,6 +29,23 @@ test('keeps the original quick settings as defaults', () => {
   ])
 })
 
+test('localizes every quick setting, select option, and category in English and German', () => {
+  for (const locale of ['en-US', 'de-DE']) {
+    const messages = load(readFileSync(new URL(`../../static/locales/${locale}.yaml`, import.meta.url), 'utf8'))
+    const translate = key => {
+      const value = key.split('.').reduce((object, part) => object?.[part], messages)
+      assert.equal(typeof value, 'string', `${locale}: ${key}`)
+      assert.ok(value.length > 0, `${locale}: ${key}`)
+      return value
+    }
+    const sections = createQuickSettingSections(translate, true)
+    assert.ok(sections.some(section => section.id === 'privacy'))
+    for (const setting of QUICK_SETTING_DEFINITIONS) {
+      for (const key of setting.optionLabelKeys ?? []) translate(key)
+    }
+  }
+})
+
 test('gives every customizable setting an icon', () => {
   for (const setting of QUICK_SETTING_DEFINITIONS) {
     assert.equal(Array.isArray(setting.icon) && setting.icon.length, 2, setting.id)
@@ -45,6 +64,7 @@ test('uses the settings category icons for quick setting sections', () => {
     language: ['fas', 'globe'],
     advanced: ['fas', 'flask'],
     'add-ons': ['fas', 'puzzle-piece'],
+    privacy: ['fas', 'lock'],
   })
 })
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Requested directly by Nico; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Quick Settings only offered a limited selection of settings. Add 17 optional controls and a Privacy category so users can change common viewing preferences without opening the full settings page.

- Privacy: watch history and search history.
- Playback: video and playlist autoplay, default playback speed, scroll mini player, and video format including audio-only.
- Add-ons: DeArrow titles and thumbnails.
- Appearance: ambient mode.
- Content: live chat and replay visibility, thumbnail previews and blur, and subscription Shorts visibility.
- Language and region: caption and comment translations.

DeArrow changes now update existing video cards and fetch missing replacements without navigation. Playback speed follows the configured limits, and thumbnail blur stays consistent with the full settings selector.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. In Settings → Appearance → Customize quick settings, add the new controls. Confirm watch and search history appear under Privacy and the remaining controls use their relevant categories.
2. Change the controls and restart the app. Confirm the selected controls and their values persist.
3. Set a different playback-speed interval and maximum in player settings. Confirm the quick speed slider uses those limits.
4. On a video list with DeArrow replacements available, switch titles and thumbnails on and off independently. Existing cards should change immediately, and their Show Original Details button should still work.
5. Select Blur in the full thumbnail preference selector, then turn blur off in Quick Settings. The full selector should show Default. Repeat with another thumbnail style and confirm that style is preserved.
6. Check the menu at 125% UI scale; controls should remain usable within the window.

## Additional context
<!-- Add any other context about the pull request here. -->
The default Quick Settings selection is unchanged. The customizable catalog was introduced after v0.33.0-beta, so this extends functionality that has not appeared in a stable release. Reuses existing icon mappings and translations, with the new thumbnail-blur label completed for every active locale.
