### PR TITLE
fix(player): preserve poster and aspect ratio during stream recovery

### DIFF
--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -593,6 +593,87 @@ test('a stale yt-dlp rejection probe preserves a newer cache entry', async ({ ap
   expect(result.loadGeneration).toBeGreaterThan(0)
 })
 
+for (const zoom of [1, 1.25]) {
+  for (const posterAvailable of [true, false]) {
+    test(`yt-dlp 403 recovery keeps the player height at ${zoom * 100}% scale with poster ${posterAvailable ? 'available' : 'unavailable'}`, async ({ app, page }, testInfo) => {
+      await mockPlayableWatchPage(app, page)
+      if (posterAvailable) {
+        // A 4:3 poster must not change the playing video's 16:9 geometry.
+        await page.route('https://i.ytimg.com/**', route => route.fulfill({
+          contentType: 'image/svg+xml',
+          body: '<svg xmlns="http://www.w3.org/2000/svg" width="480" height="360"><rect width="480" height="360" fill="#326b8a"/></svg>'
+        }))
+      }
+      await page.evaluate(async zoom => {
+        await window.ftElectron.setZoomFactor(zoom)
+        const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+        await store.dispatch('updateVideoPlaybackEngine', 'built-in')
+      }, zoom)
+      await openMockedVideo(page)
+
+      const player = page.locator('.ftVideoPlayer')
+      const before = await player.boundingBox()
+      const watchView = await watchViewHandle(page)
+      await watchView.evaluate((view) => {
+        const area = view.$el.querySelector('.videoAreaMargin')
+        window.__recoveryHeights = []
+        window.__recoveryHeightObserver = new ResizeObserver(() => {
+          window.__recoveryHeights.push(area.getBoundingClientRect().height)
+        })
+        window.__recoveryHeightObserver.observe(area)
+        view.activePlaybackEngine = 'yt-dlp'
+        view.extractYtDlpPlaybackSource = () => new Promise(resolve => {
+          window.__releaseStreamExtraction = () => resolve(true)
+        })
+        const destroyPlayer = view.$refs.player.destroyPlayer
+        const teardownPending = new Promise(resolve => { window.__releasePlayerTeardown = resolve })
+        view.$refs.player.destroyPlayer = async () => {
+          const state = await destroyPlayer()
+          window.__playerTeardownFinished = true
+          await teardownPending
+          return state
+        }
+        window.__streamRecovery = view.handlePlayerError({
+          code: 1002,
+          data: ['https://example.invalid/video', 403]
+        })
+      })
+      await expect.poll(() => page.evaluate(() => window.__playerTeardownFinished)).toBe(true)
+      expect(await player.locator('video').evaluate(element => element.videoWidth)).toBe(0)
+      await expect(player.locator('video')).toHaveAttribute('poster', /i\.ytimg\.com/)
+      const during = await player.boundingBox()
+      expect(Math.abs(during.height - before.height)).toBeLessThanOrEqual(1)
+      await testInfo.attach('player-during-teardown', {
+        body: await player.screenshot(),
+        contentType: 'image/png'
+      })
+
+      await page.evaluate(() => { window.__releasePlayerTeardown() })
+      const placeholder = page.locator('.streamPlaceholder')
+      await expect(placeholder).toBeVisible()
+      const pending = await placeholder.boundingBox()
+      expect(Math.abs(pending.height - before.height)).toBeLessThanOrEqual(1)
+      await expect(placeholder).toContainText('Fetching streams')
+      if (posterAvailable) {
+        await expect.poll(() => placeholder.locator('img').evaluate(element => element.naturalWidth)).toBe(480)
+      }
+      await page.evaluate(async () => {
+        window.__releaseStreamExtraction()
+        await window.__streamRecovery
+      })
+      await expect.poll(() => player.locator('video').evaluate(element => element.videoWidth)).toBeGreaterThan(0)
+      const after = await player.boundingBox()
+      expect(Math.abs(after.height - before.height)).toBeLessThanOrEqual(1)
+      const heights = await page.evaluate(() => {
+        window.__recoveryHeightObserver.disconnect()
+        return window.__recoveryHeights
+      })
+      expect(heights.length).toBeGreaterThan(0)
+      expect(Math.max(...heights.map(height => Math.abs(height - before.height)))).toBeLessThanOrEqual(1)
+    })
+  }
+}
+
 test('yt-dlp recovery remounts only the player and preserves playback state', async ({ app, page }) => {
   await mockPlayableWatchPage(app, page)
   await goTo(page, 'history')

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -10935,6 +10935,15 @@ export default defineComponent({
       // destroyed, after its internal manifest has already been cleared.
       hasLoaded.value = false
 
+      // Shaka clears the video's intrinsic dimensions before this component
+      // unmounts. Keep its ratio and restore the poster so recovery doesn't
+      // briefly collapse the player to the empty video's 150px default height.
+      if (video.value?.videoWidth > 0 && video.value.videoHeight > 0) {
+        video.value.style.aspectRatio = `${video.value.videoWidth} / ${video.value.videoHeight}`
+      }
+      showPoster.value = true
+      await nextTick()
+
       let uiState = {
         startNextVideoInFullscreen: false,
         startNextVideoInFullwindow: false,


### PR DESCRIPTION
During yt-dlp recovery from a 403, the player briefly collapses into a 150px black strip before the stream-loading poster appears.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Reported in the Codex task; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Preserve the video's intrinsic aspect ratio and restore its poster before Shaka clears the media element during teardown. Regression coverage checks the teardown, extraction, and remount transitions at 100% and 125% UI scale, with working and unavailable posters.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Play a video using the yt-dlp engine and trigger automatic recovery from a 403 stream error.
2. Verify the player retains its height and shows its poster while the old player is torn down, then shows the stream-loading placeholder until playback resumes.
3. Repeat at 125% UI scale and with the thumbnail unavailable. The player should keep its height in both cases.

## Additional context
<!-- Add any other context about the pull request here. -->
The player-only yt-dlp recovery path was introduced in #1068 after the latest release. The original regression test reproduced a drop from about 577 CSS pixels to 150; all seven focused checks and targeted ESLint now pass.

Implemented and reviewed with Codex.
