### PR TITLE
fix(subscriptions): restore desktop mark-all-seen position

### DIFF
--- a/e2e/tests/offline/subscriptions-header-layout.spec.mjs
+++ b/e2e/tests/offline/subscriptions-header-layout.spec.mjs
@@ -83,6 +83,37 @@ function headerBoxes (page) {
 }
 
 test.describe('subscriptions header layout', () => {
+  test('keeps keyboard focus in visual order when the header changes layout', async ({ app, page }) => {
+    await goTo(page, 'subscriptions')
+    await page.locator('[data-subscription-feed-tab="all"]').click()
+    await expect(page.locator('.headerSortSelect')).toBeVisible()
+
+    const markAllSeen = page.locator('.markAllSeenButton')
+    for (const width of [375, 1600, 640, 1600]) {
+      await markAllSeen.focus()
+      await setWindowWidth(app, page, width)
+      const compact = width <= 680
+      await expect(markAllSeen.locator('xpath=..')).toHaveClass(compact ? /headerActions/ : /tabsRow/)
+      await expect(markAllSeen).toBeFocused()
+      const controls = [
+        '.headerViewToggle .iconButton',
+        '.headerSortSelect .select-text'
+      ]
+      if (compact) {
+        controls.push('.markAllSeenButton')
+      } else {
+        controls.unshift('.markAllSeenButton')
+      }
+      controls.push('.refreshButton .iconButton')
+
+      await page.locator('[data-subscription-feed-tab="all"]').focus()
+      for (const selector of controls) {
+        await page.keyboard.press('Tab')
+        await expect(page.locator(selector)).toBeFocused()
+      }
+    }
+  })
+
   for (const uiScale of [100, 95]) {
     test(`keeps Mark all as seen beside the desktop feed tabs at ${uiScale}% scale`, async ({ app, page, attachScreenshot }) => {
       await app.electronApp.evaluate(({ BrowserWindow }, scale) => {

--- a/e2e/tests/offline/subscriptions-header-layout.spec.mjs
+++ b/e2e/tests/offline/subscriptions-header-layout.spec.mjs
@@ -83,6 +83,45 @@ function headerBoxes (page) {
 }
 
 test.describe('subscriptions header layout', () => {
+  for (const uiScale of [100, 95]) {
+    test(`keeps Mark all as seen beside the desktop feed tabs at ${uiScale}% scale`, async ({ app, page, attachScreenshot }) => {
+      await app.electronApp.evaluate(({ BrowserWindow }, scale) => {
+        BrowserWindow.getAllWindows()[0].webContents.setZoomFactor(scale / 100)
+      }, uiScale)
+      await goTo(page, 'subscriptions')
+
+      for (const tab of ['videos', 'all', 'tabbed', 'videos']) {
+        if (tab === 'tabbed') {
+          await page.getByRole('button', { name: 'Show tabbed view' }).click()
+        } else {
+          await page.locator(`[data-subscription-feed-tab="${tab}"]`).click()
+        }
+        await expect(page.locator('.subscriptionsHeader')).toHaveClass(/singleRow/)
+        await expect(page.locator('.markAllSeenButton')).toBeVisible()
+
+        await expect.poll(() => page.evaluate(() => {
+          const tabs = document.querySelector('.tabs').getBoundingClientRect()
+          const mark = document.querySelector('.markAllSeenButton').getBoundingClientRect()
+          return mark.left - tabs.right
+        })).toBeLessThanOrEqual(9)
+        const layout = await page.evaluate(() => {
+          const tabs = document.querySelector('.tabs').getBoundingClientRect()
+          const mark = document.querySelector('.markAllSeenButton').getBoundingClientRect()
+          const nextControl = document.querySelector('.headerViewToggle, .headerRefreshWidget').getBoundingClientRect()
+          return {
+            gap: mark.left - tabs.right,
+            centerOffset: Math.abs((mark.top + mark.bottom - tabs.top - tabs.bottom) / 2),
+            controlsGap: nextControl.left - mark.right
+          }
+        })
+        expect(layout.gap).toBeGreaterThanOrEqual(0)
+        expect(layout.centerOffset).toBeLessThanOrEqual(2)
+        expect(layout.controlsGap).toBeGreaterThanOrEqual(0)
+        await attachScreenshot(`desktop ${tab} feed action at ${uiScale}%`)
+      }
+    })
+  }
+
   test('shows the New feed action and regular feed refresh status on mobile', async ({ app, page, attachScreenshot }) => {
     await goTo(page, 'subscriptions')
     await page.locator('[data-subscription-feed-tab="all"]').click()

--- a/src/renderer/views/Subscriptions/Subscriptions.css
+++ b/src/renderer/views/Subscriptions/Subscriptions.css
@@ -46,7 +46,7 @@
   display: flex;
   flex: 1 1 auto;
   flex-wrap: wrap;
-  gap: 12px 8px;
+  gap: 12px 20px;
   min-inline-size: 0;
 }
 
@@ -228,16 +228,7 @@
 }
 
 .subscriptionsHeader.singleRow .headerActions {
-  flex: 1 0 auto;
-  justify-content: flex-end;
-}
-
-.subscriptionsHeader.singleRow .markAllSeenButton {
-  margin-inline-end: auto;
-}
-
-.subscriptionsHeader.singleRow .headerSortSelect {
-  flex: 0 0 220px;
+  margin-inline-start: auto;
 }
 
 .selectedTab {

--- a/src/renderer/views/Subscriptions/Subscriptions.css
+++ b/src/renderer/views/Subscriptions/Subscriptions.css
@@ -46,7 +46,7 @@
   display: flex;
   flex: 1 1 auto;
   flex-wrap: wrap;
-  gap: 12px 20px;
+  gap: 12px 8px;
   min-inline-size: 0;
 }
 
@@ -228,7 +228,16 @@
 }
 
 .subscriptionsHeader.singleRow .headerActions {
-  margin-inline-start: auto;
+  flex: 1 0 auto;
+  justify-content: flex-end;
+}
+
+.subscriptionsHeader.singleRow .markAllSeenButton {
+  margin-inline-end: auto;
+}
+
+.subscriptionsHeader.singleRow .headerSortSelect {
+  flex: 0 0 220px;
 }
 
 .selectedTab {

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -185,6 +185,18 @@
               v-if="currentTabPanel !== null"
               class="headerActions"
             >
+              <button
+                v-if="currentTabHasNewContent"
+                class="markAllSeenButton"
+                type="button"
+                :disabled="markingSeenTab !== null || currentTabRefreshing"
+                @click="markAllAsSeen(currentTab)"
+              >
+                <FtIcon :icon="['fas', 'check']" />
+                <span class="markAllSeenLabel">
+                  {{ $t('Subscriptions.Mark All as Seen') }}
+                </span>
+              </button>
               <FtIconButton
                 v-if="currentTab === 'new'"
                 class="headerViewToggle"
@@ -209,18 +221,6 @@
                 :icon="newFeedSortByIcon"
                 @change="updateNewFeedSortBy"
               />
-              <button
-                v-if="currentTabHasNewContent"
-                class="markAllSeenButton"
-                type="button"
-                :disabled="markingSeenTab !== null || currentTabRefreshing"
-                @click="markAllAsSeen(currentTab)"
-              >
-                <FtIcon :icon="['fas', 'check']" />
-                <span class="markAllSeenLabel">
-                  {{ $t('Subscriptions.Mark All as Seen') }}
-                </span>
-              </button>
               <FtRefreshWidget
                 embedded
                 class="headerRefreshWidget subscriptionsHeaderRefreshWidget"
@@ -1186,7 +1186,8 @@ function updateHeaderFitsOneRow() {
     return child === tabs ? singleLineWidth(tabs) : child.getBoundingClientRect().width
   })
   const feedTabsControlsRowWidth = singleLineWidth(feedTabsControlsRow, child => {
-    return child === tabsRow ? tabsRowWidth : child.getBoundingClientRect().width
+    // The actions stretch to keep Mark all as seen beside the tabs on desktop.
+    return child === tabsRow ? tabsRowWidth : singleLineWidth(child)
   })
   const requiredWidth = singleLineWidth(row, child => {
     // The grouped row stretches across the header in the split layout
@@ -1219,6 +1220,10 @@ function observeHeaderRow() {
   }
 
   for (const child of feedTabsControlsRowRef.value?.children ?? []) {
+    headerResizeObserver.observe(child)
+  }
+
+  for (const child of row.querySelectorAll('.headerActions > *')) {
     headerResizeObserver.observe(child)
   }
 

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -185,18 +185,6 @@
               v-if="currentTabPanel !== null"
               class="headerActions"
             >
-              <button
-                v-if="currentTabHasNewContent"
-                class="markAllSeenButton"
-                type="button"
-                :disabled="markingSeenTab !== null || currentTabRefreshing"
-                @click="markAllAsSeen(currentTab)"
-              >
-                <FtIcon :icon="['fas', 'check']" />
-                <span class="markAllSeenLabel">
-                  {{ $t('Subscriptions.Mark All as Seen') }}
-                </span>
-              </button>
               <FtIconButton
                 v-if="currentTab === 'new'"
                 class="headerViewToggle"
@@ -221,6 +209,23 @@
                 :icon="newFeedSortByIcon"
                 @change="updateNewFeedSortBy"
               />
+              <Teleport
+                v-if="currentTabHasNewContent"
+                :to="tabsRowRef"
+                :disabled="!headerFitsOneRow"
+              >
+                <button
+                  class="markAllSeenButton"
+                  type="button"
+                  :disabled="markingSeenTab !== null || currentTabRefreshing"
+                  @click="markAllAsSeen(currentTab)"
+                >
+                  <FtIcon :icon="['fas', 'check']" />
+                  <span class="markAllSeenLabel">
+                    {{ $t('Subscriptions.Mark All as Seen') }}
+                  </span>
+                </button>
+              </Teleport>
               <FtRefreshWidget
                 embedded
                 class="headerRefreshWidget subscriptionsHeaderRefreshWidget"
@@ -1186,8 +1191,7 @@ function updateHeaderFitsOneRow() {
     return child === tabs ? singleLineWidth(tabs) : child.getBoundingClientRect().width
   })
   const feedTabsControlsRowWidth = singleLineWidth(feedTabsControlsRow, child => {
-    // The actions stretch to keep Mark all as seen beside the tabs on desktop.
-    return child === tabsRow ? tabsRowWidth : singleLineWidth(child)
+    return child === tabsRow ? tabsRowWidth : child.getBoundingClientRect().width
   })
   const requiredWidth = singleLineWidth(row, child => {
     // The grouped row stretches across the header in the split layout
@@ -1223,10 +1227,6 @@ function observeHeaderRow() {
     headerResizeObserver.observe(child)
   }
 
-  for (const child of row.querySelectorAll('.headerActions > *')) {
-    headerResizeObserver.observe(child)
-  }
-
   for (const child of tabsRowRef.value?.children ?? []) {
     headerResizeObserver.observe(child)
   }
@@ -1238,10 +1238,17 @@ function observeHeaderRow() {
 
 // Which elements exist changes with the panel (the refresh widget is only
 // rendered once it is mounted) and with the Mark all as seen button
-watch([currentTabPanel, currentTabHasNewContent], () => nextTick(() => {
-  observeHeaderRow()
-  updateHeaderFitsOneRow()
-}))
+watch([currentTabPanel, currentTabHasNewContent, headerFitsOneRow], () => {
+  const restoreFocus = headerRowRef.value?.querySelector('.markAllSeenButton') === document.activeElement
+  nextTick(() => {
+    observeHeaderRow()
+    updateHeaderFitsOneRow()
+    // Moving the button between rows must preserve keyboard focus.
+    if (restoreFocus) {
+      headerRowRef.value?.querySelector('.markAllSeenButton')?.focus({ preventScroll: true })
+    }
+  })
+})
 
 // ===== Sliding feed tab indicator =====
 const tabsContainerRef = useTemplateRef('tabsContainerRef')


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Regression from #1121; reported in the Codex task.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The mobile header fix moved “Mark all as seen” away from the feed tabs on desktop, with different positions in New and regular feeds. Restore its previous spacing beside the desktop tabs while keeping the current compact mobile layout, labeled action, and refresh timing.

Move the action beside the tabs only when the header fits on one row. Keep keyboard navigation in the same order as the visible controls and preserve focus when resizing.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Restore “Mark all as seen” beside the desktop subscription tabs while preserving the mobile layout.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/c5453723-1e84-4d6f-a293-843f6d3ed6b9">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/239edf33-07a0-4a71-81d5-ba1c2f20fa4e">
  <img alt="Mark all as seen restored beside the desktop subscription tabs" src="https://github.com/user-attachments/assets/c5453723-1e84-4d6f-a293-843f6d3ed6b9">
</picture>

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Subscriptions with new content in a wide desktop window. Switch between Videos and both New feed views. “Mark all as seen” should stay directly after the main feed tabs, with sorting and refresh controls on the right.
2. Resize to phone portrait and landscape widths. The labeled action should remain with the compact controls, and regular feeds should retain their refresh timing without horizontal overflow.
3. Grow the window again and repeat at 95% UI scale. The desktop position should return without the header switching repeatedly between layouts.
4. Use Tab to move through the header controls at desktop and mobile widths. Focus should follow their visual order. Resize while “Mark all as seen” is focused and confirm it keeps focus.
5. Mark the content as seen. The action should disappear and the remaining controls should stay aligned.

## Additional context
<!-- Add any other context about the pull request here. -->

The regression was introduced after the latest release, so this is marked Not noteworthy.

