### PR TITLE
feat(settings): load channel settings as you scroll

### DIFF
--- a/e2e/tests/offline/channel-settings-infinite-scroll.spec.mjs
+++ b/e2e/tests/offline/channel-settings-infinite-scroll.spec.mjs
@@ -1,0 +1,61 @@
+import { test, expect, goToSettingsSection, setWindowSize } from '../../helpers/app.mjs'
+
+const subscriptions = Array.from({ length: 50 }, (_, index) => ({
+  id: `UC${String(index).padStart(22, '0')}`,
+  name: `Channel ${String(index).padStart(3, '0')}`,
+  thumbnail: ''
+}))
+
+for (const uiScale of [95, 125]) {
+  test.describe(`channel settings automatic loading at ${uiScale}% scale`, () => {
+    test.use({
+      seed: {
+        settings: {
+          currentLocale: 'en-US',
+          uiScale,
+          fetchSubscriptionsAutomatically: false,
+          generalAutoLoadMorePaginatedItemsEnabled: true,
+          channelPlaybackSpeeds: JSON.stringify(Object.fromEntries(subscriptions.map(channel => [channel.id, 1.25])))
+        },
+        profiles: [{ _id: 'allChannels', name: 'All Channels', subscriptions }]
+      }
+    })
+
+    for (const list of [
+      { section: 'subscription', button: 'Subscription settings', scroller: '.channelSettingsScroller', entry: '.channelSettings' },
+      { section: 'playback', button: 'Manage Saved Channels (50)', scroller: '.channelListContainer', entry: '.channelEntry' }
+    ]) {
+      test(`${list.section} settings append channels when the bottom spinner enters view`, async ({ app, page, attachScreenshot }) => {
+        await goToSettingsSection(page, list.section)
+        await page.getByRole('button', { name: list.button, exact: true }).click()
+        await setWindowSize(app, page, { width: 650, height: 700 })
+        const scroller = page.locator(list.scroller)
+        const entries = page.locator(list.entry)
+        const loader = scroller.locator('.ft-auto-load-next-page-wrapper')
+        const search = page.getByPlaceholder('Search channels', { exact: true })
+        const searchTop = await search.evaluate(element => element.getBoundingClientRect().top)
+
+        await expect(entries).toHaveCount(24)
+        await expect(loader.getByRole('status', { name: 'Loading more' })).toHaveCount(1)
+        await expect(page.getByRole('button', { name: 'Load more channels', exact: true })).toHaveCount(0)
+        await expect(page.locator('.channelSettingsPagination')).toHaveCount(0)
+        for (const count of [48, 50]) {
+          await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
+          await expect(entries).toHaveCount(count)
+          await expect(entries.first()).toContainText('Channel 000')
+          await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+          expect(await search.evaluate(element => element.getBoundingClientRect().top)).toBe(searchTop)
+        }
+        await expect(loader).toHaveCount(0)
+        await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
+        await search.fill('Channel 049')
+        await expect(entries).toHaveCount(1)
+        await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBe(0)
+        await search.fill('')
+        await expect(entries).toHaveCount(24)
+        await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBe(0)
+        await attachScreenshot(`${list.section} settings bottom loader at ${uiScale}%`)
+      })
+    }
+  })
+}

--- a/e2e/tests/offline/channel-settings-pagination.spec.mjs
+++ b/e2e/tests/offline/channel-settings-pagination.spec.mjs
@@ -20,7 +20,7 @@ function channelSettingsSeed(count, uiScale = 95) {
       channelVolumes: values(0.5),
       rememberPlaybackSpeedPerChannel: true
     },
-    profiles: [{ _id: 'allChannels', name: 'All Channels', subscriptions: subscriptions.slice(0, count + 1) }]
+    profiles: [{ _id: 'allChannels', name: 'All Channels', subscriptions: subscriptions.slice(0, count + 1).map(channel => ({ ...channel })) }]
   }
 }
 
@@ -41,15 +41,15 @@ test.describe('large channel playback settings', () => {
 })
 
 for (const uiScale of [95, 125]) {
-  test.describe(`saved channel pages at ${uiScale}% scale`, () => {
-    test.use({ seed: channelSettingsSeed(49, uiScale) })
+  test.describe(`saved channel incremental loading at ${uiScale}% scale`, () => {
+    const seed = channelSettingsSeed(49, uiScale)
+    seed.settings.generalAutoLoadMorePaginatedItemsEnabled = false
+    test.use({ seed })
 
-    test('preserves edits, reveals added channels, and clamps shorter pages', async ({ app, page }) => {
+    test('preserves edits, reveals added channels, and clamps shorter results', async ({ app, page }) => {
       await goToSettingsSection(page, 'playback')
       await page.getByRole('button', { name: 'Manage Saved Channels (49)' }).click()
-      const pagination = page.locator('.channelSettingsPagination')
-      const next = pagination.getByRole('button', { name: 'Next', exact: true })
-      const previous = pagination.getByRole('button', { name: 'Previous', exact: true })
+      const loadMore = page.getByRole('button', { name: 'Load more channels', exact: true })
       const scroller = page.locator('.channelListContainer')
       const scrollbar = scroller.locator(':scope > .os-scrollbar-vertical')
       const search = page.locator('.channelSearch input')
@@ -63,30 +63,29 @@ for (const uiScale of [95, 125]) {
       }
 
       await expect(page.locator('.channelEntry')).toHaveCount(24)
-      await expect(pagination).toContainText('1-24 / 49')
-      await expect(previous).toBeDisabled()
+      await expect(page.locator('.channelSettingsPagination')).toHaveCount(0)
       await scrollToBottom()
       await search.fill('Channel 00')
       await expect(page.locator('.channelEntry')).toHaveCount(10)
       await expectAtTop()
       await search.fill('')
       await scrollToBottom()
-      await next.click()
-      await expectAtTop()
-      await expect(pagination).toContainText('25-48 / 49')
+      await loadMore.click()
+      await expect(page.locator('.channelEntry')).toHaveCount(48)
+      await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
       const editedChannel = page.locator('.channelEntry', { hasText: 'Channel 024' })
       await editedChannel.getByRole('slider', { name: /Playback Speed/ }).fill('1.5')
-      await previous.click()
-      await next.click()
-      await expect(editedChannel.getByRole('slider', { name: /Playback Speed/ })).toHaveValue('1.5')
       await scrollToBottom()
-      await next.click()
-      await expectAtTop()
-      await expect(pagination).toContainText('49-49 / 49')
+      await loadMore.click()
+      await expect(page.locator('.channelEntry')).toHaveCount(49)
+      await expect(editedChannel.getByRole('slider', { name: /Playback Speed/ })).toHaveValue('1.5')
+      await expect(loadMore).toHaveCount(0)
+      await scrollToBottom()
+      await search.fill('Channel 048')
       await expect(page.locator('.channelEntry')).toHaveCount(1)
-      await expect(next).toBeDisabled()
+      await expectAtTop()
 
-      await setWindowSize(app, page, { width: 650, height: 400 })
+      await setWindowSize(app, page, { width: 650, height: 350 })
       await scrollToBottom()
       await page.locator('.channelEntry').getByRole('button', { name: 'Forget this setting', exact: true }).first().evaluate(button => button.click())
       await expect(page.locator('.channelPreference')).toHaveCount(3)
@@ -101,41 +100,38 @@ for (const uiScale of [95, 125]) {
       await expect(scrollbar).toHaveClass(/os-scrollbar-unusable/)
 
       await page.getByRole('button', { name: 'Forget all settings for this channel', exact: true }).click()
-      await expect(pagination).toContainText('25-48 / 48')
-      await expect(page.locator('.channelEntry')).toHaveCount(24)
+      await expect(page.locator('.channelEntry')).toHaveCount(0)
       await expectAtTop()
       await page.getByRole('button', { name: 'Add subscribed channel', exact: true }).click()
       const picker = page.getByRole('dialog', { name: 'Add subscribed channel', exact: true })
       await picker.getByPlaceholder('Search channels').fill('Channel 049')
       await picker.getByRole('button', { name: 'Channel 049', exact: true }).click()
       await expect(picker).toHaveCount(0)
-      await expect(pagination).toContainText('49-49 / 49')
-      await expect(page.locator('.channelEntry')).toContainText('Channel 049')
-      await expectAtTop()
+      await expect(page.locator('.channelEntry')).toHaveCount(49)
+      await expect(page.locator('.channelEntry', { hasText: 'Channel 049' })).toBeInViewport()
 
-      await previous.click()
       await scrollToBottom()
       await search.fill('Channel 000')
       await expect(page.locator('.channelEntry')).toHaveCount(1)
       await expect(page.locator('.channelEntry')).toContainText('Channel 000')
       await expectAtTop()
       await expect(scrollbar).toHaveClass(/os-scrollbar-unusable/)
-      await expect(pagination).toHaveCount(0)
+      await expect(loadMore).toHaveCount(0)
       await search.fill('No matching channel')
       await expect(page.locator('.channelEntry')).toHaveCount(0)
       await expect(scrollbar).toHaveClass(/os-scrollbar-unusable/)
       await search.fill('')
-      await expect(pagination).toContainText('1-24 / 49')
+      await expect(page.locator('.channelEntry')).toHaveCount(24)
     })
   })
 }
 
-test.describe('adding playback settings on the current page', () => {
+test.describe('adding playback settings in the first batch', () => {
   const seed = channelSettingsSeed(23)
   seed.profiles[0].subscriptions[23].name = 'Added channel'
   test.use({ seed })
 
-  test('reveals an added channel when pagination stays on page one', async ({ page }) => {
+  test('reveals an added channel within the first batch', async ({ page }) => {
     await goToSettingsSection(page, 'playback')
     await page.getByRole('button', { name: 'Manage Saved Channels (23)' }).click()
     const scroller = page.locator('.channelListContainer')

--- a/e2e/tests/offline/subscription-settings-performance.spec.mjs
+++ b/e2e/tests/offline/subscription-settings-performance.spec.mjs
@@ -47,23 +47,21 @@ test('subscription settings stays responsive with hundreds of channels', async (
 })
 
 for (const uiScale of [95, 125]) {
-  test.describe(`channel settings pagination at ${uiScale}% scale`, () => {
+  test.describe(`channel settings incremental loading at ${uiScale}% scale`, () => {
     test.use({
       seed: {
-        settings: { currentLocale: 'en-US', uiScale, fetchSubscriptionsAutomatically: false },
+        settings: { currentLocale: 'en-US', uiScale, fetchSubscriptionsAutomatically: false, generalAutoLoadMorePaginatedItemsEnabled: false },
         profiles: [{ _id: 'allChannels', name: 'All Channels', subscriptions: subscriptions.slice(0, 50) }]
       }
     })
 
-    test('keeps selection across pages and resets scrolling for shorter results', async ({ app, page, attachScreenshot }) => {
+    test('keeps selection while loading more and resets scrolling for shorter results', async ({ app, page, attachScreenshot }) => {
       const settings = await goToSettingsSection(page, 'subscription')
       await settings.getByRole('button', { name: 'Subscription settings', exact: true }).click()
-      const pagination = page.locator('.channelSettingsPagination')
+      const loadMore = page.getByRole('button', { name: 'Load more channels', exact: true })
       const scroller = page.locator('.channelSettingsScroller')
       const scrollbar = scroller.locator(':scope > .os-scrollbar-vertical')
       const toolbar = page.locator('.channelSelectionToolbar')
-      const next = pagination.getByRole('button', { name: 'Next', exact: true })
-      const previous = pagination.getByRole('button', { name: 'Previous', exact: true })
       const scrollToBottom = async () => {
         await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
         await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
@@ -75,9 +73,9 @@ for (const uiScale of [95, 125]) {
 
       await setWindowSize(app, page, { width: 375, height: 700 })
       await expect.poll(() => page.locator('.channelSettingsHeader').evaluate(element => element.scrollWidth - element.clientWidth)).toBeLessThanOrEqual(1)
-      await attachScreenshot(`channel settings pagination at ${uiScale}%`)
-      await expect(pagination).toContainText('1-24 / 50')
-      await expect(previous).toBeDisabled()
+      await attachScreenshot(`channel settings incremental loading at ${uiScale}%`)
+      await expect(page.locator('.channelSettings')).toHaveCount(24)
+      await expect(page.locator('.channelSettingsPagination')).toHaveCount(0)
       await scrollToBottom()
       await page.getByPlaceholder('Search channels').fill('Channel 00')
       await expect(page.locator('.channelSettings')).toHaveCount(10)
@@ -85,9 +83,10 @@ for (const uiScale of [95, 125]) {
       await page.getByPlaceholder('Search channels').fill('')
       await page.getByRole('checkbox', { name: 'Channel 000', exact: true }).click()
       await scrollToBottom()
-      await next.click()
-      await expect(pagination).toContainText('25-48 / 50')
-      await expectAtTop()
+      await loadMore.click()
+      await expect(page.locator('.channelSettings')).toHaveCount(48)
+      await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+      await expect(page.getByRole('checkbox', { name: 'Channel 000', exact: true })).toBeChecked()
       await page.getByRole('checkbox', { name: 'Channel 024', exact: true }).click()
       await expect(toolbar).toContainText('2 selected')
       await page.locator('.bulkFeedTypeSettings').getByRole('checkbox', { name: 'Videos', exact: true }).click()
@@ -98,11 +97,9 @@ for (const uiScale of [95, 125]) {
           .map(channel => channel.name)
       })).toEqual(['Channel 000', 'Channel 024'])
       await scrollToBottom()
-      await next.click()
-      await expect(pagination).toContainText('49-50 / 50')
-      await expect(page.locator('.channelSettings')).toHaveCount(2)
-      await expect(next).toBeDisabled()
-      await expectAtTop()
+      await loadMore.click()
+      await expect(page.locator('.channelSettings')).toHaveCount(50)
+      await expect(loadMore).toHaveCount(0)
 
       await scrollToBottom()
       await setWindowSize(app, page, { width: 1600, height: 900 })
@@ -128,7 +125,6 @@ for (const uiScale of [95, 125]) {
       }
       await toolbar.getByRole('button', { name: 'Select All' }).click()
       await expect(toolbar).toContainText('50 selected')
-      await previous.click()
       await toolbar.getByRole('button', { name: 'Select None' }).click()
       await expect(toolbar).toContainText('0 selected')
       await scrollToBottom()
@@ -136,11 +132,11 @@ for (const uiScale of [95, 125]) {
       await expect(page.locator('.channelSettings')).toHaveCount(1)
       await expectAtTop()
       await expect(scrollbar).toHaveClass(/os-scrollbar-unusable/)
-      await expect(pagination).toHaveCount(0)
+      await expect(loadMore).toHaveCount(0)
 
       await page.getByPlaceholder('Search channels').fill('')
-      await expect(pagination).toContainText('1-24 / 50')
-      await next.click()
+      await expect(page.locator('.channelSettings')).toHaveCount(24)
+      await loadMore.click()
       await scrollToBottom()
       await page.evaluate(() => {
         const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store

--- a/src/renderer/components/ChannelSettings/ChannelSettings.css
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.css
@@ -101,10 +101,6 @@
   margin-block-end: 1em;
 }
 
-.channelSettingsPagination {
-  margin-block-end: 1em;
-}
-
 
 .channelListContainer {
   /* Use the height the search field and the close button leave over */

--- a/src/renderer/components/ChannelSettings/ChannelSettings.vue
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.vue
@@ -75,12 +75,6 @@
         :value="searchQuery"
         @input="value => searchQuery = value"
       />
-      <FtPagination
-        v-model:page="channelPage"
-        class="channelSettingsPagination"
-        :page-size="channelsPerPage"
-        :total="visibleChannelEntries.length"
-      />
       <div
         ref="channelListContainer"
         v-overlay-scrollbars
@@ -204,6 +198,21 @@
               </div>
             </li>
           </ul>
+          <FtAutoLoadNextPageWrapper
+            v-if="hasMoreChannels"
+            :key="channelPage"
+            @load-next-page="channelPage++"
+          >
+            <FtFlexBox>
+              <FtButton
+                :label="t('Channels.Load More Channels')"
+                :icon="['fas', 'arrow-down']"
+                background-color="var(--primary-color)"
+                text-color="var(--text-with-main-color)"
+                @click="channelPage++"
+              />
+            </FtFlexBox>
+          </FtAutoLoadNextPageWrapper>
         </div>
       </div>
       <FtPrompt
@@ -299,7 +308,7 @@ import { computed, nextTick, onBeforeUnmount, ref, useTemplateRef, watch } from 
 import { useI18n } from 'vue-i18n'
 
 import FtButton from '../FtButton/FtButton.vue'
-import FtPagination from '../FtPagination/FtPagination.vue'
+import FtAutoLoadNextPageWrapper from '../FtAutoLoadNextPageWrapper.vue'
 import { useListPagination } from '../../composables/useListPagination'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import FtIconButton from '../FtIconButton/FtIconButton.vue'
@@ -621,9 +630,10 @@ const visibleChannelEntries = computed(() => {
   })
 })
 
-// Keep the number of mounted controls bounded as users page through saved channels.
-const { page: channelPage, displayedItems: displayedChannelEntries, reset: resetChannelPage, restoreScroll: restoreChannelScroll } = useListPagination(visibleChannelEntries, {
+// Mount editors in batches so large saved channel lists open quickly.
+const { page: channelPage, hasMore: hasMoreChannels, displayedItems: displayedChannelEntries, reset: resetChannelPage, restoreScroll: restoreChannelScroll } = useListPagination(visibleChannelEntries, {
   pageSize: channelsPerPage,
+  append: true,
   resetOn: searchQuery,
   scrollTarget: channelListContainer
 })

--- a/src/renderer/components/SubscriptionChannelSettings/SubscriptionChannelSettings.vue
+++ b/src/renderer/components/SubscriptionChannelSettings/SubscriptionChannelSettings.vue
@@ -18,12 +18,6 @@
         :value="searchQuery"
         @input="searchQuery = $event"
       />
-      <FtPagination
-        v-model:page="channelPage"
-        class="channelSettingsPagination"
-        :page-size="channelsPerPage"
-        :total="visibleChannels.length"
-      />
     </div>
     <div
       ref="channelSettingsScroller"
@@ -275,6 +269,21 @@
             </div>
           </li>
         </ul>
+        <FtAutoLoadNextPageWrapper
+          v-if="hasMoreChannels"
+          :key="channelPage"
+          @load-next-page="channelPage++"
+        >
+          <FtFlexBox>
+            <FtButton
+              :label="t('Channels.Load More Channels')"
+              :icon="['fas', 'arrow-down']"
+              background-color="var(--primary-color)"
+              text-color="var(--text-with-main-color)"
+              @click="channelPage++"
+            />
+          </FtFlexBox>
+        </FtAutoLoadNextPageWrapper>
       </div>
     </div>
   </FtSettingsSubpage>
@@ -286,8 +295,9 @@ import { computed, nextTick, onBeforeUnmount, ref, shallowRef, useId, useTemplat
 import { useI18n } from 'vue-i18n'
 
 import FtButton from '../FtButton/FtButton.vue'
-import FtPagination from '../FtPagination/FtPagination.vue'
+import FtAutoLoadNextPageWrapper from '../FtAutoLoadNextPageWrapper.vue'
 import { useListPagination } from '../../composables/useListPagination'
+import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import FtInput from '../FtInput/FtInput.vue'
 import FtSelect from '../FtSelect/FtSelect.vue'
 import FtSettingsSubpage from '../FtSettingsSubpage/FtSettingsSubpage.vue'
@@ -310,8 +320,7 @@ const { locale, t } = useI18n()
 const id = useId()
 const showManager = ref(false)
 const searchQuery = ref('')
-// Each editor mounts several controls and icons. Bound that work even for
-// profiles with hundreds of subscriptions, including after paging through them.
+// Mount editors in batches so large subscription lists open quickly.
 const channelsPerPage = 24
 const channelSettingsScroller = useTemplateRef('channelSettingsScroller')
 const channelSettingsContent = useTemplateRef('channelSettingsContent')
@@ -378,8 +387,9 @@ const visibleChannels = computed(() => {
   ))
 })
 
-const { page: channelPage, displayedItems: displayedChannels, reset: resetChannelPage } = useListPagination(visibleChannels, {
+const { page: channelPage, hasMore: hasMoreChannels, displayedItems: displayedChannels, reset: resetChannelPage } = useListPagination(visibleChannels, {
   pageSize: channelsPerPage,
+  append: true,
   resetOn: searchQuery,
   scrollTarget: channelSettingsScroller
 })

--- a/src/renderer/composables/useListPagination.js
+++ b/src/renderer/composables/useListPagination.js
@@ -34,11 +34,10 @@ export function useListPagination(items, { pageSize, append = false, resetOn, sc
 
   function reset() {
     // A new query is a new view even when it stays on the first page.
-    if (page.value === 0) {
+    if (append || page.value === 0) {
       restoreScroll()
-    } else {
-      page.value = 0
     }
+    page.value = 0
   }
 
   return { page, lastPage, displayedItems, hasMore, reset, restoreScroll }

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -1622,3 +1622,5 @@ Downloads:
     Audio Best: الصوت - أفضل جودة
     Audio Format: الصوت - {format}
     Subtitles Format: ترجمات - {format}
+Channels:
+  Load More Channels: "تحميل المزيد من القنوات"

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -1693,3 +1693,5 @@ Downloads:
     Audio Best: Аўдыя — найлепшая якасць
     Audio Format: Аўдыя — {format}
     Subtitles Format: Субцітры — {format}
+Channels:
+  Load More Channels: "Загрузіць больш каналаў"

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -1618,3 +1618,5 @@ Downloads:
     Audio Best: Звук - най-добро качество
     Audio Format: Звук - {format}
     Subtitles Format: Субтитри - {format}
+Channels:
+  Load More Channels: "Зареждане на още канали"

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -1623,3 +1623,5 @@ Downloads:
     Audio Best: "Son: perzhded gwellañ"
     Audio Format: "Son: {format}"
     Subtitles Format: "Istitloù: {format}"
+Channels:
+  Load More Channels: "Kargañ muioc'h a chadennoù"

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -172,6 +172,7 @@ Subscriptions:
   Posts:
     RSS Message: YouTube no proporciona canals RSS per a les publicacions. Desactiveu l'opció "{rssSetting}" per veure les publicacions o activeu l'opció "{hideSetting}" per ocultar aquesta pestanya.
 Channels:
+  Load More Channels: "Carrega més canals"
   Count: S'ha trobat 1 canal. | S'han trobat {number} canals. | S'han trobat {number} canals.
   Empty: La llista de canals està buida.
   Unsubscribe Prompt: Segur que us voleu donar de baixa de "{channelName}"?

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -1614,3 +1614,5 @@ Downloads:
     Audio Best: Zvuk – nejvyšší kvalita
     Audio Format: Zvuk – {format}
     Subtitles Format: Titulky – {format}
+Channels:
+  Load More Channels: "Načíst další kanály"

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -1627,3 +1627,5 @@ Downloads:
     Audio Best: Sain - Ansawdd gorau
     Audio Format: Sain - {format}
     Subtitles Format: Isdeitlau - {format}
+Channels:
+  Load More Channels: "Llwytho mwy o sianeli"

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -1682,3 +1682,5 @@ Downloads:
     Audio Best: Lyd - bedste kvalitet
     Audio Format: Lyd - {format}
     Subtitles Format: Undertekster - {format}
+Channels:
+  Load More Channels: "Indlæs flere kanaler"

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -1644,3 +1644,5 @@ Downloads:
     Audio Best: Ήχος - Βέλτιστη ποιότητα
     Audio Format: Ήχος - {format}
     Subtitles Format: Υπότιτλοι - {format}
+Channels:
+  Load More Channels: "Φόρτωση περισσότερων καναλιών"

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -2163,3 +2163,5 @@ Downloads:
     Audio Best: Audio - Calidad máxima
     Audio Format: Audio - {format}
     Subtitles Format: Subtítulos - {format}
+Channels:
+  Load More Channels: "Cargar más canales"

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -2036,3 +2036,5 @@ Downloads:
     Audio Best: Audio - Calidad máxima
     Audio Format: Audio - {format}
     Subtitles Format: Subtítulos - {format}
+Channels:
+  Load More Channels: "Cargar más canales"

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -1632,3 +1632,5 @@ Downloads:
     Audio Best: Audio - Calidad máxima
     Audio Format: Audio - {format}
     Subtitles Format: Subtítulos - {format}
+Channels:
+  Load More Channels: "Cargar más canales"

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -1616,3 +1616,5 @@ Downloads:
     Audio Best: Heli - parim kvaliteet
     Audio Format: Heli - {format}
     Subtitles Format: Subtiitrid - {format}
+Channels:
+  Load More Channels: "Laadi rohkem kanaleid"

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -1627,3 +1627,5 @@ Downloads:
     Audio Best: Audioa - Kalitate onena
     Audio Format: Audioa - {format}
     Subtitles Format: Azpitituluak - {format}
+Channels:
+  Load More Channels: "Kargatu kanal gehiago"

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -1684,3 +1684,5 @@ Downloads:
     Audio Best: صدا - بهترین کیفیت
     Audio Format: صدا - {format}
     Subtitles Format: زیرنویس - {format}
+Channels:
+  Load More Channels: "بارگیری کانال‌های بیشتر"

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -1644,3 +1644,5 @@ Downloads:
     Audio Best: Ääni - paras laatu
     Audio Format: Ääni - {format}
     Subtitles Format: Tekstitykset - {format}
+Channels:
+  Load More Channels: "Lataa lisää kanavia"

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -1612,3 +1612,5 @@ Downloads:
     Audio Best: Audio - Meilleure qualité
     Audio Format: Audio - {format}
     Subtitles Format: Sous-titres - {format}
+Channels:
+  Load More Channels: "Charger plus de chaînes"

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -1646,3 +1646,5 @@ Downloads:
     Audio Best: Son - Mellor calidade
     Audio Format: Son - {format}
     Subtitles Format: Subtítulos - {format}
+Channels:
+  Load More Channels: "Cargar máis canles"

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -1646,3 +1646,5 @@ Downloads:
     Audio Best: שמע - האיכות הטובה ביותר
     Audio Format: שמע - {format}
     Subtitles Format: כתוביות - {format}
+Channels:
+  Load More Channels: "טעינת ערוצים נוספים"

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -1622,3 +1622,5 @@ Downloads:
     Audio Best: Zvuk - najbolja kvaliteta
     Audio Format: Zvuk - {format}
     Subtitles Format: Titlovi - {format}
+Channels:
+  Load More Channels: "Učitaj više kanala"

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -1614,3 +1614,5 @@ Downloads:
     Audio Best: Hang - Legjobb minőség
     Audio Format: Hang - {format}
     Subtitles Format: Feliratok - {format}
+Channels:
+  Load More Channels: "További csatornák betöltése"

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -1636,3 +1636,5 @@ Downloads:
     Audio Best: Audio - Kualitas Terbaik
     Audio Format: Audio - {format}
     Subtitles Format: Takarir - {format}
+Channels:
+  Load More Channels: "Muat lebih banyak channel"

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -1643,3 +1643,5 @@ Downloads:
     Audio Best: Hljóð – bestu gæði
     Audio Format: Hljóð – {format}
     Subtitles Format: Skjátextar – {format}
+Channels:
+  Load More Channels: "Hlaða fleiri rásum"

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -1614,3 +1614,5 @@ Downloads:
     Audio Best: Audio - Qualità migliore
     Audio Format: Audio - {format}
     Subtitles Format: Sottotitoli - {format}
+Channels:
+  Load More Channels: "Carica altri canali"

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -1614,3 +1614,5 @@ Downloads:
     Audio Best: 音声 - 最高品質
     Audio Format: 音声 - {format}
     Subtitles Format: 字幕 - {format}
+Channels:
+  Load More Channels: "チャンネルをさらに読み込む"

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -2052,3 +2052,5 @@ Downloads:
     Audio Best: 오디오 - 최고 품질
     Audio Format: 오디오 - {format}
     Subtitles Format: 자막 - {format}
+Channels:
+  Load More Channels: "채널 더 불러오기"

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -2098,3 +2098,5 @@ Downloads:
     Audio Best: Garso įrašas - geriausia kokybė
     Audio Format: Garso įrašas - {format}
     Subtitles Format: Subtitrai - {format}
+Channels:
+  Load More Channels: "Įkelti daugiau kanalų"

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -1618,3 +1618,5 @@ Downloads:
     Audio Best: Lyd – beste kvalitet
     Audio Format: Lyd – {format}
     Subtitles Format: Undertekster – {format}
+Channels:
+  Load More Channels: "Last inn flere kanaler"

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -1655,3 +1655,5 @@ Downloads:
     Audio Best: Audio - beste kwaliteit
     Audio Format: Audio - {format}
     Subtitles Format: Ondertiteling - {format}
+Channels:
+  Load More Channels: "Meer kanalen laden"

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -2030,3 +2030,5 @@ Downloads:
     Audio Best: Lyd - beste kvalitet
     Audio Format: Lyd - {format}
     Subtitles Format: Undertekstar - {format}
+Channels:
+  Load More Channels: "Last inn fleire kanalar"

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -819,3 +819,5 @@ Playlist:
   Playlist Preload Complete: "Wstępnie wczytane filmy: {count}."
   Playlist Preload Partial: "Wstępnie wczytano {preloaded} z {requested} filmów. Nie udało się wczytać {failed}."
   Playlist Preload Pagination Failed: "Nie udało się wczytać całej playlisty, więc anulowano wstępne wczytywanie."
+Channels:
+  Load More Channels: "Wczytaj więcej kanałów"

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -1614,3 +1614,5 @@ Downloads:
     Audio Best: Áudio - Melhor qualidade
     Audio Format: Áudio - {format}
     Subtitles Format: Legendas - {format}
+Channels:
+  Load More Channels: "Carregar mais canais"

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -1633,3 +1633,5 @@ Downloads:
     Audio Best: Áudio - Melhor qualidade
     Audio Format: Áudio - {format}
     Subtitles Format: Legendas - {format}
+Channels:
+  Load More Channels: "Carregar mais canais"

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -1651,3 +1651,5 @@ Downloads:
     Audio Best: Áudio - Melhor qualidade
     Audio Format: Áudio - {format}
     Subtitles Format: Legendas - {format}
+Channels:
+  Load More Channels: "Carregar mais canais"

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -1646,3 +1646,5 @@ Downloads:
     Audio Best: Audio - Cea mai bună calitate
     Audio Format: Audio - {format}
     Subtitles Format: Subtitrări - {format}
+Channels:
+  Load More Channels: "Încarcă mai multe canale"

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -1612,3 +1612,5 @@ Downloads:
     Audio Best: Аудио - лучшее качество
     Audio Format: Аудио - {format}
     Subtitles Format: Субтитры - {format}
+Channels:
+  Load More Channels: "Загрузить больше каналов"

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -1614,3 +1614,5 @@ Downloads:
     Audio Best: Zvuk – najlepšia kvalita
     Audio Format: Zvuk – {format}
     Subtitles Format: Titulky – {format}
+Channels:
+  Load More Channels: "Načítať ďalšie kanály"

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -2197,3 +2197,5 @@ Downloads:
     Audio Best: Zvok - najboljša kakovost
     Audio Format: Zvok - {format}
     Subtitles Format: Podnapisi - {format}
+Channels:
+  Load More Channels: "Naloži več kanalov"

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -1673,3 +1673,5 @@ Downloads:
     Audio Best: Аудио - најбољи квалитет
     Audio Format: Аудио - {format}
     Subtitles Format: Титлови - {format}
+Channels:
+  Load More Channels: "Учитај још канала"

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -1618,3 +1618,5 @@ Downloads:
     Audio Best: Ljud – bästa kvalitet
     Audio Format: Ljud - {format}
     Subtitles Format: Undertexter - {format}
+Channels:
+  Load More Channels: "Läs in fler kanaler"

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -1649,3 +1649,5 @@ Downloads:
     Audio Best: ஒலி - சிறந்த தரம்
     Audio Format: ஒலி - {format}
     Subtitles Format: துணைத்தலைப்புகள் - {format}
+Channels:
+  Load More Channels: "மேலும் சேனல்களை ஏற்று"

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -1614,3 +1614,5 @@ Downloads:
     Audio Best: Ses - En İyi Kalite
     Audio Format: Ses - {format}
     Subtitles Format: Alt Yazılar - {format}
+Channels:
+  Load More Channels: "Daha fazla kanal yükle"

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -1637,3 +1637,5 @@ Downloads:
     Audio Best: Аудіо - найкраща якість
     Audio Format: Аудіо - {format}
     Subtitles Format: Субтитри - {format}
+Channels:
+  Load More Channels: "Завантажити більше каналів"

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -1634,3 +1634,5 @@ Downloads:
     Audio Best: Âm thanh - Chất lượng tốt nhất
     Audio Format: Âm thanh - {format}
     Subtitles Format: Phụ đề - {format}
+Channels:
+  Load More Channels: "Tải thêm kênh"

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -1614,3 +1614,5 @@ Downloads:
     Audio Best: 音频 - 最佳质量
     Audio Format: 音频 - {format}
     Subtitles Format: 字幕 - {format}
+Channels:
+  Load More Channels: "加载更多频道"

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -1616,3 +1616,5 @@ Downloads:
     Audio Best: 音訊 - 最佳品質
     Audio Format: 音訊 - {format}
     Subtitles Format: 字幕 - {format}
+Channels:
+  Load More Channels: "載入更多頻道"

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -2287,6 +2287,7 @@ Screenshot Success: Screenshot wurde gespeichert
 Screenshot Error: Screenshot fehlgeschlagen. {error}
 New Window: Neues Fenster
 Channels:
+  Load More Channels: "Weitere Kanäle laden"
   Channels: Kanäle
   Title: Kanal-Liste
   Search bar placeholder: Kanäle durchsuchen

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -267,6 +267,7 @@ Subscriptions:
     RSS Message: YouTube does not provide RSS feeds for posts. Disable the "{rssSetting}" setting to view posts or enable the "{hideSetting}" setting to hide this tab.
 More: More
 Channels:
+  Load More Channels: "Load more channels"
   Channels: Channels
   Title: Channel List
   Search bar placeholder: Search Channels


### PR DESCRIPTION
Subscription settings and saved channel settings currently require switching pages. This change loads more channels at the bottom as you scroll, using the same spinner and manual-loading preference as the channels list.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Requested directly; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Append channel editors in batches while preserving selections and edits. Searches reset the list and scroll position, and the shared load-more button now has English, German, and AI locale completions.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Subscription settings with more than 24 subscriptions. Scroll to the bottom and confirm additional channels appear without replacing earlier entries.
2. Select channels from different batches and change a shared feed setting. Search for a channel and clear the search; the list should return to its first batch at the top.
3. In Playback settings, open Manage Saved Channels with more than 24 entries. Load more, edit a setting, then add or remove a saved channel. Confirm the edited value persists and the list scrolls to an added channel.
4. Disable automatic loading of paginated items. Both lists should show a working “Load more channels” button instead of the spinner. Repeat at a non-default UI scale.

## Additional context
<!-- Add any other context about the pull request here. -->

The pagination being replaced was introduced after the latest stable release.
