### PR TITLE
fix: stop recreating deprecated playback-speed sync collections

### DIFF
--- a/src/renderer/helpers/sync-server.js
+++ b/src/renderer/helpers/sync-server.js
@@ -235,8 +235,9 @@ export class SyncServerClient {
     })
   }
 
-  getEncryptedSyncManifest() {
-    return this.request('/v1/encrypted_sync', { timeoutMs: MAX_ENCRYPTED_SYNC_TIMEOUT_MS })
+  getEncryptedSyncManifest({ playbackSpeedsInSettings = false } = {}) {
+    const query = playbackSpeedsInSettings ? '?playback_speeds_in_settings=true' : ''
+    return this.request(`/v1/encrypted_sync${query}`, { timeoutMs: MAX_ENCRYPTED_SYNC_TIMEOUT_MS })
   }
 
   getEncryptedSyncCollection(collection) {

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -295,7 +295,12 @@ async function runSync(context, { allowDataLoss = false } = {}) {
         remote,
         uploadCollections,
       } = await runStage('download', async () => {
-        const manifest = await networkClient.getEncryptedSyncManifest()
+        // The snapshot is saved only after successful collection uploads.
+        // Never infer completed migration from unrelated encrypted settings.
+        const playbackSpeedsInSettings = settings.syncServerSyncSettings &&
+          isSettingSyncEnabled(settings, 'channelPlaybackSpeeds') &&
+          Boolean(previous.settings?.channelPlaybackSpeeds)
+        const manifest = await networkClient.getEncryptedSyncManifest({ playbackSpeedsInSettings })
         const legacyEncrypted = manifest.legacy_encrypted_data
           ? await networkClient.getLegacyEncryptedSync()
           : null

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -45,7 +45,6 @@ const LEGACY_ENCRYPTED_COLLECTIONS = [
   'subscriptions',
   'playlists',
   'history',
-  'playbackSpeeds',
   'profiles',
   'playlistBookmarks',
 ]
@@ -323,6 +322,8 @@ async function runSync(context, { allowDataLoss = false } = {}) {
           ...compatibilityCollections,
         ]))
         const document = createEmptySyncDocument()
+        // Legacy speeds are read for migration into settings, never uploaded.
+        document.playbackSpeeds = legacy.playbackSpeeds ?? []
         const original = {}
         const entries = await Promise.all(downloadCollections.map(async collection => {
           const response = await networkClient.getEncryptedSyncCollection(collection)

--- a/tests/helpers/encrypt-legacy-sync-document.mjs
+++ b/tests/helpers/encrypt-legacy-sync-document.mjs
@@ -1,0 +1,36 @@
+const additionalData = new TextEncoder().encode('OpenTubeX encrypted sync v1')
+
+function bytesToBase64 (bytes) {
+  return Buffer.from(bytes).toString('base64')
+}
+
+export async function encryptLegacyDocument (document, privacy) {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    Buffer.from(privacy.key, 'base64'),
+    { name: 'AES-GCM' },
+    false,
+    ['encrypt']
+  )
+  const iv = crypto.getRandomValues(new Uint8Array(12))
+  const encoded = new TextEncoder().encode(JSON.stringify(document))
+  const plaintext = new Uint8Array(64 * 1024)
+  plaintext.fill(0x20)
+  plaintext.set(encoded)
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv, additionalData },
+    key,
+    plaintext
+  )
+  return JSON.stringify({
+    version: 1,
+    kdf: {
+      name: 'PBKDF2',
+      hash: 'SHA-256',
+      iterations: 600000,
+      salt: privacy.salt,
+    },
+    cipher: { name: 'AES-GCM', iv: bytesToBase64(iv) },
+    ciphertext: bytesToBase64(new Uint8Array(ciphertext)),
+  })
+}

--- a/tests/unit/sync-server-downgrade.test.mjs
+++ b/tests/unit/sync-server-downgrade.test.mjs
@@ -235,6 +235,8 @@ for (const source of ['plaintext', 'single document', 'collection']) {
     const expected = { 'legacy-channel': 1.5, 'local-channel': 2 }
     for (let run = 0; run < 2; run++) {
       await f.actions.syncWithSyncServer(f.context)
+      const manifests = f.requests.filter(request => new URL(request.url).pathname === '/v1/encrypted_sync')
+      assert.equal(new URL(manifests.at(-1).url).searchParams.get('playback_speeds_in_settings'), run === 1 ? 'true' : null)
       assert.equal(f.context.state.syncServerError, '')
       assert.equal(f.requests.some(request => request.method === 'PUT' &&
         request.url.endsWith('/encrypted_sync/playbackSpeeds')), false)
@@ -248,5 +250,22 @@ for (const source of ['plaintext', 'single document', 'collection']) {
     assert.equal(collections.has('playbackSpeeds'), false)
     assert.equal(f.requests.some(request => request.method === 'GET' &&
       request.url.endsWith('/encrypted_sync/playbackSpeeds')), source === 'collection')
+  })
+}
+
+for (const overrides of [
+  { syncServerSyncSettings: false },
+  { syncServerSyncSettings: true, syncServerSettingsExcluded: ['channelPlaybackSpeeds'] },
+]) {
+  test(`does not acknowledge playback-speed migration with disabled sync: ${JSON.stringify(overrides)}`, async () => {
+    const f = fixture({
+      ...overrides,
+      channelPlaybackSpeeds: '{}',
+      syncServerSnapshot: JSON.stringify({ settings: { channelPlaybackSpeeds: { value: '{}', updatedAt: 1 } } }),
+    }, { encrypted: true })
+    await f.actions.syncWithSyncServer(f.context)
+    assert.equal(f.context.state.syncServerError, '')
+    assert.ok(f.requests.some(request => request.url.endsWith('/v1/encrypted_sync')))
+    assert.equal(f.requests.some(request => request.url.includes('playback_speeds_in_settings')), false)
   })
 }

--- a/tests/unit/sync-server-downgrade.test.mjs
+++ b/tests/unit/sync-server-downgrade.test.mjs
@@ -3,6 +3,10 @@ import { readFile } from 'node:fs/promises'
 import test from 'node:test'
 import vm from 'node:vm'
 
+import { encryptLegacyDocument } from '../helpers/encrypt-legacy-sync-document.mjs'
+import { CUSTOM_THEMES_SYNC_KEY, normalizeCustomThemes } from '../../src/customTheme.js'
+import { mergeSettingEntry, resolveMergedThemeEntry } from '../../src/renderer/helpers/sync-settings-conflict.js'
+
 import * as errors from '../../src/renderer/helpers/sync-server-errors.js'
 import * as privacy from '../../src/renderer/helpers/sync-server-privacy.js'
 import { isRecentSync } from '../../src/renderer/helpers/sync-server-scheduling.js'
@@ -10,7 +14,7 @@ import { createSyncServerRequestHeaders } from '../../src/renderer/helpers/sync-
 
 // These modules use webpack imports. Keep their actual request, merge, and store
 // code while replacing platform dependencies and the network with local fixtures.
-function withoutImports(source) {
+function withoutImports (source) {
   return source.replace(/^import[\s\S]*? from ['"][^'"]+['"]\n/gm, '')
     .replace(/^export \{[\s\S]*?\}\n/gm, '')
     .replace(/^export (?=(async )?(function|class|const))/gm, '')
@@ -19,7 +23,7 @@ function withoutImports(source) {
 const helperSource = await readFile(new URL('../../src/renderer/helpers/sync-server.js', import.meta.url), 'utf8')
 const storeSource = await readFile(new URL('../../src/renderer/store/modules/sync-server.js', import.meta.url), 'utf8')
 
-function fixture(overrides = {}, { encrypted = false } = {}) {
+function fixture (overrides = {}, { encrypted = false, respond } = {}) {
   const requests = []
   const commits = []
   const settings = {
@@ -39,15 +43,33 @@ function fixture(overrides = {}, { encrypted = false } = {}) {
     ...errors,
     ...privacy,
     isRecentSync,
-    crypto, URL, Headers, Response, AbortController, setTimeout, clearTimeout,
-    structuredClone, TextEncoder, TextDecoder,
+    crypto,
+    URL,
+    Headers,
+    Response,
+    AbortController,
+    setTimeout,
+    clearTimeout,
+    structuredClone,
+    TextEncoder,
+    TextDecoder,
     process: { env: {} },
     packageDetails: { version: 'test' },
     MAIN_PROFILE_ID: 'main',
     deepCopy: structuredClone,
     createSyncServerRequestHeaders,
+    CUSTOM_THEMES_SYNC_KEY,
+    normalizeCustomThemes,
+    mergeSettingEntry,
+    resolveMergedThemeEntry,
+    getSyncableSettingKeys: () => ['channelPlaybackSpeeds'],
+    isSettingSyncEnabled: (settings, key) => !settings.syncServerSettingsExcluded?.includes(key),
     fetch: async (url, options) => {
       requests.push({ url, method: options.method ?? 'GET', body: options.body })
+      if (respond) {
+        const response = await respond(url, options)
+        if (response !== undefined) return new Response(JSON.stringify(response))
+      }
       let result = null
       if (url.endsWith('/health')) result = encrypted ? { capabilities: { encrypted_sync: 1 } } : 'OK'
       else if (url.endsWith('/account/login')) result = { jwt: 'new-token' }
@@ -58,12 +80,13 @@ function fixture(overrides = {}, { encrypted = false } = {}) {
     },
   }
   const helper = vm.createContext({ ...common })
-  vm.runInContext(withoutImports(helperSource) + '\nglobalThis.exports = { SyncServerClient, syncSubscriptions, normalizeSyncServerUrl };', helper)
+  vm.runInContext(withoutImports(helperSource) + '\nglobalThis.exports = { SyncServerClient, syncSubscriptions, syncSettings, normalizeSyncServerUrl };', helper)
   const store = vm.createContext({ ...common, ...helper.exports, getSavedOtherDeviceSessions: () => [] })
   vm.runInContext(withoutImports(storeSource).replace('export default { state, getters, actions, mutations }', 'globalThis.exports = { state, actions, mutations }'), store)
   const context = {
     rootState: {
       settings,
+      utils: { customThemes: [] },
       profiles: { profileList: [{ _id: 'main', subscriptions: [{ id: 'private-channel', name: 'Private subscription' }] }] },
     },
     rootGetters: {},
@@ -77,6 +100,7 @@ function fixture(overrides = {}, { encrypted = false } = {}) {
         const key = action.slice(6)
         settings[key[0].toLowerCase() + key.slice(1)] = value
       }
+      if (action === 'updateChannelPlaybackSpeeds') settings.channelPlaybackSpeeds = value
       if (action === 'replaceSyncServerToken') settings.syncServerToken = value
       if (action === 'syncWithSyncServer') return store.exports.actions.syncWithSyncServer(context, value)
     },
@@ -130,8 +154,13 @@ test('manual sync uses encryption when a saved key survives an earlier downgrade
 })
 
 const credentials = {
-  mode: 'login', serverUrl: 'https://sync.example', username: 'alice', password: 'account-password',
-  deviceId: 'device', deviceName: 'Laptop', deviceSystemInfo: { platform: 'linux' },
+  mode: 'login',
+  serverUrl: 'https://sync.example',
+  username: 'alice',
+  password: 'account-password',
+  deviceId: 'device',
+  deviceName: 'Laptop',
+  deviceSystemInfo: { platform: 'linux' },
 }
 
 test('reauthentication cannot downgrade the same encrypted account', async () => {
@@ -158,3 +187,66 @@ test('connecting a different legacy account does not inherit the previous accoun
   assert.equal(f.settings.syncServerUsername, 'bob')
   assert.ok(f.requests.some(request => request.url.endsWith('/account/login')))
 })
+
+for (const source of ['plaintext', 'single document', 'collection']) {
+  test(`migrates ${source} playback speeds into settings without recreating the deleted collection`, async () => {
+    const collections = new Map()
+    const speeds = [{ channel_id: 'legacy-channel', playback_speed: 1.5 }]
+    // Retain the legacy migration flag on subsequent runs, as an older server
+    // does when playbackSpeeds is missing or plaintext data remains.
+    const f = fixture({
+      syncServerSyncSettings: true,
+      channelPlaybackSpeeds: JSON.stringify({ 'local-channel': 2 }),
+    }, {
+      encrypted: true,
+      respond: (url, options) => {
+        const path = new URL(url).pathname
+        if (path === '/v1/encrypted_sync') {
+          return {
+            collections: [...collections].map(([collection, entry]) => ({ collection, revision: entry.revision })),
+            legacy_data: source === 'plaintext',
+            legacy_encrypted_data: source === 'single document',
+          }
+        }
+        if (path === '/v1/encrypted_sync/legacy') return { revision: 1, payload: legacyPayload }
+        if (path.startsWith('/v1/encrypted_sync/')) {
+          const collection = path.split('/').at(-1)
+          if (options.method === 'PUT') {
+            const entry = JSON.parse(options.body)
+            assert.equal(entry.revision, collections.get(collection)?.revision ?? 0)
+            collections.set(collection, { revision: entry.revision + 1, payload: entry.payload })
+          }
+          return collections.get(collection) ?? { revision: 0, payload: null }
+        }
+        if (path === '/v1/channel_playback_speeds/') return speeds
+        if (path.startsWith('/v1/')) return []
+      },
+    })
+    const legacyPayload = await encryptLegacyDocument({
+      ...privacy.createEmptySyncDocument(), playbackSpeeds: speeds,
+    }, { key: f.settings.syncServerPrivacyKey, salt: f.settings.syncServerPrivacySalt })
+    if (source === 'collection') {
+      collections.set('playbackSpeeds', {
+        revision: 1,
+        payload: await privacy.encryptSyncDocument(speeds, f.settings.syncServerPrivacyKey, f.settings.syncServerPrivacySalt),
+      })
+    }
+
+    const expected = { 'legacy-channel': 1.5, 'local-channel': 2 }
+    for (let run = 0; run < 2; run++) {
+      await f.actions.syncWithSyncServer(f.context)
+      assert.equal(f.context.state.syncServerError, '')
+      assert.equal(f.requests.some(request => request.method === 'PUT' &&
+        request.url.endsWith('/encrypted_sync/playbackSpeeds')), false)
+      const settings = await privacy.decryptSyncDocument(
+        collections.get('settings').payload, f.settings.syncServerPrivacyKey
+      )
+      assert.deepEqual(JSON.parse(settings.find(entry => entry.key === 'channelPlaybackSpeeds').value), expected)
+      assert.deepEqual(JSON.parse(f.settings.channelPlaybackSpeeds), expected)
+      if (run === 0) collections.delete('playbackSpeeds')
+    }
+    assert.equal(collections.has('playbackSpeeds'), false)
+    assert.equal(f.requests.some(request => request.method === 'GET' &&
+      request.url.endsWith('/encrypted_sync/playbackSpeeds')), source === 'collection')
+  })
+}

--- a/tests/unit/sync-server-privacy.test.mjs
+++ b/tests/unit/sync-server-privacy.test.mjs
@@ -10,42 +10,7 @@ import {
   preparePrivacyKey,
 } from '../../src/renderer/helpers/sync-server-privacy.js'
 
-const additionalData = new TextEncoder().encode('OpenTubeX encrypted sync v1')
-
-function bytesToBase64 (bytes) {
-  return Buffer.from(bytes).toString('base64')
-}
-
-async function encryptLegacyDocument (document, privacy) {
-  const key = await crypto.subtle.importKey(
-    'raw',
-    Buffer.from(privacy.key, 'base64'),
-    { name: 'AES-GCM' },
-    false,
-    ['encrypt']
-  )
-  const iv = crypto.getRandomValues(new Uint8Array(12))
-  const encoded = new TextEncoder().encode(JSON.stringify(document))
-  const plaintext = new Uint8Array(64 * 1024)
-  plaintext.fill(0x20)
-  plaintext.set(encoded)
-  const ciphertext = await crypto.subtle.encrypt(
-    { name: 'AES-GCM', iv, additionalData },
-    key,
-    plaintext
-  )
-  return JSON.stringify({
-    version: 1,
-    kdf: {
-      name: 'PBKDF2',
-      hash: 'SHA-256',
-      iterations: 600000,
-      salt: privacy.salt,
-    },
-    cipher: { name: 'AES-GCM', iv: bytesToBase64(iv) },
-    ciphertext: bytesToBase64(new Uint8Array(ciphertext)),
-  })
-}
+import { encryptLegacyDocument } from '../helpers/encrypt-legacy-sync-document.mjs'
 
 test('decrypts the original single-document encrypted sync format', async () => {
   const passphrase = 'legacy-privacy-passphrase'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Deleting a migrated `playbackSpeeds` collection can cause legacy migration to upload it again. Stop uploading this deprecated collection while retaining reads from plaintext data, the original encrypted document, and existing encrypted collections so saved speeds can migrate into `settings`.

After a successful settings sync, acknowledge migrated playback speeds in subsequent manifest requests. First syncs and clients with settings or playback-speed sync disabled keep the conservative migration behavior.

Regression tests cover all three sources, a subsequent sync after deletion, acknowledgment only after success, and disabled settings.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Prevent sync from recreating deprecated playback-speed collections after their data has migrated to settings.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Use a test sync account with saved channel speeds in an old `playbackSpeeds` collection. Enable enhanced privacy and settings sync, including channel playback speeds.
2. Sync and verify those speeds are available in the app and stored in encrypted `settings`. In the network inspector, confirm there is no PUT to `/v1/encrypted_sync/playbackSpeeds`.
3. Delete only the test account's migrated `playbackSpeeds` collection on the server, then sync again. The saved speeds should remain and the deprecated collection should stay absent.

## Additional context
<!-- Add any other context about the pull request here. -->

Companion server PR: https://github.com/OpenTubeX/sync-server/pull/11

Implemented with GPT-6 through Codex.
