### PR TITLE
fix(player): start playback with the original audio track

### DIFF
--- a/e2e/tests/offline/audio-track-default.spec.mjs
+++ b/e2e/tests/offline/audio-track-default.spec.mjs
@@ -1,0 +1,82 @@
+import { test, expect, sel } from '../../helpers/app.mjs'
+import { activeTab } from '../../helpers/player.mjs'
+import { mockPlayableWatchPage } from '../../helpers/watch.mjs'
+import { POST_LIVE_AUDIO_URL, POST_LIVE_VIDEO_URL, routePostLiveMedia } from '../../helpers/media.mjs'
+
+for (const [format, quality] of [['dash', '180'], ['dash', 'auto'], ['audio', 'auto']]) {
+  test.describe(`${format} with ${quality} quality`, () => {
+    test.use({
+      seed: {
+        settings: {
+          videoPlaybackEngine: 'yt-dlp',
+          ytDlpPlaybackEngineDefaultMigration: true,
+          defaultQuality: quality,
+          defaultVideoFormat: format,
+        }
+      }
+    })
+
+    test('yt-dlp HLS starts with the original audio when YouTube marks every track non-default', async ({ app, page }) => {
+      await mockPlayableWatchPage(app, page)
+      await routePostLiveMedia(page)
+
+      // Arabic comes first, and even the original has DEFAULT=NO.
+      const master = `#EXTM3U
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",LANGUAGE="ar",NAME="العربية - dubbed-auto",YT-EXT-AUDIO-CONTENT-ID="ar.10",DEFAULT=NO,AUTOSELECT=YES,URI="ar.m3u8"
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",LANGUAGE="en-US",NAME="American English - original",YT-EXT-AUDIO-CONTENT-ID="en-US.4",DEFAULT=NO,AUTOSELECT=YES,URI="en.m3u8"
+#EXT-X-STREAM-INF:BANDWIDTH=84000,CODECS="avc1.42c00d,mp4a.40.2",RESOLUTION=320x180,AUDIO="audio"
+video.m3u8
+`
+      await page.route('https://audio-default.test/*.m3u8', route => {
+        const filename = new URL(route.request().url()).pathname
+        const media = filename === '/video.m3u8' ? POST_LIVE_VIDEO_URL : POST_LIVE_AUDIO_URL
+        return route.fulfill({
+          contentType: 'application/x-mpegurl',
+          body: filename === '/master.m3u8'
+            ? master
+            : `#EXTM3U
+#EXT-X-TARGETDURATION:2
+#EXT-X-VERSION:7
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-PLAYLIST-TYPE:VOD
+#EXT-X-MAP:URI="${media}"
+#EXTINF:2,
+${media}
+#EXT-X-ENDLIST
+`
+        })
+      })
+      await app.electronApp.evaluate(({ ipcMain }) => {
+        ipcMain.removeHandler('yt-dlp-get-playback-info')
+        ipcMain.handle('yt-dlp-get-playback-info', () => ({
+          isLive: false,
+          liveStatus: 'not_live',
+          hlsManifestUrl: 'https://audio-default.test/master.m3u8',
+          formats: [],
+          duration: 2,
+          storyboardVtt: null,
+          title: 'Original audio test',
+          captions: [],
+          captionTranslations: [],
+          version: 'test'
+        }))
+      })
+
+      await page.locator(sel.searchInput).fill('https://www.youtube.com/watch?v=jNQXAC9IVRw')
+      await page.locator(sel.searchInput).press('Enter')
+      const player = page.locator(`${activeTab} .ftVideoPlayer`)
+      await expect.poll(() => player.locator('video').evaluate(video => video.readyState)).toBeGreaterThanOrEqual(2)
+      await expect.poll(() => player.evaluate(element => {
+        const shakaPlayer = element.ui?.getControls().getPlayer()
+        return shakaPlayer?.getVariantTracks().find(track => track.active)?.language
+      })).toBe('en-US')
+
+      await player.locator('.shaka-overflow-menu-button').click()
+      await player.locator('.shaka-overflow-menu').getByRole('button', { name: 'Audio Tracks' }).click()
+      await player.locator('.audio-tracks').getByRole('button', { name: 'العربية - dubbed-auto' }).click()
+      await expect.poll(() => player.evaluate(element => (
+        element.ui.getControls().getPlayer().getVariantTracks().find(track => track.active)?.language
+      ))).toBe('ar')
+    })
+  })
+}

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -78,6 +78,8 @@ import {
 } from '../../helpers/androidUi'
 import { appendTimestamp, getInvidiousVideoUrl, getYoutubeVideoShareUrl } from '../../helpers/share'
 import { MANIFEST_TYPE_SABR } from '../../helpers/player/SabrManifestParser'
+import { preferOriginalHlsAudio } from '../../helpers/player/hlsAudioTracks'
+import { getDefaultAudioVariants } from '../../helpers/player/defaultAudioTrack'
 import { MUSIC_MEDIA_TYPE } from '../../helpers/player/musicMediaType'
 import { resolveSegmentPrefetchLimit } from '../../helpers/player/segmentPrefetch'
 import { AUTO_QUALITY_FALLBACK, streamsSupportAutoQuality } from '../../helpers/player/autoQuality'
@@ -3347,6 +3349,10 @@ export default defineComponent({
         // - `powerEfficient` the spec is quite vague but in Chromium it should prioritise hardware decoding when available
         // https://developer.mozilla.org/en-US/docs/Web/API/MediaCapabilities/decodingInfo
         preferredDecodingAttributes: format === 'dash' ? ['smooth', 'powerEfficient'] : [],
+
+        // Prefer the main audio before codec/channel preferences. If there is
+        // no main role, Shaka falls back to the manifest's primary track.
+        preferredAudio: [{ role: 'main' }],
 
         // Shaka automatically shows a matching preferred text track on load.
         // Only give it a preference when captions should be enabled or restored.
@@ -6750,6 +6756,9 @@ export default defineComponent({
             response.data = new TextEncoder().encode(cleaned).buffer
           }
         }
+      } else if (type === RequestType.MANIFEST && context.type === AdvancedRequestType.MASTER_PLAYLIST) {
+        const manifest = new TextDecoder().decode(response.data)
+        response.data = new TextEncoder().encode(preferOriginalHlsAudio(manifest)).buffer
       } else if (type === RequestType.MANIFEST && context.type === AdvancedRequestType.MEDIA_PLAYLIST) {
         const url = new URL(response.uri)
 
@@ -6849,12 +6858,7 @@ export default defineComponent({
       if (label) {
         variants = variants.filter(variant => variant.label === label)
       } else if (hasMultipleAudioTracks.value) {
-        // default audio track
-        const filteredVariants = variants.filter(variant => variant.audioRoles.includes('main'))
-        // Sometimes there is nothing marked as main, don't filter in this case
-        if (filteredVariants.length > 0) {
-          variants = filteredVariants
-        }
+        variants = getDefaultAudioVariants(variants)
       }
 
       const isPortrait = variants[0].height > variants[0].width
@@ -10329,8 +10333,7 @@ export default defineComponent({
             let variants = player.getVariantTracks()
 
             if (hasMultipleAudioTracks.value) {
-              // default audio track
-              variants = variants.filter(variant => variant.audioRoles.includes('main'))
+              variants = getDefaultAudioVariants(variants)
             }
 
             if (variants.length > 0) {
@@ -10678,12 +10681,7 @@ export default defineComponent({
                 if (label) {
                   variants = variants.filter(variant => variant.label === label)
                 } else if (variants.length > 1) {
-                  // default audio track
-                  const filteredVariants = variants.filter(variant => variant.audioRoles.includes('main'))
-                  // Sometimes there is nothing marked as main, don't filter in this case
-                  if (filteredVariants.length > 0) {
-                    variants = filteredVariants
-                  }
+                  variants = getDefaultAudioVariants(variants)
                 }
 
                 let chosenVariant

--- a/src/renderer/helpers/player/defaultAudioTrack.js
+++ b/src/renderer/helpers/player/defaultAudioTrack.js
@@ -1,0 +1,12 @@
+/**
+ * DASH/SABR use the main role; HLS uses the primary flag from DEFAULT=YES.
+ * @param {shaka.extern.Track[]} variants
+ * @returns {shaka.extern.Track[]}
+ */
+export function getDefaultAudioVariants(variants) {
+  const main = variants.filter(variant => variant.audioRoles.includes('main'))
+  if (main.length > 0) return main
+
+  const primary = variants.filter(variant => variant.primary)
+  return primary.length > 0 ? primary : variants
+}

--- a/src/renderer/helpers/player/hlsAudioTracks.js
+++ b/src/renderer/helpers/player/hlsAudioTracks.js
@@ -1,0 +1,37 @@
+/**
+ * YouTube can mark every HLS audio rendition DEFAULT=NO. Its content IDs
+ * still identify the original track with suffix .4, as in the local API.
+ * @param {string} manifest
+ * @returns {string}
+ */
+export function preferOriginalHlsAudio(manifest) {
+  const lines = manifest.split('\n')
+  const audioTags = new Map()
+  const originalGroups = new Set()
+
+  for (const [index, line] of lines.entries()) {
+    if (!line.startsWith('#EXT-X-MEDIA:')) continue
+
+    // Quoted names and URIs can contain commas.
+    const attributes = new Map([...line.slice(13).trimEnd().matchAll(/(?:^|,)([\w-]+)=("[^"]*"|[^,]*)/g)]
+      .map(([, key, value]) => [key, value]))
+    if (attributes.get('TYPE') !== 'AUDIO') continue
+
+    const group = attributes.get('GROUP-ID')
+    if (!group) continue
+
+    const original = attributes.get('YT-EXT-AUDIO-CONTENT-ID')?.endsWith('.4"') ?? false
+    audioTags.set(index, { attributes, group, original })
+    if (original) originalGroups.add(group)
+  }
+
+  for (const [index, { attributes, group, original }] of audioTags) {
+    if (!originalGroups.has(group)) continue
+
+    attributes.set('DEFAULT', original ? 'YES' : 'NO')
+    if (original) attributes.set('AUTOSELECT', 'YES')
+    lines[index] = '#EXT-X-MEDIA:' + [...attributes].map(([key, value]) => `${key}=${value}`).join(',')
+  }
+
+  return lines.join('\n')
+}

--- a/tests/unit/default-audio-track.test.mjs
+++ b/tests/unit/default-audio-track.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { getDefaultAudioVariants } from '../../src/renderer/helpers/player/defaultAudioTrack.js'
+import { preferOriginalHlsAudio } from '../../src/renderer/helpers/player/hlsAudioTracks.js'
+
+test('prefers the original HLS audio within each group and preserves quoted commas', () => {
+  const dub = '#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="234",NAME="Arabic, dubbed",URI="ar.m3u8?a=1,b=2",YT-EXT-AUDIO-CONTENT-ID="ar.10",DEFAULT=YES,AUTOSELECT=YES'
+  const original = '#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="234",NAME="English original",YT-EXT-AUDIO-CONTENT-ID="en-US.4",DEFAULT=NO,AUTOSELECT=NO'
+  const otherGroup = dub.replace('"234"', '"233"')
+  const subtitles = '#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="234",DEFAULT=YES'
+  const manifest = ['#EXTM3U', dub, original, otherGroup, subtitles, ''].join('\n')
+  assert.equal(preferOriginalHlsAudio(manifest), [
+    '#EXTM3U',
+    dub.replace('DEFAULT=YES', 'DEFAULT=NO'),
+    original.replace('DEFAULT=NO', 'DEFAULT=YES').replace('AUTOSELECT=NO', 'AUTOSELECT=YES'),
+    otherGroup,
+    subtitles,
+    ''
+  ].join('\n'))
+})
+
+test('leaves HLS without YouTube original-track metadata unchanged', () => {
+  const manifest = '#EXTM3U\r\n#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="English original",DEFAULT=NO\r\n'
+  assert.equal(preferOriginalHlsAudio(manifest), manifest)
+})
+
+test('selects DASH/SABR main audio and HLS primary audio without discarding unlabelled streams', () => {
+  const dub = { audioRoles: ['dub'], primary: false }
+  const main = { audioRoles: ['main'], primary: false }
+  const hlsOriginal = { audioRoles: [], primary: true }
+  assert.deepEqual(getDefaultAudioVariants([dub, main]), [main])
+  assert.deepEqual(getDefaultAudioVariants([dub, hlsOriginal]), [hlsOriginal])
+  assert.deepEqual(getDefaultAudioVariants([dub]), [dub])
+  assert.deepEqual(getDefaultAudioVariants([]), [])
+})


### PR DESCRIPTION
Videos with multiple audio tracks can start on the first listed dub instead of the original when played through yt-dlp.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Prefer the original audio using YouTube’s track metadata, and respect that choice during automatic and fixed-quality playback. Manual audio selection remains available.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed videos starting with a dubbed audio track instead of the original when using yt-dlp playback.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run this branch in dev mode and choose yt-dlp as the playback engine.
2. Open a video with original and dubbed audio tracks. Confirm playback starts on the original audio with fixed quality, Auto quality, and audio-only mode.
3. Select a dub in Audio Tracks and confirm the player switches to it.

## Additional context
<!-- Add any other context about the pull request here. -->
