### PR TITLE
perf: reduce idle player polling and UI rendering work

### DIFF
--- a/e2e/tests/offline/performance-audit.spec.mjs
+++ b/e2e/tests/offline/performance-audit.spec.mjs
@@ -1,0 +1,134 @@
+import { test, expect, goTo, setWindowSize } from '../../helpers/app.mjs'
+import { openMockedVideo } from '../../helpers/player.mjs'
+import { mockPlayableWatchPage } from '../../helpers/watch.mjs'
+
+test.use({
+  seed: { settings: { videoPlaybackEngine: 'built-in', ytDlpPlaybackEngineDefaultMigration: true } },
+})
+
+test('default-speed button transitions do not query animations in JavaScript', async ({ page }) => {
+  await page.evaluate(async () => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    await store.dispatch('updateReducedMotion', 'off')
+  })
+  const button = page.getByRole('button', { name: 'Expand side navigation', exact: true })
+  await page.mouse.move(800, 500)
+  await button.evaluate(element => {
+    window.__buttonAnimationWork = { transitions: 0, queries: 0 }
+    element.addEventListener('transitionrun', () => window.__buttonAnimationWork.transitions++)
+    const original = element.getAnimations
+    element.getAnimations = function (options) {
+      window.__buttonAnimationWork.queries++
+      return original.call(this, options)
+    }
+  })
+  await button.hover()
+  await expect.poll(() => page.evaluate(() => window.__buttonAnimationWork.transitions)).toBeGreaterThan(0)
+  const metrics = await page.evaluate(() => window.__buttonAnimationWork)
+  console.log('Default-speed button animation work:', metrics)
+  expect(metrics.queries).toBe(0)
+})
+
+test.describe('history progress direction', () => {
+  test.use({
+    seed: {
+      settings: { uiScale: 95, uiRoundness: 200 },
+      history: Array.from({ length: 100 }, (_, index) => ({
+        _id: String(index).padStart(11, '0'),
+        videoId: String(index).padStart(11, '0'),
+        title: `Progress video ${index}`,
+        author: 'Performance fixture',
+        authorId: 'UC0000000000000000000000',
+        timeWatched: Date.now() - index * 1000,
+        lengthSeconds: 120,
+        watchProgress: 30,
+        isWatched: false,
+        type: 'video',
+      })),
+    },
+  })
+
+  test('mirrors progress without per-card JavaScript style reads', async ({ app, page }, testInfo) => {
+    await page.evaluate(() => {
+      const original = window.getComputedStyle
+      window.__progressStyleReads = 0
+      window.getComputedStyle = function (element, pseudo) {
+        if (element.matches?.('svg.embeddedProgress')) window.__progressStyleReads++
+        return original.call(this, element, pseudo)
+      }
+    })
+    await goTo(page, 'history')
+    const paths = page.locator('.watchedProgressBar .embeddedProgressPath')
+    // Cards below the viewport are intentionally rendered lazily.
+    await expect.poll(() => paths.count()).toBeGreaterThan(10)
+    const path = paths.first()
+
+    const progressStartsOn = async direction => {
+      await expect.poll(() => path.evaluate(element => {
+        const start = element.getPointAtLength(0).matrixTransform(element.getScreenCTM())
+        const end = element.getPointAtLength(element.getTotalLength()).matrixTransform(element.getScreenCTM())
+        return start.x < end.x ? 'left' : 'right'
+      })).toBe(direction)
+    }
+
+    await progressStartsOn('left')
+    const mountReads = await page.evaluate(() => window.__progressStyleReads)
+    await page.evaluate(() => { document.body.dir = 'rtl' })
+    await progressStartsOn('right')
+    const directionReads = await page.evaluate(() => window.__progressStyleReads) - mountReads
+    await testInfo.attach('progress JavaScript work', {
+      body: JSON.stringify({ cards: await paths.count(), mountReads, directionReads }),
+      contentType: 'application/json',
+    })
+    console.log('Progress style reads:', { mountReads, directionReads })
+    expect.soft(mountReads).toBe(0)
+    expect.soft(directionReads).toBe(0)
+
+    await setWindowSize(app, page, { width: 900, height: 700 })
+    await page.evaluate(() => window.ftElectron.setZoomFactor(1.25))
+    await progressStartsOn('right')
+    await page.evaluate(() => { document.body.dir = 'ltr' })
+    await progressStartsOn('left')
+    await expect.poll(() => path.evaluate(element => {
+      const svg = element.ownerSVGElement
+      return Math.abs(svg.viewBox.baseVal.width - Number.parseFloat(getComputedStyle(svg).width))
+    })).toBeLessThan(0.1)
+  })
+})
+
+test('loop controls update on changes without polling an idle player', async ({ app, page }, testInfo) => {
+  await mockPlayableWatchPage(app, page)
+  const video = await openMockedVideo(page)
+  await video.evaluate(element => element.pause())
+  const buttons = page.locator('.ftVideoPlayer .loop-button')
+  await expect(buttons.first()).toBeAttached()
+
+  for (const enabled of [true, false]) {
+    await video.evaluate((element, enabled) => { element.loop = enabled }, enabled)
+    await expect.poll(() => buttons.evaluateAll((elements, enabled) => elements.every(element => (
+      element.getAttribute('aria-pressed') === String(enabled)
+    )), enabled)).toBe(true)
+  }
+
+  const metrics = await page.evaluate(async () => {
+    const buttons = [...document.querySelectorAll('.ftVideoPlayer .loop-button')]
+    const classes = new Set(buttons.map(button => button.classList))
+    const original = DOMTokenList.prototype.toggle
+    let visibilityChecks = 0
+    DOMTokenList.prototype.toggle = function (...args) {
+      if (classes.has(this)) visibilityChecks++
+      return original.apply(this, args)
+    }
+    try {
+      await new Promise(resolve => setTimeout(resolve, 1100))
+      return { buttons: buttons.length, visibilityChecks }
+    } finally {
+      DOMTokenList.prototype.toggle = original
+    }
+  })
+  await testInfo.attach('idle loop control work', {
+    body: JSON.stringify(metrics), contentType: 'application/json',
+  })
+  console.log('Idle loop control work:', metrics)
+  expect(metrics.visibilityChecks).toBe(0)
+})

--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -1391,11 +1391,17 @@ test.describe('thumbnail watched progress', () => {
     expect(Math.abs(progressBounds.width - thumbnailBounds.width)).toBeLessThanOrEqual(1)
     expect(progressGeometry.pathLength).toBeGreaterThan(thumbnailBounds.width - 20)
 
-    const leftToRightPath = progressGeometry.path
+    const renderedDirection = () => progressPath.evaluate(element => {
+      const matrix = element.getScreenCTM()
+      const start = element.getPointAtLength(0).matrixTransform(matrix)
+      const end = element.getPointAtLength(element.getTotalLength()).matrixTransform(matrix)
+      return start.x < end.x ? 'ltr' : 'rtl'
+    })
+    await expect.poll(renderedDirection).toBe('ltr')
     await page.evaluate(() => {
       document.body.dir = 'rtl'
     })
-    await expect.poll(() => progressPath.getAttribute('d')).not.toBe(leftToRightPath)
+    await expect.poll(renderedDirection).toBe('rtl')
   })
 
   test('keeps full progress aligned across Android screen shapes and UI scales', async ({ app, page }) => {

--- a/src/renderer/components/FtEmbeddedProgress/FtEmbeddedProgress.vue
+++ b/src/renderer/components/FtEmbeddedProgress/FtEmbeddedProgress.vue
@@ -47,9 +47,7 @@ const props = defineProps({
 const svg = useTemplateRef('svg')
 const width = ref(1)
 const height = ref(1)
-const rightToLeft = ref(false)
 let resizeObserver = null
-let directionObserver = null
 
 const clampedProgress = computed(() => Math.min(100, Math.max(0, props.progress)))
 
@@ -103,15 +101,6 @@ const path = computed(() => {
     startTop,
   } = geometry.value
 
-  if (rightToLeft.value) {
-    return [
-      `M ${width.value - startInset} ${startTop}`,
-      `A ${arcRadius} ${arcRadius} 0 0 1 ${width.value - radius} ${bottom}`,
-      `H ${radius}`,
-      `A ${arcRadius} ${arcRadius} 0 0 1 ${width.value - endInset} ${endTop}`,
-    ].join(' ')
-  }
-
   return [
     `M ${startInset} ${startTop}`,
     `A ${arcRadius} ${arcRadius} 0 0 0 ${radius} ${bottom}`,
@@ -133,23 +122,13 @@ function updateGeometry(entry) {
   height.value = Math.max(1, box ? box.blockSize : entry.contentRect.height)
 }
 
-function updateDirection() {
-  rightToLeft.value = getComputedStyle(svg.value).direction === 'rtl'
-}
-
 onMounted(() => {
   resizeObserver = new ResizeObserver(entries => updateGeometry(entries[0]))
   resizeObserver.observe(svg.value)
-  directionObserver = new MutationObserver(updateDirection)
-  directionObserver.observe(document.body, {
-    attributeFilter: ['dir'],
-  })
-  updateDirection()
 })
 
 onBeforeUnmount(() => {
   resizeObserver?.disconnect()
-  directionObserver?.disconnect()
 })
 </script>
 
@@ -169,5 +148,11 @@ onBeforeUnmount(() => {
   stroke-linecap: round;
   stroke-linejoin: round;
   stroke-width: v-bind(lineWidth);
+}
+
+.embeddedProgress:dir(rtl) .embeddedProgressPath {
+  transform: scaleX(-1);
+  transform-origin: center;
+  transform-box: view-box;
 }
 </style>

--- a/src/renderer/components/ft-shaka-video-player/player-components/LoopButton.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/LoopButton.js
@@ -54,9 +54,10 @@ export class LoopButton extends shaka.ui.Element {
     this.loopVisible_ = this.isLoopVisible_()
 
     /** @private */
-    this.statePoller_ = window.setInterval(() => {
-      this.updateState_()
-    }, 250)
+    this.loopObserver_ = new MutationObserver(() => this.updateState_())
+    // HTMLMediaElement.loop reflects the attribute, including changes from
+    // shortcuts and other controls. A-B repeat uses the context subscription.
+    this.loopObserver_.observe(controls.getLocalVideo(), { attributes: true, attributeFilter: ['loop'] })
 
     /** @private */
     this.button_ = document.createElement('button')
@@ -129,7 +130,7 @@ export class LoopButton extends shaka.ui.Element {
   }
 
   release() {
-    window.clearInterval(this.statePoller_)
+    this.loopObserver_.disconnect()
     this.stopStateWatch_?.()
     super.release()
   }

--- a/src/renderer/helpers/animationSpeed.js
+++ b/src/renderer/helpers/animationSpeed.js
@@ -32,6 +32,10 @@ function isAnimationSpeedManaged(target) {
 }
 
 function updateTargetAnimations(event) {
+  // CSS already runs at this rate. Avoid querying animations (and flushing
+  // pending styles) for every hover transition at the default setting.
+  if (animationPlaybackRate === 1) { return }
+
   queueMicrotask(() => {
     if (isAnimationSpeedManaged(event.target)) { return }
     if (!(event.target instanceof Element)) { return }

--- a/tests/unit/animation-speed.test.mjs
+++ b/tests/unit/animation-speed.test.mjs
@@ -91,3 +91,28 @@ test('applies speed to newly started unmanaged animations', async () => {
 
   assert.deepEqual(playbackRates, [2, 2])
 })
+
+test('lets CSS run at its default speed without querying animations for each event', async () => {
+  let queries = 0
+  const target = new FakeElement()
+  target.getAnimations = () => { queries++; return [] }
+  setAnimationSpeed(100)
+  for (let index = 0; index < 100; index++) {
+    listeners.get('animationstart')({ target })
+    listeners.get('transitionrun')({ target })
+  }
+  await Promise.resolve()
+  assert.equal(queries, 0)
+})
+
+test('restores existing animations when returning to default speed', () => {
+  const playbackRates = []
+  activeAnimations.push({
+    effect: { target: new FakeElement() },
+    updatePlaybackRate: rate => playbackRates.push(rate),
+  })
+  setAnimationSpeed(200)
+  setAnimationSpeed(100)
+  assert.deepEqual(playbackRates, [2, 1])
+  activeAnimations.length = 0
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description

The performance audit found recurring loop-button polling, per-progress-bar direction observers and style reads, and animation queries at the default speed. This removes those costs while preserving the existing controls and appearance.

Loop controls now observe the local video’s loop attribute, progress bars use CSS for RTL mirroring, and default-speed animations skip redundant discovery. Regression coverage checks the removed work and preserves loop behavior, RTL geometry, resizing, and fractional UI scales.
<!-- Please write a clear and concise description of what the pull request does. -->

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Reduce unnecessary background work in player controls, progress indicators, and interface animations.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing

1. In dev mode, hover navigation buttons at 100% animation speed, change the setting to a custom speed, then restore 100%. Transitions should follow the selected speed and return to normal.
2. Open history with partially watched videos. Switch between LTR and RTL languages, resize the window, and try 95% and 125% UI scales. Progress indicators should mirror correctly and retain their rounded geometry.
3. Play a video and toggle looping through the player controls. Confirm both loop buttons reflect the state, A–B repeat still works, and overflow controls hide while a submenu is open.
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

## Additional context

Measured work reductions: a default-speed hover performs zero animation queries instead of one; 16 visible history progress bars perform zero direction-related style reads instead of 16 on mount and another 16 on direction change; two paused loop controls perform zero periodic visibility checks instead of eight in 1.1 seconds. Seven alternating samples per build passed all performance regression gates, but do not establish a material overall speedup.

Validation before rebasing onto the unrelated subscriptions-header change: 938 unit tests and 20 targeted E2E tests passed. The full desktop suite ran all 1,121 tests under private X servers: 1,053 offline and 47 network tests passed; 12 network tests failed live and skipped on retry; nine skipped initially. All 12 live failures also reproduced against the saved pre-change production bundle with retries disabled. The full suite is therefore not clean, but identified no new regression. Changed-file ESLint and whitespace checks passed.

Independent Standards and Spec reviews reported zero findings.
<!-- Add any other context about the pull request here. -->
