### PR TITLE
feat(themes): add homepage-inspired OpenTubeX light and dark themes

### DIFF
--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -1351,3 +1351,86 @@ test.describe('narrow layout top padding', () => {
     await attachScreenshot('narrow layout')
   })
 })
+
+// Sample the empty padding beside the settings content, away from text and controls.
+async function settingsBackgroundVariation(page) {
+  const screenshot = await page.locator('.settingsContent').screenshot({ animations: 'disabled' })
+  return page.evaluate(async base64 => {
+    const bytes = Uint8Array.from(atob(base64), character => character.charCodeAt(0))
+    const bitmap = await createImageBitmap(new Blob([bytes], { type: 'image/png' }))
+    const canvas = new OffscreenCanvas(bitmap.width, bitmap.height)
+    const context = canvas.getContext('2d')
+    context.drawImage(bitmap, 0, 0)
+    const samples = [0.1, 0.3, 0.5, 0.7, 0.9].map(fraction =>
+      [...context.getImageData(4, Math.floor(bitmap.height * fraction), 1, 1).data].slice(0, 3))
+    bitmap.close()
+    return Math.max(...[0, 1, 2].map(channel =>
+      Math.max(...samples.map(color => color[channel])) - Math.min(...samples.map(color => color[channel]))))
+  }, screenshot.toString('base64'))
+}
+
+test.describe('OpenTubeX homepage themes', () => {
+  test('selects, persists, and follows the system with the homepage palettes', async ({ app, page, attachScreenshot }) => {
+    await goToSettingsSection(page, 'theme')
+    for (const [mode, background, accent] of [
+      ['Light', 'rgb(232, 242, 240)', 'rgb(17, 104, 95)'],
+      ['Dark', 'rgb(11, 20, 22)', 'rgb(46, 196, 182)'],
+    ]) {
+      await page.getByRole('combobox', { name: /^Base theme/i }).click()
+      await page.getByRole('option', { name: `OpenTubeX ${mode}`, exact: true }).click()
+      await expect(page.locator('body')).toHaveCSS('background-color', background)
+      await expect(page.getByRole('combobox', { name: /Main colou?r theme/i })).toBeDisabled()
+      await expect(page.getByRole('combobox', { name: /Secondary colou?r theme/i })).toBeDisabled()
+      // Read resolved colors so accidental inheritance from Red/Blue is detected.
+      expect(await page.locator('body').evaluate(body => {
+        const probe = document.createElement('span')
+        probe.style.color = 'var(--accent-color)'
+        body.append(probe)
+        const color = getComputedStyle(probe).color
+        probe.remove()
+        return color
+      })).toBe(accent)
+      for (const selector of ['.app', '.ft-card', '.settingsWindow']) {
+        await expect(page.locator(selector).first()).not.toHaveCSS('background-image', 'none')
+      }
+      await expect(page.locator('.sectionBody').first()).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+      for (const scale of [100, 125]) {
+        await page.evaluate(scale => document.querySelector('#app').__vue_app__.config.globalProperties.$store
+          .dispatch('updateUiScale', scale), scale)
+        await expect.poll(() => app.electronApp.evaluate(({ BrowserWindow }) =>
+          BrowserWindow.getAllWindows()[0].webContents.getZoomFactor())).toBe(scale / 100)
+        const variation = await settingsBackgroundVariation(page)
+        expect(variation).toBeGreaterThanOrEqual(4)
+        await page.locator('.settingsContent').evaluate(element => { element.scrollTop = element.scrollHeight })
+        expect(await settingsBackgroundVariation(page)).toBe(variation)
+        await page.locator('.settingsContent').evaluate(element => { element.scrollTop = 0 })
+      }
+      await page.evaluate(() => document.querySelector('#app').__vue_app__.config.globalProperties.$store
+        .dispatch('updateUiScale', 100))
+      await attachScreenshot(`OpenTubeX ${mode} settings`)
+    }
+
+    ;({ page } = await app.relaunch())
+    await expect(page.locator('body')).toHaveClass(/openTubeXDark/)
+    expect(await app.electronApp.evaluate(({ nativeTheme }) => nativeTheme.shouldUseDarkColors)).toBe(true)
+    await goToSettingsSection(page, 'theme')
+    await page.getByRole('combobox', { name: /^Base theme/i }).click()
+    await page.getByRole('option', { name: /^System default$/i }).click()
+    for (const [mode, other] of [['Light', 'Dark'], ['Dark', 'Light']]) {
+      await page.getByRole('combobox', { name: `${mode} theme`, exact: true }).click()
+      await expect(page.getByRole('option', { name: `OpenTubeX ${other}`, exact: true })).toHaveCount(0)
+      await page.getByRole('option', { name: `OpenTubeX ${mode}`, exact: true }).click()
+      await page.emulateMedia({ colorScheme: mode.toLowerCase() })
+      await expect(page.locator('body')).toHaveClass(new RegExp(`openTubeX${mode}`))
+    }
+
+    // Leaving a fixed palette restores the user's normal color controls.
+    await page.getByRole('combobox', { name: /^Base theme/i }).click()
+    await page.getByRole('option', { name: 'Light', exact: true }).click()
+    await expect(page.getByRole('combobox', { name: /Main colou?r theme/i })).toBeEnabled()
+    await expect(page.locator('body')).toHaveCSS('--primary-color', '#f44336')
+    await expect(page.locator('.app')).toHaveCSS('background-image', 'none')
+    await expect(page.locator('.settingsWindow')).toHaveCSS('background-image', 'none')
+    expect(await settingsBackgroundVariation(page)).toBe(0)
+  })
+})

--- a/e2e/tests/offline/theme-contrast.spec.mjs
+++ b/e2e/tests/offline/theme-contrast.spec.mjs
@@ -1,0 +1,129 @@
+import { test, expect, goToSettingsSection } from '../../helpers/app.mjs'
+
+function contrastRatio(first, second) {
+  const luminance = rgb => rgb.map(value => value / 255)
+    .map(value => value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4)
+    .reduce((total, value, index) => total + value * [0.2126, 0.7152, 0.0722][index], 0)
+  const values = [luminance(first), luminance(second)].sort((a, b) => b - a)
+  return (values[0] + 0.05) / (values[1] + 0.05)
+}
+
+async function sampleColors(app, region, points) {
+  const { page } = app
+  await region.scrollIntoViewIfNeeded()
+  await page.evaluate(async () => {
+    document.getAnimations().forEach(animation => {
+      if (animation.effect.getComputedTiming().iterations !== Infinity) animation.finish()
+    })
+    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+  })
+  const origin = await region.evaluate(element => { const { x, y } = element.getBoundingClientRect(); return { x, y } })
+  const viewport = await page.evaluate(() => ({ width: innerWidth, height: innerHeight }))
+  // Capture Electron's actual zoomed framebuffer; Playwright's screenshot
+  // viewport emulation changes the pixel mapping at non-default UI scales.
+  const base64 = await app.electronApp.evaluate(async ({ BrowserWindow }) =>
+    (await BrowserWindow.getAllWindows()[0].webContents.capturePage()).toPNG().toString('base64'))
+  return page.evaluate(async ({ base64, points, origin, viewport }) => {
+    const bitmap = await createImageBitmap(new Blob([
+      Uint8Array.from(atob(base64), character => character.charCodeAt(0))
+    ], { type: 'image/png' }))
+    const canvas = new OffscreenCanvas(bitmap.width, bitmap.height)
+    const context = canvas.getContext('2d')
+    context.drawImage(bitmap, 0, 0)
+    const colors = points.map(([x, y]) =>
+      [...context.getImageData(Math.floor((x + origin.x) * bitmap.width / viewport.width), Math.floor((y + origin.y) * bitmap.height / viewport.height), 1, 1).data].slice(0, 3))
+    bitmap.close()
+    return colors
+  }, { base64, points, origin, viewport })
+}
+
+async function switchContrast(app, label, checked) {
+  const height = await label.evaluate(element => element.getBoundingClientRect().height)
+  // Sample the exposed half of the track, its adjacent background and the
+  // thumb's center. Avoid rounded edges and the thumb's shadow.
+  const trackX = checked ? 12 : 34
+  const [track, surface, thumb] = await sampleColors(app, label, [
+    [trackX, height / 2], [trackX, height / 2 - 15], [checked ? 30 : 15, height / 2]
+  ])
+  return { track, surface, thumb, trackRatio: contrastRatio(track, surface), thumbRatio: contrastRatio(thumb, track), thumbSurfaceRatio: contrastRatio(thumb, surface) }
+}
+
+async function controlContrast(app, control, kind) {
+  const { page } = app
+  await control.scrollIntoViewIfNeeded()
+  const points = await control.evaluate((element, kind) => {
+    const rect = element.getBoundingClientRect()
+    const container = element.closest('.settingsWindow').getBoundingClientRect()
+    const x = rect.left - container.left
+    const y = rect.top - container.top + rect.height / 2
+    // Locate the strongest edge pixel near the CSS boundary. Fractional zoom
+    // can spread a one-pixel stroke across neighboring screenshot pixels.
+    return kind === 'slider'
+      ? [[x + rect.width * 0.85, y - 8], ...[-1, 0, 1].map(offset => [x + rect.width * 0.85, y + offset])]
+      : [[x - 4, y], ...[-0.5, 0.5, 1.5].map(offset => [x + offset, y])]
+  }, kind)
+  const [surface, ...edge] = await sampleColors(app, page.locator('.settingsWindow'), points)
+  return { surface, edge, ratio: Math.max(...edge.map(color => contrastRatio(color, surface))) }
+}
+
+for (const theme of ['openTubeXLight', 'openTubeXDark']) {
+  for (const scale of [100, 125]) {
+    test.describe(`${theme} control contrast at ${scale}%`, () => {
+      test.use({ seed: { settings: { baseTheme: theme, currentLocale: 'en-US', uiScale: scale } } })
+
+      test('toggle track and thumb remain distinct in both states', async ({ app, page, attachScreenshot }) => {
+        await goToSettingsSection(page, 'general')
+        const toggle = page.getByRole('checkbox', { name: 'Keep relative timestamps updated' })
+        for (const checked of [true, false]) {
+          if (await toggle.isChecked() !== checked) await toggle.locator('..').locator('.switch-label').click()
+          await expect(toggle).toBeChecked({ checked })
+          const contrast = await switchContrast(app, toggle.locator('..').locator('.switch-label'), checked)
+          // The thumb identifies the control with 3:1 contrast. The light track
+          // uses a softer fill, but must not disappear into the page gradient.
+          expect.soft(contrast.trackRatio, `track ${JSON.stringify(contrast)}`).toBeGreaterThanOrEqual(theme === 'openTubeXLight' ? 1.5 : 3)
+          expect.soft(contrast.thumbSurfaceRatio, `thumb against background ${JSON.stringify(contrast)}`).toBeGreaterThanOrEqual(3)
+          expect.soft(contrast.thumbRatio, `thumb ${JSON.stringify(contrast)}`).toBeGreaterThanOrEqual(3)
+          await attachScreenshot(`${theme} toggle ${checked ? 'on' : 'off'} at ${scale}%`)
+        }
+        // Keyboard focus and toggling still work with the new control colors.
+        await toggle.focus()
+        await page.keyboard.press('Space')
+        await expect(toggle).toBeChecked()
+        await expect(toggle.locator('..').locator('.switch-label')).toHaveCSS('outline-style', 'solid')
+        await attachScreenshot(`${theme} toggle contrast at ${scale}%`)
+      })
+
+      test('active settings-header icons remain visible', async ({ page }) => {
+        await goToSettingsSection(page, 'general')
+        for (const name of ['Highlight settings changed from defaults', 'Show performance impact indicators']) {
+          const button = page.getByRole('button', { name, exact: true })
+          if (await button.getAttribute('aria-pressed') !== 'true') await button.click()
+          await expect(button).toHaveAttribute('aria-pressed', 'true')
+          const colors = await button.evaluate(element => {
+            const style = getComputedStyle(element)
+            const rgb = color => color.match(/[\d.]+/g).slice(0, 3).map(Number)
+            return { foreground: rgb(style.color), background: rgb(style.backgroundColor) }
+          })
+          expect.soft(contrastRatio(colors.foreground, colors.background), name).toBeGreaterThanOrEqual(3)
+          await button.click()
+          await expect(button).toHaveAttribute('aria-pressed', 'false')
+        }
+      })
+
+      test('slider tracks and field boundaries remain visible', async ({ app, page, attachScreenshot }) => {
+        await goToSettingsSection(page, 'theme')
+        const slider = await controlContrast(app, page.getByRole('slider', { name: /UI Roundness/ }), 'slider')
+        expect.soft(slider.ratio, `slider ${JSON.stringify(slider)}`).toBeGreaterThanOrEqual(3)
+        const select = await controlContrast(app, page.getByRole('combobox', { name: /^Base theme/i }), 'field')
+        expect.soft(select.ratio, `dropdown ${JSON.stringify(select)}`).toBeGreaterThanOrEqual(3)
+        const icon = page.locator('.changedSettingIndicator').first()
+        const iconColor = await icon.evaluate(element => getComputedStyle(element).color.match(/[\d.]+/g).slice(0, 3).map(Number))
+        expect.soft(contrastRatio(iconColor, select.surface), `reset icon ${JSON.stringify({ iconColor, surface: select.surface })}`).toBeGreaterThanOrEqual(3)
+        const search = await controlContrast(app, page.locator('.settingsSearch'), 'field')
+        expect.soft(search.ratio, `search ${JSON.stringify(search)}`).toBeGreaterThanOrEqual(3)
+        await expect(page.getByRole('combobox', { name: /Main color theme/i })).toBeDisabled()
+        await attachScreenshot(`${theme} fields and sliders at ${scale}%`)
+      })
+    })
+  }
+}

--- a/src/appearanceSettings.js
+++ b/src/appearanceSettings.js
@@ -1,6 +1,11 @@
 import { DARK_BASE_THEMES, LIGHT_BASE_THEMES } from './constants.js'
+import { isCustomThemeValue } from './customTheme.js'
 
 const BUILTIN_BASE_THEMES = new Set(['system', ...LIGHT_BASE_THEMES, ...DARK_BASE_THEMES])
+
+function hasFixedThemeColors(theme) {
+  return ['hotPink', 'openTubeXLight', 'openTubeXDark'].includes(theme) || isCustomThemeValue(theme)
+}
 
 function getThemeClassification(value, customThemes = []) {
   if (LIGHT_BASE_THEMES.includes(value)) return 'light'
@@ -34,6 +39,7 @@ function resolveSystemThemeSettings(settings, customThemes = []) {
 }
 
 export {
+  hasFixedThemeColors,
   getThemeClassification,
   resolveBaseTheme,
   resolveSystemTheme,

--- a/src/constants.js
+++ b/src/constants.js
@@ -714,6 +714,7 @@ const DEFAULT_QUICK_PLAYBACK_SPEED_BAR_OPTIONS = Object.freeze([
 
 const LIGHT_BASE_THEMES = [
   'light',
+  'openTubeXLight',
   'pastelPink',
   'catppuccinLatte',
   'everforestLightHard',
@@ -725,6 +726,7 @@ const LIGHT_BASE_THEMES = [
 
 const DARK_BASE_THEMES = [
   'dark',
+  'openTubeXDark',
   'black',
   'nordic',
   'hotPink',

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -2640,6 +2640,10 @@ function runApp() {
           return '#0f0f0f'
         case 'light':
           return '#f1f1f1'
+        case 'openTubeXLight':
+          return '#e8f2f0'
+        case 'openTubeXDark':
+          return '#0b1416'
         case 'black':
           return '#000000'
         case 'dracula':

--- a/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
+++ b/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
@@ -199,14 +199,14 @@ const pendingColorPreviews = new Map()
 let colorPreviewTimer = null
 
 const BASE_THEME_VALUES = [
-  'light', 'dark', 'black', 'nordic', 'hotPink', 'pastelPink',
+  'light', 'dark', 'black', 'openTubeXLight', 'openTubeXDark', 'nordic', 'hotPink', 'pastelPink',
   'catppuccinFrappe', 'catppuccinLatte', 'catppuccinMocha', 'dracula',
   'everforestDarkHard', 'everforestDarkMedium', 'everforestDarkLow',
   'everforestLightHard', 'everforestLightMedium', 'everforestLightLow',
   'gruvboxDark', 'gruvboxLight', 'solarizedDark', 'solarizedLight'
 ]
 const BASE_THEME_TRANSLATION_KEYS = [
-  'Light', 'Dark', 'Black', 'Nordic', 'Hot Pink', 'Pastel Pink',
+  'Light', 'Dark', 'Black', 'OpenTubeX Light', 'OpenTubeX Dark', 'Nordic', 'Hot Pink', 'Pastel Pink',
   'Catppuccin Frappe', 'Catppuccin Latte', 'Catppuccin Mocha', 'Dracula',
   'Everforest Dark Hard', 'Everforest Dark Medium', 'Everforest Dark Low',
   'Everforest Light Hard', 'Everforest Light Medium', 'Everforest Light Low',

--- a/src/renderer/components/FtInput/FtInput.css
+++ b/src/renderer/components/FtInput/FtInput.css
@@ -137,6 +137,7 @@ body[dir='rtl'] .ft-input-component.search.showClearTextButton:focus-within .inp
   color: var(--secondary-text-color);
   border-radius: calc(5px * var(--ui-roundness));
   background-color: var(--search-bar-color);
+  box-shadow: inset 0 0 0 1px var(--input-border-color, transparent);
   backdrop-filter: var(--search-bar-blur, none);
 }
 

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
@@ -422,8 +422,8 @@ import {
 } from '../../helpers/quickSettings'
 import { defaultUpdaterId } from '../../store/modules/settings'
 import { switchActiveProfile, translateProfileName as getTranslatedProfileName } from '../../helpers/profileSwitching'
-import { customThemeValue, isCustomThemeValue } from '../../../customTheme'
-import { getThemeClassification } from '../../../appearanceSettings'
+import { customThemeValue } from '../../../customTheme'
+import { getThemeClassification, hasFixedThemeColors } from '../../../appearanceSettings'
 
 const { locale, t } = useI18n()
 const id = useId()
@@ -456,7 +456,7 @@ const profileInitials = computed(() => profileList.value.reduce((initials, profi
 }, {}))
 
 const BUILTIN_BASE_THEME_VALUES = [
-  'system', 'light', 'dark', 'black', 'nordic', 'hotPink', 'pastelPink',
+  'system', 'light', 'dark', 'black', 'openTubeXLight', 'openTubeXDark', 'nordic', 'hotPink', 'pastelPink',
   'catppuccinFrappe', 'catppuccinLatte', 'catppuccinMocha', 'dracula',
   'everforestDarkHard', 'everforestDarkMedium', 'everforestDarkLow',
   'everforestLightHard', 'everforestLightMedium', 'everforestLightLow',
@@ -468,6 +468,8 @@ const builtInBaseThemeNames = computed(() => [
   t('Settings.Theme Settings.Base Theme.Light'),
   t('Settings.Theme Settings.Base Theme.Dark'),
   t('Settings.Theme Settings.Base Theme.Black'),
+  t('Settings.Theme Settings.Base Theme.OpenTubeX Light'),
+  t('Settings.Theme Settings.Base Theme.OpenTubeX Dark'),
   t('Settings.Theme Settings.Base Theme.Nordic'),
   t('Settings.Theme Settings.Base Theme.Hot Pink'),
   t('Settings.Theme Settings.Base Theme.Pastel Pink'),
@@ -521,17 +523,14 @@ const localeNames = computed(() => [
 ])
 
 const baseTheme = computed(() => store.getters.getBaseTheme)
-const usesCustomThemePalette = computed(() => isCustomThemeValue(baseTheme.value) || (
-  baseTheme.value === 'system' && isCustomThemeValue(systemUsesDarkTheme.value
-    ? store.getters.getSystemDarkTheme
-    : store.getters.getSystemLightTheme)
-))
+const usesFixedThemePalette = computed(() => hasFixedThemeColors(baseTheme.value === 'system'
+  ? (systemUsesDarkTheme.value ? store.getters.getSystemDarkTheme : store.getters.getSystemLightTheme)
+  : baseTheme.value))
 const customThemeEditorOpen = computed(() => store.getters.getCustomThemeEditorOpen)
 const mainColor = computed(() => store.getters.getMainColor)
 const mainColorAvailable = computed(() => (
   !customThemeEditorOpen.value &&
-  baseTheme.value !== 'hotPink' &&
-  !usesCustomThemePalette.value
+  !usesFixedThemePalette.value
 ))
 const uiScale = computed(() => store.getters.getUiScale)
 const thumbnailSize = computed(() => store.getters.getThumbnailSize)

--- a/src/renderer/components/FtSelect/FtSelect.css
+++ b/src/renderer/components/FtSelect/FtSelect.css
@@ -47,6 +47,7 @@
   position: relative;
   font-family: inherit;
   background-color: var(--search-bar-color);
+  box-shadow: inset 0 0 0 1px var(--input-border-color, transparent);
   backdrop-filter: var(--search-bar-blur, none);
   color: var(--primary-text-color);
   inline-size: 100%;

--- a/src/renderer/components/FtSettingsSection/FtSettingsSection.scss
+++ b/src/renderer/components/FtSettingsSection/FtSettingsSection.scss
@@ -13,7 +13,7 @@
 }
 
 .sectionBody {
-  background-color: var(--card-bg-color);
+  background-color: var(--settings-section-bg-color, var(--card-bg-color));
   backdrop-filter: var(--card-bg-blur, none);
   border-radius: calc(8px * var(--ui-roundness));
   padding-block: 10px;

--- a/src/renderer/components/FtSlider/FtSlider.css
+++ b/src/renderer/components/FtSlider/FtSlider.css
@@ -67,7 +67,7 @@
   border-radius: calc(1px * var(--ui-roundness));
   inline-size: 100%;
   block-size: 2px;
-  background-color: var(--accent-color-opacity4);
+  background-color: var(--slider-track-color, var(--accent-color-opacity4));
 }
 
 .input::-webkit-slider-thumb {
@@ -114,7 +114,7 @@
   border-radius: calc(1px * var(--ui-roundness));
   inline-size: 100%;
   block-size: 2px;
-  background-color: var(--accent-color-opacity4);
+  background-color: var(--slider-track-color, var(--accent-color-opacity4));
 }
 
 .input::-moz-range-thumb {

--- a/src/renderer/components/FtSyncedSettingIndicator/FtSyncedSettingIndicator.vue
+++ b/src/renderer/components/FtSyncedSettingIndicator/FtSyncedSettingIndicator.vue
@@ -178,13 +178,13 @@ async function toggleSync() {
 .syncedSettingIndicator:focus-visible,
 .changedSettingIndicator:hover,
 .changedSettingIndicator:focus-visible {
-  color: var(--primary-color);
-  outline: 2px solid var(--primary-color);
+  color: var(--settings-changed-color, var(--primary-color));
+  outline: 2px solid var(--settings-changed-color, var(--primary-color));
   outline-offset: 2px;
 }
 
 .changedSettingIndicator {
-  color: var(--primary-color);
+  color: var(--settings-changed-color, var(--primary-color));
 }
 
 .changedSettingIndicatorPlaceholder {

--- a/src/renderer/components/FtToggleSwitch/FtToggleSwitch.scss
+++ b/src/renderer/components/FtToggleSwitch/FtToggleSwitch.scss
@@ -43,14 +43,14 @@
   }
 
   &::before {
-    background-color: #9e9e9e;
+    background-color: var(--toggle-track-color, #9e9e9e);
     border-radius: 8px;
     block-size: 14px;
     inset-inline-start: 6px;
     inline-size: 34px;
 
     .switch-input:checked + & {
-      background-color: var(--accent-color-light);
+      background-color: var(--toggle-checked-track-color, var(--accent-color-light));
     }
 
     .switch-input:disabled + & {
@@ -59,7 +59,7 @@
   }
 
   &::after {
-    background-color: #fafafa;
+    background-color: var(--toggle-thumb-color, #fafafa);
     border-radius: 50%;
     box-shadow: 0 3px 1px -2px rgb(0 0 0 / 14%), 0 2px 2px 0 rgb(0 0 0 / 9.8%), 0 1px 5px 0 rgb(0 0 0 / 8.4%);
     block-size: 20px;
@@ -67,7 +67,7 @@
     inline-size: 20px;
 
     .switch-input:checked + & {
-      background-color: var(--accent-color);
+      background-color: var(--toggle-checked-thumb-color, var(--accent-color));
       transform: translate(calc(80% * var(--horizontal-directionality-coefficient)), -50%);
     }
 

--- a/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
+++ b/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
@@ -202,7 +202,7 @@ let targetResizeObserver = null
 let observedTarget = null
 
 const BASE_THEME_VALUES = [
-  'system', 'light', 'dark', 'black', 'nordic', 'hotPink', 'pastelPink',
+  'system', 'light', 'dark', 'black', 'openTubeXLight', 'openTubeXDark', 'nordic', 'hotPink', 'pastelPink',
   'catppuccinFrappe', 'catppuccinLatte', 'catppuccinMocha', 'dracula',
   'everforestDarkHard', 'everforestDarkMedium', 'everforestDarkLow',
   'everforestLightHard', 'everforestLightMedium', 'everforestLightLow',
@@ -280,6 +280,8 @@ const baseThemeNames = computed(() => [
   t('Settings.Theme Settings.Base Theme.Light'),
   t('Settings.Theme Settings.Base Theme.Dark'),
   t('Settings.Theme Settings.Base Theme.Black'),
+  t('Settings.Theme Settings.Base Theme.OpenTubeX Light'),
+  t('Settings.Theme Settings.Base Theme.OpenTubeX Dark'),
   t('Settings.Theme Settings.Base Theme.Nordic'),
   t('Settings.Theme Settings.Base Theme.Hot Pink'),
   t('Settings.Theme Settings.Base Theme.Pastel Pink'),

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -389,8 +389,8 @@ import CustomThemeEditor from './CustomThemeEditor/CustomThemeEditor.vue'
 import QuickSettingsCustomizer from './QuickSettingsCustomizer/QuickSettingsCustomizer.vue'
 
 import store from '../store/index'
-import { getThemeClassification } from '../../appearanceSettings'
-import { customThemeIdFromValue, customThemeValue, isCustomThemeValue } from '../../customTheme'
+import { getThemeClassification, hasFixedThemeColors } from '../../appearanceSettings'
+import { customThemeIdFromValue, customThemeValue } from '../../customTheme'
 
 import { colors } from '../helpers/colors'
 import { useColorTranslations } from '../composables/colors'
@@ -449,6 +449,8 @@ const BUILTIN_BASE_THEME_VALUES = [
   'dark',
   'black',
   // Second group
+  'openTubeXLight',
+  'openTubeXDark',
   'nordic',
   'hotPink',
   'pastelPink',
@@ -475,6 +477,8 @@ const builtInBaseThemeNames = computed(() => [
   t('Settings.Theme Settings.Base Theme.Light'),
   t('Settings.Theme Settings.Base Theme.Dark'),
   t('Settings.Theme Settings.Base Theme.Black'),
+  t('Settings.Theme Settings.Base Theme.OpenTubeX Light'),
+  t('Settings.Theme Settings.Base Theme.OpenTubeX Dark'),
   // Second group
   t('Settings.Theme Settings.Base Theme.Nordic'),
   t('Settings.Theme Settings.Base Theme.Hot Pink'),
@@ -633,11 +637,9 @@ function updateIconPack(value) {
   store.dispatch('updateIconPack', value)
 }
 
-const areColorThemesEnabled = computed(() => baseTheme.value !== 'hotPink' && !(
-  isCustomThemeValue(baseTheme.value) ||
-  (baseTheme.value === 'system' &&
-    (isCustomThemeValue(systemLightTheme.value) || isCustomThemeValue(systemDarkTheme.value)))
-))
+const areColorThemesEnabled = computed(() => baseTheme.value === 'system'
+  ? !hasFixedThemeColors(systemLightTheme.value) && !hasFixedThemeColors(systemDarkTheme.value)
+  : !hasFixedThemeColors(baseTheme.value))
 const selectedCustomThemeId = computed(() => customThemeIdFromValue(baseTheme.value === 'system'
   ? (systemUsesDarkTheme.value ? systemDarkTheme.value : systemLightTheme.value)
   : baseTheme.value))

--- a/src/renderer/components/ft-card/ft-card.css
+++ b/src/renderer/components/ft-card/ft-card.css
@@ -1,5 +1,7 @@
 .ft-card {
   background-color: var(--card-bg-color);
+  background-image: var(--card-bg-image);
+  background-attachment: fixed;
   backdrop-filter: var(--card-bg-blur, none);
   border-radius: calc(8px * var(--ui-roundness));
   margin: 8px;

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -4,9 +4,16 @@ body {
   font-family: var(--app-font-family);
   color: var(--primary-text-color);
   background-color: var(--bg-color);
+  background-image: var(--bg-image);
+  background-attachment: fixed;
 
   --app-font-family: 'Roboto', system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   --ui-roundness: 1;
+
+  /* Optional decorative layers, separate from colors used by contrast checks
+     and native windows. Fixed backgrounds keep the field aligned on scroll. */
+  --bg-image: none;
+  --card-bg-image: none;
   --scrollbar-thumb-width: 6px;
   --scrollbar-track-width: calc(var(--scrollbar-thumb-width) + 4px);
   --border-color: var(--tertiary-text-color);
@@ -155,6 +162,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
 /* Dark theme Youtube and Invidious logo styling (in FtShareButton) */
 .system[data-system-theme*='dark'],
 .dark,
+.openTubeXDark,
 .black,
 .custom[data-custom-theme='dark'],
 .dracula,
@@ -292,10 +300,10 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --logo-text: url('../../_icons/textBlackSmall.svg');
 }
 
-/* Custom themes tint the header logo instead of displaying the fixed-color
+/* Custom and OpenTubeX themes tint the header logo instead of displaying the fixed-color
    theme assets. Keeping the assets as masks preserves their sharp edges. */
-.custom .topNav .logoIcon,
-.custom .topNav .logoText {
+:is(.custom, .openTubeXLight, .openTubeXDark) .topNav .logoIcon,
+:is(.custom, .openTubeXLight, .openTubeXDark) .topNav .logoText {
   /* The component's fixed SVG has intentionally high scoped specificity. */
   /* stylelint-disable-next-line declaration-no-important */
   background-image: none !important;
@@ -305,23 +313,23 @@ it can be safely elided. This looks quite pleasant on this theme. */
   mask-position: center;
 }
 
-.custom .topNav .logoIcon {
+:is(.custom, .openTubeXLight, .openTubeXDark) .topNav .logoIcon {
   background-color: var(--logo-primary-color);
   mask-image: var(--logo-icon);
   mask-size: 25px;
 }
 
-.custom .topNav .logoText {
+:is(.custom, .openTubeXLight, .openTubeXDark) .topNav .logoText {
   background-color: var(--logo-secondary-color);
   mask-image: var(--logo-text);
   mask-size: 100px;
 }
 
-.custom .logo:hover :is(.logoIcon, .logoText) {
+:is(.custom, .openTubeXLight, .openTubeXDark) .logo:hover :is(.logoIcon, .logoText) {
   background-color: var(--logo-tertiary-color);
 }
 
-.custom .logo:active :is(.logoIcon, .logoText) {
+:is(.custom, .openTubeXLight, .openTubeXDark) .logo:active :is(.logoIcon, .logoText) {
   background-color: var(--logo-pressed-color);
 }
 
@@ -2217,6 +2225,8 @@ html[lang='ur'] [data-prefix='fas'][data-icon='circle-question'] {
 .app {
   color: var(--primary-text-color);
   background-color: var(--bg-color);
+  background-image: var(--bg-image);
+  background-attachment: fixed;
 }
 
 
@@ -2333,4 +2343,130 @@ body .os-scrollbar {
   to {
     background-position: 0% 50%;
   }
+}
+
+
+/* Homepage palette from opentubex.github.io/src/styles/signal.css.
+   Keep these after the selectable color palettes: the brand themes supply
+   their own primary and secondary colors. */
+.openTubeXLight,
+.openTubeXDark {
+  --toggle-track-color: #758b87;
+  --toggle-checked-track-color: #4e9185;
+  --toggle-thumb-color: #e6f4f1;
+  --bg-glows:
+    radial-gradient(ellipse 80% 50% at 15% 10%, var(--bg-glow-teal), transparent 55%),
+    radial-gradient(ellipse 60% 45% at 90% 20%, var(--bg-glow-ink), transparent 50%),
+    radial-gradient(ellipse 70% 40% at 50% 100%, var(--bg-glow-teal-soft), transparent 55%);
+  --bg-image:
+    var(--bg-glows),
+    linear-gradient(165deg, var(--bg-gradient-start), var(--bg-color) 40%, var(--bg-gradient-end));
+  --card-bg-image:
+    var(--bg-glows),
+    linear-gradient(165deg, var(--card-bg-color), var(--card-bg-color) 40%, var(--bg-gradient-end));
+
+  /* Settings sections share the window's field instead of repeating it. */
+  --settings-section-bg-color: transparent;
+  --settings-changed-color: var(--accent-color);
+
+  /* Keep thumbs distinct from their tracks and the surrounding gradient. */
+  --toggle-checked-thumb-color: var(--toggle-thumb-color);
+  --slider-track-color: var(--tertiary-text-color);
+  --input-border-color: var(--tertiary-text-color);
+  --primary-color: #147a70;
+  --text-with-main-color: #fbfefd;
+  --title-color: var(--primary-text-color);
+  --divider-color: var(--border-color);
+  --subtle-surface-color: var(--secondary-card-bg-color);
+  --dropdown-item-hover-color: var(--side-nav-hover-color);
+  --dropdown-item-hover-text-color: var(--primary-text-color);
+  --settings-search-bar-color: var(--search-bar-color);
+  --logo-primary-color: var(--primary-text-color);
+  --logo-secondary-color: var(--primary-text-color);
+  --logo-tertiary-color: var(--accent-color);
+  --logo-pressed-color: var(--accent-color-active);
+  --logo-icon: url('../../_icons/iconWhiteSmall.svg');
+  --logo-text: url('../../_icons/textWhiteSmall.svg');
+}
+
+.openTubeXLight {
+  --toggle-track-color: #b7c9c5;
+  --toggle-checked-track-color: #8cbaae;
+  --toggle-thumb-color: #17665f;
+  --bg-glow-teal: rgb(26 155 142 / 14%);
+  --bg-glow-ink: rgb(11 61 62 / 8%);
+  --bg-glow-teal-soft: rgb(26 155 142 / 10%);
+  --bg-gradient-start: #eef6f4;
+  --bg-gradient-end: #dceee9;
+  --primary-text-color: #0b3d3e;
+  --secondary-text-color: #3d5a5b;
+  --tertiary-text-color: #476263;
+  --bg-color: #e8f2f0;
+  --card-bg-color: #fbfefd;
+  --secondary-card-bg-color: #f4f9f8;
+  --side-nav-color: #f4f9f8;
+  --side-nav-hover-color: #d5e8e4;
+  --side-nav-active-color: #bfdcd6;
+  --search-bar-color: #e8f2f0;
+  --border-color: rgb(11 61 62 / 12%);
+  --primary-shadow-color: rgb(11 61 62 / 12%);
+  --primary-color-hover: #0b3d3e;
+  --primary-color-active: #1a4f50;
+  --accent-color-rgb: 17 104 95;
+  --accent-color-hover: #0b3d3e;
+  --accent-color-active: #1a4f50;
+  --accent-color-light: #d5e8e4;
+  --accent-color-visited: #3d5a5b;
+  --text-with-accent-color: #fbfefd;
+  --selection-background-color: #147a70;
+  --selection-text-color: #fbfefd;
+  --scrollbar-color: #49968a;
+  --scrollbar-color-hover: #147a70;
+  --scrollbar-color-active: #0b3d3e;
+  --favorite-icon-color: #147a70;
+}
+
+.openTubeXDark {
+  --toggle-track-color: #758b87;
+  --toggle-checked-track-color: #4e9185;
+  --toggle-thumb-color: #e6f4f1;
+  --bg-glow-teal: rgb(46 196 182 / 12%);
+  --bg-glow-ink: rgb(46 196 182 / 6%);
+  --bg-glow-teal-soft: rgb(26 155 142 / 10%);
+  --bg-gradient-start: #0e1a1c;
+  --bg-gradient-end: #0a1618;
+  --primary-text-color: #e6f4f1;
+  --secondary-text-color: #8aa3a4;
+  --tertiary-text-color: #8aa3a4;
+  --bg-color: #0b1416;
+  --card-bg-color: #142224;
+  --secondary-card-bg-color: #122022;
+  --side-nav-color: #101a1c;
+  --side-nav-hover-color: #203638;
+  --side-nav-active-color: #2a4547;
+  --search-bar-color: #122022;
+  --border-color: rgb(232 242 240 / 12%);
+  --primary-shadow-color: rgb(0 0 0 / 24%);
+  --primary-color-hover: #0f625c;
+  --primary-color-active: #0b3d3e;
+  --accent-color-rgb: 46 196 182;
+  --accent-color-hover: #68d8ce;
+  --accent-color-active: #1fb5a7;
+  --accent-color-light: #122022;
+  --accent-color-visited: #8aa3a4;
+  --text-with-accent-color: #071113;
+  --selection-background-color: #2ec4b6;
+  --selection-text-color: #071113;
+  --scrollbar-color: #549c98;
+  --scrollbar-color-hover: #2ec4b6;
+  --scrollbar-color-active: #68d8ce;
+  --favorite-icon-color: #2ec4b6;
+}
+
+
+:is(.openTubeXLight, .openTubeXDark) .topNavBarColor {
+  --logo-primary-color: var(--text-with-main-color);
+  --logo-secondary-color: var(--text-with-main-color);
+  --logo-tertiary-color: var(--text-with-main-color);
+  --logo-pressed-color: var(--text-with-main-color);
 }

--- a/src/renderer/views/Settings/Settings.css
+++ b/src/renderer/views/Settings/Settings.css
@@ -14,6 +14,8 @@
   flex-direction: column;
   color: var(--primary-text-color);
   background: var(--card-bg-color);
+  background-image: var(--card-bg-image);
+  background-attachment: fixed;
   backdrop-filter: var(--card-bg-blur, none);
   border: 1px solid var(--border-color);
   border-radius: calc(10px * var(--ui-roundness));
@@ -168,6 +170,7 @@
   border-radius: calc(6px * var(--ui-roundness));
   color: var(--tertiary-text-color);
   background: var(--settings-search-bar-color);
+  box-shadow: inset 0 0 0 1px var(--input-border-color, transparent);
   backdrop-filter: var(--settings-search-bar-blur, none);
   cursor: text;
 }
@@ -217,7 +220,7 @@
 }
 
 .settingsHeaderButton.active {
-  color: var(--primary-color);
+  color: var(--settings-changed-color, var(--primary-color));
 }
 
 .settingsPage {
@@ -425,7 +428,7 @@
 :deep(.pure-checkbox:has(.changedSettingIndicator)),
 :deep(.inputTags:has(.changedSettingIndicator)),
 :deep(.sponsorBlockCategory:has(.changedSettingIndicator)) {
-  border-inline-start: 3px solid var(--primary-color);
+  border-inline-start: 3px solid var(--settings-changed-color, var(--primary-color));
   padding-inline-start: 9px;
 }
 

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -369,6 +369,8 @@ Settings:
       Unable to Load: غير قادر على تحميل خطوط النظام المثبتة
     Always Show Scrollbars: إظهار أشرطة التمرير دائمًا
     Base Theme:
+      OpenTubeX Light: "OpenTubeX فاتح"
+      OpenTubeX Dark: "OpenTubeX داكن"
       Custom: مخصص
     Light Theme: سمة فاتحة
     Dark Theme: سمة داكنة

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -382,6 +382,8 @@ Settings:
       Unable to Load: Не ўдалося загрузіць усталяваныя сістэмныя шрыфты
     Always Show Scrollbars: Заўсёды паказваць палосы пракруткі
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Светлая"
+      OpenTubeX Dark: "OpenTubeX Цёмная"
       Custom: Карыстальніцкая
       Catppuccin Latte: Catppuccin Latte
     Light Theme: Светлая тэма

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -367,6 +367,8 @@ Settings:
       Unable to Load: Инсталираните системни шрифтове не могат да бъдат заредени
     Always Show Scrollbars: Винаги показвай лентите за превъртане
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Светла"
+      OpenTubeX Dark: "OpenTubeX Тъмна"
       Custom: Персонализирана
     Light Theme: Светла тема
     Dark Theme: Тъмна тема

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -365,6 +365,8 @@ Settings:
       Unable to Load: "N'eus ket bet gallet kargañ nodrezhoù ar reizhiad staliet"
     Always Show Scrollbars: "Diskouez ar barrennoù dibunañ bepred"
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Sklaer"
+      OpenTubeX Dark: "OpenTubeX Teñval"
       Custom: "Personelaet"
     Light Theme: "Neuz sklaer"
     Dark Theme: "Neuz teñval"

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -504,6 +504,8 @@ Settings:
     Always Show Scrollbars: Mostra sempre les barres de desplaçament
     Hide OpenTubeX Header Logo: Oculta el logotip de l'OpenTubeX de la capçalera
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Clar"
+      OpenTubeX Dark: "OpenTubeX Fosc"
       Custom: Personalitzat
       Catppuccin Frappe: Catppuccin Frappe
       Catppuccin Latte: Catppuccin Latte

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -365,6 +365,8 @@ Settings:
       Unable to Load: Nainstalovaná systémová písma se nepodařilo načíst
     Always Show Scrollbars: Vždy zobrazovat posuvníky
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Světlý"
+      OpenTubeX Dark: "OpenTubeX Tmavý"
       Custom: Vlastní
     Light Theme: Světlý motiv
     Dark Theme: Tmavý motiv

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -367,6 +367,8 @@ Settings:
       Unable to Load: Nid oedd modd llwytho ffontiau'r system sydd wedi'u gosod
     Always Show Scrollbars: Dangos bariau sgrolio bob amser
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Golau"
+      OpenTubeX Dark: "OpenTubeX Tywyll"
       Custom: Personol
     Light Theme: Thema olau
     Dark Theme: Thema dywyll

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -377,6 +377,8 @@ Settings:
       Unable to Load: Installerede systemskrifttyper kunne ikke indlæses
     Always Show Scrollbars: Vis altid rullebjælker
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Lys"
+      OpenTubeX Dark: "OpenTubeX Mørk"
       Custom: Brugerdefineret
       Catppuccin Latte: Catppuccin Latte
     Light Theme: Lyst tema

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -369,6 +369,8 @@ Settings:
       Unable to Load: Δεν ήταν δυνατή η φόρτωση των εγκατεστημένων γραμματοσειρών συστήματος
     Always Show Scrollbars: Μόνιμη εμφάνιση γραμμών κύλισης
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Φωτεινό"
+      OpenTubeX Dark: "OpenTubeX Σκοτεινό"
       Custom: Προσαρμοσμένο
     Light Theme: Φωτεινό θέμα
     Dark Theme: Σκοτεινό θέμα

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -352,6 +352,8 @@ Settings:
       Unable to Load: Unable to load installed system fonts
     Always Show Scrollbars: Always Show Scrollbars
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Light"
+      OpenTubeX Dark: "OpenTubeX Dark"
       Custom: Custom
     Light Theme: Light theme
     Dark Theme: Dark theme

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -386,6 +386,8 @@ Settings:
       Unable to Load: No se pudieron cargar las fuentes instaladas en el sistema
     Always Show Scrollbars: Mostrar siempre las barras de desplazamiento
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Claro"
+      OpenTubeX Dark: "OpenTubeX Oscuro"
       Custom: Personalizado
       Catppuccin Latte: Capuchino con leche
       Gruvbox Dark: Gruvbox oscuro

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -394,6 +394,8 @@ Settings:
       Unable to Load: No se pudieron cargar las fuentes instaladas en el sistema
     Always Show Scrollbars: Mostrar siempre las barras de desplazamiento
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Claro"
+      OpenTubeX Dark: "OpenTubeX Oscuro"
       Custom: Personalizado
       Catppuccin Latte: Capuchino con leche
       Solarized Light: Solarized claro

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -367,6 +367,8 @@ Settings:
       Unable to Load: No se pudieron cargar las fuentes instaladas en el sistema
     Always Show Scrollbars: Mostrar siempre las barras de desplazamiento
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Claro"
+      OpenTubeX Dark: "OpenTubeX Oscuro"
       Custom: Personalizado
     Light Theme: Tema claro
     Dark Theme: Tema oscuro

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -365,6 +365,8 @@ Settings:
       Unable to Load: Paigaldatud süsteemifonte ei saa laadida
     Always Show Scrollbars: Kuva kerimisribad alati
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Hele"
+      OpenTubeX Dark: "OpenTubeX Tume"
       Custom: Kohandatud
     Light Theme: Hele teema
     Dark Theme: Tume teema

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -367,6 +367,8 @@ Settings:
       Unable to Load: Ezin izan dira sisteman instalatutako letra-tipoak kargatu
     Always Show Scrollbars: Erakutsi beti korritze-barrak
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Argia"
+      OpenTubeX Dark: "OpenTubeX Iluna"
       Custom: Pertsonalizatua
     Light Theme: Gai argia
     Dark Theme: Gai iluna

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -382,6 +382,8 @@ Settings:
       Unable to Load: قلم‌های نصب‌شدهٔ سیستم بارگیری نشدند
     Always Show Scrollbars: نمایش همیشگی نوارهای پیمایش
     Base Theme:
+      OpenTubeX Light: "OpenTubeX روشن"
+      OpenTubeX Dark: "OpenTubeX تاریک"
       Custom: سفارشی
       Catppuccin Latte: Catppuccin Latte
     Light Theme: زمینهٔ روشن

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -369,6 +369,8 @@ Settings:
       Unable to Load: Asennettuja järjestelmäfontteja ei voitu ladata
     Always Show Scrollbars: Näytä vierityspalkit aina
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Vaalea"
+      OpenTubeX Dark: "OpenTubeX Tumma"
       Custom: Mukautettu
     Light Theme: Vaalea teema
     Dark Theme: Tumma teema

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -365,6 +365,8 @@ Settings:
       Unable to Load: Impossible de charger les polices installées sur le système
     Always Show Scrollbars: Toujours afficher les barres de défilement
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Clair"
+      OpenTubeX Dark: "OpenTubeX Sombre"
       Custom: Personnalisé
     Light Theme: Thème clair
     Dark Theme: Thème sombre

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -369,6 +369,8 @@ Settings:
       Unable to Load: Non se puideron cargar os tipos de letra instalados no sistema
     Always Show Scrollbars: Amosar sempre as barras de desprazamento
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Claro"
+      OpenTubeX Dark: "OpenTubeX Escuro"
       Custom: Personalizado
     Light Theme: Tema claro
     Dark Theme: Tema escuro

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -369,8 +369,8 @@ Settings:
       Unable to Load: לא ניתן לטעון גופני מערכת מותקנים
     Always Show Scrollbars: הצגת פסי גלילה תמיד
     Base Theme:
-      OpenTubeX Light: "OpenTubeX בהיר"
-      OpenTubeX Dark: "OpenTubeX חשוך"
+      OpenTubeX Light: "OpenTubeX בהירה"
+      OpenTubeX Dark: "OpenTubeX כהה"
       Custom: מותאמת אישית
     Light Theme: ערכת נושא בהירה
     Dark Theme: ערכת נושא כהה

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -369,6 +369,8 @@ Settings:
       Unable to Load: לא ניתן לטעון גופני מערכת מותקנים
     Always Show Scrollbars: הצגת פסי גלילה תמיד
     Base Theme:
+      OpenTubeX Light: "OpenTubeX בהיר"
+      OpenTubeX Dark: "OpenTubeX חשוך"
       Custom: מותאמת אישית
     Light Theme: ערכת נושא בהירה
     Dark Theme: ערכת נושא כהה

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -367,6 +367,8 @@ Settings:
       Unable to Load: Instalirane fontove sustava nije moguće učitati
     Always Show Scrollbars: Uvijek prikaži klizne trake
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Svijetla"
+      OpenTubeX Dark: "OpenTubeX Tamna"
       Custom: Prilagođena
     Light Theme: Svijetla tema
     Dark Theme: Tamna tema

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -365,6 +365,8 @@ Settings:
       Unable to Load: A rendszerre telepített betűkészletek nem tölthetők be
     Always Show Scrollbars: Görgetősávok mindig láthatók
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Világos"
+      OpenTubeX Dark: "OpenTubeX Sötét"
       Custom: Egyéni
     Light Theme: Világos téma
     Dark Theme: Sötét téma

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -369,6 +369,8 @@ Settings:
       Unable to Load: Tidak dapat memuat font sistem yang terpasang
     Always Show Scrollbars: Selalu Tampilkan Bilah Gulir
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Terang"
+      OpenTubeX Dark: "OpenTubeX Gelap"
       Custom: Khusus
     Light Theme: Tema terang
     Dark Theme: Tema gelap

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -369,6 +369,8 @@ Settings:
       Unable to Load: Ekki tókst að hlaða uppsettum kerfisleturgerðum
     Always Show Scrollbars: Sýna alltaf skrunstikur
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Ljóst"
+      OpenTubeX Dark: "OpenTubeX Dökkt"
       Custom: Sérsniðið
     Light Theme: Ljóst þema
     Dark Theme: Dökkt þema

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -365,6 +365,8 @@ Settings:
       Unable to Load: Impossibile caricare i caratteri installati nel sistema
     Always Show Scrollbars: Mostra sempre le barre di scorrimento
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Chiaro"
+      OpenTubeX Dark: "OpenTubeX Scuro"
       Custom: Personalizzato
     Light Theme: Tema chiaro
     Dark Theme: Tema scuro

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -365,6 +365,8 @@ Settings:
       Unable to Load: インストール済みのシステムフォントを読み込めませんでした
     Always Show Scrollbars: スクロールバーを常に表示
     Base Theme:
+      OpenTubeX Light: "OpenTubeX ライト"
+      OpenTubeX Dark: "OpenTubeX ダーク"
       Custom: カスタム
     Light Theme: ライトテーマ
     Dark Theme: ダークテーマ

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -461,6 +461,8 @@ Settings:
       Unable to Load: 설치된 시스템 글꼴을 불러올 수 없습니다
     Always Show Scrollbars: 스크롤바 항상 표시
     Base Theme:
+      OpenTubeX Light: "OpenTubeX 밝은 테마"
+      OpenTubeX Dark: "OpenTubeX 어두운 테마"
       Custom: 사용자 지정
       Catppuccin Frappe: Catppuccin Frappe
       Catppuccin Latte: Catppuccin Latte

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -486,6 +486,8 @@ Settings:
       Unable to Load: Nepavyko įkelti įdiegtų sistemos šriftų
     Always Show Scrollbars: Visada rodyti slankjuostes
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Šviesi"
+      OpenTubeX Dark: "OpenTubeX Tamsi"
       Custom: Pasirinktinė
       Catppuccin Frappe: Catppuccin Frappe
       Catppuccin Latte: Catppuccin Latte

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -365,6 +365,8 @@ Settings:
       Unable to Load: Kan ikke laste inn installerte systemskrifter
     Always Show Scrollbars: Vis alltid rullefelt
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Lys"
+      OpenTubeX Dark: "OpenTubeX Mørk"
       Custom: Egendefinert
     Light Theme: Lyst tema
     Dark Theme: Mørkt tema

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -369,6 +369,8 @@ Settings:
       Unable to Load: Geïnstalleerde systeemlettertypen kunnen niet worden geladen
     Always Show Scrollbars: Schuifbalken altijd tonen
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Licht"
+      OpenTubeX Dark: "OpenTubeX Donker"
       Custom: Aangepast
     Light Theme: Licht thema
     Dark Theme: Donker thema

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -428,6 +428,8 @@ Settings:
       Unable to Load: Klarte ikkje å laste inn installerte systemskrifter
     Always Show Scrollbars: Vis alltid rullefelt
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Lys"
+      OpenTubeX Dark: "OpenTubeX Mørk"
       Custom: Eige
       Catppuccin Frappe: Catppuccin Frappe
       Catppuccin Latte: Catppuccin Latte

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -119,6 +119,9 @@ Settings:
       Phone: 'Telefon'
       Tablet: 'Tablet'
   Theme Settings:
+    Base Theme:
+      OpenTubeX Light: "OpenTubeX Jasny"
+      OpenTubeX Dark: "OpenTubeX Ciemny"
     Toast Position:
       Test Toast: Powiadomienie testowe
     Scroll Speed: Szybkość przewijania

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -365,6 +365,8 @@ Settings:
       Unable to Load: Não foi possível carregar os tipos de letra instalados no sistema
     Always Show Scrollbars: Mostrar sempre as barras de deslocamento
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Claro"
+      OpenTubeX Dark: "OpenTubeX Escuro"
       Custom: Personalizado
     Light Theme: Tema claro
     Dark Theme: Tema escuro

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -369,6 +369,8 @@ Settings:
       Unable to Load: Não foi possível carregar os tipos de letra instalados no sistema
     Always Show Scrollbars: Mostrar sempre as barras de deslocamento
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Claro"
+      OpenTubeX Dark: "OpenTubeX Escuro"
       Custom: Personalizado
     Light Theme: Tema claro
     Dark Theme: Tema escuro

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -369,6 +369,8 @@ Settings:
       Unable to Load: Não foi possível carregar os tipos de letra instalados no sistema
     Always Show Scrollbars: Mostrar sempre as barras de deslocamento
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Claro"
+      OpenTubeX Dark: "OpenTubeX Escuro"
       Custom: Personalizado
     Light Theme: Tema claro
     Dark Theme: Tema escuro

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -367,6 +367,8 @@ Settings:
       Unable to Load: Fonturile instalate în sistem nu au putut fi încărcate
     Always Show Scrollbars: Afișează întotdeauna barele de derulare
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Luminoasă"
+      OpenTubeX Dark: "OpenTubeX Întunecată"
       Custom: Personalizată
     Light Theme: Temă luminoasă
     Dark Theme: Temă întunecată

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -344,6 +344,8 @@ Settings:
       Unable to Load: Не удалось загрузить установленные системные шрифты
     Always Show Scrollbars: Всегда показывать полосы прокрутки
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Светлая"
+      OpenTubeX Dark: "OpenTubeX Тёмная"
       Custom: Пользовательская
     Light Theme: Светлая тема
     Dark Theme: Тёмная тема

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -365,6 +365,8 @@ Settings:
       Unable to Load: Nainštalované systémové písma sa nepodarilo načítať
     Always Show Scrollbars: Vždy zobrazovať posúvače
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Svetlá"
+      OpenTubeX Dark: "OpenTubeX Tmavá"
       Custom: Vlastný
     Light Theme: Svetlý motív
     Dark Theme: Tmavý motív

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -495,6 +495,8 @@ Settings:
       Unable to Load: Nameščenih sistemskih pisav ni mogoče naložiti
     Always Show Scrollbars: Vedno prikaži drsne trakove
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Svetla"
+      OpenTubeX Dark: "OpenTubeX Temna"
       Custom: Po meri
       Catppuccin Frappe: Catppuccin Frappe
       Catppuccin Latte: Catppuccin Latte

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -495,8 +495,8 @@ Settings:
       Unable to Load: Nameščenih sistemskih pisav ni mogoče naložiti
     Always Show Scrollbars: Vedno prikaži drsne trakove
     Base Theme:
-      OpenTubeX Light: "OpenTubeX Svetla"
-      OpenTubeX Dark: "OpenTubeX Temna"
+      OpenTubeX Light: "OpenTubeX svetla"
+      OpenTubeX Dark: "OpenTubeX temna"
       Custom: Po meri
       Catppuccin Frappe: Catppuccin Frappe
       Catppuccin Latte: Catppuccin Latte

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -375,6 +375,8 @@ Settings:
       Unable to Load: Није могуће учитати инсталиране системске фонтове
     Always Show Scrollbars: Увек приказуј траке за померање
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Светла"
+      OpenTubeX Dark: "OpenTubeX Тамна"
       Custom: Прилагођена
       Catppuccin Latte: Catppuccin Latte
     Light Theme: Светла тема

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -367,6 +367,8 @@ Settings:
       Unable to Load: Det gick inte att läsa in installerade systemtypsnitt
     Always Show Scrollbars: Visa alltid rullningslister
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Ljust"
+      OpenTubeX Dark: "OpenTubeX Mörkt"
       Custom: Anpassat
     Light Theme: Ljust tema
     Dark Theme: Mörkt tema

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -370,6 +370,8 @@ Settings:
       Unable to Load: நிறுவப்பட்ட கணினி எழுத்துருக்களை ஏற்ற முடியவில்லை
     Always Show Scrollbars: உருள் பட்டைகளை எப்போதும் காட்டு
     Base Theme:
+      OpenTubeX Light: "OpenTubeX ஒளி"
+      OpenTubeX Dark: "OpenTubeX இருண்ட"
       Custom: தனிப்பயன்
     Light Theme: வெளிர் அலங்காரம்
     Dark Theme: கருமை அலங்காரம்

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -365,6 +365,8 @@ Settings:
       Unable to Load: Yüklü sistem yazı tipleri yüklenemedi
     Always Show Scrollbars: Kaydırma Çubuklarını Her Zaman Göster
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Açık"
+      OpenTubeX Dark: "OpenTubeX Koyu"
       Custom: Özel
     Light Theme: Açık tema
     Dark Theme: Koyu tema

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -369,6 +369,8 @@ Settings:
       Unable to Load: Не вдалося завантажити встановлені системні шрифти
     Always Show Scrollbars: Завжди показувати смуги прокручування
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Світла"
+      OpenTubeX Dark: "OpenTubeX Темна"
       Custom: Власна
     Light Theme: Світла тема
     Dark Theme: Темна тема

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -369,6 +369,8 @@ Settings:
       Unable to Load: Không thể tải các phông chữ hệ thống đã cài đặt
     Always Show Scrollbars: Luôn hiện thanh cuộn
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Sáng"
+      OpenTubeX Dark: "OpenTubeX Tối"
       Custom: Tùy chỉnh
     Light Theme: Chủ đề sáng
     Dark Theme: Chủ đề tối

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -365,8 +365,8 @@ Settings:
       Unable to Load: 无法加载已安装的系统字体
     Always Show Scrollbars: 始终显示滚动条
     Base Theme:
-      OpenTubeX Light: "OpenTubeX 浅"
-      OpenTubeX Dark: "OpenTubeX 深"
+      OpenTubeX Light: "OpenTubeX 浅色"
+      OpenTubeX Dark: "OpenTubeX 深色"
       Custom: 自定义
     Light Theme: 浅色主题
     Dark Theme: 深色主题

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -365,6 +365,8 @@ Settings:
       Unable to Load: 无法加载已安装的系统字体
     Always Show Scrollbars: 始终显示滚动条
     Base Theme:
+      OpenTubeX Light: "OpenTubeX 浅"
+      OpenTubeX Dark: "OpenTubeX 深"
       Custom: 自定义
     Light Theme: 浅色主题
     Dark Theme: 深色主题

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -365,6 +365,8 @@ Settings:
       Unable to Load: 無法載入已安裝的系統字型
     Always Show Scrollbars: 永遠顯示捲軸
     Base Theme:
+      OpenTubeX Light: "OpenTubeX 淺色"
+      OpenTubeX Dark: "OpenTubeX 深色"
       Custom: 自訂
     Light Theme: 淺色主題
     Dark Theme: 深色主題

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -445,6 +445,8 @@ Settings:
     Theme Settings: Farbschema
     Match Top Bar with Main Color: Obere Leiste an Hauptfarbe anpassen
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Hell"
+      OpenTubeX Dark: "OpenTubeX Dunkel"
       Base Theme: Grundlegendes Farbschema
       Black: Schwarz
       Dark: Dunkel

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -680,6 +680,8 @@ Settings:
     Hide Side Bar Labels: Hide Side Bar Labels
     Hide OpenTubeX Header Logo: Hide OpenTubeX Header Logo
     Base Theme:
+      OpenTubeX Light: "OpenTubeX Light"
+      OpenTubeX Dark: "OpenTubeX Dark"
       Base Theme: Base Theme
       Black: Black
       Custom: Custom


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

The app did not have themes matching the OpenTubeX homepage. This adds light and dark palettes with the same teal gradients and readable controls.

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Requested directly in the development task; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Add OpenTubeX Light and OpenTubeX Dark throughout the theme selectors, including system-theme selection. Both use fixed brand colors and homepage-inspired gradient backgrounds. Improve switch thumbs and tracks, sliders, input boundaries, reset indicators, and active settings-header icons in these themes.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [x] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Choose OpenTubeX Light or OpenTubeX Dark for homepage-inspired teal colors and soft gradient backgrounds.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/d5ad010e-c20b-4b4a-a8e0-2a4fb160f910">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/156d0ab8-63e9-4a5a-9bfd-ff563d1932b0">
  <img alt="OpenTubeX homepage-inspired theme in Settings" src="https://github.com/user-attachments/assets/d5ad010e-c20b-4b4a-a8e0-2a4fb160f910">
</picture>
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. In Settings → Appearance, select OpenTubeX Light, then OpenTubeX Dark. Check the gradient backgrounds, theme-colored logo, and disabled main/secondary color selectors.
2. In General settings, toggle switches with the mouse and keyboard. Light mode should have teal thumbs and plain muted tracks; dark mode should keep light thumbs in both states. Check the field boundaries and reset icons, then repeat at 125% UI scale.
3. Select System default and choose the OpenTubeX light/dark pair. Change the system appearance and confirm the app follows it. Restart the app to check persistence, then select a standard theme and confirm the gradient disappears and color selectors become available.

## Additional context
<!-- Add any other context about the pull request here. -->

