### PR TITLE
fix(sync): prevent encrypted accounts from falling back to plaintext

### DIFF
--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -130,9 +130,21 @@ function withSyncLock(callback) {
   return callback()
 }
 
+function requiresEncryptedSync(settings) {
+  // A key may survive a privacy-mode downgrade made by an older app version.
+  return settings.syncServerPrivacyMode === 'enhanced' || Boolean(settings.syncServerPrivacyKey)
+}
+
+function assertEncryptionSupported(supported, required) {
+  if (required && !supported) {
+    throw new Error('This account requires encrypted sync, but the server no longer supports it')
+  }
+}
+
 async function runSync(context, { allowDataLoss = false } = {}) {
   const { commit, dispatch, rootGetters, rootState } = context
   const settings = rootState.settings
+  const encrypted = requiresEncryptedSync(settings)
   const networkClient = trackSyncClient(
     new SyncServerClient(settings.syncServerUrl, settings.syncServerToken)
   )
@@ -143,21 +155,21 @@ async function runSync(context, { allowDataLoss = false } = {}) {
   const result = {}
   const store = { state: rootState, getters: rootGetters, commit, dispatch }
   const stages = [
-    ...(settings.syncServerPrivacyMode === 'enhanced' ? ['download'] : []),
+    ...(encrypted ? ['download'] : []),
     ...(settings.syncServerSyncSubscriptions ? ['subscriptions'] : []),
     ...(settings.syncServerSyncPlaylists ? ['playlists'] : []),
     ...(settings.syncServerSyncPlaylists ? ['playlistBookmarks'] : []),
     ...(settings.syncServerSyncHistory ? ['history'] : []),
     ...(settings.syncServerSyncProfiles ? ['profiles'] : []),
     ...((process.env.IS_ELECTRON || process.env.IS_CAPACITOR) &&
-      settings.syncServerPrivacyMode === 'enhanced' &&
+      encrypted &&
       settings.syncServerSyncSessions
       ? ['sessionsV2']
       : []),
-    ...(settings.syncServerPrivacyMode === 'enhanced' && settings.syncServerSyncSettings
+    ...(encrypted && settings.syncServerSyncSettings
       ? ['settings']
       : []),
-    ...(settings.syncServerPrivacyMode === 'enhanced' ? ['upload'] : []),
+    ...(encrypted ? ['upload'] : []),
     'finishing',
   ]
   let completedStages = 0
@@ -269,7 +281,7 @@ async function runSync(context, { allowDataLoss = false } = {}) {
   }
 
   try {
-    if (settings.syncServerPrivacyMode === 'enhanced') {
+    if (encrypted) {
       if (!settings.syncServerPrivacyKey) {
         throw new Error('Reconnect and enter your privacy passphrase to enable enhanced privacy')
       }
@@ -623,6 +635,10 @@ const actions = {
       }
 
       const privacySupported = await client.supportsEncryptedSync()
+      const sameAccount = normalizedUrl === rootState.settings.syncServerUrl &&
+        trimmedUsername === rootState.settings.syncServerUsername
+      assertEncryptionSupported(privacySupported, Boolean(privacyPassphrase) ||
+        (sameAccount && requiresEncryptedSync(rootState.settings)))
       if (privacySupported && !privacyPassphrase) {
         throw new Error('A privacy passphrase is required by this server')
       }
@@ -816,6 +832,7 @@ const actions = {
       } finally {
         releaseSyncClient(client)
       }
+      assertEncryptionSupported(privacySupported, requiresEncryptedSync(rootState.settings))
       const privacyMode = privacySupported ? 'enhanced' : 'legacy'
       await dispatch('updateSyncServerPrivacyMode', privacyMode, { root: true })
       if (privacySupported && !rootState.settings.syncServerPrivacyKey) {

--- a/tests/unit/sync-server-downgrade.test.mjs
+++ b/tests/unit/sync-server-downgrade.test.mjs
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import vm from 'node:vm'
+
+import * as errors from '../../src/renderer/helpers/sync-server-errors.js'
+import * as privacy from '../../src/renderer/helpers/sync-server-privacy.js'
+import { isRecentSync } from '../../src/renderer/helpers/sync-server-scheduling.js'
+import { createSyncServerRequestHeaders } from '../../src/renderer/helpers/sync-server-request.js'
+
+// These modules use webpack imports. Keep their actual request, merge, and store
+// code while replacing platform dependencies and the network with local fixtures.
+function withoutImports(source) {
+  return source.replace(/^import[\s\S]*? from ['"][^'"]+['"]\n/gm, '')
+    .replace(/^export \{[\s\S]*?\}\n/gm, '')
+    .replace(/^export (?=(async )?(function|class|const))/gm, '')
+}
+
+const helperSource = await readFile(new URL('../../src/renderer/helpers/sync-server.js', import.meta.url), 'utf8')
+const storeSource = await readFile(new URL('../../src/renderer/store/modules/sync-server.js', import.meta.url), 'utf8')
+
+function fixture(overrides = {}, { encrypted = false } = {}) {
+  const requests = []
+  const commits = []
+  const settings = {
+    syncServerEnabled: true,
+    syncServerUrl: 'https://sync.example',
+    syncServerUsername: 'alice',
+    syncServerToken: 'saved-token',
+    syncServerPrivacyMode: 'enhanced',
+    syncServerPrivacyKey: Buffer.alloc(32, 1).toString('base64'),
+    syncServerPrivacySalt: Buffer.alloc(16, 2).toString('base64'),
+    syncServerSnapshot: '{}',
+    syncServerAutoSync: true,
+    syncServerSyncSubscriptions: true,
+    ...overrides,
+  }
+  const common = {
+    ...errors,
+    ...privacy,
+    isRecentSync,
+    crypto, URL, Headers, Response, AbortController, setTimeout, clearTimeout,
+    structuredClone, TextEncoder, TextDecoder,
+    process: { env: {} },
+    packageDetails: { version: 'test' },
+    MAIN_PROFILE_ID: 'main',
+    deepCopy: structuredClone,
+    createSyncServerRequestHeaders,
+    fetch: async (url, options) => {
+      requests.push({ url, method: options.method ?? 'GET', body: options.body })
+      let result = null
+      if (url.endsWith('/health')) result = encrypted ? { capabilities: { encrypted_sync: 1 } } : 'OK'
+      else if (url.endsWith('/account/login')) result = { jwt: 'new-token' }
+      else if (url.endsWith('/encrypted_sync')) result = { collections: [], legacy_data: false }
+      else if (url.includes('/encrypted_sync/')) result = { revision: 0, payload: null }
+      else if (url.endsWith('/subscriptions/') && !options.method) result = []
+      return new Response(JSON.stringify(result))
+    },
+  }
+  const helper = vm.createContext({ ...common })
+  vm.runInContext(withoutImports(helperSource) + '\nglobalThis.exports = { SyncServerClient, syncSubscriptions, normalizeSyncServerUrl };', helper)
+  const store = vm.createContext({ ...common, ...helper.exports, getSavedOtherDeviceSessions: () => [] })
+  vm.runInContext(withoutImports(storeSource).replace('export default { state, getters, actions, mutations }', 'globalThis.exports = { state, actions, mutations }'), store)
+  const context = {
+    rootState: {
+      settings,
+      profiles: { profileList: [{ _id: 'main', subscriptions: [{ id: 'private-channel', name: 'Private subscription' }] }] },
+    },
+    rootGetters: {},
+    state: store.exports.state,
+    commit: (action, value) => {
+      commits.push([action, value])
+      store.exports.mutations[action]?.(store.exports.state, value)
+    },
+    dispatch: async (action, value) => {
+      if (action.startsWith('updateSyncServer')) {
+        const key = action.slice(6)
+        settings[key[0].toLowerCase() + key.slice(1)] = value
+      }
+      if (action === 'replaceSyncServerToken') settings.syncServerToken = value
+      if (action === 'syncWithSyncServer') return store.exports.actions.syncWithSyncServer(context, value)
+    },
+  }
+  return { settings, requests, commits, context, actions: store.exports.actions }
+}
+
+for (const overrides of [
+  {},
+  { syncServerPrivacyKey: '' },
+  { syncServerPrivacyMode: 'legacy' },
+]) {
+  test(`startup refuses a capability downgrade with ${JSON.stringify(overrides)}`, async () => {
+    const f = fixture(overrides)
+    const saved = { ...f.settings }
+    await f.actions.initializeSyncServer(f.context)
+    assert.deepEqual(f.settings, saved)
+    assert.equal(f.requests.length, 1)
+    assert.ok(f.context.state.syncServerError.includes('encrypted sync'))
+  })
+}
+
+test('legacy clients still upload subscriptions to legacy servers', async () => {
+  const f = fixture({ syncServerPrivacyMode: 'legacy', syncServerPrivacyKey: '' })
+  await f.actions.initializeSyncServer(f.context)
+  assert.equal(f.settings.syncServerPrivacyMode, 'legacy')
+  assert.ok(f.requests.some(request => request.method === 'PUT' && request.url.endsWith('/subscriptions/') && request.body.includes('Private subscription')))
+})
+
+test('encrypted accounts still sync when the server supports encryption', async () => {
+  const f = fixture({}, { encrypted: true })
+  await f.actions.initializeSyncServer(f.context)
+  assert.equal(f.settings.syncServerPrivacyMode, 'enhanced')
+  const uploads = f.requests.filter(request => request.method === 'PUT')
+  assert.equal(uploads.length, 1)
+  assert.ok(uploads[0].url.endsWith('/encrypted_sync/subscriptions'))
+  const document = await privacy.decryptSyncDocument(
+    JSON.parse(uploads[0].body).payload,
+    f.settings.syncServerPrivacyKey
+  )
+  assert.equal(document[0].name, 'Private subscription')
+})
+
+test('manual sync uses encryption when a saved key survives an earlier downgrade', async () => {
+  const f = fixture({ syncServerPrivacyMode: 'legacy' }, { encrypted: true })
+  await f.actions.syncWithSyncServer(f.context)
+  const uploads = f.requests.filter(request => request.method === 'PUT')
+  assert.equal(uploads.length, 1)
+  assert.ok(uploads[0].url.endsWith('/encrypted_sync/subscriptions'))
+  assert.ok(!uploads[0].body.includes('Private subscription'))
+})
+
+const credentials = {
+  mode: 'login', serverUrl: 'https://sync.example', username: 'alice', password: 'account-password',
+  deviceId: 'device', deviceName: 'Laptop', deviceSystemInfo: { platform: 'linux' },
+}
+
+test('reauthentication cannot downgrade the same encrypted account', async () => {
+  const f = fixture()
+  const saved = { ...f.settings }
+  await assert.rejects(f.actions.authenticateSyncServer(f.context, credentials), /encrypted sync/)
+  assert.deepEqual(f.settings, saved)
+  assert.ok(!f.requests.some(request => request.url.endsWith('/account/login')))
+})
+
+test('a supplied privacy passphrase cannot silently select plaintext login', async () => {
+  const f = fixture({ syncServerPrivacyMode: 'unknown', syncServerPrivacyKey: '' })
+  await assert.rejects(f.actions.authenticateSyncServer(f.context, {
+    ...credentials, privacyPassphrase: 'privacy-passphrase',
+  }), /encrypted sync/)
+  assert.ok(!f.requests.some(request => request.url.endsWith('/account/login')))
+})
+
+test('connecting a different legacy account does not inherit the previous account encryption requirement', async () => {
+  const f = fixture()
+  await f.actions.authenticateSyncServer(f.context, { ...credentials, username: 'bob' })
+  assert.equal(f.settings.syncServerPrivacyMode, 'legacy')
+  assert.equal(f.settings.syncServerPrivacyKey, '')
+  assert.equal(f.settings.syncServerUsername, 'bob')
+  assert.ok(f.requests.some(request => request.url.endsWith('/account/login')))
+})


### PR DESCRIPTION
An encrypted sync account could switch to plaintext when the server stopped advertising encryption. Keep its encryption requirement during startup, manual sync, and sign-in, while retaining support for accounts on legacy servers.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

Companion server fixes: https://github.com/OpenTubeX/sync-server/pull/8. Detailed report issues will be created after merge and deployment.
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description

Refuse a capability downgrade for the saved encrypted account before replacing credentials or starting sync. A retained privacy key also forces encrypted transfers if an older app already changed the saved mode. Supplying a privacy passphrase cannot silently select plaintext login. Connecting a different legacy account remains supported.

No server API, encryption format, or stored-data migration changes are needed.
<!-- Please write a clear and concise description of what the pull request does. -->

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Keep encrypted sync accounts from silently falling back to plaintext when a server stops advertising encryption.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing

1. Run this branch in dev mode and connect to a legacy sync server. Confirm that subscriptions still synchronize.
2. Connect to an encrypted sync server and confirm that normal sync works after restarting the app.
3. Using a controlled test server or proxy, make only `/health` return `OK`. Restart the app. Expect an encryption-support error, preserved credentials and privacy mode, and no plaintext synchronization.
4. Try signing in to that same account while it reports legacy capabilities. Expect the same refusal. Restore its encryption capability and confirm that syncing works again.
5. Connect to a different legacy account without a privacy passphrase and confirm that legacy sync remains available.
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

## Additional context

Regression coverage executes the actual store, request, and merge functions with a mocked transport. It covers rejected downgrades, normal encrypted transfers, and continued legacy support. The full unit suite and targeted source lint pass. Older installed apps need an update to gain the client-side protection.
<!-- Add any other context about the pull request here. -->
