### PR TITLE
fix(tabs): open desktop tabs on mobile and correct synced URLs and device icons

### DIFF
--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -2286,8 +2286,8 @@ test.describe('tab organizer', () => {
           syncPlatform: 'mobile',
           sessionId: 'mobile-session-e2e',
           tabs: [
-            { id: 'synced-watch', title: 'Synced watch tab', url: '/watch/synced-video' },
-            { id: 'synced-history', title: 'Synced history tab', url: '/history' },
+            { id: 'synced-watch', title: 'Synced watch tab', url: 'https://localhost/watch/synced-video?timestamp=42#details' },
+            { id: 'synced-history', title: 'Synced history tab', url: 'https://localhost/history' },
           ],
         },
         {
@@ -2295,7 +2295,7 @@ test.describe('tab organizer', () => {
           syncPlatform: 'desktop',
           sessionId: 'desktop-session-e2e',
           tabs: [
-            { id: 'synced-desktop', title: 'Desktop synced tab', url: '/subscriptions' },
+            { id: 'synced-desktop', title: 'Desktop synced tab', url: 'app://bundle/index.html#/subscriptions' },
           ],
         },
       ])
@@ -2325,12 +2325,13 @@ test.describe('tab organizer', () => {
     await expect(sessionTabs.getByRole('tab')).toHaveCount(2)
     await expect(mobileTab).toHaveAttribute('aria-selected', 'true')
     await expect(desktopTab).toHaveAttribute('aria-selected', 'false')
-    await expect(sessionTabs.locator('[data-icon="layer-group"]')).toBeVisible()
+    await expect(mobileTab.locator('[data-icon="smartphone"]')).toBeVisible()
     await expect(sessionTabs.locator('[data-icon="display"]')).toBeVisible()
     await expect(syncedSet.locator('[data-icon="clapperboard"]')).toBeVisible()
     await expect(syncedSet.locator('[data-icon="clock-rotate-left"]')).toBeVisible()
     await expect(syncedSet.locator('[data-icon="arrow-up-right-from-square"]')).toHaveCount(2)
     await expect(syncedSet).not.toContainText('Desktop synced tab')
+    await expect(syncedSet.locator('small')).toHaveText(['/watch/synced-video?timestamp=42#details', '/history'])
 
     encryptedPhoneInfo = await encryptSyncServerDeviceInfo(
       { ...phoneDeviceInfo, name: 'Stale phone' },
@@ -2367,6 +2368,7 @@ test.describe('tab organizer', () => {
     await expect(desktopTab).toBeFocused()
     await expect(desktopTab).toHaveAttribute('aria-selected', 'true')
     await expect(syncedSet).toContainText('Desktop synced tab')
+    await expect(syncedSet.locator('small')).toHaveText(['/subscriptions'])
     await expect(syncedSet).not.toContainText('Synced watch tab')
 
     await desktopTab.press('Home')
@@ -2407,6 +2409,63 @@ test.describe('tab organizer', () => {
       return store.getters.getSyncServerToken
     })).toBe('replacement-token')
   })
+
+  for (const iconPack of ['material', 'remix']) {
+    test(`opens synced mobile and desktop routes with ${iconPack} device icons`, async ({ page }, testInfo) => {
+      await page.evaluate(async (pack) => {
+        const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+        await store.dispatch('updateIconPack', pack)
+        store.commit('setSyncServerEnabled', true)
+        store.commit('setSyncServerToken', 'e2e-token')
+        store.commit('setSyncServerPrivacyMode', 'enhanced')
+        store.commit('setSyncServerSyncSessions', true)
+        store.commit('setSyncServerSharedTabs', false)
+        store.commit('setSyncServerOtherDeviceSessions', [
+          {
+            syncDeviceId: 'phone-e2e',
+            syncPlatform: 'mobile',
+            sessionId: 'phone-session',
+            tabs: [{ id: 'phone-tab', title: 'Subscriptions', url: 'https://localhost/subscriptions' }],
+          },
+          {
+            syncDeviceId: 'desktop-e2e',
+            syncPlatform: 'desktop',
+            sessionId: 'desktop-session',
+            tabs: [
+              { id: 'desktop-history', title: 'History', url: 'app://bundle/index.html#/history' },
+              { id: 'desktop-playlists', title: 'Playlists', url: 'app://bundle/index.html#/playlists' },
+            ],
+          },
+        ])
+      }, iconPack)
+
+      await page.locator(sel.tabOrganizerButton).click()
+      const organizer = page.getByRole('dialog', { name: 'Tab Organizer' })
+      const syncedSection = organizer.locator('.syncedTabsSection')
+      const phoneIcon = syncedSection.getByRole('tab', { name: 'Mobile · 1 tab', exact: true })
+        .locator('[data-icon="smartphone"]')
+      await expect(phoneIcon).toBeVisible()
+      await expect(phoneIcon).toHaveAttribute('data-icon-pack', iconPack)
+      await expect(syncedSection.locator('small')).toHaveText(['/subscriptions'])
+      const screenshot = testInfo.outputPath(`synced-tabs-${iconPack}.png`)
+      await syncedSection.screenshot({ path: screenshot })
+      await testInfo.attach(`Synced tabs with ${iconPack} icons`, { path: screenshot, contentType: 'image/png' })
+
+      await syncedSection.locator('.syncedTabTarget').click()
+      await expect.poll(() => page.evaluate(() => window.ftElectron.tabs.getState().then(state => (
+        state.tabs.find(tab => tab.id === state.activeTabId)?.route.fullPath
+      )))).toBe('/subscriptions')
+
+      await syncedSection.getByRole('tab', { name: 'Desktop · 2 tabs', exact: true }).click()
+      await expect(syncedSection.locator('small')).toHaveText(['/history', '/playlists'])
+      await syncedSection.getByRole('button', { name: 'Open all tabs' }).click()
+      await expect.poll(() => page.evaluate(() => window.ftElectron.tabs.getState().then(state => (
+        state.tabs.slice(-3).map(tab => tab.route.fullPath)
+      )))).toEqual(['/subscriptions', '/history', '/playlists'])
+      await organizer.locator('.tabOrganizerHeader .iconButton').click()
+      await expect.poll(() => page.evaluate(() => window.location.hash)).toBe('#/playlists')
+    })
+  }
 
   test('clamps scroll after switching to a shorter synced session at fractional UI scale', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 })

--- a/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.vue
+++ b/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.vue
@@ -248,7 +248,7 @@
                     @keydown.end.prevent="selectOtherDeviceSessionAt(otherDeviceSessions.length - 1, true)"
                   >
                     <FtIcon
-                      :icon="session.syncPlatform === 'mobile' ? ['fas', 'layer-group'] : ['fas', 'display']"
+                      :icon="session.syncPlatform === 'mobile' ? ['fas', 'smartphone'] : ['fas', 'display']"
                       aria-hidden="true"
                     />
                     <strong>{{ formatDeviceSessionLabel(session, t) }}</strong>

--- a/src/renderer/components/TabOrganizer/TabOrganizer.vue
+++ b/src/renderer/components/TabOrganizer/TabOrganizer.vue
@@ -466,7 +466,7 @@
                 >
                   <span class="syncedSessionIcon">
                     <FtIcon
-                      :icon="session.syncPlatform === 'mobile' ? ['fas', 'layer-group'] : ['fas', 'display']"
+                      :icon="session.syncPlatform === 'mobile' ? ['fas', 'smartphone'] : ['fas', 'display']"
                       aria-hidden="true"
                     />
                   </span>
@@ -533,8 +533,8 @@
                           />
                         </span>
                         <span class="syncedTabIdentity">
-                          <span dir="auto">{{ formatTabTitle(tab.title || tab.url) }}</span>
-                          <small>{{ tab.url }}</small>
+                          <span dir="auto">{{ formatTabTitle(tab.title || getSyncTabRoute(tab.url)) }}</span>
+                          <small>{{ getSyncTabRoute(tab.url) }}</small>
                         </span>
                         <FtIcon
                           class="syncedTabOpenIcon"
@@ -623,7 +623,7 @@ import { useI18n } from 'vue-i18n'
 
 import { getTabAccentColor } from '../../constants/tabColors'
 import { clampOverlayScrollTop, restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
-import { formatDeviceSessionLabel, shouldShowOtherDeviceSessions } from '../../helpers/sync-sessions'
+import { formatDeviceSessionLabel, getSyncTabRoute, shouldShowOtherDeviceSessions } from '../../helpers/sync-sessions'
 import { showToast } from '../../helpers/utils'
 import store from '../../store/index'
 import { getTabAvatarUrl, getTabPageIcon } from '../../tabs/tabPreview'
@@ -839,7 +839,7 @@ function handleTabAvatarError(tab) {
 
 function syncedTabPreview(tab) {
   try {
-    const url = new URL(tab.url, window.location.origin)
+    const url = new URL(getSyncTabRoute(tab.url), window.location.origin)
     return { ...tab, route: { path: url.pathname } }
   } catch {
     return tab

--- a/src/renderer/helpers/sync-sessions.js
+++ b/src/renderer/helpers/sync-sessions.js
@@ -2,6 +2,21 @@ import { areJsonValuesEqual } from './jsonValues.js'
 
 export const SYNC_SESSIONS_VERSION = 1
 
+export function getSyncTabRoute(value) {
+  if (typeof value !== 'string' || value.length === 0) return '/'
+
+  try {
+    const url = new URL(value, 'https://opentubex.invalid')
+    // Electron stores the route in the app shell's hash; Capacitor uses paths.
+    if ((url.pathname === '/' || url.pathname === '/index.html') && url.hash.startsWith('#/')) {
+      return url.hash.slice(1)
+    }
+    return `${url.pathname}${url.search}${url.hash}`
+  } catch {
+    return '/'
+  }
+}
+
 function clone(value) {
   return structuredClone(value)
 }

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -31,7 +31,7 @@ import {
   loadSyncServerDeviceNames,
 } from '../../helpers/sync-server-sessions'
 import { mergePlaylistBookmarkConflict } from '../../helpers/playlist-bookmarks'
-import { getPreviousSyncSessions, removeSyncSession } from '../../helpers/sync-sessions'
+import { getPreviousSyncSessions, getSyncTabRoute, removeSyncSession } from '../../helpers/sync-sessions'
 import {
   AUTO_SYNC_INTERVAL_MS,
   isRecentSync,
@@ -464,13 +464,8 @@ const actions = {
     if (!process.env.IS_ELECTRON) return false
 
     for (const [index, tab] of session.tabs.entries()) {
-      let route = '/'
-      try {
-        const url = new URL(tab.url, window.location.origin)
-        route = `${url.pathname}${url.search}${url.hash}`
-      } catch {}
       await window.ftElectron.tabs.create({
-        route,
+        route: getSyncTabRoute(tab.url),
         title: tab.title ?? '',
         makeActive: index === session.tabs.length - 1,
       })

--- a/src/renderer/tabs/CapacitorTabService.js
+++ b/src/renderer/tabs/CapacitorTabService.js
@@ -14,6 +14,7 @@ import {
   unloadCapacitorTab
 } from './capacitorTabState.js'
 import { tabMediaCoordinator } from './TabMediaCoordinator.js'
+import { getSyncTabRoute } from '../helpers/sync-sessions.js'
 
 const STORAGE_KEY = 'opentubex-capacitor-tabs'
 const PERSISTED_MUTATIONS = new Set([
@@ -178,7 +179,7 @@ export class CapacitorTabService {
 
     const previous = this.currentSession()
     const tabs = synced.tabs.map(tab => createCapacitorTab(
-      this.router.resolve(syncTabRoute(tab.url)),
+      this.router.resolve(getSyncTabRoute(tab.url)),
       tab.title,
       tab.id
     )).map((tab, index) => ({
@@ -203,7 +204,7 @@ export class CapacitorTabService {
     if (!Array.isArray(session?.tabs) || session.tabs.length === 0) return false
 
     for (const tab of session.tabs) {
-      const tabId = await this.createTab(syncTabRoute(tab.url), tab.title)
+      const tabId = await this.createTab(getSyncTabRoute(tab.url), tab.title)
       if (!tabId) return false
       if (tab.isPinned === true) this.setPinned(tabId, true)
     }
@@ -403,15 +404,6 @@ function toPersistedSession(session) {
     activeTabId: session.activeTabId,
     selectionRevision: session.selectionRevision,
     updatedAt: session.updatedAt
-  }
-}
-
-function syncTabRoute(value) {
-  try {
-    const url = new URL(value, window.location.origin)
-    return `${url.pathname}${url.search}${url.hash}`
-  } catch {
-    return '/'
   }
 }
 

--- a/tests/unit/capacitor-tab-service.test.mjs
+++ b/tests/unit/capacitor-tab-service.test.mjs
@@ -213,6 +213,26 @@ test('restores the previous session when synced-tab presentation fails', async (
   assert.equal(store.getters.getPresentedTabId, 'tab-a')
 })
 
+for (const action of ['openSyncedSession', 'applySyncSessions']) {
+  test(`${action} opens Electron hash routes on mobile`, async () => {
+    const store = createStore(createLoadedSession())
+    const service = new CapacitorTabService(createRouter(), store, createNavigation(store, true))
+    const synced = {
+      activeTabId: 'desktop-watch',
+      tabs: [{
+        id: 'desktop-watch',
+        title: 'Desktop video',
+        url: 'app://bundle/index.html#/watch/video?timestamp=42#details',
+        isPinned: true
+      }]
+    }
+
+    assert.equal(await service[action](action === 'applySyncSessions' ? [synced] : synced), true)
+    assert.equal(store.getters.getActiveTab.route.fullPath, '/watch/video?timestamp=42#details')
+    assert.equal(store.getters.getActiveTab.isPinned, true)
+  })
+}
+
 test('uses tab actions on Android WebViews without Array.toReversed', async () => {
   let session = createLoadedSession()
   session = addCapacitorTab(session, createCapacitorTab(WATCH_ROUTE, 'Video', 'tab-b'))

--- a/tests/unit/sync-sessions.test.mjs
+++ b/tests/unit/sync-sessions.test.mjs
@@ -5,6 +5,7 @@ import {
   formatDeviceSessionLabel,
   getOtherDeviceSessions,
   getPreviousSyncSessions,
+  getSyncTabRoute,
   mergeSyncSessions,
   normalizeSyncSessionsDocument,
   removeSyncSession,
@@ -16,6 +17,26 @@ const session = (id, updatedAt, url = `https://opentubex.local/${id}`) => ({
   updatedAt,
   activeTabId: `${id}-tab`,
   tabs: [{ id: `${id}-tab`, url }],
+})
+
+test('extracts synced routes from desktop, mobile, and relative URLs', () => {
+  const route = '/watch/video?timestamp=42&list=PL123#details'
+  for (const prefix of [
+    'app://bundle/index.html#',
+    'app://bundle/#',
+    'http://localhost:9080/#',
+    'https://localhost',
+    'capacitor://localhost',
+    '',
+  ]) {
+    assert.equal(getSyncTabRoute(`${prefix}${route}`), route)
+  }
+  assert.equal(getSyncTabRoute('app://bundle/index.html#/subscriptions'), '/subscriptions')
+  assert.equal(getSyncTabRoute('https://localhost/watch/video#/details'), '/watch/video#/details')
+  assert.equal(getSyncTabRoute('/search/a%20b?searchQuery=a%2Fb'), '/search/a%20b?searchQuery=a%2Fb')
+  for (const value of [null, undefined, '', {}, 'https://[invalid']) {
+    assert.equal(getSyncTabRoute(value), '/')
+  }
 })
 
 test('formats device session labels with localized tab plurals', () => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

Desktop tabs failed to open on Android because Electron stores routes after `#`, while Capacitor uses URL paths. A shared route parser fixes opening synced tabs and makes the organizer show internal paths. Mobile sessions now use the existing phone icon in both icon packs.

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Reported directly; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
For example, `app://bundle/index.html#/subscriptions` now opens `/subscriptions` on Android. Synced rows display `/subscriptions` and `/watch/…` without the app origin.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run this branch on desktop and Android, pair them with session sync enabled, and keep their tab sets separate.
2. Open Subscriptions and a video on desktop. On Android, open the tab organizer, choose the desktop device, and open each synced tab. Confirm the intended page loads and the video can play.
3. On desktop, open the organizer and select the phone. Confirm route labels omit `https://localhost` and the device uses a phone icon in both Material and Remix. Check that “Open all tabs” opens the listed pages.

## Additional context
<!-- Add any other context about the pull request here. -->
Android tab sync has not appeared in a stable release, so this is marked not noteworthy.

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/1b687a8a-3f82-43c8-9af0-6ff2160f1159">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/015b5551-55a9-4800-96d9-91777a05c4ad">
  <img alt="Synced mobile tabs show a phone icon and internal route labels" src="https://github.com/user-attachments/assets/1b687a8a-3f82-43c8-9af0-6ff2160f1159">
</picture>

Implemented and reviewed using GPT-6 in Codex.

