### PR TITLE
fix(player): prevent live captions from interrupting playback

### DIFF
--- a/e2e/tests/offline/live-captions.spec.mjs
+++ b/e2e/tests/offline/live-captions.spec.mjs
@@ -1,0 +1,61 @@
+import { test, expect, sel } from '../../helpers/app.mjs'
+import { activeTab } from '../../helpers/player.mjs'
+import { mockPlayableWatchPage, watchViewHandle } from '../../helpers/watch.mjs'
+import { POST_LIVE_VIDEO_URL, routePostLiveMedia } from '../../helpers/media.mjs'
+
+test.use({ seed: { settings: { videoPlaybackEngine: 'yt-dlp' } } })
+
+test('keeps live HLS playback when external captions are advertised', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page, { captionTranslations: true })
+  await routePostLiveMedia(page)
+  const manifest = 'https://example.invalid/live-captions.m3u8'
+  await page.route(manifest, route => route.fulfill({
+    contentType: 'application/x-mpegURL',
+    body: '#EXTM3U\n#EXT-X-VERSION:7\n#EXT-X-TARGETDURATION:2\n#EXT-X-MEDIA-SEQUENCE:0\n' +
+      Array.from({ length: 20 }, (_, index) =>
+        `${index ? '#EXT-X-DISCONTINUITY\n' : ''}#EXTINF:2,\n${POST_LIVE_VIDEO_URL}&segment=${index}\n`
+      ).join('')
+  }))
+  await app.electronApp.evaluate(({ ipcMain }, manifestUrl) => {
+    globalThis.__liveCaptionExtractions = 0
+    ipcMain.removeHandler('yt-dlp-get-playback-info')
+    ipcMain.handle('yt-dlp-get-playback-info', () => {
+      globalThis.__liveCaptionExtractions++
+      return {
+        isLive: true,
+        liveStatus: 'is_live',
+        hlsManifestUrl: manifestUrl,
+        formats: [],
+        duration: null,
+        storyboardVtt: null,
+        captions: [],
+        captionTranslations: [],
+        version: 'test'
+      }
+    })
+  }, manifest)
+  const errors = []
+  page.on('console', message => {
+    if (message.type() === 'error') errors.push(message.text())
+  })
+  await page.locator(sel.searchInput).fill('https://youtu.be/jNQXAC9IVRw')
+  await page.locator(sel.searchInput).press('Enter')
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  await expect(page.locator(`${activeTab} .videoTitle`)).toBeVisible()
+  const watch = await watchViewHandle(page)
+  await expect.poll(() => watch.evaluate(view => view.captions.length)).toBeGreaterThan(0)
+  const video = page.locator(`${activeTab} video`)
+  await expect(video).toBeVisible()
+  await video.evaluate(element => element.play())
+  await expect.poll(() => video.evaluate(element => element.currentTime).catch(() => 0)).toBeGreaterThan(0)
+  // Allow playback to advance through a segment boundary, catching reloads as
+  // well as the caption error itself.
+  const start = await video.evaluate(element => element.currentTime)
+  await expect.poll(() => video.evaluate(element => element.currentTime)).toBeGreaterThan(start + 2)
+  expect(errors.filter(message => /4033|addTextTrackAsync/.test(message))).toEqual([])
+  expect(await page.locator(`${activeTab} .ftVideoPlayer`).evaluate(element =>
+    element.ui.getControls().getPlayer().isLive()
+  )).toBe(true)
+  expect(await app.electronApp.evaluate(() => globalThis.__liveCaptionExtractions)).toBe(1)
+  expect(await watch.evaluate(view => view.activePlaybackEngine)).toBe('yt-dlp')
+})

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -7218,7 +7218,7 @@ export default defineComponent({
             () => captionSettings.value,
             updateCaptionAppearance,
             resetCaptionAppearance,
-            () => props.captionTranslations,
+            () => controls.getPlayer().isLive() ? [] : props.captionTranslations,
             caption => Boolean(findMatchingTextTrack(controls.getPlayer().getTextTracks(), caption)?.active),
             caption => selectCaptionTranslation(caption, controls.getPlayer()),
             rootElement,
@@ -7258,6 +7258,10 @@ export default defineComponent({
      * @returns {Promise<boolean>}
      */
     async function selectCaptionTranslation(caption, captionPlayer) {
+      if (captionPlayer.isLive()) {
+        return false
+      }
+
       const selectionGeneration = ++captionTranslationSelectionGeneration
       let track = findMatchingTextTrack(captionPlayer.getTextTracks(), caption)
 
@@ -9708,10 +9712,11 @@ export default defineComponent({
 
       logShakaError(error, context, props.videoId, details)
 
-      // text related errors aren't serious (captions and seek bar thumbnails), so we should just log them
-      // TODO: consider only emitting when the severity is crititcal?
+      // Caption loading can also fail with MANIFEST errors (e.g. 4033).
+      // Log caption and thumbnail failures without triggering video recovery.
       if (
         !ignoreErrors &&
+        context !== 'addTextTrackAsync' &&
         error.category !== shaka.util.Error.Category.TEXT &&
         !(error.code === shaka.util.Error.Code.BAD_HTTP_STATUS && error.data[0].startsWith('https://www.youtube.com/api/timedtext'))
       ) {
@@ -10411,8 +10416,10 @@ export default defineComponent({
         sabrManifest = player.getManifest()
       }
 
-      // For SABR we include the thumbnails, chapters and subtitles in the manifest
-      if (!process.env.SUPPORTS_LOCAL_API || props.format === 'legacy' || props.manifestMimeType !== MANIFEST_TYPE_SABR) {
+      // Shaka cannot add external text tracks to a live presentation. Keep any
+      // captions supplied by the live manifest instead. SABR already includes
+      // the thumbnails, chapters and subtitles in its manifest.
+      if (!isLive.value && (!process.env.SUPPORTS_LOCAL_API || props.format === 'legacy' || props.manifestMimeType !== MANIFEST_TYPE_SABR)) {
         const promises = []
 
         for (const caption of props.captions) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Live streams and premieres could stop with error 4033 on either playback engine because the player tried to load external subtitles that Shaka cannot attach to a live presentation. The subtitle error then triggered video recovery and repeated extraction attempts.

Skip external captions and automatic translation for live presentations while retaining captions supplied by the manifest. Keep external-caption loading failures from triggering video recovery.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed live streams and premieres stopping with error 4033 when external subtitles were available.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a live stream or an ongoing premiere that advertises external captions. Verify playback continues without error 4033, repeated reloads, or extraction-engine fallback.
2. Repeat with each extraction engine. Captions included in the stream manifest should remain available; unsupported external-caption translations should not be offered.
3. Open an ordinary video with captions. Verify caption selection and automatic translation still work.

## Additional context
<!-- Add any other context about the pull request here. -->
