### PR TITLE
fix(player): refresh rejected yt-dlp timeout URLs

### DIFF
--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -536,6 +536,63 @@ test('yt-dlp player reload reuses cache unless the timed-out URL is rejected', a
   })
 })
 
+test('a stale yt-dlp rejection probe preserves a newer cache entry', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  await goTo(page, 'history')
+  await page.getByText('SABR test video').click()
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  await expect(page.locator('.ftVideoPlayer')).toBeVisible({ timeout: 30_000 })
+
+  const watchView = await watchViewHandle(page)
+  const result = await watchView.evaluate(async (view) => {
+    const rejectedStreamUrl = 'https://example.invalid/stale-rejected-yt-dlp-stream'
+    const useAuthentication = view.alwaysUseYtDlpPlaybackCookies
+    const cacheKey = JSON.stringify([view.ytDlpPlaybackCacheKey, useAuthentication])
+    const source = {
+      manifestSrc: 'data:application/dash+xml;charset=UTF-8,newer',
+      manifestMimeType: 'application/dash+xml',
+      legacyFormats: [],
+      title: 'Newer timeout recovery',
+      isLive: false,
+      subtitlesIncluded: true,
+      version: 'test'
+    }
+    const originalFetch = window.fetch
+
+    window.fetch = async (url, options) => {
+      if (url !== rejectedStreamUrl) return originalFetch(url, options)
+
+      view.videoLoadGeneration++
+      if (!await window.ftElectron.ytDlpPlaybackCacheSet(
+        view.videoId,
+        cacheKey,
+        Date.now() + 60 * 60 * 1000,
+        source
+      )) {
+        throw new Error('Unable to seed the newer yt-dlp playback cache')
+      }
+      return new Response('', { status: 403 })
+    }
+
+    try {
+      await view.reloadYtDlpPlayerAfterStreamErrorOnce(
+        '[PLAYER_ERROR: 1003]',
+        rejectedStreamUrl
+      )
+    } finally {
+      window.fetch = originalFetch
+    }
+
+    return {
+      cacheEntry: await window.ftElectron.ytDlpPlaybackCacheGet(view.videoId, cacheKey),
+      loadGeneration: view.videoLoadGeneration
+    }
+  })
+
+  expect(result.cacheEntry?.source.title).toBe('Newer timeout recovery')
+  expect(result.loadGeneration).toBeGreaterThan(0)
+})
+
 test('yt-dlp recovery remounts only the player and preserves playback state', async ({ app, page }) => {
   await mockPlayableWatchPage(app, page)
   await goTo(page, 'history')

--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -396,8 +396,13 @@ test('yt-dlp playback refreshes once then prefers built-in SABR over legacy', as
   })
 })
 
-test('yt-dlp player reload keeps metadata and reuses cache while a rejected source is invalidated', async ({ app, page }) => {
+test('yt-dlp player reload reuses cache unless the timed-out URL is rejected', async ({ app, page }) => {
+  const rejectedStreamUrl = 'https://example.invalid/rejected-yt-dlp-stream'
   await mockPlayableWatchPage(app, page)
+  await page.route(rejectedStreamUrl, route => route.fulfill({
+    status: 403,
+    headers: { 'access-control-allow-origin': '*' }
+  }))
   await goTo(page, 'history')
   await page.getByText('SABR test video').click()
   await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
@@ -405,7 +410,6 @@ test('yt-dlp player reload keeps metadata and reuses cache while a rejected sour
 
   const watchView = await watchViewHandle(page)
   const result = await watchView.evaluate(async (view) => {
-    const BAD_HTTP_STATUS = 1001
     const TIMEOUT = 1003
     const useAuthentication = view.alwaysUseYtDlpPlaybackCookies
     const cacheKey = JSON.stringify([view.ytDlpPlaybackCacheKey, useAuthentication])
@@ -499,7 +503,7 @@ test('yt-dlp player reload keeps metadata and reuses cache while a rejected sour
       throw new Error('Unable to restore the yt-dlp playback cache')
     }
     view.streamErrorReloadAttemptedForCurrentVideo = false
-    await view.handlePlayerError({ code: BAD_HTTP_STATUS, data: ['https://example.invalid/video', 403] })
+    await view.handlePlayerError({ code: TIMEOUT, data: ['https://example.invalid/rejected-yt-dlp-stream'] })
     await waitForCacheLookup(2)
 
     return {

--- a/src/renderer/helpers/player/ytDlpPlayback.js
+++ b/src/renderer/helpers/player/ytDlpPlayback.js
@@ -27,6 +27,7 @@ import { getEarliestYtDlpFormatExpiry, YtDlpPlaybackSourceCache } from './ytDlpP
 // yt-dlp appends the audio track or a suffix like "-drc" to the itag for some formats
 const ITAG_REGEX = /^\d+/
 const URL_PROBE_TIMEOUT = 10_000
+const REJECTED_PLAYBACK_URL_STATUSES = new Set([401, 403, 404, 410])
 const MINIMUM_LIVE_DVR_WINDOW_SECONDS = 30
 const playbackSourceCache = new YtDlpPlaybackSourceCache()
 const pendingPlaybackSourceLoads = new Map()
@@ -331,6 +332,42 @@ async function probeYtDlpUrl(url) {
     return response.ok
   } catch {
     return false
+  }
+}
+
+/**
+ * Checks whether the exact URL that timed out is still serving stream data.
+ * @param {unknown} url
+ * @returns {Promise<'accepted' | 'rejected' | 'inconclusive'>}
+ */
+export async function checkYtDlpPlaybackUrl(url) {
+  if (typeof url !== 'string' || url.length === 0) return 'inconclusive'
+
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(URL_PROBE_TIMEOUT) })
+
+    if (REJECTED_PLAYBACK_URL_STATUSES.has(response.status)) {
+      await response.body?.cancel().catch(() => {})
+      return 'rejected'
+    }
+
+    if (!response.ok || response.body === null) {
+      await response.body?.cancel().catch(() => {})
+      return 'inconclusive'
+    }
+
+    const reader = response.body.getReader()
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (value !== undefined && value.byteLength > 0) return 'accepted'
+        if (done) return 'inconclusive'
+      }
+    } finally {
+      await reader.cancel().catch(() => {})
+    }
+  } catch {
+    return 'inconclusive'
   }
 }
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -4789,18 +4789,19 @@ export default defineComponent({
         return true
       }
 
-      if (
-        playbackUrl !== undefined &&
-        await checkYtDlpPlaybackUrl(playbackUrl) === 'rejected'
-      ) {
-        invalidateYtDlpPlaybackSource(videoId)
-      }
+      const playbackUrlStatus = playbackUrl === undefined
+        ? 'inconclusive'
+        : await checkYtDlpPlaybackUrl(playbackUrl)
 
       if (
         !this.isCurrentVideoLoad(loadGeneration, videoId) ||
         playbackEngineSwitchGeneration !== this.playbackEngineSwitchGeneration
       ) {
         return true
+      }
+
+      if (playbackUrlStatus === 'rejected') {
+        invalidateYtDlpPlaybackSource(videoId)
       }
 
       this.ytDlpStreamsPending = true

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -77,7 +77,11 @@ import {
   MANIFEST_TYPE_DASH,
   MANIFEST_TYPE_HLS
 } from '../../helpers/player/utils'
-import { getYtDlpPlaybackSource, invalidateYtDlpPlaybackSource } from '../../helpers/player/ytDlpPlayback'
+import {
+  checkYtDlpPlaybackUrl,
+  getYtDlpPlaybackSource,
+  invalidateYtDlpPlaybackSource
+} from '../../helpers/player/ytDlpPlayback'
 import {
   buildYtDlpPlaybackCacheKey,
   preloadYtDlpPlaybackSources,
@@ -4755,9 +4759,10 @@ export default defineComponent({
      * Refreshes yt-dlp's streams and recreates only the player. The watch-page
      * metadata and the built-in fallback source stay loaded.
      * @param {string} specificError
+     * @param {unknown} [playbackUrl] exact URL to verify after a timeout
      * @returns {Promise<boolean>} whether recovery handled the error
      */
-    reloadYtDlpPlayerAfterStreamErrorOnce: async function (specificError) {
+    reloadYtDlpPlayerAfterStreamErrorOnce: async function (specificError, playbackUrl) {
       if (!this.beginStreamErrorRecoveryOnce(specificError)) {
         return false
       }
@@ -4775,6 +4780,20 @@ export default defineComponent({
 
       if (this.$refs.player) {
         await this.destroyPlayer()
+      }
+
+      if (
+        !this.isCurrentVideoLoad(loadGeneration, videoId) ||
+        playbackEngineSwitchGeneration !== this.playbackEngineSwitchGeneration
+      ) {
+        return true
+      }
+
+      if (
+        playbackUrl !== undefined &&
+        await checkYtDlpPlaybackUrl(playbackUrl) === 'rejected'
+      ) {
+        invalidateYtDlpPlaybackSource(videoId)
       }
 
       if (
@@ -4834,14 +4853,12 @@ export default defineComponent({
       // URL or extraction. Refresh those streams once before changing format or
       // restoring the cached built-in source (which may use SABR).
       if (this.activePlaybackEngine === 'yt-dlp') {
-        // A timeout says nothing about whether the cached source is stale. Keep
-        // valid cached streams for that reload so recovery does not needlessly
-        // run yt-dlp again, while other failures retain the existing refresh.
         if (error.code !== Code.TIMEOUT) {
           invalidateYtDlpPlaybackSource(this.videoId)
         }
         const status = error.code === Code.BAD_HTTP_STATUS ? error.data[1] : error.code
-        if (await this.reloadYtDlpPlayerAfterStreamErrorOnce(`[PLAYER_ERROR: ${status}]`)) {
+        const playbackUrl = error.code === Code.TIMEOUT ? error.data?.[0] : undefined
+        if (await this.reloadYtDlpPlayerAfterStreamErrorOnce(`[PLAYER_ERROR: ${status}]`, playbackUrl)) {
           return
         }
       }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #1068.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

A yt-dlp stream can fail with Shaka's `TIMEOUT` error even when its cached URL has actually expired or been rejected. The player-only recovery previously reused every cached source after a timeout, so it could mount the same broken URL and then fall back to the built-in engine.

Probe the exact failed URL before remounting the player. A `401`, `403`, `404`, or `410` response now invalidates the cached source and starts a fresh yt-dlp extraction. A successful response must provide at least one byte before the cache is accepted. Network failures, empty responses, and other HTTP statuses remain inconclusive and preserve the cache.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Start the app in development mode with yt-dlp selected as the playback engine and play a video long enough to cache its source.
2. Trigger a Shaka `TIMEOUT` whose failed URL still returns stream data. The player should remount without reloading the watch page or rerunning yt-dlp.
3. Repeat with an expired URL that returns `403`. The player should remount after a fresh yt-dlp extraction instead of reusing the rejected cache entry.
4. Confirm that the title, description, recommendations, and playback position remain intact through either recovery.

## Additional context
<!-- Add any other context about the pull request here. -->

The regression test uses a synthetic URL. Signed URLs from local playback caches were used only for manual response checks and were not added to the repository.
