### PR TITLE
fix: recover mobile subscription refreshes and correct navigation overlays

### DIFF
--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -67,6 +67,110 @@ async function phoneTabScrollState(page, contentSelector) {
   }, contentSelector)
 }
 
+for (const theme of ['light', 'dark']) {
+  test(`phone organizer covers navigation and keeps themed safe areas in ${theme} mode`, async ({ app, page }) => {
+    await setWindowSize(app, page, { width: 375, height: 760 })
+    await page.evaluate(async baseTheme => {
+      const store = document.querySelector('#app')._vnode.component.appContext.config.globalProperties.$store
+      await store.dispatch('updateBaseTheme', baseTheme)
+      document.documentElement.style.setProperty('--safe-area-inset-top', '28px')
+      document.documentElement.style.setProperty('--safe-area-inset-bottom', '24px')
+    }, theme)
+    await enablePhoneTabSwitcher(page)
+    await page.locator('.capacitorPhoneTabSwitcherButton').click()
+    const overlay = page.locator('.capacitorPhoneTabOverlay')
+    await expect(overlay).toBeVisible()
+    for (const size of [{ width: 375, height: 760 }, { width: 760, height: 375 }]) {
+      if (size.width !== 375) await setWindowSize(app, page, size)
+      const metrics = await overlay.evaluate(element => {
+        const dialog = element.querySelector('.capacitorPhoneTabDialog')
+        const header = element.querySelector('.capacitorPhoneTabHeader')
+        const bounds = dialog.getBoundingClientRect()
+        return {
+          top: bounds.top,
+          bottom: innerHeight - bounds.bottom,
+          left: bounds.left,
+          right: innerWidth - bounds.right,
+          background: getComputedStyle(element).backgroundColor,
+          headerBackground: getComputedStyle(header).backgroundColor,
+        }
+      })
+      expect(metrics.background).toBe(metrics.headerBackground)
+      expect(metrics.top).toBeCloseTo(28, 0)
+      expect(metrics.bottom).toBeCloseTo(24, 0)
+      expect(metrics.left).toBeCloseTo(0, 0)
+      expect(metrics.right).toBeCloseTo(0, 0)
+    }
+  })
+}
+
+test('phone organizer clamps its scroller when a taller viewport removes overflow', async ({ app, page }) => {
+  await setWindowSize(app, page, { width: 375, height: 400 })
+  await page.evaluate(async () => {
+    await window.ftElectron.setZoomFactor(0.95)
+    const store = document.querySelector('#app')._vnode.component.appContext.config.globalProperties.$store
+    for (let index = 0; index < 6; index++) {
+      await store.dispatch('createTab', { route: '/subscriptions', makeActive: false })
+    }
+  })
+  await enablePhoneTabSwitcher(page)
+  await page.locator('.capacitorPhoneTabSwitcherButton').click()
+  const panel = page.locator('#capacitor-phone-open-tabs-panel')
+  await panel.evaluate(element => { element.scrollTop = element.scrollHeight })
+  await expect.poll(async () => (await phoneTabScrollState(page, '.capacitorPhoneOpenTabs')).scrollTop)
+    .toBeGreaterThan(100)
+  await setWindowSize(app, page, { width: 376, height: 950 })
+  await expect.poll(() => phoneTabScrollState(page, '.capacitorPhoneOpenTabs')).toEqual({
+    scrollTop: 0,
+    maximum: 0,
+    scrollbarUnusable: true,
+  })
+})
+
+for (const zoom of [1, 0.95]) {
+  test(`mobile progress sits above the navigation without moving its active indicator at ${zoom} scale`, async ({ app, page }) => {
+    await setWindowSize(app, page, { width: 375, height: 760 })
+    await page.evaluate(async factor => {
+      await window.ftElectron.setZoomFactor(factor)
+      document.documentElement.style.setProperty('--safe-area-inset-bottom', '24px')
+      const store = document.querySelector('#app')._vnode.component.appContext.config.globalProperties.$store
+      store.commit('setShowProgressBarToast', false)
+      store.commit('setShowProgressBar', false)
+    }, zoom)
+    const nav = page.locator('.sideNav')
+    await expect.poll(() => nav.locator('.activeIndicator').evaluate(element => element.getBoundingClientRect().height))
+      .toBeCloseTo(3, 1)
+    await expect.poll(() => nav.locator('.activeIndicator').evaluate(element => (
+      new DOMMatrix(getComputedStyle(element).transform).m42
+    ))).toBeCloseTo(0, 2)
+    const originalHeight = await nav.evaluate(element => element.getBoundingClientRect().height)
+    await page.evaluate(() => {
+      const store = document.querySelector('#app')._vnode.component.appContext.config.globalProperties.$store
+      store.commit('setProgressBarPercentage', 50)
+      store.commit('setShowProgressBar', true)
+    })
+    await expect(page.locator('.progressBar')).toBeVisible()
+    const metrics = await nav.evaluate(element => {
+      const indicator = element.querySelector('.activeIndicator').getBoundingClientRect()
+      const progress = document.querySelector('.progressBar').getBoundingClientRect()
+      return {
+        height: element.getBoundingClientRect().height,
+        progressBottom: progress.bottom,
+        navTop: element.getBoundingClientRect().top,
+        indicatorBottomInset: innerHeight - indicator.bottom,
+      }
+    })
+    expect(metrics.height).toBeCloseTo(originalHeight, 0)
+    expect(metrics.progressBottom).toBeCloseTo(metrics.navTop, 0)
+    expect(metrics.indicatorBottomInset).toBeCloseTo(24, 0)
+    await page.evaluate(() => {
+      document.querySelector('#app')._vnode.component.appContext.config.globalProperties.$store.commit('setShowProgressBar', false)
+    })
+    await expect(page.locator('.progressBar')).toHaveCount(0)
+    expect(await nav.evaluate(element => element.getBoundingClientRect().height)).toBeCloseTo(originalHeight, 0)
+  })
+}
+
 test('centers phone tab close controls within their rows', async ({ page }) => {
   await page.addStyleTag({
     path: path.join(

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -6,6 +6,11 @@
 .app {
   --app-safe-area-inset-top: var(--safe-area-inset-top, env(safe-area-inset-top, 0));
   --top-nav-height: 60px;
+  --progress-bar-height: 6px;
+
+  /* Keep a length so the empty space can be added inside calc(). */
+  /* stylelint-disable-next-line length-zero-no-unit */
+  --mobile-progress-bar-space: 0px;
   --top-tab-bar-height: 32px;
   --top-nav-sticky-offset: calc(var(--app-safe-area-inset-top) + var(--top-nav-height));
 
@@ -233,7 +238,7 @@
   inline-size: 100%;
   max-inline-size: none;
   margin: 0;
-  padding-block-end: calc(60px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)));
+  padding-block-end: calc(60px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)) + var(--mobile-progress-bar-space));
 }
 
 /* Narrow viewports normally reserve a phone-sized top gap. The tablet tab
@@ -578,8 +583,12 @@
 }
 
 @media only screen and (width <= 680px) {
+  .app:has(> .progressBar) {
+    --mobile-progress-bar-space: var(--progress-bar-height);
+  }
+
   .routerView {
-    margin-block: 68px;
+    margin-block: 68px calc(68px + var(--mobile-progress-bar-space));
     margin-inline: 8px;
   }
 
@@ -656,7 +665,7 @@
 
 @media only screen and (width <= 680px) {
   .app:is(.topTabs, .bottomTabs) :deep(.sideNav) {
-    block-size: 60px;
+    block-size: calc(60px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)));
     inset-block-start: auto;
   }
 
@@ -664,8 +673,12 @@
     inset-block-end: 34px;
   }
 
+  .app.bottomTabs :deep(.progressBar) {
+    inset-block-end: calc(94px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)));
+  }
+
   .app.bottomTabs :deep(.moreOptionContainer) {
-    inset-block-end: 94px;
+    inset-block-end: calc(94px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)) + var(--mobile-progress-bar-space));
   }
 
   .sideNavBackdrop {

--- a/src/renderer/components/FtProgressBar/FtProgressBar.css
+++ b/src/renderer/components/FtProgressBar/FtProgressBar.css
@@ -1,7 +1,7 @@
 .progressBar {
   position: fixed;
   box-sizing: border-box;
-  block-size: 6px;
+  block-size: var(--progress-bar-height, 6px);
   padding-block: 1px;
   inset-block-end: 0;
   inset-inline: 0;
@@ -33,4 +33,12 @@
   background-color: color-mix(in srgb, var(--primary-color) 55%, #fff);
   box-shadow: 0 0 8px 2px color-mix(in srgb, var(--primary-color) 75%, transparent);
   content: '';
+}
+
+@media only screen and (width <= 680px) {
+  .progressBar {
+    inset-block-end: calc(60px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0)));
+    overflow: hidden;
+    box-shadow: none;
+  }
 }

--- a/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.css
+++ b/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.css
@@ -34,7 +34,7 @@
 .moreOptionContainer {
   position: fixed;
   background-color: var(--side-nav-color);
-  inset-block-end: calc(60px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0)));
+  inset-block-end: calc(60px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0)) + var(--mobile-progress-bar-space, 0px));
   inline-size: 70px;
   z-index: 0;
   box-shadow: 3px -3px 5px 0 rgb(0 0 0 / 20%);

--- a/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.css
+++ b/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.css
@@ -84,8 +84,8 @@
   box-sizing: border-box;
   display: grid;
   place-items: stretch;
-  padding-block: var(--safe-area-inset-top, env(safe-area-inset-top, 0)) calc(60px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)));
-  background-color: rgb(0 0 0 / 68%);
+  padding-block: var(--safe-area-inset-top, env(safe-area-inset-top, 0)) var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0));
+  background-color: var(--card-bg-color);
   -webkit-tap-highlight-color: transparent;
   user-select: none;
 }
@@ -531,22 +531,6 @@
 .capacitorPhoneTabFab:focus-visible {
   outline: 2px solid var(--primary-color);
   outline-offset: -3px;
-}
-
-@media only screen and (width >= 681px) {
-  .capacitorPhoneTabOverlay {
-    place-items: center;
-    padding-block: max(16px, var(--safe-area-inset-top, env(safe-area-inset-top, 0))) max(16px, var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0)));
-    padding-inline: 16px;
-  }
-
-  .capacitorPhoneTabDialog {
-    inline-size: min(560px, 100%);
-    block-size: min(720px, 100%);
-    border: 1px solid var(--border-color);
-    border-radius: calc(12px * var(--ui-roundness));
-    box-shadow: 0 18px 55px rgb(0 0 0 / 55%);
-  }
 }
 
 @media only screen and (width >= 768px) {

--- a/src/renderer/helpers/api/capacitor-http.js
+++ b/src/renderer/helpers/api/capacitor-http.js
@@ -98,9 +98,10 @@ async function getRequestBody(input, init) {
  * Uses Capacitor's native HTTP client for small HTML and JSON requests that
  * cannot rely on WebView CORS access. Media requests must keep using the
  * WebView so their response bodies are streamed instead of copied through the
- * JavaScript bridge as base64.
+ * JavaScript bridge as base64. nativeTimeoutMs bounds connection and read
+ * inactivity on Android; signal still limits the JavaScript wait.
  * @param {RequestInfo | URL} input
- * @param {RequestInit | undefined} init
+ * @param {RequestInit & { nativeTimeoutMs?: number }} [init]
  * @returns {Promise<Response>}
  */
 export async function capacitorHttpFetch(input, init = undefined) {
@@ -129,6 +130,8 @@ export async function capacitorHttpFetch(input, init = undefined) {
     data: await getRequestBody(input, init),
     responseType: 'text',
     disableRedirects: redirect !== 'follow',
+    connectTimeout: init?.nativeTimeoutMs,
+    readTimeout: init?.nativeTimeoutMs,
   }, signal)
 
   if (redirect === 'error' && REDIRECT_STATUSES.has(nativeResponse.status)) {

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -38,7 +38,12 @@ const TRACKING_PARAM_NAMES = [
   'utm_content',
 ]
 
-async function localApiFetch(input, init) {
+/**
+ * Uses native HTTP on Android, where YouTube does not allow WebView CORS access.
+ * @param {RequestInfo | URL} input
+ * @param {RequestInit} [init]
+ */
+export async function localApiFetch(input, init) {
   if (process.env.IS_CAPACITOR) {
     const { capacitorHttpFetch } = await import('./capacitor-http')
     return await capacitorHttpFetch(input, init)

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -41,7 +41,7 @@ const TRACKING_PARAM_NAMES = [
 /**
  * Uses native HTTP on Android, where YouTube does not allow WebView CORS access.
  * @param {RequestInfo | URL} input
- * @param {RequestInit} [init]
+ * @param {RequestInit & { nativeTimeoutMs?: number }} [init]
  */
 export async function localApiFetch(input, init) {
   if (process.env.IS_CAPACITOR) {

--- a/src/renderer/helpers/subscriptionNetworkRecovery.js
+++ b/src/renderer/helpers/subscriptionNetworkRecovery.js
@@ -1,0 +1,101 @@
+// Distinguish transport failures from errors in parsing or cache updates.
+export class SubscriptionNetworkError extends Error {
+  constructor(cause) {
+    super('Subscription refresh is waiting for the network', { cause })
+  }
+}
+
+const INITIAL_RETRY_DELAY_MS = 5000
+const MAX_RETRY_DELAY_MS = 60_000
+
+/**
+ * Pauses all channel workers after a transport failure. Once the connection
+ * returns, one channel checks it before the rest of the queue resumes.
+ * @param {{ eventTarget: EventTarget, isOnline: () => boolean, allowFallback?: boolean }} options
+ */
+export function createSubscriptionNetworkRecovery({ eventTarget, isOnline, allowFallback = false }) {
+  const cancellation = new AbortController()
+  let recovery = null
+  let useFallback = false
+
+  function waitForConnection(delay) {
+    return new Promise(resolve => {
+      let timer
+      const finish = () => {
+        clearTimeout(timer)
+        eventTarget.removeEventListener('online', onOnline)
+        eventTarget.removeEventListener('offline', onOffline)
+        cancellation.signal.removeEventListener('abort', finish)
+        resolve()
+      }
+      const onOnline = () => {
+        if (isOnline()) finish()
+      }
+      const onOffline = () => { clearTimeout(timer) }
+      eventTarget.addEventListener('online', onOnline)
+      eventTarget.addEventListener('offline', onOffline)
+      cancellation.signal.addEventListener('abort', finish, { once: true })
+      // WebView can report online despite a broken route or unreachable server.
+      // Probe with backoff in that case, but send nothing while actually offline.
+      if (isOnline()) timer = setTimeout(finish, delay)
+      if (cancellation.signal.aborted) finish()
+    })
+  }
+
+  async function recover(task) {
+    let delay = INITIAL_RETRY_DELAY_MS
+    while (!cancellation.signal.aborted) {
+      await waitForConnection(delay)
+      if (cancellation.signal.aborted) return
+      if (!isOnline()) continue
+      try {
+        await task(useFallback)
+        return
+      } catch (error) {
+        if (!(error instanceof SubscriptionNetworkError)) throw error
+        if (allowFallback && isOnline() && !cancellation.signal.aborted) {
+          try {
+            await task(!useFallback)
+            // Keep the working backend for this refresh, including later batches.
+            useFallback = !useFallback
+            return
+          } catch (fallbackError) {
+            if (!(fallbackError instanceof SubscriptionNetworkError)) throw fallbackError
+          }
+        }
+        delay = Math.min(delay * 2, MAX_RETRY_DELAY_MS)
+      }
+    }
+  }
+
+  function startRecovery(task) {
+    recovery = recover(task).finally(() => { recovery = null })
+    return recovery
+  }
+
+  return {
+    cancel() { cancellation.abort() },
+    async run(task) {
+      while (!cancellation.signal.aborted) {
+        if (recovery) {
+          await recovery
+          continue
+        }
+        if (!isOnline()) {
+          await startRecovery(task)
+          return
+        }
+        try {
+          await task(useFallback)
+          return
+        } catch (error) {
+          if (!(error instanceof SubscriptionNetworkError)) throw error
+          if (!recovery) {
+            await startRecovery(task)
+            return
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -495,7 +495,10 @@ async function fetchRssVideoUpcomingInfoUncached(videoId) {
     // lookup, so it is not cached and the next refresh tries again.
     const response = await localApiFetch(
       `https://www.youtube.com/watch?v=${videoId}`,
-      { signal: AbortSignal.timeout(RSS_ENRICHMENT_TIMEOUT_MS) }
+      {
+        signal: AbortSignal.timeout(RSS_ENRICHMENT_TIMEOUT_MS),
+        nativeTimeoutMs: RSS_ENRICHMENT_TIMEOUT_MS,
+      }
     )
 
     if (!response.ok) {
@@ -635,7 +638,10 @@ async function enrichScrapedUpcomingPublicationDates(channelId, videos) {
   try {
     const response = await localApiFetch(
       `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`,
-      { signal: AbortSignal.timeout(RSS_ENRICHMENT_TIMEOUT_MS) }
+      {
+        signal: AbortSignal.timeout(RSS_ENRICHMENT_TIMEOUT_MS),
+        nativeTimeoutMs: RSS_ENRICHMENT_TIMEOUT_MS,
+      }
     )
 
     if (!response.ok) {

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -10,10 +10,10 @@ import {
   getLocalChannelLiveStreams,
   getLocalChannelVideos,
   getLocalPlaylist,
+  localApiFetch,
   parseLocalPlaylistVideos
 } from './api/local'
 import {
-  fetchWithTimeout,
   getChannelPlaylistId,
   showApiErrorToast,
   showToast,
@@ -36,7 +36,8 @@ import { extractAssignedJsonObject } from './assigned-json'
 import { getLocalPremiereState } from './premiere'
 import { shouldShowProgressStartToast } from './progressPresentation'
 import { isAndroidSubscriptionRefreshActive } from './androidSubscriptionRefresh'
-import { buildRequestDiagnostic, formatRequestDiagnostic } from './api/requestDiagnostics'
+import { createSubscriptionNetworkRecovery, SubscriptionNetworkError } from './subscriptionNetworkRecovery'
+import { buildRequestDiagnostic, classifyRequestFailure, formatRequestDiagnostic } from './api/requestDiagnostics'
 
 const AUTO_REFRESH_TOAST_DURATION = 5000
 export const SUBSCRIPTION_REFRESH_CHANNEL_EVENT = 'opentubex-subscription-refresh-channel'
@@ -54,7 +55,7 @@ let electronRefreshOwnerTabId = null
 
 /**
  * Cancellation state of the refresh this renderer is running, if any.
- * @type {{ cancelled: boolean, tab: string, profileId: string, refreshId: number } | null}
+ * @type {{ cancelled: boolean, tab: string, profileId: string, refreshId: number, networkRecovery: ReturnType<typeof createSubscriptionNetworkRecovery> | null } | null}
  */
 let activeRefresh = null
 let nextRefreshId = 0
@@ -84,6 +85,7 @@ export function cancelSubscriptionRefresh() {
 function markActiveSubscriptionRefreshCancelled() {
   if (activeRefresh !== null && !activeRefresh.cancelled) {
     activeRefresh.cancelled = true
+    activeRefresh.networkRecovery?.cancel()
     window.dispatchEvent(new CustomEvent(SUBSCRIPTION_REFRESH_CANCELLED_EVENT, {
       detail: {
         tab: activeRefresh.tab,
@@ -151,7 +153,19 @@ async function runWithSubscriptionRefreshLock(tab, profileId, refresh) {
   const cancelCountAtStart = cancelCount
   const refreshId = ++nextRefreshId
   const runRefresh = async () => {
-    activeRefresh = { cancelled: false, tab, profileId, refreshId }
+    activeRefresh = {
+      cancelled: false,
+      tab,
+      profileId,
+      refreshId,
+      networkRecovery: process.env.IS_CAPACITOR
+        ? createSubscriptionNetworkRecovery({
+            eventTarget: window,
+            isOnline: () => navigator.onLine !== false,
+            allowFallback: process.env.SUPPORTS_LOCAL_API && store.getters.getBackendFallback
+          })
+        : null
+    }
     window.dispatchEvent(new CustomEvent(SUBSCRIPTION_REFRESH_STARTED_EVENT, {
       detail: { tab, profileId, refreshId }
     }))
@@ -163,6 +177,7 @@ async function runWithSubscriptionRefreshLock(tab, profileId, refresh) {
     try {
       return await refresh()
     } finally {
+      activeRefresh.networkRecovery?.cancel()
       activeRefresh = null
       window.dispatchEvent(new CustomEvent(SUBSCRIPTION_REFRESH_FINISHED_EVENT, {
         detail: { tab, profileId, refreshId }
@@ -247,7 +262,15 @@ async function fetchSubscriptionsConcurrently(channels, fetchChannel) {
         await window.ftElectron.waitForIpBlockRecoveryScript()
       }
 
-      await fetchChannel(channel)
+      if (activeRefresh?.networkRecovery) {
+        const preferredBackend = store.getters.getBackendPreference
+        await activeRefresh.networkRecovery.run(useFallback => fetchChannel(
+          channel,
+          useFallback ? (preferredBackend === 'local' ? 'invidious' : 'local') : preferredBackend
+        ))
+      } else {
+        await fetchChannel(channel)
+      }
 
       // Let input and navigation tasks run between parsing/cache updates.
       await new Promise(resolve => setTimeout(resolve, 0))
@@ -276,7 +299,13 @@ async function fetchSubscriptionsInBatches(channels, fetchChannel) {
  * @param {string} title
  * @param {{ category: string, backend: string }} context
  */
-export function showSubscriptionFetchError(channel, error, title, context) {
+function handleSubscriptionFetchError(channel, error, title, context) {
+  if (activeRefresh?.networkRecovery && classifyRequestFailure(error) === 'network') {
+    // Let the shared queue probe both enabled backends after backoff without
+    // cache writes, completion timestamps, or one toast per subscribed channel.
+    throw new SubscriptionNetworkError(error)
+  }
+
   const channelLabel = channel.name ? `${channel.name} (${channel.id})` : channel.id
   const diagnostic = formatRequestDiagnostic(buildRequestDiagnostic(error, context))
   const message = `${channelLabel}: ${diagnostic}`
@@ -464,9 +493,9 @@ async function fetchRssVideoUpcomingInfoUncached(videoId) {
     // request that never settles would hold its worker forever, leaving the
     // channel's feed permanently unresolved. A timeout counts as a failed
     // lookup, so it is not cached and the next refresh tries again.
-    const response = await fetchWithTimeout(
-      RSS_ENRICHMENT_TIMEOUT_MS,
-      `https://www.youtube.com/watch?v=${videoId}`
+    const response = await localApiFetch(
+      `https://www.youtube.com/watch?v=${videoId}`,
+      { signal: AbortSignal.timeout(RSS_ENRICHMENT_TIMEOUT_MS) }
     )
 
     if (!response.ok) {
@@ -604,9 +633,9 @@ async function enrichScrapedUpcomingPublicationDates(channelId, videos) {
   }
 
   try {
-    const response = await fetchWithTimeout(
-      RSS_ENRICHMENT_TIMEOUT_MS,
-      `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`
+    const response = await localApiFetch(
+      `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`,
+      { signal: AbortSignal.timeout(RSS_ENRICHMENT_TIMEOUT_MS) }
     )
 
     if (!response.ok) {
@@ -660,10 +689,10 @@ async function refreshSubscriptionVideosFromRemoteUnlocked({
   const useRss = store.getters.getUseRssFeeds
 
   try {
-    const fetchChannel = async (channel) => {
+    const fetchChannel = async (channel, backend = store.getters.getBackendPreference) => {
       let videos, name, thumbnailUrl
 
-      if (!process.env.SUPPORTS_LOCAL_API || store.getters.getBackendPreference === 'invidious') {
+      if (!process.env.SUPPORTS_LOCAL_API || backend === 'invidious') {
         if (useRss) {
           ({ videos, name, thumbnailUrl } = await getChannelVideosInvidiousRSS(channel, t, errorChannels))
         } else {
@@ -765,10 +794,10 @@ async function refreshSubscriptionShortsFromRemoteUnlocked({
   let channelCount = 0
 
   try {
-    await fetchSubscriptionsConcurrently(subscriptionList, async (channel) => {
+    await fetchSubscriptionsConcurrently(subscriptionList, async (channel, backend = store.getters.getBackendPreference) => {
       let videos, name
 
-      if (!process.env.SUPPORTS_LOCAL_API || store.getters.getBackendPreference === 'invidious') {
+      if (!process.env.SUPPORTS_LOCAL_API || backend === 'invidious') {
         ({ videos, name } = await getChannelShortsInvidious(channel, t, errorChannels))
       } else {
         ({ videos, name } = await getChannelShortsLocal(channel, t, errorChannels))
@@ -856,10 +885,10 @@ async function refreshSubscriptionLiveFromRemoteUnlocked({
   const useRss = store.getters.getUseRssFeeds
 
   try {
-    const fetchChannel = async (channel) => {
+    const fetchChannel = async (channel, backend = store.getters.getBackendPreference) => {
       let videos, name, thumbnailUrl
 
-      if (!process.env.SUPPORTS_LOCAL_API || store.getters.getBackendPreference === 'invidious') {
+      if (!process.env.SUPPORTS_LOCAL_API || backend === 'invidious') {
         if (useRss) {
           ({ videos, name, thumbnailUrl } = await getChannelLiveInvidiousRSS(channel, t, errorChannels))
         } else {
@@ -960,10 +989,10 @@ async function refreshSubscriptionPostsFromRemoteUnlocked({
   let channelCount = 0
 
   try {
-    const processChannel = async (channel) => {
+    const processChannel = async (channel, backend = store.getters.getBackendPreference) => {
       let posts
 
-      if (!process.env.SUPPORTS_LOCAL_API || store.getters.getBackendPreference === 'invidious') {
+      if (!process.env.SUPPORTS_LOCAL_API || backend === 'invidious') {
         posts = await getChannelPostsInvidious(channel, t, errorChannels)
       } else {
         posts = await getChannelPostsLocal(channel, t, errorChannels)
@@ -1030,7 +1059,7 @@ async function getChannelPostsLocal(channel, t, errorChannels) {
 
     return posts
   } catch (err) {
-    showSubscriptionFetchError(channel, err, t('Local API Error (Click to copy)'), {
+    handleSubscriptionFetchError(channel, err, t('Local API Error (Click to copy)'), {
       category: 'subscription posts',
       backend: 'local API'
     })
@@ -1050,7 +1079,7 @@ async function getChannelPostsInvidious(channel, t, errorChannels) {
 
     return result.posts
   } catch (err) {
-    showSubscriptionFetchError(channel, err, t('Invidious API Error (Click to copy)'), {
+    handleSubscriptionFetchError(channel, err, t('Invidious API Error (Click to copy)'), {
       category: 'subscription posts',
       backend: 'Invidious API'
     })
@@ -1084,7 +1113,7 @@ async function getChannelVideosLocalScraper(channel, t, errorChannels, failedAtt
         : await enrichScrapedUpcomingPublicationDates(channel.id, result.videos)
     }
   } catch (err) {
-    showSubscriptionFetchError(channel, err, t('Local API Error (Click to copy)'), {
+    handleSubscriptionFetchError(channel, err, t('Local API Error (Click to copy)'), {
       category: 'subscription videos',
       backend: 'local API'
     })
@@ -1111,14 +1140,14 @@ async function getChannelVideosLocalRSS(channel, t, errorChannels, failedAttempt
   const feedUrl = `https://www.youtube.com/feeds/videos.xml?playlist_id=${playlistId}`
 
   try {
-    const response = await fetch(feedUrl)
+    const response = await localApiFetch(feedUrl)
 
     if (response.status === 403) {
       return { videos: null }
     }
 
     if (response.status === 404) {
-      const response2 = await fetch(`https://www.youtube.com/feeds/videos.xml?channel_id=${channel.id}`, {
+      const response2 = await localApiFetch(`https://www.youtube.com/feeds/videos.xml?channel_id=${channel.id}`, {
         method: 'HEAD'
       })
 
@@ -1132,7 +1161,7 @@ async function getChannelVideosLocalRSS(channel, t, errorChannels, failedAttempt
 
     return await parseYouTubeRSSFeed(await response.text(), channel.id)
   } catch (error) {
-    showSubscriptionFetchError(channel, error, t('Local API Error (Click to copy)'), {
+    handleSubscriptionFetchError(channel, error, t('Local API Error (Click to copy)'), {
       category: 'subscription videos',
       backend: 'YouTube RSS'
     })
@@ -1168,7 +1197,7 @@ async function getChannelVideosInvidiousScraper(channel, t, errorChannels, faile
       videos: result.videos
     }
   } catch (err) {
-    showSubscriptionFetchError(channel, err, t('Invidious API Error (Click to copy)'), {
+    handleSubscriptionFetchError(channel, err, t('Invidious API Error (Click to copy)'), {
       category: 'subscription videos',
       backend: 'Invidious API'
     })
@@ -1212,7 +1241,7 @@ async function getChannelVideosInvidiousRSS(channel, t, errorChannels, failedAtt
 
     return await parseYouTubeRSSFeed(await response.text(), channel.id)
   } catch (error) {
-    showSubscriptionFetchError(channel, error, t('Invidious API Error (Click to copy)'), {
+    handleSubscriptionFetchError(channel, error, t('Invidious API Error (Click to copy)'), {
       category: 'subscription videos',
       backend: 'Invidious RSS'
     })
@@ -1239,14 +1268,14 @@ async function getChannelShortsLocal(channel, t, errorChannels, failedAttempts =
   const feedUrl = `https://www.youtube.com/feeds/videos.xml?playlist_id=${playlistId}`
 
   try {
-    const response = await fetch(feedUrl)
+    const response = await localApiFetch(feedUrl)
 
     if (response.status === 403) {
       return { videos: null }
     }
 
     if (response.status === 404) {
-      const response2 = await fetch(`https://www.youtube.com/feeds/videos.xml?channel_id=${channel.id}`, {
+      const response2 = await localApiFetch(`https://www.youtube.com/feeds/videos.xml?channel_id=${channel.id}`, {
         method: 'HEAD'
       })
 
@@ -1266,7 +1295,7 @@ async function getChannelShortsLocal(channel, t, errorChannels, failedAttempts =
     result.videos.forEach(video => { video.isShort = true })
     return result
   } catch (error) {
-    showSubscriptionFetchError(channel, error, t('Local API Error (Click to copy)'), {
+    handleSubscriptionFetchError(channel, error, t('Local API Error (Click to copy)'), {
       category: 'subscription Shorts',
       backend: 'YouTube RSS'
     })
@@ -1314,7 +1343,7 @@ async function getChannelShortsInvidious(channel, t, errorChannels, failedAttemp
     result.videos.forEach(video => { video.isShort = true })
     return result
   } catch (error) {
-    showSubscriptionFetchError(channel, error, t('Invidious API Error (Click to copy)'), {
+    handleSubscriptionFetchError(channel, error, t('Invidious API Error (Click to copy)'), {
       category: 'subscription Shorts',
       backend: 'Invidious RSS'
     })
@@ -1339,7 +1368,7 @@ async function getChannelLiveLocal(channel, t, errorChannels, failedAttempts = 0
 
     return result
   } catch (err) {
-    showSubscriptionFetchError(channel, err, t('Local API Error (Click to copy)'), {
+    handleSubscriptionFetchError(channel, err, t('Local API Error (Click to copy)'), {
       category: 'subscription live streams',
       backend: 'local API'
     })
@@ -1366,14 +1395,14 @@ async function getChannelLiveLocalRSS(channel, t, errorChannels, failedAttempts 
   const feedUrl = `https://www.youtube.com/feeds/videos.xml?playlist_id=${playlistId}`
 
   try {
-    const response = await fetch(feedUrl)
+    const response = await localApiFetch(feedUrl)
 
     if (response.status === 403) {
       return { videos: null }
     }
 
     if (response.status === 404) {
-      const response2 = await fetch(`https://www.youtube.com/feeds/videos.xml?channel_id=${channel.id}`, {
+      const response2 = await localApiFetch(`https://www.youtube.com/feeds/videos.xml?channel_id=${channel.id}`, {
         method: 'HEAD'
       })
 
@@ -1387,7 +1416,7 @@ async function getChannelLiveLocalRSS(channel, t, errorChannels, failedAttempts 
 
     return await parseYouTubeRSSFeed(await response.text(), channel.id)
   } catch (error) {
-    showSubscriptionFetchError(channel, error, t('Local API Error (Click to copy)'), {
+    handleSubscriptionFetchError(channel, error, t('Local API Error (Click to copy)'), {
       category: 'subscription live streams',
       backend: 'YouTube RSS'
     })
@@ -1423,7 +1452,7 @@ async function getChannelLiveInvidious(channel, t, errorChannels, failedAttempts
       videos: result.videos
     }
   } catch (err) {
-    showSubscriptionFetchError(channel, err, t('Invidious API Error (Click to copy)'), {
+    handleSubscriptionFetchError(channel, err, t('Invidious API Error (Click to copy)'), {
       category: 'subscription live streams',
       backend: 'Invidious API'
     })
@@ -1467,7 +1496,7 @@ async function getChannelLiveInvidiousRSS(channel, t, errorChannels, failedAttem
 
     return await parseYouTubeRSSFeed(await response.text(), channel.id)
   } catch (error) {
-    showSubscriptionFetchError(channel, error, t('Invidious API Error (Click to copy)'), {
+    handleSubscriptionFetchError(channel, error, t('Invidious API Error (Click to copy)'), {
       category: 'subscription live streams',
       backend: 'Invidious RSS'
     })

--- a/tests/unit/capacitor-http.test.mjs
+++ b/tests/unit/capacitor-http.test.mjs
@@ -1,5 +1,9 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { readFile } from 'node:fs/promises'
+import vm from 'node:vm'
+
+import { createAbortError } from '../../src/renderer/helpers/api/requestErrors.js'
 
 import {
   capacitorHttpFetch,
@@ -232,5 +236,37 @@ test('rejects invalid native avatar responses', async () => {
       await fetchCapacitorAvatarDataUrl('https://yt3.ggpht.com/avatar'),
       null
     )
+  }
+})
+
+test('bounds native connection and stalled reads while retaining JavaScript cancellation', async () => {
+  const source = (await readFile(new URL('../../src/renderer/helpers/api/capacitor-http.js', import.meta.url), 'utf8'))
+    .replace(/^import .* from .*\n/gm, '')
+    .replace(/^export /gm, '')
+  const requests = []
+  const context = vm.createContext({
+    CapacitorHttp: {
+      request(options) {
+        requests.push(options)
+        return new Promise(() => {})
+      },
+    },
+    createAbortError, Request, Response, Headers, URL, URLSearchParams, setTimeout, clearTimeout,
+  })
+  vm.runInContext(`${source}\nglobalThis.fetchNative = capacitorHttpFetch`, context)
+  const controller = new AbortController()
+  const pending = context.fetchNative('https://www.youtube.com/watch?v=test', {
+    signal: controller.signal,
+    nativeTimeoutMs: 15_000,
+  })
+  const rejected = assert.rejects(pending, { name: 'AbortError' })
+  try {
+    await Promise.resolve()
+    assert.equal(requests.length, 1)
+    assert.equal(requests[0].connectTimeout, 15_000)
+    assert.equal(requests[0].readTimeout, 15_000)
+  } finally {
+    controller.abort()
+    await rejected
   }
 })

--- a/tests/unit/subscription-network-recovery.test.mjs
+++ b/tests/unit/subscription-network-recovery.test.mjs
@@ -1,0 +1,284 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import vm from 'node:vm'
+
+import { createSubscriptionNetworkRecovery, SubscriptionNetworkError } from '../../src/renderer/helpers/subscriptionNetworkRecovery.js'
+import { mapConcurrently } from '../../src/renderer/helpers/concurrent-map.js'
+import { buildRequestDiagnostic, classifyRequestFailure, formatRequestDiagnostic } from '../../src/renderer/helpers/api/requestDiagnostics.js'
+import { getSubscriptionsForFeed } from '../../src/renderer/helpers/subscription-channels.js'
+import { reconcileFetchedSubscriptionEntries } from '../../src/renderer/helpers/subscription-entries.js'
+
+const source = (await readFile(new URL('../../src/renderer/helpers/subscriptions.js', import.meta.url), 'utf8'))
+  .replace(/^import[\s\S]*? from ['"][^'"]+['"]\n/gm, '')
+  .replace(/^export /gm, '')
+
+// Exercise the real refresh, fallback, cache, and notification paths with fake
+// platform APIs. Webpack-only imports are supplied in the isolated context.
+function createRefresh({ online = true, feed = 'Shorts', error = new TypeError('Failed to fetch'), webCors = false, backend = 'local', fallbackWorks = false } = {}) {
+  const window = new EventTarget()
+  const navigator = { onLine: online }
+  const toasts = []
+  const requests = []
+  const fallbackRequests = []
+  const writes = []
+  const events = []
+  let fail = !webCors
+  const getters = {
+    getActiveProfile: { _id: 'all', subscriptions: Array.from({ length: 20 }, (_, i) => ({ id: `UC${i}` })) },
+    getBackendPreference: backend,
+    getBackendFallback: true,
+    getUseRssFeeds: true,
+    getVideoCache: {},
+    getShortsCache: {},
+    getLiveCache: {},
+    getPostsCache: {},
+  }
+  for (const event of ['completed', 'finished']) {
+    window.addEventListener(`opentubex-subscription-refresh-${event}`, () => events.push(event))
+  }
+  const fetchChannel = async url => {
+    requests.push(url)
+    if (fail) throw error
+    return { videos: [], posts: [], status: 200, text: async () => '<feed/>' }
+  }
+  const fetchFallback = async url => {
+    fallbackRequests.push(url)
+    return { videos: [], posts: [], status: 200, text: async () => '<feed/>' }
+  }
+  const fetchLocal = fallbackWorks && backend === 'invidious' ? fetchFallback : fetchChannel
+  const fetchInvidious = fallbackWorks && backend === 'local' ? fetchFallback : fetchChannel
+  const context = vm.createContext({
+    window, navigator, CustomEvent, setTimeout, clearTimeout, console: { error() {}, warn() {} },
+    process: { env: { IS_CAPACITOR: true, SUPPORTS_LOCAL_API: true } },
+    store: {
+      getters,
+      commit(key, value) { if (key === 'setSubscriptionFeedRefreshInProgress') getters.getSubscriptionFeedRefreshInProgress = value },
+      async dispatch(key, value) { writes.push({ key, value }) },
+    },
+    createSubscriptionNetworkRecovery, SubscriptionNetworkError,
+    mapConcurrently, buildRequestDiagnostic, classifyRequestFailure, formatRequestDiagnostic, getSubscriptionsForFeed,
+    reconcileFetchedSubscriptionEntries,
+    isAndroidSubscriptionRefreshActive: async () => false,
+    includeAutomaticDownloadChannels: channels => channels,
+    startAutomaticDownloadsForChannel: async () => {},
+    getChannelPlaylistId: id => id,
+    showApiErrorToast: (...args) => toasts.push(args),
+    showToast: (...args) => toasts.push(args),
+    localApiFetch: fetchLocal,
+    fetch: webCors ? async () => { throw new TypeError('Failed to fetch') } : fetchChannel,
+    invidiousFetch: fetchInvidious,
+    getLocalChannelVideos: fetchLocal,
+    getLocalChannelLiveStreams: fetchLocal,
+    getLocalChannelCommunity: async id => (await fetchLocal(id)).posts,
+    invidiousGetCommunityPosts: fetchInvidious,
+    getLocalPlaylist: async () => ({ items: [] }),
+    parseLocalPlaylistVideos: () => [],
+    mergeSubscriptionShortThumbnails: videos => videos,
+    DOMParser: class {
+      parseFromString() {
+        return { querySelector: () => ({ textContent: 'Channel' }), querySelectorAll: () => [] }
+      }
+    },
+  })
+  vm.runInContext(`${source}\nglobalThis.api = { refreshSubscriptionVideosFromRemote, refreshSubscriptionShortsFromRemote, refreshSubscriptionLiveFromRemote, refreshSubscriptionPostsFromRemote, cancelSubscriptionRefresh }`, context)
+  return {
+    ...context.api, refresh: context.api[`refreshSubscription${feed}FromRemote`], navigator, requests, fallbackRequests, toasts, writes, events, getters,
+    reconnect() {
+      fail = false
+      navigator.onLine = true
+      window.dispatchEvent(new Event('online'))
+    },
+  }
+}
+
+const settle = () => new Promise(resolve => setTimeout(resolve, 30))
+
+test('mobile Shorts refresh waits offline without requests or error toasts, then resumes', async () => {
+  const app = createRefresh({ online: false })
+  const refresh = app.refresh({ t: key => key })
+  try {
+    await settle()
+    assert.equal(app.requests.length, 0)
+    assert.equal(app.toasts.length, 0)
+    assert.deepEqual(app.events, [])
+    app.reconnect()
+    await refresh
+    assert.equal(app.requests.length, 20)
+    assert.deepEqual(app.events, ['completed', 'finished'])
+    assert.equal(app.writes.filter(write => write.key.endsWith('CacheByChannel')).length, 20)
+  } finally {
+    app.cancelSubscriptionRefresh()
+    await refresh
+  }
+})
+
+for (const feed of ['Videos', 'Shorts', 'Live', 'Posts']) {
+  test(`mobile ${feed} connection failure pauses the channel queue and fallbacks without toast spam`, async () => {
+    const app = createRefresh({ feed })
+    const refresh = app.refresh({ t: key => key })
+    try {
+      await settle()
+      assert.equal(app.requests.length, 8, 'only already-running channel requests may fail')
+      assert.equal(app.toasts.length, 0)
+      assert.equal(app.writes.length, 0)
+      assert.deepEqual(app.events, [])
+      assert.equal(app.getters.getSubscriptionFeedRefreshInProgress, true)
+      assert.equal(await app.refresh({ t: key => key }), null, 'another refresh cannot restart the paused queue')
+      assert.equal(app.requests.length, 8)
+      app.reconnect()
+      await refresh
+      assert.equal(app.requests.length, 28, 'failed channels must be retried after reconnection')
+      assert.deepEqual(app.events, ['completed', 'finished'])
+      assert.equal(app.writes.filter(write => write.key.endsWith('CacheByChannel')).length, 20)
+    } finally {
+      app.cancelSubscriptionRefresh()
+      await refresh
+    }
+  })
+}
+
+for (const online of [false, true]) {
+  test(`cancelling a refresh waiting ${online ? 'to retry' : 'offline'} releases ownership without marking it complete`, async () => {
+    const app = createRefresh({ online })
+    const refresh = app.refresh({ t: key => key })
+    await settle()
+    app.cancelSubscriptionRefresh()
+    assert.equal(await refresh, null)
+    assert.equal(app.getters.getSubscriptionFeedRefreshInProgress, false)
+    assert.deepEqual(app.events, ['finished'])
+    assert.equal(app.toasts.length, 0)
+    assert.equal(app.writes.filter(write => write.key.endsWith('CacheByChannel')).length, 0)
+
+    app.reconnect()
+    await app.refresh({ t: key => key })
+    assert.deepEqual(app.events, ['finished', 'completed', 'finished'])
+    assert.equal(app.requests.length, online ? 28 : 20)
+  })
+}
+
+for (const error of [Object.assign(new Error('HTTP 503'), { status: 503 }), new SyntaxError('Invalid JSON')]) {
+  test(`${error.message} keeps the existing error and fallback behavior`, async () => {
+    const app = createRefresh({ error })
+    await app.refresh({ t: key => key })
+    assert.equal(app.requests.length, 40)
+    assert.ok(app.toasts.length > 0)
+    assert.deepEqual(app.events, ['completed', 'finished'])
+  })
+}
+
+async function flushPromises() {
+  for (let i = 0; i < 30; i++) await Promise.resolve()
+}
+
+for (const allowFallback of [false, true]) {
+  test(`an unreported outage probes one channel with capped backoff with fallback ${allowFallback ? 'enabled' : 'disabled'}`, async t => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+    const eventTarget = new EventTarget()
+    const recovery = createSubscriptionNetworkRecovery({ eventTarget, isOnline: () => true, allowFallback })
+    let failed = true
+    const attempts = []
+    const run = id => recovery.run(async () => {
+      attempts.push(id)
+      if (failed) throw new SubscriptionNetworkError(new TypeError('Failed to fetch'))
+    })
+    const tasks = [run(1), run(2), run(3)]
+    try {
+      await flushPromises()
+      assert.deepEqual(attempts, [1, 2, 3])
+      for (const delay of [5000, 10000, 20000, 40000, 60000, 60000]) {
+        const count = attempts.length
+        t.mock.timers.tick(delay - 1)
+        await flushPromises()
+        assert.equal(attempts.length, count)
+        t.mock.timers.tick(1)
+        await flushPromises()
+        assert.equal(attempts.length, count + (allowFallback ? 2 : 1), 'one channel probes the enabled backends for the entire queue')
+        assert.equal(attempts.at(-1), 1)
+      }
+      failed = false
+      t.mock.timers.tick(60000)
+      await Promise.all(tasks)
+      assert.deepEqual(attempts.slice(-3), [1, 2, 3])
+    } finally {
+      recovery.cancel()
+      await Promise.all(tasks)
+    }
+  })
+}
+
+test('going offline during backoff stops probes until an online event', async t => {
+  t.mock.timers.enable({ apis: ['setTimeout'] })
+  const eventTarget = new EventTarget()
+  let online = true
+  let attempts = 0
+  const recovery = createSubscriptionNetworkRecovery({ eventTarget, isOnline: () => online })
+  const task = recovery.run(async () => {
+    attempts++
+    if (attempts === 1) throw new SubscriptionNetworkError(new TypeError('Failed to fetch'))
+  })
+  try {
+    await flushPromises()
+    online = false
+    eventTarget.dispatchEvent(new Event('offline'))
+    t.mock.timers.tick(120000)
+    await flushPromises()
+    assert.equal(attempts, 1)
+    online = true
+    eventTarget.dispatchEvent(new Event('online'))
+    await task
+    assert.equal(attempts, 2)
+  } finally {
+    recovery.cancel()
+    await task
+  }
+})
+
+for (const feed of ['Videos', 'Shorts', 'Live']) {
+  test(`mobile ${feed} RSS refresh uses native HTTP when WebView CORS blocks YouTube`, async () => {
+    const app = createRefresh({ feed, webCors: true })
+    const refresh = app.refresh({ t: key => key })
+    try {
+      await settle()
+      assert.equal(app.writes.filter(write => write.key.endsWith('CacheByChannel')).length, 20)
+      assert.equal(app.toasts.length, 0)
+      assert.deepEqual(app.events, ['completed', 'finished'])
+    } finally {
+      app.cancelSubscriptionRefresh()
+      await refresh
+    }
+  })
+}
+
+for (const feed of ['Videos', 'Shorts', 'Live', 'Posts']) {
+  for (const backend of ['local', 'invidious']) {
+    test(`mobile ${feed} recovers through the alternate backend when ${backend} is unreachable`, async t => {
+      t.mock.timers.enable({ apis: ['setTimeout'] })
+      const app = createRefresh({ feed, backend, fallbackWorks: true })
+      const refresh = app.refresh({ t: key => key })
+      try {
+        await flushPromises()
+        assert.equal(app.requests.length, 8)
+        assert.equal(app.fallbackRequests.length, 0, 'no fallback burst before backoff')
+        t.mock.timers.tick(5000)
+        await flushPromises()
+        assert.ok(app.fallbackRequests.length > 0, 'recovery must try the reachable fallback')
+        for (let i = 0; i < 30; i++) {
+          t.mock.timers.tick(1000)
+          await flushPromises()
+        }
+        assert.equal(app.writes.filter(write => write.key.endsWith('CacheByChannel')).length, 20)
+        assert.equal(app.requests.length, 9, 'reuse the working backend for the rest of this refresh')
+        assert.equal(app.toasts.length, 0)
+        assert.deepEqual(app.events, ['completed', 'finished'])
+      } finally {
+        app.cancelSubscriptionRefresh()
+        for (let i = 0; i < 30; i++) {
+          t.mock.timers.runAll()
+          await flushPromises()
+        }
+        await refresh
+      }
+    })
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Mobile subscription refreshes could repeatedly retry failed connections and flood error notifications. Pause the shared queue offline, probe with capped backoff, and use the enabled fallback backend when only one service is unreachable. Use native HTTP for YouTube RSS so Android WebView CORS does not masquerade as a connection outage.

Make the phone tab organizer fill the available screen with themed safe areas, and place global progress above the bottom navigation without moving its active indicator.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. In Android dev mode, start a subscription refresh while offline. The refresh should wait without repeated errors, then resume when connectivity returns. Cancelling while waiting should release the refresh.
2. Enable backend fallback and make only the preferred backend unreachable. After the retry delay, the alternate backend should complete the refresh without repeated notifications.
3. Open the phone tab organizer in light and dark themes, in portrait and landscape. The top and bottom safe areas should match the organizer, with no dimmed navigation gap.
4. Start a refresh with global progress enabled. The strip should sit directly above the bottom navigation; the active-page indicator should remain visible and stationary. Also check a non-default UI scale.

## Additional context
<!-- Add any other context about the pull request here. -->

Android functionality has not appeared in the latest stable release, so this is marked Not noteworthy.
