### PR TITLE
fix(subscriptions): speed up refreshes and prevent Android background stalls

### DIFF
--- a/android/app/src/androidTest/java/org/opentubex/app/SubscriptionRefreshWebViewTest.java
+++ b/android/app/src/androidTest/java/org/opentubex/app/SubscriptionRefreshWebViewTest.java
@@ -1,0 +1,86 @@
+package org.opentubex.app;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.view.View;
+import android.view.ViewGroup;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+@RunWith(AndroidJUnit4.class)
+public class SubscriptionRefreshWebViewTest {
+    @Test
+    public void hiddenWindowKeepsChromiumActiveOnlyForTheCurrentRefresh() throws Exception {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            AtomicReference<SubscriptionRefreshWebView> view = new AtomicReference<>();
+            CountDownLatch loaded = new CountDownLatch(1);
+            SubscriptionRefreshState state = new SubscriptionRefreshState();
+            scenario.onActivity(activity -> {
+                SubscriptionRefreshWebView webView = new SubscriptionRefreshWebView(activity, null);
+                view.set(webView);
+                webView.getSettings().setJavaScriptEnabled(true);
+                webView.setWebViewClient(new WebViewClient() {
+                    @Override
+                    public void onPageFinished(WebView ignored, String url) {
+                        loaded.countDown();
+                    }
+                });
+                activity.addContentView(webView, new ViewGroup.LayoutParams(1, 1));
+                state.observeActive(webView::setRefreshActive);
+                webView.loadDataWithBaseURL("https://refresh-test.invalid", "<html></html>", "text/html", "UTF-8", null);
+            });
+            assertTrue("test page loaded", loaded.await(10, TimeUnit.SECONDS));
+            try {
+                onMain(() -> {
+                    state.begin("refresh", "Refreshing", "Cancel");
+                    view.get().onWindowVisibilityChanged(View.GONE);
+                });
+                assertVisibility(view.get(), "visible");
+                onMain(() -> state.finish("stale"));
+                assertVisibility(view.get(), "visible");
+                onMain(() -> state.finish("refresh"));
+                assertVisibility(view.get(), "hidden");
+
+                // A refresh started while already hidden must reactivate it too.
+                onMain(() -> state.begin("next", "Refreshing", "Cancel"));
+                assertVisibility(view.get(), "visible");
+                onMain(() -> state.finish("next"));
+                assertVisibility(view.get(), "hidden");
+                onMain(() -> view.get().onWindowVisibilityChanged(View.VISIBLE));
+                assertVisibility(view.get(), "visible");
+            } finally {
+                onMain(() -> {
+                    ((ViewGroup) view.get().getParent()).removeView(view.get());
+                    view.get().destroy();
+                });
+            }
+        }
+    }
+
+    private static void assertVisibility(WebView view, String expected) throws Exception {
+        AtomicReference<String> actual = new AtomicReference<>();
+        CountDownLatch evaluated = new CountDownLatch(1);
+        onMain(() -> view.evaluateJavascript("document.visibilityState", result -> {
+            actual.set(result);
+            evaluated.countDown();
+        }));
+        assertTrue("page responds", evaluated.await(5, TimeUnit.SECONDS));
+        assertEquals("\"" + expected + "\"", actual.get());
+    }
+
+    private static void onMain(Runnable action) {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(action);
+    }
+}

--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshPlugin.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshPlugin.java
@@ -16,15 +16,23 @@ import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 
 import java.util.UUID;
+import java.util.function.Consumer;
 
 import androidx.core.content.ContextCompat;
 
 @CapacitorPlugin(name = "SubscriptionRefresh")
 public class SubscriptionRefreshPlugin extends Plugin {
     private BroadcastReceiver cancellationReceiver;
+    private Consumer<Boolean> rendererActiveListener;
 
     @Override
     public void load() {
+        rendererActiveListener = active -> bridge.executeOnMainThread(() -> {
+            if (bridge.getWebView() instanceof SubscriptionRefreshWebView webView) {
+                webView.setRefreshActive(active);
+            }
+        });
+        SubscriptionRefreshWorker.observeRendererActive(rendererActiveListener);
         cancellationReceiver = new BroadcastReceiver() {
             @Override
             public void onReceive(Context context, Intent intent) {
@@ -41,6 +49,7 @@ public class SubscriptionRefreshPlugin extends Plugin {
 
     @Override
     protected void handleOnDestroy() {
+        SubscriptionRefreshWorker.removeRendererActiveListener(rendererActiveListener);
         if (cancellationReceiver != null) {
             getContext().unregisterReceiver(cancellationReceiver);
             cancellationReceiver = null;

--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshState.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshState.java
@@ -1,6 +1,7 @@
 package org.opentubex.app;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.function.Consumer;
 
 final class SubscriptionRefreshState {
     static final class Snapshot {
@@ -24,6 +25,16 @@ final class SubscriptionRefreshState {
     private final SubscriptionRefreshNotificationProgress notificationProgress =
         new SubscriptionRefreshNotificationProgress();
     private CountDownLatch completion = new CountDownLatch(0);
+    private Consumer<Boolean> activeListener;
+
+    synchronized void observeActive(Consumer<Boolean> listener) {
+        activeListener = listener;
+        listener.accept(token != null);
+    }
+
+    synchronized void removeActiveListener(Consumer<Boolean> listener) {
+        if (activeListener == listener) activeListener = null;
+    }
 
     synchronized void begin(String nextToken, String nextTitle, String nextCancelLabel) {
         completion.countDown();
@@ -33,6 +44,7 @@ final class SubscriptionRefreshState {
         progress = 0;
         notificationProgress.reset();
         completion = new CountDownLatch(1);
+        if (activeListener != null) activeListener.accept(true);
     }
 
     synchronized boolean update(String expectedToken, int nextProgress) {
@@ -68,6 +80,7 @@ final class SubscriptionRefreshState {
         progress = 0;
         notificationProgress.reset();
         completion.countDown();
+        if (activeListener != null) activeListener.accept(false);
         return true;
     }
 

--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshWebView.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshWebView.java
@@ -1,0 +1,29 @@
+package org.opentubex.app;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+import com.getcapacitor.CapacitorWebView;
+
+/** Keep an active renderer refresh out of Chromium's hidden-page freezer. */
+public final class SubscriptionRefreshWebView extends CapacitorWebView {
+    private boolean refreshActive;
+    private int actualWindowVisibility = VISIBLE;
+
+    public SubscriptionRefreshWebView(Context context, AttributeSet attributes) {
+        super(context, attributes);
+    }
+
+    @Override
+    protected void onWindowVisibilityChanged(int visibility) {
+        actualWindowVisibility = visibility;
+        super.onWindowVisibilityChanged(refreshActive ? VISIBLE : visibility);
+    }
+
+    void setRefreshActive(boolean active) {
+        refreshActive = active;
+        // This changes Chromium's lifecycle, not Android's window visibility.
+        // Renderer UI behavior uses the actual activity state via appVisibility.
+        super.onWindowVisibilityChanged(active ? VISIBLE : actualWindowVisibility);
+    }
+}

--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshWorker.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshWorker.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 public final class SubscriptionRefreshWorker extends Worker {
     private static final String LOG_TAG = "OpenTubeXFetch";
@@ -32,6 +33,14 @@ public final class SubscriptionRefreshWorker extends Worker {
     static final String FEED_TYPE_INPUT = "feedType";
     private static final long MAXIMUM_BATCH_MILLIS = 5 * 60 * 1000;
     private static final SubscriptionRefreshState STATE = new SubscriptionRefreshState();
+
+    static void observeRendererActive(Consumer<Boolean> listener) {
+        STATE.observeActive(listener);
+    }
+
+    static void removeRendererActiveListener(Consumer<Boolean> listener) {
+        STATE.removeActiveListener(listener);
+    }
 
     @FunctionalInterface
     interface ProfileCompletionWriter {
@@ -132,6 +141,7 @@ public final class SubscriptionRefreshWorker extends Worker {
         } catch (Exception error) {
             return Result.failure();
         } finally {
+            STATE.finish(token);
             if (SubscriptionRefreshCoordinator.finish(token)) {
                 getApplicationContext().getSystemService(NotificationManager.class)
                     .cancel(SubscriptionRefreshNotification.NOTIFICATION_ID);

--- a/android/app/src/main/res/layout/capacitor_bridge_layout_main.xml
+++ b/android/app/src/main/res/layout/capacitor_bridge_layout_main.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <org.opentubex.app.SubscriptionRefreshWebView
+        android:id="@+id/webview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshStateTest.java
+++ b/android/app/src/test/java/org/opentubex/app/SubscriptionRefreshStateTest.java
@@ -6,8 +6,41 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
 
 public class SubscriptionRefreshStateTest {
+    @Test
+    public void rendererStaysActiveOnlyUntilItsOwnRefreshFinishes() {
+        SubscriptionRefreshState state = new SubscriptionRefreshState();
+        List<Boolean> activity = new ArrayList<>();
+        state.observeActive(activity::add);
+        state.begin("current", "Refreshing", "Cancel");
+        state.finish("stale");
+        assertEquals(Arrays.asList(false, true), activity);
+        state.finish("current");
+        assertEquals(Arrays.asList(false, true, false), activity);
+    }
+
+    @Test
+    public void recreatedWebViewInheritsActiveRefreshWithoutOldListenerRemovingIt() {
+        SubscriptionRefreshState state = new SubscriptionRefreshState();
+        Consumer<Boolean> oldListener = active -> {};
+        state.observeActive(oldListener);
+        state.begin("current", "Refreshing", "Cancel");
+        List<Boolean> activity = new ArrayList<>();
+        Consumer<Boolean> newListener = activity::add;
+        state.observeActive(newListener);
+        state.removeActiveListener(oldListener);
+        state.finish("current");
+        assertEquals(Arrays.asList(true, false), activity);
+        state.removeActiveListener(newListener);
+        state.begin("next", "Refreshing", "Cancel");
+        assertEquals(Arrays.asList(true, false), activity);
+    }
+
     @Test
     public void onlyCurrentRefreshCanUpdateOrFinish() {
         SubscriptionRefreshState state = new SubscriptionRefreshState();

--- a/e2e/tests/offline/browser-subscription-cache.spec.mjs
+++ b/e2e/tests/offline/browser-subscription-cache.spec.mjs
@@ -1,0 +1,172 @@
+import { readFile } from 'node:fs/promises'
+import { test, expect } from '../../helpers/app.mjs'
+
+const source = await readFile(new URL('../../../src/datastores/browserSubscriptionCache.js', import.meta.url), 'utf8')
+
+test.beforeEach(async ({ page }) => {
+  // Exercise the browser backend against Chromium's real IndexedDB, including
+  // transaction commits and structured cloning, without touching the app cache.
+  await page.evaluate(`${source.replace('export function', 'function')}; window.createTestCache = createBrowserSubscriptionCache`)
+})
+
+test('refresh writes scale with one channel instead of the entire subscription cache', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const records = Array.from({ length: 938 }, (_, index) => ({
+      _id: `channel-${index}`,
+      videosTimestamp: new Date(1000),
+      videos: Array.from({ length: 20 }, (_, video) => ({
+        videoId: `${index}-${video}`, title: 'Video title '.repeat(30), isNewInSubscriptionFeed: true
+      }))
+    }))
+    const cache = window.createTestCache(async () => records, 'cache-size-test')
+    await cache.find()
+    const original = IDBObjectStore.prototype.put
+    const sizes = []
+    IDBObjectStore.prototype.put = function (value, ...args) {
+      sizes.push(JSON.stringify(value).length)
+      return original.call(this, value, ...args)
+    }
+    const started = performance.now()
+    try {
+      await Promise.all(records.slice(0, 8).map(record => (
+        cache.updateVideosByChannelId(record._id, record.videos, new Date(2000))
+      )))
+    } finally {
+      IDBObjectStore.prototype.put = original
+    }
+    return { sizes, elapsedMs: performance.now() - started, count: (await cache.find()).length }
+  })
+  expect(result.count).toBe(938)
+  expect(result.sizes).toHaveLength(8)
+  expect(Math.max(...result.sizes)).toBeLessThan(20_000)
+})
+
+test('imports cached feeds once and keeps clear operations cleared after reopening', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const record = {
+      _id: 'channel',
+      videosTimestamp: new Date(1000),
+      videos: [{ videoId: 'video', isNewInSubscriptionFeed: false }],
+      shorts: [{ videoId: 'short', isNewInSubscriptionFeed: true }],
+      liveStreams: [],
+      communityPosts: [{ postId: 'post' }]
+    }
+    let imports = 0
+    const load = async () => { imports++; return [record] }
+    const cache = window.createTestCache(load, 'cache-import-test')
+    const other = window.createTestCache(load, 'cache-import-test')
+    const [first] = await Promise.all([cache.find(), other.find()])
+    await cache.updateVideosByChannelId('channel', [{ videoId: 'new' }], new Date(2000))
+    const reopened = window.createTestCache(load, 'cache-import-test')
+    const persisted = await reopened.find()
+    await cache.deleteAll()
+    const cleared = await window.createTestCache(load, 'cache-import-test').find()
+    return { first, persisted, cleared, imports }
+  })
+  expect(result.first[0].videos[0].isNewInSubscriptionFeed).toBe(false)
+  expect(result.first[0].shorts[0].isNewInSubscriptionFeed).toBe(true)
+  expect(result.first[0].communityPosts[0].postId).toBe('post')
+  expect(result.persisted[0].videos[0].videoId).toBe('new')
+  expect(result.persisted[0].shorts[0].videoId).toBe('short')
+  expect(result.cleared).toEqual([])
+  expect(result.imports).toBeLessThanOrEqual(2)
+})
+
+test('serializes competing feeds, stale writes and Shorts enrichment across connections', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const cache = window.createTestCache(async () => [], 'cache-race-test')
+    const other = window.createTestCache(async () => [], 'cache-race-test')
+    await Promise.all([cache.find(), other.find()])
+    await Promise.all([
+      cache.updateVideosByChannelId('channel', [{ videoId: 'video' }], new Date(3000)),
+      other.updateShortsByChannelId('channel', [{ videoId: 'short', title: 'Original', viewCount: 100 }], new Date(1000))
+    ])
+    const stale = await other.updateVideosByChannelId('channel', [], new Date(2000))
+    await Promise.all([
+      cache.updateShortsByChannelId('channel', [{ videoId: 'short', title: 'Refreshed', viewCount: 100 }, { videoId: 'new-short' }], new Date(2000)),
+      other.updateShortsWithChannelPageShortsByChannelId('channel', [{ videoId: 'short', title: 'Enriched', viewCount: 200 }])
+    ])
+    const records = await cache.find()
+    await cache.deleteMultipleChannels(['channel'])
+    return { stale, records, removed: await other.find() }
+  })
+  expect(result.stale).toBe(false)
+  expect(result.records[0].videos[0].videoId).toBe('video')
+  expect(result.records[0].shorts.map(video => video.videoId)).toEqual(['short', 'new-short'])
+  expect(result.records[0].shorts[0].title).toBe('Enriched')
+  expect(result.records[0].shorts[0].viewCount).toBe(200)
+  expect(result.removed).toEqual([])
+})
+
+test('failed imports retry atomically and failed writes reject without losing cached data', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    let invalid = true
+    const cache = window.createTestCache(async () => [
+      { _id: 'channel', videos: [{ videoId: 'old' }], videosTimestamp: new Date(1000) },
+      invalid ? { _id: 'invalid', uncloneable: () => {} } : { _id: 'second' }
+    ], 'cache-failure-test')
+    const importError = await cache.find().then(() => null, error => error.name)
+    invalid = false
+    const imported = await cache.find()
+    const original = IDBObjectStore.prototype.put
+    IDBObjectStore.prototype.put = function () {
+      throw new DOMException('Simulated storage failure', 'QuotaExceededError')
+    }
+    let writeError
+    try {
+      writeError = await cache.updateVideosByChannelId('channel', [], new Date(2000))
+        .then(() => null, error => error.name)
+    } finally {
+      IDBObjectStore.prototype.put = original
+    }
+    return { importError, writeError, imported, persisted: await cache.find() }
+  })
+  expect(result.importError).toBe('DataCloneError')
+  expect(result.imported).toHaveLength(2)
+  expect(result.writeError).toBe('QuotaExceededError')
+  expect(result.persisted.find(record => record._id === 'channel').videos[0].videoId).toBe('old')
+})
+
+test('cleans up the old log after import and retries interrupted cleanup without reimporting', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    let imports = 0
+    let cleanups = 0
+    const load = async () => {
+      imports++
+      return [{ _id: 'channel', videos: [{ videoId: 'old' }] }]
+    }
+    const cleanup = async () => {
+      cleanups++
+      if (cleanups === 1) throw new Error('Interrupted cleanup')
+    }
+    const cache = window.createTestCache(load, 'cache-cleanup-test', cleanup)
+    const error = await cache.find().then(() => null, error => error.message)
+    const reopened = window.createTestCache(load, 'cache-cleanup-test', cleanup)
+    const records = await reopened.find()
+    await reopened.deleteAll()
+    const cleared = await window.createTestCache(load, 'cache-cleanup-test', cleanup).find()
+    return { error, records, cleared, imports, cleanups }
+  })
+  expect(result.error).toBe('Interrupted cleanup')
+  expect(result.records[0].videos[0].videoId).toBe('old')
+  expect(result.imports).toBe(1)
+  expect(result.cleanups).toBe(2)
+  expect(result.cleared).toEqual([])
+})
+
+test('snapshots reactive entries before awaiting storage and preserves other feed data', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const cache = window.createTestCache(async () => [], 'cache-proxy-test')
+    const entry = { videoId: 'video', isNewInSubscriptionFeed: true }
+    const entries = new Proxy([new Proxy(entry, {})], {})
+    const update = cache.updateVideosByChannelId('channel', entries, new Date(1000))
+    entry.isNewInSubscriptionFeed = false
+    await update
+    await cache.updateLiveStreamsByChannelId('channel', [{ videoId: 'live' }], new Date(1000))
+    await cache.updateCommunityPostsByChannelId('channel', [{ postId: 'post' }], new Date(1000))
+    return cache.find()
+  })
+  expect(result[0].videos[0].isNewInSubscriptionFeed).toBe(true)
+  expect(result[0].liveStreams[0].videoId).toBe('live')
+  expect(result[0].communityPosts[0].postId).toBe('post')
+})

--- a/e2e/tests/offline/browser-subscription-cache.spec.mjs
+++ b/e2e/tests/offline/browser-subscription-cache.spec.mjs
@@ -170,3 +170,43 @@ test('snapshots reactive entries before awaiting storage and preserves other fee
   expect(result[0].liveStreams[0].videoId).toBe('live')
   expect(result[0].communityPosts[0].postId).toBe('post')
 })
+
+for (const closure of ['versionchange', 'close']) {
+  test(`reopens the cache after ${closure} without letting old close events discard a new connection`, async ({ page }) => {
+    const result = await page.evaluate(async reason => {
+      const name = `cache-${reason}-test`
+      const original = IDBFactory.prototype.open
+      const connections = []
+      IDBFactory.prototype.open = function (...args) {
+        const request = original.apply(this, args)
+        if (args[0] === name) request.addEventListener('success', () => connections.push(request.result))
+        return request
+      }
+      try {
+        const cache = window.createTestCache(async () => [], name)
+        await cache.updateVideosByChannelId('channel', [{ videoId: 'old' }], new Date(1000))
+        const first = connections[0]
+        if (reason === 'versionchange') {
+          await new Promise((resolve, reject) => {
+            const request = indexedDB.deleteDatabase(name)
+            request.onsuccess = resolve
+            request.onerror = () => reject(request.error)
+          })
+        } else {
+          // Chromium has no public force-close API. Close the real connection
+          // and deliver the event emitted by an abnormal storage closure.
+          first.close()
+          first.dispatchEvent(new Event('close'))
+        }
+        await cache.updateVideosByChannelId('channel', [{ videoId: 'new' }], new Date(2000))
+        first.dispatchEvent(new Event('close'))
+        return { records: await cache.find(), opens: connections.length }
+      } finally {
+        IDBFactory.prototype.open = original
+        connections.forEach(connection => connection.close())
+      }
+    }, closure)
+    expect(result.records[0].videos[0].videoId).toBe('new')
+    expect(result.opens).toBe(2)
+  })
+}

--- a/e2e/tests/offline/subscription-cache-refresh-performance.spec.mjs
+++ b/e2e/tests/offline/subscription-cache-refresh-performance.spec.mjs
@@ -1,0 +1,98 @@
+import { test, expect, goTo } from '../../helpers/app.mjs'
+import { largeSubscriptionsSeed } from '../../performance/subscriptions.mjs'
+
+test.use({ seed: largeSubscriptionsSeed })
+
+for (const feed of ['videos', 'new']) {
+  test(`refreshes cached channels efficiently with the ${feed} feed visible`, async ({ page }, testInfo) => {
+    await page.route(/^https?:\/\//, route => route.abort())
+    await goTo(page, 'subscriptions')
+    await page.locator(`[data-subscription-feed-tab="${feed === 'new' ? 'all' : 'videos'}"]`).click()
+    if (feed === 'new') await expect(page.locator('#subscriptionsPanel.newFeed')).toBeVisible()
+    else await expect(page.locator('#subscriptionsPanel:not(.newFeed)')).toBeVisible()
+    await expect(page.getByText('Video 0-0', { exact: true })).toBeVisible()
+
+    const cdp = process.env.OPENTUBEX_REFRESH_CPU_PROFILE
+      ? await page.context().newCDPSession(page)
+      : null
+    if (cdp) {
+      await cdp.send('Profiler.enable')
+      await cdp.send('Profiler.start')
+    }
+    const metrics = await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      // Replay fetched channel responses through the real cache IPC, persistence,
+      // Vuex mutation and incremental-feed event, without network variability.
+      const responses = Object.entries(store.getters.getVideoCache).slice(0, 80)
+        .map(([channelId, cache]) => ({
+          channelId,
+          videos: JSON.parse(JSON.stringify(cache.videos))
+        }))
+      responses[0].videos[0].title = 'Refreshed video 0-0'
+      const durations = []
+      let next = 0
+      const started = performance.now()
+      await Promise.all(Array.from({ length: 8 }, async () => {
+        while (next < responses.length) {
+          const response = responses[next++]
+          const before = performance.now()
+          await store.dispatch('updateSubscriptionVideosCacheByChannel', response)
+          durations.push(performance.now() - before)
+          window.dispatchEvent(new CustomEvent('opentubex-subscription-refresh-channel', {
+            detail: { tab: 'videos' }
+          }))
+          await new Promise(resolve => setTimeout(resolve, 20))
+        }
+      }))
+      return {
+        elapsedMs: performance.now() - started,
+        updates: durations.length,
+        medianUpdateMs: durations.sort((a, b) => a - b)[Math.floor(durations.length / 2)]
+      }
+    })
+    if (cdp) {
+      const { profile } = await cdp.send('Profiler.stop')
+      await cdp.detach()
+      await testInfo.attach('refresh CPU profile', {
+        body: JSON.stringify(profile), contentType: 'application/json'
+      })
+    }
+    await testInfo.attach('refresh timings', {
+      body: JSON.stringify(metrics), contentType: 'application/json'
+    })
+    expect(metrics.updates).toBe(80)
+    await expect(page.getByText('Refreshed video 0-0', { exact: true })).toBeVisible()
+    // The full-feed dependency scan took ~40 seconds for this replay. Leave
+    // room for runner jitter while catching that repeated work reliably.
+    expect(metrics.elapsedMs, JSON.stringify(metrics)).toBeLessThan(10_000)
+    expect(metrics.medianUpdateMs, JSON.stringify(metrics)).toBeLessThan(500)
+  })
+}
+
+test('rechecks premiere history after the clock advances and the Home feed recomputes', async ({ page }) => {
+  const published = largeSubscriptionsSeed.subscriptionCache[0].videos[0].published
+  await page.clock.setFixedTime(new Date(published))
+  await page.evaluate(async timestamp => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    const history = {
+      ...store.getters.getHistoryCacheById,
+      'video-0-0': {
+        videoId: 'video-0-0',
+        isUpcoming: true,
+        isWatched: true,
+        premiereTimestamp: (timestamp + 60_000) / 1000
+      }
+    }
+    store.commit('setHistoryCacheById', history)
+  }, published)
+  await goTo(page, 'home')
+  await expect(page.getByText('Video 0-0', { exact: true })).toBeVisible()
+  await page.clock.setFixedTime(new Date(published + 120_000))
+  // An unrelated settings change recomputes the selector, but does not mutate
+  // this channel's entries or history record.
+  await page.evaluate(async () => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    await store.dispatch('updateOnlyShowLatestFromChannel', true)
+  })
+  await expect(page.getByText('Video 0-0', { exact: true })).toHaveCount(0)
+})

--- a/src/datastores/browserSubscriptionCache.js
+++ b/src/datastores/browserSubscriptionCache.js
@@ -28,7 +28,7 @@ export function createBrowserSubscriptionCache(loadLegacyRecords, name = 'opentu
     })
   }
 
-  async function open() {
+  async function open(onClose) {
     const database = await new Promise((resolve, reject) => {
       const request = indexedDB.open(name, 1)
       request.onupgradeneeded = () => {
@@ -38,7 +38,11 @@ export function createBrowserSubscriptionCache(loadLegacyRecords, name = 'opentu
       request.onerror = () => reject(request.error)
       request.onsuccess = () => resolve(request.result)
     })
-    database.onversionchange = () => database.close()
+    database.onversionchange = () => {
+      onClose()
+      database.close()
+    }
+    database.onclose = onClose
 
     try {
       const imported = await transaction(database, ['metadata'], 'readonly', (tx, done) => {
@@ -79,10 +83,16 @@ export function createBrowserSubscriptionCache(loadLegacyRecords, name = 'opentu
   }
 
   function database() {
-    ready ??= open().catch(error => {
-      ready = null
-      throw error
-    })
+    if (!ready) {
+      const forget = () => {
+        if (ready === pending) ready = null
+      }
+      const pending = open(forget).catch(error => {
+        forget()
+        throw error
+      })
+      ready = pending
+    }
     return ready
   }
 

--- a/src/datastores/browserSubscriptionCache.js
+++ b/src/datastores/browserSubscriptionCache.js
@@ -1,0 +1,157 @@
+/**
+ * Browser NeDB rewrites its entire append log for every channel update. Keep
+ * channels in separate IndexedDB records instead, with atomic read/write
+ * transactions so refreshes and seen-state updates cannot overwrite each other.
+ * @param {() => Promise<object[]>} loadLegacyRecords
+ * @param {string} name
+ * @param {() => Promise<void>} removeLegacyRecords
+ */
+export function createBrowserSubscriptionCache(loadLegacyRecords, name = 'opentubex-subscription-cache', removeLegacyRecords = async () => {}) {
+  let ready = null
+
+  function transaction(database, stores, mode, operation) {
+    return new Promise((resolve, reject) => {
+      const tx = database.transaction(stores, mode)
+      let result
+      let failure
+      const fail = error => {
+        failure = error
+        tx.abort()
+      }
+      tx.oncomplete = () => resolve(result)
+      tx.onabort = () => reject(failure ?? tx.error)
+      try {
+        operation(tx, value => { result = value }, fail)
+      } catch (error) {
+        fail(error)
+      }
+    })
+  }
+
+  async function open() {
+    const database = await new Promise((resolve, reject) => {
+      const request = indexedDB.open(name, 1)
+      request.onupgradeneeded = () => {
+        request.result.createObjectStore('channels', { keyPath: '_id' })
+        request.result.createObjectStore('metadata')
+      }
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => resolve(request.result)
+    })
+    database.onversionchange = () => database.close()
+
+    try {
+      const imported = await transaction(database, ['metadata'], 'readonly', (tx, done) => {
+        const request = tx.objectStore('metadata').get('imported')
+        request.onsuccess = () => done(request.result)
+      })
+      if (!imported) {
+        const records = await loadLegacyRecords()
+        await transaction(database, ['channels', 'metadata'], 'readwrite', (tx, done, fail) => {
+          const metadata = tx.objectStore('metadata')
+          const request = metadata.get('imported')
+          request.onsuccess = () => {
+            // Another window may have completed the import while we loaded NeDB.
+            if (request.result) return
+            try {
+              const channels = tx.objectStore('channels')
+              for (const record of records) channels.put(record)
+              metadata.put('imported', 'imported')
+            } catch (error) {
+              fail(error)
+            }
+          }
+        })
+      }
+      if (imported !== 'complete') {
+        // Delete the old log only after the import commits. If interrupted,
+        // retry cleanup on startup without importing stale records again.
+        await removeLegacyRecords()
+        await transaction(database, ['metadata'], 'readwrite', tx => {
+          tx.objectStore('metadata').put('complete', 'imported')
+        })
+      }
+      return database
+    } catch (error) {
+      database.close()
+      throw error
+    }
+  }
+
+  function database() {
+    ready ??= open().catch(error => {
+      ready = null
+      throw error
+    })
+    return ready
+  }
+
+  async function updateChannel(channelId, change) {
+    return transaction(await database(), ['channels'], 'readwrite', (tx, done, fail) => {
+      const channels = tx.objectStore('channels')
+      const request = channels.get(channelId)
+      request.onsuccess = () => {
+        try {
+          const record = request.result ?? { _id: channelId }
+          const applied = change(record)
+          if (applied) channels.put(record)
+          done(applied)
+        } catch (error) {
+          fail(error)
+        }
+      }
+    })
+  }
+
+  function updateFeed(channelId, entries, timestamp, field) {
+    // Vue proxies cannot cross IndexedDB's structured-clone boundary. Snapshot
+    // only this channel, as Electron's datastore IPC does for its payloads.
+    const snapshot = JSON.parse(JSON.stringify(entries))
+    const date = new Date(timestamp)
+    return updateChannel(channelId, record => {
+      const timestampField = `${field}Timestamp`
+      if (new Date(record[timestampField]).getTime() > date.getTime()) return false
+      record[field] = snapshot
+      record[timestampField] = date
+      return true
+    })
+  }
+
+  return {
+    async find() {
+      return transaction(await database(), ['channels'], 'readonly', (tx, done) => {
+        const request = tx.objectStore('channels').getAll()
+        request.onsuccess = () => done(request.result)
+      })
+    },
+    updateVideosByChannelId: (id, entries, timestamp) => updateFeed(id, entries, timestamp, 'videos'),
+    updateShortsByChannelId: (id, entries, timestamp) => updateFeed(id, entries, timestamp, 'shorts'),
+    updateLiveStreamsByChannelId: (id, entries, timestamp) => updateFeed(id, entries, timestamp, 'liveStreams'),
+    updateCommunityPostsByChannelId: (id, entries, timestamp) => updateFeed(id, entries, timestamp, 'communityPosts'),
+    updateShortsWithChannelPageShortsByChannelId(channelId, entries) {
+      const snapshot = JSON.parse(JSON.stringify(entries))
+      return updateChannel(channelId, record => {
+        let changed = false
+        for (const cached of record.shorts ?? []) {
+          const entry = snapshot.find(short => short.videoId === cached.videoId)
+          if (!entry) continue
+          changed = true
+          cached.title = entry.title
+          cached.author = entry.author
+          if (entry.viewCount > cached.viewCount) cached.viewCount = entry.viewCount
+        }
+        return changed
+      })
+    },
+    async deleteMultipleChannels(channelIds) {
+      return transaction(await database(), ['channels'], 'readwrite', tx => {
+        for (const channelId of channelIds) tx.objectStore('channels').delete(channelId)
+      })
+    },
+    async deleteAll() {
+      return transaction(await database(), ['channels'], 'readwrite', tx => {
+        tx.objectStore('channels').clear()
+      })
+    }
+  }
+}

--- a/src/datastores/handlers/base.js
+++ b/src/datastores/handlers/base.js
@@ -819,7 +819,8 @@ function compactAllDatastores() {
     db.profiles.compactDatafileAsync(),
     db.playlists.compactDatafileAsync(),
     db.searchHistory.compactDatafileAsync(),
-    db.subscriptionCache.compactDatafileAsync(),
+    // IndexedDB stores each browser cache record directly and needs no compaction.
+    ...(db.subscriptionCache ? [db.subscriptionCache.compactDatafileAsync()] : []),
     db.tabSession.compactDatafileAsync(),
     db.liveReminders.compactDatafileAsync(),
     db.videoMetadataCache.compactDatafileAsync(),

--- a/src/datastores/handlers/web.js
+++ b/src/datastores/handlers/web.js
@@ -1,4 +1,12 @@
 import * as baseHandlers from './base'
+import { loadLegacySubscriptionCache, removeLegacySubscriptionCache } from '../index'
+import { createBrowserSubscriptionCache } from '../browserSubscriptionCache'
+
+export const subscriptionCache = createBrowserSubscriptionCache(
+  loadLegacySubscriptionCache,
+  'opentubex-subscription-cache',
+  removeLegacySubscriptionCache
+)
 
 // TODO: Syncing
 // Syncing on the web would involve a different implementation
@@ -34,6 +42,5 @@ export {
   profiles,
   playlists,
   searchHistory,
-  subscriptionCache,
   compactAllDatastores,
 } from './base'

--- a/src/datastores/index.js
+++ b/src/datastores/index.js
@@ -40,7 +40,17 @@ export const playlists = createDatastore('playlists')
 export const history = createDatastore('history')
 export const watchStats = createDatastore('watch-stats')
 export const searchHistory = createDatastore('search-history')
-export const subscriptionCache = createDatastore('subscription-cache')
+// Web/Android use channel records in IndexedDB. Load the old NeDB cache only
+// when importing an existing installation, not on every application startup.
+export const subscriptionCache = process.env.IS_ELECTRON_MAIN ? createDatastore('subscription-cache') : null
+
+export function loadLegacySubscriptionCache() {
+  return createDatastore('subscription-cache').findAsync({})
+}
+
+export function removeLegacySubscriptionCache() {
+  return new Datastore({ filename: dbPath('subscription-cache') }).dropDatabaseAsync()
+}
 export const tabSession = createDatastore('tab-session')
 export const liveReminders = createDatastore('live-reminders')
 export const videoMetadataCache = createDatastore('video-metadata-cache')

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -383,6 +383,7 @@
 </template>
 
 <script setup>
+import { isAppHidden, setAndroidAppVisible } from './helpers/appVisibility.js'
 import { FtIcon } from '@opentubex/icons'
 import { App as CapacitorApp } from '@capacitor/app'
 import { Capacitor, SystemBarType, SystemBars, SystemBarsStyle } from '@capacitor/core'
@@ -1610,7 +1611,7 @@ async function processPendingSubscriptionAutoRefreshes() {
           profileId !== activeSubscriptionProfileId.value ||
           !isSubscriptionTabAutoRefreshEnabled(tab) ||
           navigator.onLine === false ||
-          document.hidden
+          isAppHidden()
         ) {
           continue
         }
@@ -1698,7 +1699,7 @@ function refreshOverdueSubscriptionFeeds() {
 }
 
 function handleSubscriptionAutoRefreshVisibilityChange() {
-  if (!document.hidden) {
+  if (!isAppHidden()) {
     synchronizeSubscriptionRefreshInProgress()
     if (isCapacitor && subscriptionCacheReady.value) {
       reconcileAndroidSubscriptionRefreshResults()
@@ -4005,6 +4006,7 @@ async function enableCapacitorIntegrations() {
     tabMediaCoordinator.dispatchAction(action, details)
   })
   const appStateHandle = await CapacitorApp.addListener('appStateChange', ({ isActive }) => {
+    setAndroidAppVisible(isActive)
     if (shouldPauseAndroidPlaybackOnAppStateChange(
       isActive,
       store.getters.getContinuePlaybackWhenScreenIsLocked
@@ -4012,12 +4014,15 @@ async function enableCapacitorIntegrations() {
       tabMediaCoordinator.pauseAll()
     }
   })
+  const appState = await CapacitorApp.getState()
+  setAndroidAppVisible(appState.isActive)
   const launch = await CapacitorApp.getLaunchUrl()
   if (launch?.url) await handleYoutubeLink(launch.url)
 
   return () => {
     urlHandle.remove()
     appStateHandle.remove()
+    setAndroidAppVisible(null)
     removeReminderActions()
     removeMediaActions()
   }

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -4005,7 +4005,9 @@ async function enableCapacitorIntegrations() {
   const removeMediaActions = await addAndroidMediaSessionActionListener(({ action, ...details }) => {
     tabMediaCoordinator.dispatchAction(action, details)
   })
+  let receivedAppState = false
   const appStateHandle = await CapacitorApp.addListener('appStateChange', ({ isActive }) => {
+    receivedAppState = true
     setAndroidAppVisible(isActive)
     if (shouldPauseAndroidPlaybackOnAppStateChange(
       isActive,
@@ -4015,7 +4017,7 @@ async function enableCapacitorIntegrations() {
     }
   })
   const appState = await CapacitorApp.getState()
-  setAndroidAppVisible(appState.isActive)
+  if (!receivedAppState) setAndroidAppVisible(appState.isActive)
   const launch = await CapacitorApp.getLaunchUrl()
   if (launch?.url) await handleYoutubeLink(launch.url)
 

--- a/src/renderer/components/StorageSettings/StorageSettings.vue
+++ b/src/renderer/components/StorageSettings/StorageSettings.vue
@@ -350,6 +350,7 @@
 </template>
 
 <script setup>
+import { isAppHidden } from '../../helpers/appVisibility.js'
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -848,7 +849,7 @@ function openProfileDirectory() {
 }
 
 function refreshWhenVisible() {
-  if (!document.hidden) refreshUsage()
+  if (!isAppHidden()) refreshUsage()
 }
 
 onMounted(async () => {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1,3 +1,4 @@
+import { isAppHidden } from '../../helpers/appVisibility.js'
 import { computed, defineComponent, inject, nextTick, onBeforeUnmount, onMounted, onUnmounted, reactive, ref, shallowRef, watch } from 'vue'
 import FtPaidPromotionBadge from '../FtPaidPromotionBadge/FtPaidPromotionBadge.vue'
 import FtSelect from '../FtSelect/FtSelect.vue'
@@ -9294,7 +9295,7 @@ export default defineComponent({
     }
 
     function handleTemporaryPlaybackRateVisibilityChange() {
-      if (document.hidden) {
+      if (isAppHidden()) {
         handleTemporaryPlaybackRateFocusLoss()
       }
     }

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useAmbientMode.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useAmbientMode.js
@@ -1,3 +1,4 @@
+import { isAppHidden } from '../../../helpers/appVisibility.js'
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
 const AMBIENT_FRAME_INTERVAL_MS = 100
@@ -39,7 +40,7 @@ export function useAmbientMode({ enabled, video }) {
 
     const videoTimeChanged = videoElement?.currentTime !== lastVideoTime
 
-    if (!enabled.value || document.hidden || !canvas || !videoElement ||
+    if (!enabled.value || isAppHidden() || !canvas || !videoElement ||
       videoElement.readyState < HTMLMediaElement.HAVE_CURRENT_DATA ||
       (!videoTimeChanged && blendTicksRemaining === 0)) {
       // Nothing left to draw and no new frames coming: 'play' restarts the timer.

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useAutoPictureInPicture.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useAutoPictureInPicture.js
@@ -1,3 +1,4 @@
+import { isAppHidden } from '../../../helpers/appVisibility.js'
 import { computed, watch } from 'vue'
 
 import store from '../../../store/index'
@@ -61,10 +62,10 @@ export function useAutoPictureInPicture({
   const autoPipEnabled = computed(() => autoPictureInPictureTriggers.value.length > 0)
 
   // In Electron the minimized state is driven by native window events (see setup below),
-  // because `document.hidden` doesn't fire on minimize on Wayland. On the web we fall back
-  // to `document.hidden`, which also covers browser-tab switches.
+  // because document visibility doesn't change on minimize on Wayland. Other
+  // platforms use app visibility, which also covers browser-tab switches.
   const state = createAutoPictureInPictureState(initialState ?? {
-    minimized: process.env.IS_ELECTRON ? false : document.hidden,
+    minimized: process.env.IS_ELECTRON ? false : isAppHidden(),
     focused: document.hasFocus()
   })
   let stopActiveTabWatch = null
@@ -164,7 +165,7 @@ export function useAutoPictureInPicture({
   }
 
   function refreshVisibilityState() {
-    state.windowMinimized = document.hidden
+    state.windowMinimized = isAppHidden()
     applyFocusState(state, document.hasFocus())
     updateAutoPip()
   }
@@ -198,7 +199,7 @@ export function useAutoPictureInPicture({
   function initializeActiveTab() {
     applyFocusState(state, document.hasFocus())
     if (!process.env.IS_ELECTRON) {
-      state.windowMinimized = document.hidden
+      state.windowMinimized = isAppHidden()
     }
     updateAutoPip()
   }

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useMusicVisualizer.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useMusicVisualizer.js
@@ -1,3 +1,4 @@
+import { isAppHidden } from '../../../helpers/appVisibility.js'
 import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
 const FFT_SIZE = 256
@@ -48,7 +49,7 @@ export function useMusicVisualizer({ active, video, sourceKey }) {
 
   function canDraw() {
     return active.value &&
-      !document.hidden &&
+      !isAppHidden() &&
       document.documentElement.dataset.reducedMotion !== 'reduce' &&
       video.value?.paused === false
   }
@@ -268,7 +269,7 @@ export function useMusicVisualizer({ active, video, sourceKey }) {
   }
 
   function handleVisibilityChange() {
-    if (document.hidden) {
+    if (isAppHidden()) {
       stopDrawing()
     } else {
       runVisualizerTask(startDrawing())

--- a/src/renderer/helpers/api/requestDiagnostics.js
+++ b/src/renderer/helpers/api/requestDiagnostics.js
@@ -1,9 +1,10 @@
+import { isAppHidden } from '../appVisibility.js'
 const RESUME_WINDOW_MS = 5000
 let lastVisibleAt = Number.NEGATIVE_INFINITY
 
 if (typeof document !== 'undefined') {
   document.addEventListener('visibilitychange', () => {
-    if (document.visibilityState === 'visible') lastVisibleAt = Date.now()
+    if (!isAppHidden()) lastVisibleAt = Date.now()
   })
 }
 
@@ -67,7 +68,7 @@ export function classifyRequestLifecycle(visibilityState, visibleAt, now = Date.
 }
 
 export function getRequestLifecycle() {
-  const visibilityState = typeof document === 'undefined' ? 'visible' : document.visibilityState
+  const visibilityState = isAppHidden() ? 'hidden' : 'visible'
   return classifyRequestLifecycle(visibilityState, lastVisibleAt)
 }
 

--- a/src/renderer/helpers/appVisibility.js
+++ b/src/renderer/helpers/appVisibility.js
@@ -1,0 +1,17 @@
+// Android may keep Chromium active for a subscription refresh while its window
+// is hidden. UI and playback must still follow the real activity visibility.
+let androidVisible = null
+
+export function isAppHidden() {
+  return androidVisible === null
+    ? typeof document !== 'undefined' && document.hidden
+    : !androidVisible
+}
+
+export function setAndroidAppVisible(visible) {
+  const wasHidden = isAppHidden()
+  androidVisible = visible
+  if (wasHidden !== isAppHidden()) {
+    document.dispatchEvent(new Event('visibilitychange'))
+  }
+}

--- a/src/renderer/helpers/newSubscriptionFeed.js
+++ b/src/renderer/helpers/newSubscriptionFeed.js
@@ -6,6 +6,7 @@ import {
   isSubscriptionFeedTypeEnabled
 } from './subscription-channels'
 import { isVideoHiddenByPreferences } from './subscriptions'
+import { getNewSubscriptionEntriesSnapshot } from './subscription-entry-snapshot'
 
 /**
  * Returns the locally cached subscription feeds enabled by the current
@@ -78,7 +79,7 @@ export function getNewSubscriptionFeedEntries({
         return
       }
 
-      cacheEntry?.[entriesKey]?.forEach(entry => {
+      getNewSubscriptionEntriesSnapshot(cacheEntry?.[entriesKey] ?? []).forEach(entry => {
         if (!isMembersOnlySubscriptionVideoVisible(
           entry,
           subscription,
@@ -87,10 +88,8 @@ export function getNewSubscriptionFeedEntries({
           return
         }
 
-        if (entry.isNewInSubscriptionFeed !== true) {
-          return
-        }
-
+        // Premiere history depends on the clock, so recheck it even when this
+        // channel's entry snapshot has not changed.
         if (entry.videoId != null && isHistoryEntryWatched(historyCacheById[entry.videoId])) {
           return
         }
@@ -101,11 +100,7 @@ export function getNewSubscriptionFeedEntries({
         }
 
         seenIds.add(id)
-        entries[category].push({
-          ...entry,
-          hideNewSubscriptionFeedIndicator: true,
-          isInNewSubscriptionFeed: true,
-        })
+        entries[category].push(entry)
       })
     })
   })

--- a/src/renderer/helpers/subscription-entry-snapshot.js
+++ b/src/renderer/helpers/subscription-entry-snapshot.js
@@ -1,0 +1,26 @@
+import { computed, isReactive } from 'vue'
+
+const snapshots = new WeakMap()
+
+/**
+ * Track each channel's reactive entries once, rather than copying every entry
+ * in the entire New feed after any channel changes. Replacements, in-place
+ * metadata edits and seen-state changes invalidate only the affected snapshot.
+ * @param {object[]} entries
+ * @returns {object[]}
+ */
+export function getNewSubscriptionEntriesSnapshot(entries) {
+  const select = () => entries.filter(entry => entry.isNewInSubscriptionFeed === true).map(entry => ({
+    ...entry,
+    hideNewSubscriptionFeedIndicator: true,
+    isInNewSubscriptionFeed: true,
+  }))
+  if (!isReactive(entries)) return select()
+
+  let snapshot = snapshots.get(entries)
+  if (!snapshot) {
+    snapshot = computed(select)
+    snapshots.set(entries, snapshot)
+  }
+  return snapshot.value
+}

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -1,3 +1,4 @@
+import { isAppHidden } from '../../helpers/appVisibility.js'
 import {
   SyncServerClient,
   SyncServerCancelledError,
@@ -835,7 +836,7 @@ const actions = {
       lifecycleSyncStarted = true
       window.addEventListener('online', () => dispatch('scheduleSyncServer', 'automatic'))
       document.addEventListener('visibilitychange', () => {
-        if (document.visibilityState === 'visible') {
+        if (!isAppHidden()) {
           dispatch('scheduleSyncServer', 'automatic')
         }
       })

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1,3 +1,4 @@
+import { isAppHidden } from '../../helpers/appVisibility.js'
 import { defineComponent } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { mapActions } from 'vuex'
@@ -1276,7 +1277,7 @@ export default defineComponent({
       if (!process.env.IS_CAPACITOR) return
 
       const change = resolveAndroidBackgroundPlaybackFormat({
-        hidden: document.hidden,
+        hidden: isAppHidden(),
         continuePlayback: this.$store.getters.getContinuePlaybackWhenScreenIsLocked,
         activeFormat: this.activeFormat,
         audioFormatAvailable: this.audioFormatAvailable,
@@ -4035,7 +4036,7 @@ export default defineComponent({
       this.handleWatchProgressAutoSaveWhenProgressEnabled()
     },
     handleVideoPlay() {
-      if (document.hidden) this.updateAndroidBackgroundPlaybackFormat()
+      if (isAppHidden()) this.updateAndroidBackgroundPlaybackFormat()
     },
     handlePlayerSeeking() {
       if (!this.customShortsPlayerActive) {

--- a/tests/unit/app-visibility.test.mjs
+++ b/tests/unit/app-visibility.test.mjs
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { readFile } from 'node:fs/promises'
+import vm from 'node:vm'
 
 import { isAppHidden, setAndroidAppVisible } from '../../src/renderer/helpers/appVisibility.js'
 import { resolveAndroidBackgroundPlaybackFormat } from '../../src/renderer/helpers/player/androidBackgroundPlayback.js'
@@ -38,3 +40,41 @@ test('Android background playback follows Home even when Chromium stays visible 
     else globalThis.document = originalDocument
   }
 })
+
+for (const eventFirst of [false, true]) {
+  test(`Android initial visibility preserves ${eventFirst ? 'a newer app-state event' : 'the initial snapshot without an event'}`, async () => {
+    const source = await readFile(new URL('../../src/renderer/App.vue', import.meta.url), 'utf8')
+    const start = source.indexOf('async function enableCapacitorIntegrations() {')
+    const integration = source.slice(start, source.indexOf('\nconst windowTitle', start))
+    const initialState = Promise.withResolvers()
+    const requestedState = Promise.withResolvers()
+    const changes = []
+    let listener
+    let pauses = 0
+    const enable = vm.runInNewContext(`${integration}\nenableCapacitorIntegrations`, {
+      CapacitorApp: {
+        addListener: async (name, callback) => {
+          if (name === 'appStateChange') listener = callback
+          return { remove() {} }
+        },
+        getState: () => { requestedState.resolve(); return initialState.promise },
+        getLaunchUrl: async () => null,
+      },
+      initializeCapacitorLiveReminderActions: async () => () => {},
+      addAndroidMediaSessionActionListener: async () => () => {},
+      setAndroidAppVisible: visible => changes.push(visible),
+      shouldPauseAndroidPlaybackOnAppStateChange: active => !active,
+      store: { getters: { getContinuePlaybackWhenScreenIsLocked: false } },
+      tabMediaCoordinator: { pauseAll: () => { pauses++ } },
+    })
+    const enabling = enable()
+    await requestedState.promise
+    if (eventFirst) listener({ isActive: false })
+    initialState.resolve({ isActive: true })
+    const cleanup = await enabling
+    assert.deepEqual(changes, eventFirst ? [false] : [true])
+    assert.equal(pauses, eventFirst ? 1 : 0)
+    cleanup()
+    assert.equal(changes.at(-1), null)
+  })
+}

--- a/tests/unit/app-visibility.test.mjs
+++ b/tests/unit/app-visibility.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { isAppHidden, setAndroidAppVisible } from '../../src/renderer/helpers/appVisibility.js'
+import { resolveAndroidBackgroundPlaybackFormat } from '../../src/renderer/helpers/player/androidBackgroundPlayback.js'
+
+test('Android background playback follows Home even when Chromium stays visible for a refresh', () => {
+  const originalDocument = globalThis.document
+  const document = new EventTarget()
+  document.hidden = false
+  globalThis.document = document
+  const changes = []
+  document.addEventListener('visibilitychange', () => { changes.push(isAppHidden()) })
+  try {
+    setAndroidAppVisible(true)
+    setAndroidAppVisible(false)
+    assert.equal(isAppHidden(), true)
+    assert.deepEqual(resolveAndroidBackgroundPlaybackFormat({
+      hidden: isAppHidden(), continuePlayback: true, activeFormat: 'dash',
+      audioFormatAvailable: true, paused: false
+    }), { activeFormat: 'audio', restoreFormat: 'dash' })
+
+    // Releasing the refresh changes Chromium visibility too, but the activity
+    // remains hidden. Returning to the app must still publish a resume event.
+    document.hidden = true
+    assert.equal(isAppHidden(), true)
+    document.hidden = false
+    setAndroidAppVisible(true)
+    assert.equal(isAppHidden(), false)
+    assert.deepEqual(changes, [true, false])
+
+    setAndroidAppVisible(null)
+    document.hidden = true
+    assert.equal(isAppHidden(), true, 'other platforms use document visibility')
+  } finally {
+    setAndroidAppVisible(null)
+    if (originalDocument === undefined) delete globalThis.document
+    else globalThis.document = originalDocument
+  }
+})

--- a/tests/unit/subscription-entry-snapshot.test.mjs
+++ b/tests/unit/subscription-entry-snapshot.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { computed, reactive } from 'vue'
+import { getNewSubscriptionEntriesSnapshot } from '../../src/renderer/helpers/subscription-entry-snapshot.js'
+
+test('refreshing one channel reuses the other channels without copying their entries', () => {
+  let copied = 0
+  const cache = reactive(Object.fromEntries(Array.from({ length: 938 }, (_, channel) => [channel, {
+    videos: [{ get title() { copied++; return `Channel ${channel}` }, isNewInSubscriptionFeed: true }]
+  }])))
+  const feed = computed(() => Object.values(cache).flatMap(channel => getNewSubscriptionEntriesSnapshot(channel.videos)))
+  assert.equal(feed.value.length, 938)
+  const initialCopies = copied
+  const unchangedEntry = feed.value[1]
+  cache[0].videos = [{ title: 'Refreshed', isNewInSubscriptionFeed: true }]
+  assert.equal(feed.value[0].title, 'Refreshed')
+  assert.equal(feed.value[1], unchangedEntry)
+  assert.equal(copied, initialCopies)
+})
+
+test('tracks seen flags, metadata, added properties and changed array membership', () => {
+  const entries = reactive([{ videoId: 'video', title: 'Old', isNewInSubscriptionFeed: true }])
+  const feed = computed(() => getNewSubscriptionEntriesSnapshot(entries))
+  const initial = feed.value
+  entries[0].isNewInSubscriptionFeed = false
+  assert.equal(feed.value.length, 0)
+  entries[0].isNewInSubscriptionFeed = true
+  assert.equal(initial[0].isNewInSubscriptionFeed, true)
+  entries[0].title = 'Updated'
+  entries[0].viewCount = 1234
+  assert.equal(feed.value[0].title, 'Updated')
+  assert.equal(feed.value[0].viewCount, 1234)
+  delete entries[0].viewCount
+  assert.equal('viewCount' in feed.value[0], false)
+  entries.push({ videoId: 'another', isNewInSubscriptionFeed: true })
+  assert.equal(feed.value.length, 2)
+  entries.splice(0, 1)
+  assert.equal(feed.value[0].videoId, 'another')
+})
+
+test('does not cache non-reactive input that cannot invalidate a snapshot', () => {
+  const entries = [{ title: 'Old', isNewInSubscriptionFeed: true }]
+  assert.equal(getNewSubscriptionEntriesSnapshot(entries)[0].title, 'Old')
+  entries[0].title = 'New'
+  assert.equal(getNewSubscriptionEntriesSnapshot(entries)[0].title, 'New')
+})


### PR DESCRIPTION
Large subscription lists made refreshes slow while the New feed was visible. Android refreshes also stalled after returning Home.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Reported directly during Pixel testing; no tracked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Reuse copied New-feed entries for unchanged channels, shared by Subscriptions and Home. Keep history and preference filtering reactive, including time-sensitive premiere history.

Keep Chromium active while a renderer refresh owns the Android foreground service, and use the actual activity visibility for playback and UI behavior. Store Android/web subscription caches as individual IndexedDB channel records instead of rewriting the entire NeDB log for each channel. Import existing feeds and seen state atomically, then remove the old log.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Subscription refreshes are faster with large New feeds and continue when the Android app is in the background.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. On desktop with a large subscription list, open New and refresh Videos. Progress should advance without prolonged UI pauses. Updated titles and new/seen indicators should remain correct in New and Home, including after changing display filters or marking videos watched.
2. Run this branch on Android with a large subscription list. Refresh Videos, return to Home, and leave the app in the background for more than a minute. Progress should continue through completion and the refresh notification should disappear.
3. Reopen the app and reload it. Cached feeds and their new/seen indicators should persist. Clear the subscription cache and reload again; the old cache must not reappear.
4. Start another refresh and cancel it. Background playback should still follow the existing screen-lock playback setting.

## Additional context
<!-- Add any other context about the pull request here. -->

Measured on a Pixel 8 Pro with 938 subscriptions: a full video refresh completed on Home in 100.9 seconds. The same five cache updates fell from 1,853 ms to 45 ms, and the largest write fell from 27 MB to 36 KB. All 21,708 cached videos survived a reload. The separate laptop measurement was 451.8 seconds with matching backend/RSS settings.

A deterministic Electron replay of 80 channel updates with New visible fell from 39.5 seconds to 6.6 seconds, with median cache action time falling from 1,962 ms to 328 ms. The fixture has 933 channels with 36 videos each. This measures cache persistence and renderer work, not a full network refresh; the laptop has not been remeasured.

Validation includes 907 JavaScript unit tests, 41 targeted desktop New/Home E2E tests, 44 Android unit tests, eight IndexedDB regression tests, a physical-device WebView lifecycle regression, and the background refresh above. Independent Standards and Spec reviews have no remaining findings after correcting a premiere-history invalidation edge case and adding a regression test. Android remains a preview feature.

