### PR TITLE
fix(android): prevent stuck subscription refreshes and notifications

### DIFF
--- a/android/app/src/androidTest/java/org/opentubex/app/SubscriptionRefreshLifecycleTest.java
+++ b/android/app/src/androidTest/java/org/opentubex/app/SubscriptionRefreshLifecycleTest.java
@@ -1,0 +1,142 @@
+package org.opentubex.app;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.app.NotificationManager;
+import android.content.Context;
+import android.os.SystemClock;
+
+import androidx.lifecycle.Lifecycle;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.PluginCall;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+
+@RunWith(AndroidJUnit4.class)
+public class SubscriptionRefreshLifecycleTest {
+    private final Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+
+    @Test
+    public void removingTaskFinishesRefreshButBackgroundingDoesNot() throws Exception {
+        AtomicReference<String> token = new AtomicReference<>();
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            try {
+                scenario.onActivity(activity -> {
+                    // Exercise the real plugin and worker without network requests or profile changes.
+                    activity.getBridge().getWebView().loadUrl("about:blank");
+                    SubscriptionRefreshPlugin plugin = plugin(activity);
+                    JSObject started = start(plugin);
+                    assertTrue(started.getBool("acquired"));
+                    token.set(started.getString("token"));
+                    // A rejected overlapping start must not lose ownership of the first refresh.
+                    assertFalse(start(plugin).getBool("acquired"));
+                });
+                await("foreground notification appears", this::hasRefreshNotification);
+                assertTrue(SubscriptionRefreshWorker.update(context, token.get(), 12));
+
+                scenario.moveToState(Lifecycle.State.CREATED);
+                assertTrue(SubscriptionRefreshCoordinator.isCurrent(token.get()));
+                assertTrue(hasRefreshNotification());
+                assertTrue(SubscriptionRefreshWorker.update(context, token.get(), 13));
+
+                scenario.moveToState(Lifecycle.State.RESUMED);
+                scenario.onActivity(MainActivity::finishAndRemoveTask);
+                await("activity destroyed", () -> scenario.getState() == Lifecycle.State.DESTROYED);
+                await("refresh notification removed", () -> !hasRefreshNotification());
+                assertFalse(SubscriptionRefreshCoordinator.isActive());
+                assertFalse(SubscriptionRefreshWorker.update(context, token.get(), 14));
+            } finally {
+                if (token.get() != null) SubscriptionRefreshWorker.finish(context, token.get());
+            }
+        }
+    }
+
+    @Test
+    public void destroyingRendererDoesNotFinishAnIndependentRefresh() {
+        String token = "independent-scheduled-refresh";
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            try {
+                scenario.onActivity(activity -> {
+                    activity.getBridge().getWebView().loadUrl("about:blank");
+                    assertTrue(SubscriptionRefreshCoordinator.begin(token));
+                    assertFalse(start(plugin(activity)).getBool("acquired"));
+                });
+                scenario.moveToState(Lifecycle.State.DESTROYED);
+                assertTrue(SubscriptionRefreshCoordinator.isCurrent(token));
+            } finally {
+                SubscriptionRefreshCoordinator.finish(token);
+            }
+        }
+    }
+
+    @Test
+    public void queuedStartCannotAcquireWorkAfterRendererDestruction() {
+        AtomicReference<SubscriptionRefreshPlugin> plugin = new AtomicReference<>();
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(activity -> {
+                activity.getBridge().getWebView().loadUrl("about:blank");
+                plugin.set(plugin(activity));
+            });
+            scenario.moveToState(Lifecycle.State.DESTROYED);
+            AtomicReference<String> rejection = new AtomicReference<>();
+            JSObject data = new JSObject();
+            data.put("title", "Refreshing subscription videos");
+            plugin.get().start(new PluginCall(null, "SubscriptionRefresh", "test", "start", data) {
+                @Override
+                public void reject(String message) {
+                    rejection.set(message);
+                }
+
+                @Override
+                public void resolve(JSObject response) {
+                    SubscriptionRefreshWorker.finish(context, response.getString("token"));
+                }
+            });
+            assertNotNull("destroyed renderer rejects queued start", rejection.get());
+            assertFalse(SubscriptionRefreshCoordinator.isActive());
+        }
+    }
+
+    private static SubscriptionRefreshPlugin plugin(MainActivity activity) {
+        return (SubscriptionRefreshPlugin) activity.getBridge().getPlugin("SubscriptionRefresh").getInstance();
+    }
+
+    private static JSObject start(SubscriptionRefreshPlugin plugin) {
+        AtomicReference<JSObject> result = new AtomicReference<>();
+        JSObject data = new JSObject();
+        data.put("title", "Refreshing subscription videos");
+        data.put("cancelLabel", "Cancel refresh");
+        plugin.start(new PluginCall(null, "SubscriptionRefresh", "test", "start", data) {
+            @Override
+            public void resolve(JSObject response) {
+                result.set(response);
+            }
+        });
+        assertNotNull(result.get());
+        return result.get();
+    }
+
+    private boolean hasRefreshNotification() {
+        return Arrays.stream(context.getSystemService(NotificationManager.class).getActiveNotifications())
+            .anyMatch(notification -> notification.getId() == SubscriptionRefreshNotification.NOTIFICATION_ID);
+    }
+
+    private static void await(String message, BooleanSupplier condition) throws Exception {
+        long deadline = SystemClock.elapsedRealtime() + 10000;
+        while (!condition.getAsBoolean() && SystemClock.elapsedRealtime() < deadline) {
+            Thread.sleep(50);
+        }
+        assertTrue(message, condition.getAsBoolean());
+    }
+}

--- a/android/app/src/androidTest/java/org/opentubex/app/SubscriptionRefreshLifecycleTest.java
+++ b/android/app/src/androidTest/java/org/opentubex/app/SubscriptionRefreshLifecycleTest.java
@@ -16,6 +16,7 @@ import androidx.test.platform.app.InstrumentationRegistry;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.PluginCall;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -26,6 +27,11 @@ import java.util.function.BooleanSupplier;
 @RunWith(AndroidJUnit4.class)
 public class SubscriptionRefreshLifecycleTest {
     private final Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+
+    @Before
+    public void resetCoordinator() {
+        SubscriptionRefreshCoordinator.resetForTest();
+    }
 
     @Test
     public void removingTaskFinishesRefreshButBackgroundingDoesNot() throws Exception {

--- a/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshPlugin.java
+++ b/android/app/src/main/java/org/opentubex/app/SubscriptionRefreshPlugin.java
@@ -24,6 +24,8 @@ import androidx.core.content.ContextCompat;
 public class SubscriptionRefreshPlugin extends Plugin {
     private BroadcastReceiver cancellationReceiver;
     private Consumer<Boolean> rendererActiveListener;
+    private String rendererToken;
+    private boolean destroyed;
 
     @Override
     public void load() {
@@ -48,8 +50,15 @@ public class SubscriptionRefreshPlugin extends Plugin {
     }
 
     @Override
-    protected void handleOnDestroy() {
+    protected synchronized void handleOnDestroy() {
+        destroyed = true;
         SubscriptionRefreshWorker.removeRendererActiveListener(rendererActiveListener);
+        // The renderer cannot finish its refresh once its WebView is destroyed.
+        // Only release work acquired by this plugin, leaving scheduled work alone.
+        if (rendererToken != null) {
+            SubscriptionRefreshWorker.finish(getContext(), rendererToken);
+            rendererToken = null;
+        }
         if (cancellationReceiver != null) {
             getContext().unregisterReceiver(cancellationReceiver);
             cancellationReceiver = null;
@@ -58,7 +67,11 @@ public class SubscriptionRefreshPlugin extends Plugin {
     }
 
     @PluginMethod
-    public void start(PluginCall call) {
+    public synchronized void start(PluginCall call) {
+        if (destroyed) {
+            call.reject("The subscription refresh renderer was destroyed");
+            return;
+        }
         String title = call.getString("title");
         if (title == null || title.trim().isEmpty()) {
             call.reject("A notification title is required");
@@ -68,6 +81,7 @@ public class SubscriptionRefreshPlugin extends Plugin {
         String token = UUID.randomUUID().toString();
         String cancelLabel = call.getString("cancelLabel", "Cancel");
         boolean acquired = SubscriptionRefreshWorker.start(getContext(), token, title, cancelLabel);
+        if (acquired) rendererToken = token;
         JSObject result = new JSObject();
         result.put("token", token);
         result.put("acquired", acquired);
@@ -153,7 +167,7 @@ public class SubscriptionRefreshPlugin extends Plugin {
     }
 
     @PluginMethod
-    public void update(PluginCall call) {
+    public synchronized void update(PluginCall call) {
         String token = call.getString("token");
         Integer progress = call.getInt("progress");
         if (token == null || progress == null) {
@@ -166,7 +180,7 @@ public class SubscriptionRefreshPlugin extends Plugin {
     }
 
     @PluginMethod
-    public void finish(PluginCall call) {
+    public synchronized void finish(PluginCall call) {
         String token = call.getString("token");
         if (token == null) {
             call.reject("A token is required");

--- a/src/renderer/helpers/api/capacitor-http.js
+++ b/src/renderer/helpers/api/capacitor-http.js
@@ -18,6 +18,7 @@ const AVATAR_MIME_TYPES = new Set([
 const MAX_AVATAR_BYTES = 2 * 1024 * 1024
 const MAX_AVATAR_BASE64_LENGTH = Math.ceil(MAX_AVATAR_BYTES / 3) * 4
 const DNS_RETRY_DELAYS_MS = [150, 500]
+const DEFAULT_NATIVE_TIMEOUT_MS = 30_000
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308])
 
 /**
@@ -99,7 +100,8 @@ async function getRequestBody(input, init) {
  * cannot rely on WebView CORS access. Media requests must keep using the
  * WebView so their response bodies are streamed instead of copied through the
  * JavaScript bridge as base64. nativeTimeoutMs bounds connection and read
- * inactivity on Android; signal still limits the JavaScript wait.
+ * inactivity on Android, defaulting to 30 seconds so stalled requests release
+ * the subscription queue. signal still limits the JavaScript wait.
  * @param {RequestInfo | URL} input
  * @param {RequestInit & { nativeTimeoutMs?: number }} [init]
  * @returns {Promise<Response>}
@@ -130,8 +132,8 @@ export async function capacitorHttpFetch(input, init = undefined) {
     data: await getRequestBody(input, init),
     responseType: 'text',
     disableRedirects: redirect !== 'follow',
-    connectTimeout: init?.nativeTimeoutMs,
-    readTimeout: init?.nativeTimeoutMs,
+    connectTimeout: init?.nativeTimeoutMs ?? DEFAULT_NATIVE_TIMEOUT_MS,
+    readTimeout: init?.nativeTimeoutMs ?? DEFAULT_NATIVE_TIMEOUT_MS,
   }, signal)
 
   if (redirect === 'error' && REDIRECT_STATUSES.has(nativeResponse.status)) {

--- a/tests/unit/capacitor-http.test.mjs
+++ b/tests/unit/capacitor-http.test.mjs
@@ -4,6 +4,8 @@ import { readFile } from 'node:fs/promises'
 import vm from 'node:vm'
 
 import { createAbortError } from '../../src/renderer/helpers/api/requestErrors.js'
+import { classifyRequestFailure } from '../../src/renderer/helpers/api/requestDiagnostics.js'
+import { createSubscriptionNetworkRecovery, SubscriptionNetworkError } from '../../src/renderer/helpers/subscriptionNetworkRecovery.js'
 
 import {
   capacitorHttpFetch,
@@ -239,23 +241,26 @@ test('rejects invalid native avatar responses', async () => {
   }
 })
 
-test('bounds native connection and stalled reads while retaining JavaScript cancellation', async () => {
+async function loadNativeHttp(request) {
   const source = (await readFile(new URL('../../src/renderer/helpers/api/capacitor-http.js', import.meta.url), 'utf8'))
     .replace(/^import .* from .*\n/gm, '')
     .replace(/^export /gm, '')
-  const requests = []
   const context = vm.createContext({
-    CapacitorHttp: {
-      request(options) {
-        requests.push(options)
-        return new Promise(() => {})
-      },
-    },
+    CapacitorHttp: { request },
     createAbortError, Request, Response, Headers, URL, URLSearchParams, setTimeout, clearTimeout,
   })
   vm.runInContext(`${source}\nglobalThis.fetchNative = capacitorHttpFetch`, context)
+  return context.fetchNative
+}
+
+test('bounds native connection and stalled reads while retaining JavaScript cancellation', async () => {
+  const requests = []
+  const fetchNative = await loadNativeHttp(options => {
+    requests.push(options)
+    return new Promise(() => {})
+  })
   const controller = new AbortController()
-  const pending = context.fetchNative('https://www.youtube.com/watch?v=test', {
+  const pending = fetchNative('https://www.youtube.com/watch?v=test', {
     signal: controller.signal,
     nativeTimeoutMs: 15_000,
   })
@@ -270,3 +275,50 @@ test('bounds native connection and stalled reads while retaining JavaScript canc
     await rejected
   }
 })
+
+for (const timeoutOption of ['connectTimeout', 'readTimeout']) {
+  test(`a stalled native ${timeoutOption} releases subscription recovery without a caller timeout`, async t => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+    let attempts = 0
+    const fetchNative = await loadNativeHttp(options => {
+      attempts++
+      if (attempts > 1) return Promise.resolve({ status: 200, data: 'recovered', headers: {} })
+      return new Promise((resolve, reject) => {
+        // Android's socket timeout of zero or an omitted timeout waits forever.
+        if (options[timeoutOption] > 0) {
+          setTimeout(() => reject(Object.assign(new Error('Read timed out'), {
+            code: 'SocketTimeoutException'
+          })), options[timeoutOption])
+        }
+      })
+    })
+    const controller = new AbortController()
+    const recovery = createSubscriptionNetworkRecovery({ eventTarget: new EventTarget(), isOnline: () => true })
+    let body
+    const pending = recovery.run(async () => {
+      try {
+        body = await (await fetchNative('https://www.youtube.com/youtubei/v1/browse', {
+          signal: controller.signal
+        })).text()
+      } catch (error) {
+        if (classifyRequestFailure(error) === 'network') throw new SubscriptionNetworkError(error)
+        throw error
+      }
+    })
+    const flush = async () => { for (let i = 0; i < 30; i++) await Promise.resolve() }
+    try {
+      await flush()
+      t.mock.timers.tick(30_000)
+      await flush()
+      t.mock.timers.tick(5000)
+      await flush()
+      assert.equal(attempts, 2, 'the timed-out channel must retry instead of holding the queue forever')
+      await pending
+      assert.equal(body, 'recovered')
+    } finally {
+      recovery.cancel()
+      controller.abort()
+      await pending.catch(() => {})
+    }
+  })
+}


### PR DESCRIPTION
Android subscription refreshes could stall on a network request or leave their progress notification behind when the app was cleared from recents. Bound native requests so refresh recovery can retry, and stop the refresh owned by a destroyed WebView.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Reported and reproduced on the Pixel in this task; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Track the refresh token acquired by each plugin instance and finish it when that instance is destroyed. Serialize refresh bridge calls with destruction and reject queued starts after teardown. Independent scheduled refreshes retain their ownership. Native API requests now default to 30-second connection and read inactivity timeouts, preserving shorter caller-specific limits.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. On Android, start a subscription refresh and wait for its progress notification.
2. Go Home, then return to OpenTubeX. The refresh should keep progressing and eventually finish; its notification should disappear on completion.
3. Start another refresh. Open recents and swipe OpenTubeX away while it is still running. Its progress notification should disappear.
4. Reopen OpenTubeX and confirm another refresh can start.

## Additional context
<!-- Add any other context about the pull request here. -->

Pixel debugging identified two indefinite waits: a native HTTP socket with timeout zero, and a foreground worker waiting for completion from a destroyed WebView. This Android functionality has not appeared in a stable release.

Implemented with GPT-6 in Codex.
