### PR TITLE
feat(themes): import custom themes from the clipboard

### DIFF
--- a/android/app/src/main/java/org/opentubex/app/AndroidUiPlugin.java
+++ b/android/app/src/main/java/org/opentubex/app/AndroidUiPlugin.java
@@ -140,6 +140,20 @@ public class AndroidUiPlugin extends Plugin {
         });
     }
 
+    @PluginMethod
+    public void readClipboard(PluginCall call) {
+        getActivity().runOnUiThread(() -> {
+            ClipboardManager clipboard = (ClipboardManager) getContext()
+                .getSystemService(Context.CLIPBOARD_SERVICE);
+            ClipData clip = clipboard.getPrimaryClip();
+            CharSequence text = clip != null && clip.getItemCount() > 0
+                ? clip.getItemAt(0).getText() : null;
+            JSObject result = new JSObject();
+            result.put("text", text == null ? "" : text.toString());
+            call.resolve(result);
+        });
+    }
+
     public boolean hasHardwareKeyboard() {
         InputManager inputManager = (InputManager) getContext()
             .getSystemService(Context.INPUT_SERVICE);

--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -1,5 +1,6 @@
 import { readFile, readdir } from 'node:fs/promises'
 import path from 'node:path'
+import { cloneDefaultCustomTheme } from '../../../src/customTheme.js'
 
 import {
   test,
@@ -411,6 +412,82 @@ test.describe('custom theme editor', () => {
         quickSettings: ['baseTheme', 'mainColor'],
       },
     },
+  })
+
+  test('imports clipboard themes as new drafts and saves only on confirmation', async ({ app, page }) => {
+    const theme = cloneDefaultCustomTheme()
+    theme.name = 'Clipboard midnight'
+    theme.colors.background = '#112233'
+    await app.electronApp.evaluate(({ clipboard }, text) => clipboard.writeText(text), JSON.stringify(theme))
+    await goToSettingsSection(page, 'theme')
+    await page.getByRole('button', { name: 'Create custom theme' }).click()
+    const importButton = page.getByRole('button', { name: 'Import from clipboard' })
+    await expect(importButton.locator('.ft-icon')).toBeVisible()
+    await importButton.focus()
+    await page.keyboard.press('Enter')
+    await expect(page.getByRole('textbox', { name: 'Theme name' })).toHaveValue(theme.name)
+    await expect(page.locator('body')).toHaveCSS('--bg-color', '#112233')
+    expect(await page.evaluate(() => window.ftElectron.loadCustomTheme())).toEqual([])
+    await page.getByRole('button', { name: 'Save and apply' }).click()
+    const saved = await page.evaluate(() => window.ftElectron.loadCustomTheme())
+    expect(saved).toHaveLength(1)
+    expect(saved[0].id).not.toBe(theme.id)
+    expect(saved[0].colors.background).toBe('#112233')
+
+    await page.getByRole('button', { name: 'Edit custom theme' }).click()
+    await importButton.click()
+    await page.getByRole('button', { name: 'Save and apply' }).click()
+    const importedAgain = await page.evaluate(() => window.ftElectron.loadCustomTheme())
+    expect(importedAgain).toHaveLength(2)
+    expect(new Set(importedAgain.map(({ id }) => id)).size).toBe(2)
+    expect(importedAgain).toContainEqual(saved[0])
+  })
+
+  test('reports clipboard read failures without replacing the draft', async ({ app, page }) => {
+    await app.electronApp.evaluate(({ clipboard }) => {
+      clipboard.readText = () => { throw new Error('Clipboard read failed') }
+    })
+    await goToSettingsSection(page, 'theme')
+    await page.getByRole('button', { name: 'Create custom theme' }).click()
+    const name = page.getByRole('textbox', { name: 'Theme name' })
+    await name.fill('Keep my draft')
+    await page.getByRole('button', { name: 'Import from clipboard' }).click()
+    await expect(page.locator('.toast').filter({ hasText: 'Clipboard unavailable' })).toBeVisible()
+    await expect(name).toHaveValue('Keep my draft')
+  })
+
+  test('keeps clipboard import controls visible in narrow and scaled windows', async ({ app, page }, testInfo) => {
+    await goToSettingsSection(page, 'theme')
+    await page.getByRole('button', { name: 'Create custom theme' }).click()
+    for (const [width, scale] of [[1200, 1], [420, 1], [500, 1.25]]) {
+      await setWindowWidth(app, width)
+      await page.evaluate(value => window.ftElectron.setZoomFactor(value), scale)
+      const buttons = page.locator('.fileActions button')
+      await expect(buttons).toHaveCount(4)
+      for (const button of await buttons.all()) {
+        await expect(button).toBeInViewport({ ratio: 1 })
+      }
+      await expect.poll(() => page.locator('.editorHeader').evaluate(element =>
+        element.scrollWidth <= element.clientWidth)).toBe(true)
+    }
+    await page.evaluate(() => window.ftElectron.setZoomFactor(1))
+    await page.screenshot({ path: testInfo.outputPath('clipboard-import.png') })
+  })
+
+  test('preserves the draft when clipboard themes are empty or invalid', async ({ app, page }) => {
+    await goToSettingsSection(page, 'theme')
+    await page.getByRole('button', { name: 'Create custom theme' }).click()
+    const name = page.getByRole('textbox', { name: 'Theme name' })
+    await name.fill('Keep my draft')
+    const originalBackground = await page.locator('body').evaluate(element => element.style.getPropertyValue('--bg-color'))
+    for (const text of ['', 'not JSON', '{"name":"Missing colors"}']) {
+      await app.electronApp.evaluate(({ clipboard }, value) => clipboard.writeText(value), text)
+      await page.getByRole('button', { name: 'Import from clipboard' }).click()
+      await expect(page.locator('.toast').filter({ hasText: 'Clipboard does not contain a valid theme' }).last()).toBeVisible()
+      await expect(name).toHaveValue('Keep my draft')
+      await expect(page.locator('body')).toHaveCSS('--bg-color', originalBackground)
+      expect(await page.evaluate(() => window.ftElectron.loadCustomTheme())).toEqual([])
+    }
   })
 
   test('clamps the color-source list after a responsive reflow', async ({ app, page }) => {

--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -456,6 +456,39 @@ test.describe('custom theme editor', () => {
     await expect(name).toHaveValue('Keep my draft')
   })
 
+  test('ignores clipboard read failures after leaving the editor session', async ({ app, page }) => {
+    const staleErrors = []
+    page.on('console', message => {
+      if (message.type() === 'error' && message.text().includes('Delayed clipboard failure')) {
+        staleErrors.push(message.text())
+      }
+    })
+    await app.electronApp.evaluate(({ clipboard }) => {
+      clipboard.readText = () => new Promise((resolve, reject) => {
+        globalThis.rejectThemeClipboardRead = () => {
+          clipboard.readText = () => ''
+          reject(new Error('Delayed clipboard failure'))
+        }
+      })
+    })
+    await goToSettingsSection(page, 'theme')
+    await page.getByRole('button', { name: 'Create custom theme' }).click()
+    await page.getByRole('button', { name: 'Import from clipboard' }).click()
+    await expect.poll(() => app.electronApp.evaluate(() =>
+      typeof globalThis.rejectThemeClipboardRead)).toBe('function')
+    await page.locator('.settingsBackButton').click()
+    await page.getByRole('button', { name: 'Create custom theme' }).click()
+    await page.getByRole('textbox', { name: 'Theme name' }).fill('New session')
+    await app.electronApp.evaluate(() => globalThis.rejectThemeClipboardRead())
+    // A second IPC round trip lets the renderer process the earlier rejection.
+    await page.evaluate(() => window.ftElectron.readClipboard())
+    // Allow deferred toast rendering before asserting that no stale error appears.
+    await page.waitForTimeout(500)
+    expect(staleErrors).toEqual([])
+    await expect(page.locator('.toast').filter({ hasText: 'Delayed clipboard failure' })).toHaveCount(0)
+    await expect(page.getByRole('textbox', { name: 'Theme name' })).toHaveValue('New session')
+  })
+
   test('keeps clipboard import controls visible in narrow and scaled windows', async ({ app, page }, testInfo) => {
     await goToSettingsSection(page, 'theme')
     await page.getByRole('button', { name: 'Create custom theme' }).click()

--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -434,6 +434,12 @@ test.describe('custom theme editor', () => {
     expect(saved[0].id).not.toBe(theme.id)
     expect(saved[0].colors.background).toBe('#112233')
 
+    await page.emulateMedia({ colorScheme: 'dark' })
+    await page.evaluate(async (themeId) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateSystemDarkTheme', `custom:${themeId}`)
+      await store.dispatch('updateBaseTheme', 'system')
+    }, saved[0].id)
     await page.getByRole('button', { name: 'Edit custom theme' }).click()
     await importButton.click()
     await page.getByRole('button', { name: 'Save and apply' }).click()
@@ -441,6 +447,41 @@ test.describe('custom theme editor', () => {
     expect(importedAgain).toHaveLength(2)
     expect(new Set(importedAgain.map(({ id }) => id)).size).toBe(2)
     expect(importedAgain).toContainEqual(saved[0])
+    const importedId = importedAgain.find(({ id }) => id !== saved[0].id).id
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.getters.getBaseTheme
+    })).toBe(`custom:${importedId}`)
+  })
+
+  test('ignores clipboard imports after the editor unmounts', async ({ app, page }) => {
+    const theme = cloneDefaultCustomTheme()
+    theme.colors.background = '#112233'
+    await app.electronApp.evaluate(({ clipboard }) => {
+      clipboard.readText = () => new Promise(resolve => {
+        globalThis.resolveThemeClipboardRead = (text) => {
+          clipboard.readText = () => ''
+          resolve(text)
+        }
+      })
+    })
+    await goToSettingsSection(page, 'theme')
+    await page.getByRole('button', { name: 'Create custom theme' }).click()
+    await page.getByRole('button', { name: 'Import from clipboard' }).click()
+    await expect.poll(() => app.electronApp.evaluate(() =>
+      typeof globalThis.resolveThemeClipboardRead)).toBe('function')
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setSettingsWindowView', 'about')
+    })
+    await expect(page.locator('.customThemeEditor')).toHaveCount(0)
+    const background = await page.locator('body').evaluate(element => element.style.getPropertyValue('--bg-color'))
+    await app.electronApp.evaluate((_, text) => globalThis.resolveThemeClipboardRead(text), JSON.stringify(theme))
+    await page.evaluate(() => window.ftElectron.readClipboard())
+    // Observe the completed IPC result before checking that no preview was applied.
+    await page.waitForTimeout(500)
+    await expect(page.locator('body')).toHaveCSS('--bg-color', background)
+    expect(await page.evaluate(() => window.ftElectron.loadCustomTheme())).toEqual([])
   })
 
   test('reports clipboard read failures without replacing the draft', async ({ app, page }) => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,6 +6,7 @@ const IpcChannels = {
   GET_DEVICE_INFO: 'get-device-info',
   GET_SYSTEM_LOCALE: 'get-system-locale',
   GET_SYSTEM_FONTS: 'get-system-fonts',
+  READ_CLIPBOARD: 'read-clipboard',
   GET_NAVIGATION_HISTORY: 'get-navigation-history',
   IS_WAYLAND_PLATFORM: 'is-wayland-platform',
   STOP_POWER_SAVE_BLOCKER: 'stop-power-save-blocker',

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -4540,6 +4540,11 @@ function runApp() {
           : 'system')
   }
 
+  ipcMain.handle(IpcChannels.READ_CLIPBOARD, (event) => {
+    if (!isOpenTubeXUrl(event.senderFrame.url)) throw new Error('Untrusted clipboard request')
+    return clipboard.readText()
+  })
+
   ipcMain.handle(IpcChannels.CUSTOM_THEME_LOAD, async (event) => {
     if (!isOpenTubeXUrl(event.senderFrame.url)) return
     return await loadCustomThemes()

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -89,6 +89,13 @@ export default {
     return ipcRenderer.invoke(IpcChannels.GET_SYSTEM_FONTS)
   },
 
+  /**
+   * @returns {Promise<string>}
+   */
+  readClipboard: () => {
+    return ipcRenderer.invoke(IpcChannels.READ_CLIPBOARD)
+  },
+
   loadCustomTheme: () => {
     return ipcRenderer.invoke(IpcChannels.CUSTOM_THEME_LOAD)
   },

--- a/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
+++ b/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
@@ -560,6 +560,7 @@ async function importTheme() {
     if (file === null || !props.open || loadId !== editorLoadId) return
     importThemeContent(file.content)
   } catch (error) {
+    if (!props.open || loadId !== editorLoadId) return
     showError(t('Settings.Theme Settings.Custom Theme.Invalid Theme File'), error)
   }
 }
@@ -570,6 +571,7 @@ async function importThemeFromClipboard() {
   try {
     content = await readClipboard()
   } catch (error) {
+    if (!props.open || loadId !== editorLoadId) return
     showError(t('Color Picker.Clipboard Unavailable'), error)
     return
   }

--- a/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
+++ b/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
@@ -24,6 +24,11 @@
             @click="importTheme"
           />
           <FtIconButton
+            :title="t('Settings.Theme Settings.Custom Theme.Import from Clipboard')"
+            :icon="['fas', 'paste']"
+            @click="importThemeFromClipboard"
+          />
+          <FtIconButton
             :title="t('Settings.Theme Settings.Custom Theme.Export Theme')"
             :icon="['fas', 'download']"
             @click="exportTheme"
@@ -166,7 +171,7 @@ import {
   saveCustomTheme,
 } from '../../helpers/customTheme'
 import { colors } from '../../helpers/colors'
-import { openExternalLink, readFileWithPicker, showToast, writeFileWithPicker } from '../../helpers/utils'
+import { openExternalLink, readClipboard, readFileWithPicker, showToast, writeFileWithPicker } from '../../helpers/utils'
 
 const CUSTOM_THEME_DISCUSSION_URL = 'https://github.com/OpenTubeX/OpenTubeX/discussions/new'
 
@@ -544,6 +549,7 @@ async function handleDeletePrompt(value) {
 }
 
 async function importTheme() {
+  const loadId = editorLoadId
   try {
     const file = await readFileWithPicker(
       t('Settings.Theme Settings.Custom Theme.Theme File'),
@@ -551,21 +557,42 @@ async function importTheme() {
       'custom-theme-import',
       'documents'
     )
-    if (file === null) return
-    cancelPendingColorPreviews()
-    const importedTheme = normalizeCustomTheme(JSON.parse(file.content))
-    importedTheme.id = crypto.randomUUID()
-    setDraft(importedTheme)
-    themeSourceColors.value = readThemeSourceColors()
-    previewing = true
-    previewTheme()
-    showToast({
-      message: t('Settings.Theme Settings.Custom Theme.Theme Imported'),
-      icon: ['fas', 'check']
-    })
+    if (file === null || !props.open || loadId !== editorLoadId) return
+    importThemeContent(file.content)
   } catch (error) {
     showError(t('Settings.Theme Settings.Custom Theme.Invalid Theme File'), error)
   }
+}
+
+async function importThemeFromClipboard() {
+  const loadId = editorLoadId
+  let content
+  try {
+    content = await readClipboard()
+  } catch (error) {
+    showError(t('Color Picker.Clipboard Unavailable'), error)
+    return
+  }
+  if (!props.open || loadId !== editorLoadId) return
+  try {
+    importThemeContent(content)
+  } catch (error) {
+    showError(t('Settings.Theme Settings.Custom Theme.Invalid Clipboard Theme'), error)
+  }
+}
+
+function importThemeContent(content) {
+  const importedTheme = normalizeCustomTheme(JSON.parse(content))
+  importedTheme.id = crypto.randomUUID()
+  cancelPendingColorPreviews()
+  setDraft(importedTheme)
+  themeSourceColors.value = readThemeSourceColors()
+  previewing = true
+  previewTheme()
+  showToast({
+    message: t('Settings.Theme Settings.Custom Theme.Theme Imported'),
+    icon: ['fas', 'check']
+  })
 }
 
 async function exportTheme() {
@@ -680,6 +707,7 @@ onBeforeUnmount(() => {
 
 .themeNameField {
   flex: 1;
+  min-inline-size: 0;
   display: grid;
   gap: 8px;
   color: var(--secondary-text-color);

--- a/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
+++ b/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
@@ -586,6 +586,7 @@ async function importThemeFromClipboard() {
 function importThemeContent(content) {
   const importedTheme = normalizeCustomTheme(JSON.parse(content))
   importedTheme.id = crypto.randomUUID()
+  keepSystemThemeOnSave = false
   cancelPendingColorPreviews()
   setDraft(importedTheme)
   themeSourceColors.value = readThemeSourceColors()
@@ -665,6 +666,7 @@ function showError(message, error) {
 }
 
 onBeforeUnmount(() => {
+  editorLoadId++
   cancelPendingColorPreviews()
   store.commit('setCustomThemeEditorOpen', false)
 })

--- a/src/renderer/helpers/androidUi.js
+++ b/src/renderer/helpers/androidUi.js
@@ -78,6 +78,11 @@ export function writeAndroidClipboard(text) {
   return AndroidUi?.writeClipboard({ text }) ?? Promise.resolve()
 }
 
+export async function readAndroidClipboard() {
+  const result = await AndroidUi.readClipboard()
+  return result.text
+}
+
 export function exitAndroidApp() {
   return AndroidUi?.exitApp() ?? Promise.resolve()
 }

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -8,7 +8,7 @@ import { UnsupportedPlayerActions } from '../../constants'
 import { getSearchHistoryEntryKey } from '../../search-history'
 import { getPreferredShortThumbnailUrl } from './player/shorts'
 import { isRoundedNumber } from './viewCounts'
-import { writeAndroidClipboard } from './androidUi'
+import { readAndroidClipboard, writeAndroidClipboard } from './androidUi'
 
 // allowed characters in channel handle: A-Z, a-z, 0-9, -, _, .
 // https://support.google.com/youtube/answer/11585688#change_handle
@@ -328,6 +328,13 @@ export function showToastOnAllTabs(message, time = null, icon = null) {
   } else {
     showToast({ message, time, icon })
   }
+}
+
+/** @returns {Promise<string>} */
+export async function readClipboard() {
+  if (process.env.IS_ELECTRON) return window.ftElectron.readClipboard()
+  if (process.env.IS_CAPACITOR) return readAndroidClipboard()
+  return navigator.clipboard.readText()
 }
 
 /**

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -349,6 +349,8 @@ Settings:
     Light Theme: سمة فاتحة
     Dark Theme: سمة داكنة
     Custom Theme:
+      Import from Clipboard: "استيراد من الحافظة"
+      Invalid Clipboard Theme: "لا تحتوي الحافظة على سمة صالحة. انسخ JSON السمة وحاول مجددًا."
       Create Custom Theme: إنشاء موضوع مخصص
       Edit Custom Theme: تحرير الموضوع المخصص
       Custom Theme Creator: منشئ موضوع مخصص

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -363,6 +363,8 @@ Settings:
     Light Theme: Светлая тэма
     Dark Theme: Цёмная тэма
     Custom Theme:
+      Import from Clipboard: "Імпартаваць з буфера абмену"
+      Invalid Clipboard Theme: "Буфер абмену не змяшчае сапраўднай тэмы. Скапіруйце JSON тэмы і паўтарыце спробу."
       Create Custom Theme: Стварыць карыстальніцкую тэму
       Edit Custom Theme: Рэдагаваць карыстальніцкую тэму
       Custom Theme Creator: Рэдактар карыстальніцкіх тэм

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -347,6 +347,8 @@ Settings:
     Light Theme: Светла тема
     Dark Theme: Тъмна тема
     Custom Theme:
+      Import from Clipboard: "Импортиране от клипборда"
+      Invalid Clipboard Theme: "Клипбордът не съдържа валидна тема. Копирайте JSON кода на темата и опитайте отново."
       Create Custom Theme: Създаване на персонализирана тема
       Edit Custom Theme: Редактиране на персонализираната тема
       Custom Theme Creator: Редактор на персонализирана тема

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -345,6 +345,8 @@ Settings:
     Light Theme: "Neuz sklaer"
     Dark Theme: "Neuz teñval"
     Custom Theme:
+      Import from Clipboard: "Enporzhiañ eus ar golver"
+      Invalid Clipboard Theme: "N’eus tem reizh ebet er golver. Eilit JSON an tem ha klaskit en-dro."
       Create Custom Theme: "Krouiñ un neuz personelaet"
       Edit Custom Theme: "Kemmañ an neuz personelaet"
       Custom Theme Creator: "Krouer neuzioù personelaet"

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -497,6 +497,8 @@ Settings:
     Light Theme: Tema clar
     Dark Theme: Tema fosc
     Custom Theme:
+      Import from Clipboard: "Importa del porta-retalls"
+      Invalid Clipboard Theme: "El porta-retalls no conté cap tema vàlid. Copieu el JSON del tema i torneu-ho a provar."
       Create Custom Theme: Crea un tema personalitzat
       Edit Custom Theme: Edita el tema personalitzat
       Custom Theme Creator: Creador de temes personalitzats

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -345,6 +345,8 @@ Settings:
     Light Theme: Světlý motiv
     Dark Theme: Tmavý motiv
     Custom Theme:
+      Import from Clipboard: "Importovat ze schránky"
+      Invalid Clipboard Theme: "Schránka neobsahuje platný motiv. Zkopírujte JSON motivu a zkuste to znovu."
       Create Custom Theme: Vytvořit vlastní motiv
       Edit Custom Theme: Upravit vlastní motiv
       Custom Theme Creator: Editor vlastního motivu

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -347,6 +347,8 @@ Settings:
     Light Theme: Thema olau
     Dark Theme: Thema dywyll
     Custom Theme:
+      Import from Clipboard: "Mewnforio o’r clipfwrdd"
+      Invalid Clipboard Theme: "Nid yw’r clipfwrdd yn cynnwys thema ddilys. Copïwch JSON y thema a rhowch gynnig arall arni."
       Create Custom Theme: Creu thema bersonol
       Edit Custom Theme: Golygu thema bersonol
       Custom Theme Creator: Crëwr themâu personol

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -358,6 +358,8 @@ Settings:
     Light Theme: Lyst tema
     Dark Theme: Mørkt tema
     Custom Theme:
+      Import from Clipboard: "Importér fra udklipsholder"
+      Invalid Clipboard Theme: "Udklipsholderen indeholder ikke et gyldigt tema. Kopiér temaets JSON, og prøv igen."
       Create Custom Theme: Opret brugerdefineret tema
       Edit Custom Theme: Rediger brugerdefineret tema
       Custom Theme Creator: Temaeditor

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -349,6 +349,8 @@ Settings:
     Light Theme: Φωτεινό θέμα
     Dark Theme: Σκοτεινό θέμα
     Custom Theme:
+      Import from Clipboard: "Εισαγωγή από το πρόχειρο"
+      Invalid Clipboard Theme: "Το πρόχειρο δεν περιέχει έγκυρο θέμα. Αντιγράψτε το JSON του θέματος και δοκιμάστε ξανά."
       Create Custom Theme: Δημιουργία προσαρμοσμένου θέματος
       Edit Custom Theme: Επεξεργασία προσαρμοσμένου θέματος
       Custom Theme Creator: Δημιουργία προσαρμοσμένου θέματος

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -332,6 +332,8 @@ Settings:
     Light Theme: Light theme
     Dark Theme: Dark theme
     Custom Theme:
+      Import from Clipboard: "Import from clipboard"
+      Invalid Clipboard Theme: "Clipboard does not contain a valid theme. Copy the theme JSON and try again."
       Create Custom Theme: Create custom theme
       Edit Custom Theme: Edit custom theme
       Custom Theme Creator: Custom theme creator

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -377,6 +377,8 @@ Settings:
     Light Theme: Tema claro
     Dark Theme: Tema oscuro
     Custom Theme:
+      Import from Clipboard: "Importar desde el portapapeles"
+      Invalid Clipboard Theme: "El portapapeles no contiene un tema válido. Copiá el JSON del tema e intentalo de nuevo."
       Create Custom Theme: Crear tema personalizado
       Edit Custom Theme: Editar tema personalizado
       Custom Theme Creator: Creador de temas personalizados

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -382,6 +382,8 @@ Settings:
     Light Theme: Tema claro
     Dark Theme: Tema oscuro
     Custom Theme:
+      Import from Clipboard: "Importar desde el portapapeles"
+      Invalid Clipboard Theme: "El portapapeles no contiene un tema válido. Copia el JSON del tema e inténtalo de nuevo."
       Create Custom Theme: Crear tema personalizado
       Edit Custom Theme: Editar tema personalizado
       Custom Theme Creator: Creador de temas personalizados

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -347,6 +347,8 @@ Settings:
     Light Theme: Tema claro
     Dark Theme: Tema oscuro
     Custom Theme:
+      Import from Clipboard: "Importar desde el portapapeles"
+      Invalid Clipboard Theme: "El portapapeles no contiene un tema válido. Copia el JSON del tema e inténtalo de nuevo."
       Create Custom Theme: Crear tema personalizado
       Edit Custom Theme: Editar tema personalizado
       Custom Theme Creator: Creador de temas personalizados

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -345,6 +345,8 @@ Settings:
     Light Theme: Hele teema
     Dark Theme: Tume teema
     Custom Theme:
+      Import from Clipboard: "Impordi lõikelaualt"
+      Invalid Clipboard Theme: "Lõikelaual pole kehtivat teemat. Kopeeri teema JSON ja proovi uuesti."
       Create Custom Theme: Loo kohandatud teema
       Edit Custom Theme: Muuda kohandatud teemat
       Custom Theme Creator: Kohandatud teema loomine

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -347,6 +347,8 @@ Settings:
     Light Theme: Gai argia
     Dark Theme: Gai iluna
     Custom Theme:
+      Import from Clipboard: "Inportatu arbeletik"
+      Invalid Clipboard Theme: "Arbelak ez du baliozko gairik. Kopiatu gaiaren JSONa eta saiatu berriro."
       Create Custom Theme: Sortu gai pertsonalizatua
       Edit Custom Theme: Editatu gai pertsonalizatua
       Custom Theme Creator: Gai pertsonalizatuen sortzailea

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -364,7 +364,7 @@ Settings:
     Dark Theme: زمینهٔ تیره
     Custom Theme:
       Import from Clipboard: "درون‌ریزی از کلیپ‌بورد"
-      Invalid Clipboard Theme: "کلیپ‌بورد حاوی پوستهٔ معتبری نیست. JSON پوسته را کپی کنید و دوباره تلاش کنید."
+      Invalid Clipboard Theme: "کلیپ‌بورد حاوی زمینهٔ معتبری نیست. JSON زمینه را کپی کنید و دوباره تلاش کنید."
       Create Custom Theme: ساخت زمینهٔ سفارشی
       Edit Custom Theme: ویرایش زمینهٔ سفارشی
       Custom Theme Creator: سازندهٔ زمینهٔ سفارشی

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -363,6 +363,8 @@ Settings:
     Light Theme: زمینهٔ روشن
     Dark Theme: زمینهٔ تیره
     Custom Theme:
+      Import from Clipboard: "درون‌ریزی از کلیپ‌بورد"
+      Invalid Clipboard Theme: "کلیپ‌بورد حاوی پوستهٔ معتبری نیست. JSON پوسته را کپی کنید و دوباره تلاش کنید."
       Create Custom Theme: ساخت زمینهٔ سفارشی
       Edit Custom Theme: ویرایش زمینهٔ سفارشی
       Custom Theme Creator: سازندهٔ زمینهٔ سفارشی

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -349,6 +349,8 @@ Settings:
     Light Theme: Vaalea teema
     Dark Theme: Tumma teema
     Custom Theme:
+      Import from Clipboard: "Tuo leikepöydältä"
+      Invalid Clipboard Theme: "Leikepöydällä ei ole kelvollista teemaa. Kopioi teeman JSON ja yritä uudelleen."
       Create Custom Theme: Luo mukautettu teema
       Edit Custom Theme: Muokkaa mukautettua teemaa
       Custom Theme Creator: Mukautetun teeman luonti

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -345,6 +345,8 @@ Settings:
     Light Theme: Thème clair
     Dark Theme: Thème sombre
     Custom Theme:
+      Import from Clipboard: "Importer depuis le presse-papiers"
+      Invalid Clipboard Theme: "Le presse-papiers ne contient pas de thème valide. Copiez le JSON du thème et réessayez."
       Create Custom Theme: Créer un thème personnalisé
       Edit Custom Theme: Modifier le thème personnalisé
       Custom Theme Creator: Créateur de thèmes personnalisés

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -349,6 +349,8 @@ Settings:
     Light Theme: Tema claro
     Dark Theme: Tema escuro
     Custom Theme:
+      Import from Clipboard: "Importar do portapapeis"
+      Invalid Clipboard Theme: "O portapapeis non contén un tema válido. Copia o JSON do tema e téntao de novo."
       Create Custom Theme: Crear un tema personalizado
       Edit Custom Theme: Editar o tema personalizado
       Custom Theme Creator: Creador de temas personalizados

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -349,6 +349,8 @@ Settings:
     Light Theme: ערכת נושא בהירה
     Dark Theme: ערכת נושא כהה
     Custom Theme:
+      Import from Clipboard: "ייבוא מהלוח"
+      Invalid Clipboard Theme: "הלוח אינו מכיל ערכת נושא תקינה. יש להעתיק את ה־JSON של ערכת הנושא ולנסות שוב."
       Create Custom Theme: יצירת ערכת נושא מותאמת אישית
       Edit Custom Theme: עריכת ערכת נושא מותאמת אישית
       Custom Theme Creator: יוצר ערכות נושא מותאמות אישית

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -347,6 +347,8 @@ Settings:
     Light Theme: Svijetla tema
     Dark Theme: Tamna tema
     Custom Theme:
+      Import from Clipboard: "Uvezi iz međuspremnika"
+      Invalid Clipboard Theme: "Međuspremnik ne sadrži valjanu temu. Kopirajte JSON teme i pokušajte ponovno."
       Create Custom Theme: Izradi prilagođenu temu
       Edit Custom Theme: Uredi prilagođenu temu
       Custom Theme Creator: Izrada prilagođene teme

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -345,6 +345,8 @@ Settings:
     Light Theme: Világos téma
     Dark Theme: Sötét téma
     Custom Theme:
+      Import from Clipboard: "Importálás a vágólapról"
+      Invalid Clipboard Theme: "A vágólap nem tartalmaz érvényes témát. Másolja a téma JSON-kódját, és próbálja újra."
       Create Custom Theme: Egyéni téma létrehozása
       Edit Custom Theme: Egyéni téma szerkesztése
       Custom Theme Creator: Egyénitéma-készítő

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -349,6 +349,8 @@ Settings:
     Light Theme: Tema terang
     Dark Theme: Tema gelap
     Custom Theme:
+      Import from Clipboard: "Impor dari papan klip"
+      Invalid Clipboard Theme: "Papan klip tidak berisi tema yang valid. Salin JSON tema dan coba lagi."
       Create Custom Theme: Buat tema khusus
       Edit Custom Theme: Edit tema khusus
       Custom Theme Creator: Pembuat tema khusus

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -349,6 +349,8 @@ Settings:
     Light Theme: Ljóst þema
     Dark Theme: Dökkt þema
     Custom Theme:
+      Import from Clipboard: "Flytja inn af klippispjaldi"
+      Invalid Clipboard Theme: "Klippispjaldið inniheldur ekki gilt þema. Afritaðu JSON þemans og reyndu aftur."
       Create Custom Theme: Búa til sérsniðið þema
       Edit Custom Theme: Breyta sérsniðnu þema
       Custom Theme Creator: Sérsniðinn þemasmiður

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -345,6 +345,8 @@ Settings:
     Light Theme: Tema chiaro
     Dark Theme: Tema scuro
     Custom Theme:
+      Import from Clipboard: "Importa dagli appunti"
+      Invalid Clipboard Theme: "Gli appunti non contengono un tema valido. Copia il JSON del tema e riprova."
       Create Custom Theme: Crea tema personalizzato
       Edit Custom Theme: Modifica tema personalizzato
       Custom Theme Creator: Editor dei temi personalizzati

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -345,6 +345,8 @@ Settings:
     Light Theme: ライトテーマ
     Dark Theme: ダークテーマ
     Custom Theme:
+      Import from Clipboard: "クリップボードからインポート"
+      Invalid Clipboard Theme: "クリップボードに有効なテーマがありません。テーマのJSONをコピーして、もう一度お試しください。"
       Create Custom Theme: カスタムテーマを作成
       Edit Custom Theme: カスタムテーマを編集
       Custom Theme Creator: カスタムテーマ作成

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -456,6 +456,8 @@ Settings:
     Light Theme: 밝은 테마
     Dark Theme: 어두운 테마
     Custom Theme:
+      Import from Clipboard: "클립보드에서 가져오기"
+      Invalid Clipboard Theme: "클립보드에 유효한 테마가 없습니다. 테마 JSON을 복사한 후 다시 시도하세요."
       Create Custom Theme: 사용자 지정 테마 만들기
       Edit Custom Theme: 사용자 지정 테마 편집
       Custom Theme Creator: 사용자 지정 테마 만들기

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -481,6 +481,8 @@ Settings:
     Light Theme: Šviesi tema
     Dark Theme: Tamsi tema
     Custom Theme:
+      Import from Clipboard: "Importuoti iš iškarpinės"
+      Invalid Clipboard Theme: "Iškarpinėje nėra tinkamo apipavidalinimo. Nukopijuokite apipavidalinimo JSON ir bandykite dar kartą."
       Create Custom Theme: Kurti pasirinktinę temą
       Edit Custom Theme: Redaguoti pasirinktinę temą
       Custom Theme Creator: Pasirinktinės temos kūrimo priemonė

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -482,7 +482,7 @@ Settings:
     Dark Theme: Tamsi tema
     Custom Theme:
       Import from Clipboard: "Importuoti iš iškarpinės"
-      Invalid Clipboard Theme: "Iškarpinėje nėra tinkamo apipavidalinimo. Nukopijuokite apipavidalinimo JSON ir bandykite dar kartą."
+      Invalid Clipboard Theme: "Iškarpinėje nėra tinkamos temos. Nukopijuokite temos JSON ir bandykite dar kartą."
       Create Custom Theme: Kurti pasirinktinę temą
       Edit Custom Theme: Redaguoti pasirinktinę temą
       Custom Theme Creator: Pasirinktinės temos kūrimo priemonė

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -345,6 +345,8 @@ Settings:
     Light Theme: Lyst tema
     Dark Theme: Mørkt tema
     Custom Theme:
+      Import from Clipboard: "Importer fra utklippstavlen"
+      Invalid Clipboard Theme: "Utklippstavlen inneholder ikke et gyldig tema. Kopier temaets JSON og prøv igjen."
       Create Custom Theme: Opprett egendefinert tema
       Edit Custom Theme: Rediger egendefinert tema
       Custom Theme Creator: Lag egendefinert tema

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -349,6 +349,8 @@ Settings:
     Light Theme: Licht thema
     Dark Theme: Donker thema
     Custom Theme:
+      Import from Clipboard: "Importeren van klembord"
+      Invalid Clipboard Theme: "Het klembord bevat geen geldig thema. Kopieer de JSON van het thema en probeer het opnieuw."
       Create Custom Theme: Aangepast thema maken
       Edit Custom Theme: Aangepast thema bewerken
       Custom Theme Creator: Editor voor aangepaste thema's

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -349,7 +349,7 @@ Settings:
     Light Theme: Licht thema
     Dark Theme: Donker thema
     Custom Theme:
-      Import from Clipboard: "Importeren van klembord"
+      Import from Clipboard: "Importeren uit het klembord"
       Invalid Clipboard Theme: "Het klembord bevat geen geldig thema. Kopieer de JSON van het thema en probeer het opnieuw."
       Create Custom Theme: Aangepast thema maken
       Edit Custom Theme: Aangepast thema bewerken

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -423,6 +423,8 @@ Settings:
     Light Theme: Lyst tema
     Dark Theme: Mørkt tema
     Custom Theme:
+      Import from Clipboard: "Importer frå utklippstavla"
+      Invalid Clipboard Theme: "Utklippstavla inneheld ikkje eit gyldig tema. Kopier JSON-koden til temaet og prøv igjen."
       Create Custom Theme: Lag eit eige tema
       Edit Custom Theme: Rediger eige tema
       Custom Theme Creator: Temaverktøy

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -99,6 +99,8 @@ Settings:
       Test Toast: Powiadomienie testowe
     Scroll Speed: Szybkość przewijania
     Custom Theme:
+      Import from Clipboard: "Importuj ze schowka"
+      Invalid Clipboard Theme: "Schowek nie zawiera prawidłowego motywu. Skopiuj JSON motywu i spróbuj ponownie."
       Share Theme: Udostępnij motyw
       Share Description Heading: Opis
       Share Description Prompt: Opisz motyw i wszystko, co warto wiedzieć przed jego użyciem.

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -345,6 +345,8 @@ Settings:
     Light Theme: Tema claro
     Dark Theme: Tema escuro
     Custom Theme:
+      Import from Clipboard: "Importar da área de transferência"
+      Invalid Clipboard Theme: "A área de transferência não contém um tema válido. Copie o JSON do tema e tente novamente."
       Create Custom Theme: Criar tema personalizado
       Edit Custom Theme: Editar tema personalizado
       Custom Theme Creator: Criador de temas personalizados

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -349,6 +349,8 @@ Settings:
     Light Theme: Tema claro
     Dark Theme: Tema escuro
     Custom Theme:
+      Import from Clipboard: "Importar da área de transferência"
+      Invalid Clipboard Theme: "A área de transferência não contém um tema válido. Copie o JSON do tema e tente novamente."
       Create Custom Theme: Criar tema personalizado
       Edit Custom Theme: Editar tema personalizado
       Custom Theme Creator: Criador de temas personalizados

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -349,6 +349,8 @@ Settings:
     Light Theme: Tema claro
     Dark Theme: Tema escuro
     Custom Theme:
+      Import from Clipboard: "Importar da área de transferência"
+      Invalid Clipboard Theme: "A área de transferência não contém um tema válido. Copie o JSON do tema e tente novamente."
       Create Custom Theme: Criar tema personalizado
       Edit Custom Theme: Editar tema personalizado
       Custom Theme Creator: Criador de temas personalizados

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -347,6 +347,8 @@ Settings:
     Light Theme: Temă luminoasă
     Dark Theme: Temă întunecată
     Custom Theme:
+      Import from Clipboard: "Importă din clipboard"
+      Invalid Clipboard Theme: "Clipboardul nu conține o temă validă. Copiază JSON-ul temei și încearcă din nou."
       Create Custom Theme: Creează o temă personalizată
       Edit Custom Theme: Editează tema personalizată
       Custom Theme Creator: Editor de teme personalizate

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -324,6 +324,8 @@ Settings:
     Light Theme: Светлая тема
     Dark Theme: Тёмная тема
     Custom Theme:
+      Import from Clipboard: "Импортировать из буфера обмена"
+      Invalid Clipboard Theme: "Буфер обмена не содержит допустимой темы. Скопируйте JSON темы и повторите попытку."
       Create Custom Theme: Создать тему
       Edit Custom Theme: Изменить тему
       Custom Theme Creator: Редактор тем

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -345,6 +345,8 @@ Settings:
     Light Theme: Svetlý motív
     Dark Theme: Tmavý motív
     Custom Theme:
+      Import from Clipboard: "Importovať zo schránky"
+      Invalid Clipboard Theme: "Schránka neobsahuje platný motív. Skopírujte JSON motívu a skúste to znova."
       Create Custom Theme: Vytvoriť vlastný motív
       Edit Custom Theme: Upraviť vlastný motív
       Custom Theme Creator: Tvorba vlastného motívu

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -488,6 +488,8 @@ Settings:
     Light Theme: Svetla tema
     Dark Theme: Temna tema
     Custom Theme:
+      Import from Clipboard: "Uvozi iz odložišča"
+      Invalid Clipboard Theme: "Odložišče ne vsebuje veljavne teme. Kopirajte JSON teme in poskusite znova."
       Create Custom Theme: Ustvari temo po meri
       Edit Custom Theme: Uredi temo po meri
       Custom Theme Creator: Urejevalnik tem po meri

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -356,8 +356,8 @@ Settings:
     Light Theme: Светла тема
     Dark Theme: Тамна тема
     Custom Theme:
-      Import from Clipboard: "Увези из оставе"
-      Invalid Clipboard Theme: "Остава не садржи исправну тему. Копирајте JSON теме и покушајте поново."
+      Import from Clipboard: "Увези из међуспремника"
+      Invalid Clipboard Theme: "Међуспремник не садржи исправну тему. Копирајте JSON теме и покушајте поново."
       Create Custom Theme: Направи прилагођену тему
       Edit Custom Theme: Уреди прилагођену тему
       Custom Theme Creator: Прављење прилагођене теме

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -356,6 +356,8 @@ Settings:
     Light Theme: Светла тема
     Dark Theme: Тамна тема
     Custom Theme:
+      Import from Clipboard: "Увези из оставе"
+      Invalid Clipboard Theme: "Остава не садржи исправну тему. Копирајте JSON теме и покушајте поново."
       Create Custom Theme: Направи прилагођену тему
       Edit Custom Theme: Уреди прилагођену тему
       Custom Theme Creator: Прављење прилагођене теме

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -347,6 +347,8 @@ Settings:
     Light Theme: Ljust tema
     Dark Theme: Mörkt tema
     Custom Theme:
+      Import from Clipboard: "Importera från urklipp"
+      Invalid Clipboard Theme: "Urklipp innehåller inget giltigt tema. Kopiera temats JSON och försök igen."
       Create Custom Theme: Skapa eget tema
       Edit Custom Theme: Redigera eget tema
       Custom Theme Creator: Skapa eget tema

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -350,6 +350,8 @@ Settings:
     Light Theme: வெளிர் அலங்காரம்
     Dark Theme: கருமை அலங்காரம்
     Custom Theme:
+      Import from Clipboard: "இடைநிலைப் பலகையிலிருந்து இறக்குமதி செய்"
+      Invalid Clipboard Theme: "இடைநிலைப் பலகையில் செல்லுபடியான கருப்பொருள் இல்லை. கருப்பொருளின் JSON ஐ நகலெடுத்து மீண்டும் முயற்சிக்கவும்."
       Create Custom Theme: தனிப்பயன் அலங்காரத்தை உருவாக்கு
       Edit Custom Theme: தனிப்பயன் அலங்காரத்தைத் திருத்து
       Custom Theme Creator: தனிப்பயன் அலங்கார உருவாக்கி

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -345,6 +345,8 @@ Settings:
     Light Theme: Açık tema
     Dark Theme: Koyu tema
     Custom Theme:
+      Import from Clipboard: "Panodan içe aktar"
+      Invalid Clipboard Theme: "Pano geçerli bir tema içermiyor. Temanın JSON kodunu kopyalayıp tekrar deneyin."
       Create Custom Theme: Özel tema oluştur
       Edit Custom Theme: Özel temayı düzenle
       Custom Theme Creator: Özel tema oluşturucu

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -349,6 +349,8 @@ Settings:
     Light Theme: Світла тема
     Dark Theme: Темна тема
     Custom Theme:
+      Import from Clipboard: "Імпортувати з буфера обміну"
+      Invalid Clipboard Theme: "Буфер обміну не містить дійсної теми. Скопіюйте JSON теми та повторіть спробу."
       Create Custom Theme: Створити власну тему
       Edit Custom Theme: Редагувати власну тему
       Custom Theme Creator: Редактор власної теми

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -349,6 +349,8 @@ Settings:
     Light Theme: Chủ đề sáng
     Dark Theme: Chủ đề tối
     Custom Theme:
+      Import from Clipboard: "Nhập từ bảng nhớ tạm"
+      Invalid Clipboard Theme: "Bảng nhớ tạm không chứa giao diện hợp lệ. Sao chép JSON của giao diện rồi thử lại."
       Create Custom Theme: Tạo chủ đề tùy chỉnh
       Edit Custom Theme: Sửa chủ đề tùy chỉnh
       Custom Theme Creator: Trình tạo chủ đề tùy chỉnh

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -345,6 +345,8 @@ Settings:
     Light Theme: 浅色主题
     Dark Theme: 深色主题
     Custom Theme:
+      Import from Clipboard: "从剪贴板导入"
+      Invalid Clipboard Theme: "剪贴板中没有有效的主题。请复制主题 JSON 后重试。"
       Create Custom Theme: 创建自定义主题
       Edit Custom Theme: 编辑自定义主题
       Custom Theme Creator: 自定义主题编辑器

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -345,6 +345,8 @@ Settings:
     Light Theme: 淺色主題
     Dark Theme: 深色主題
     Custom Theme:
+      Import from Clipboard: "從剪貼簿匯入"
+      Invalid Clipboard Theme: "剪貼簿中沒有有效的佈景主題。請複製佈景主題 JSON 後再試一次。"
       Create Custom Theme: 建立自訂主題
       Edit Custom Theme: 編輯自訂主題
       Custom Theme Creator: 自訂主題建立工具

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -586,6 +586,8 @@ Settings:
     Light Theme: Helles Design
     Dark Theme: Dunkles Design
     Custom Theme:
+      Import from Clipboard: "Aus Zwischenablage importieren"
+      Invalid Clipboard Theme: "Die Zwischenablage enthält kein gültiges Theme. Kopiere den Theme-JSON-Code und versuche es erneut."
       Create Custom Theme: Benutzerdefiniertes Design erstellen
       Edit Custom Theme: Benutzerdefiniertes Design bearbeiten
       Custom Theme Creator: Editor für benutzerdefinierte Designs

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -679,6 +679,8 @@ Settings:
     Light Theme: Light theme
     Dark Theme: Dark theme
     Custom Theme:
+      Import from Clipboard: "Import from clipboard"
+      Invalid Clipboard Theme: "Clipboard does not contain a valid theme. Copy the theme JSON and try again."
       Create Custom Theme: Create custom theme
       Edit Custom Theme: Edit custom theme
       Custom Theme Creator: Custom theme creator


### PR DESCRIPTION
Themes copied from a shared JSON snippet currently need to be saved as a file before importing. This adds an Import from clipboard button to the custom theme editor.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Requested directly; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Clipboard imports use the existing theme validation and preview flow on desktop, Android, and the web. Each import gets a new theme ID and is saved only after selecting Save and apply. Invalid contents or clipboard read failures leave the current draft intact. Includes English, German, and AI locale translations.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Import custom themes directly from the clipboard in the theme editor.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114505Z-clipboard-theme-dark-dark-77a7c75ce6.png">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114505Z-clipboard-theme-light-light-093dbda2e6.png">
  <img alt="Custom theme editor with the clipboard import control and a loaded theme" src="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114505Z-clipboard-theme-dark-dark-77a7c75ce6.png">
</picture>
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Settings → Appearance → Create custom theme or Edit custom theme.
2. Copy valid theme JSON, such as an exported theme or a shared theme snippet, and click Import from clipboard beside the file import button. Check that its name and colors appear in the editor.
3. Select Save and apply, then import the same JSON again. Saving should create another theme without overwriting the first.
4. Copy plain text or empty the clipboard and try importing. An error should appear while your draft remains intact.
5. Check that the import controls remain accessible in a narrow window and at a non-default UI scale.

## Additional context
<!-- Add any other context about the pull request here. -->

Implemented with GPT-6 in the Codex desktop app.
