### PR TITLE
feat(comments): toggle reply threads by clicking their indicator lines

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -4889,7 +4889,7 @@ test.describe('manual comment loading', () => {
     await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
     await expect(page.locator('.getMoreComments')).toHaveCount(1)
 
-    const ownerReplyToggle = page.getByRole('button', {
+    const ownerReplyToggle = page.locator('.commentReplyRootToggle').getByRole('button', {
       name: /replies from .+ and others/
     })
     await expect(ownerReplyToggle).toBeVisible()
@@ -4920,6 +4920,120 @@ test.describe('manual comment loading', () => {
     })).toBe(true)
     await ownerReplyThreadElement.dispose()
   })
+
+  for (const scale of [100, 125]) {
+    test(`toggles comment thread lines with mouse and keyboard at ${scale}% scale`, async ({ app, page, attachScreenshot }) => {
+      await mockPlayableWatchPage(app, page)
+      await openMockedVideo(page)
+      await page.evaluate(async scale => {
+        const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+        await store.dispatch('updateUiScale', scale)
+        await store.dispatch('updateBaseTheme', scale === 100 ? 'dark' : 'light')
+      }, scale)
+      await page.locator('.getCommentsTitle').click()
+      await expect(page.locator('.commentsTitle')).toBeVisible()
+
+      const thread = page.locator('.commentThread').first()
+      const line = thread.locator(':scope > .commentThreadLineToggle')
+      await expect(line).toHaveAttribute('aria-expanded', 'false')
+      await page.mouse.move(0, 0)
+      const restingColor = await thread.evaluate(element => getComputedStyle(element, '::before').borderInlineStartColor)
+      await line.hover({ position: { x: 10, y: 5 } })
+      await expect(line).toHaveCSS('cursor', 'pointer')
+      await expect.poll(() => thread.evaluate(element => getComputedStyle(element, '::before').borderInlineStartColor)).not.toBe(restingColor)
+      await line.click({ position: { x: 10, y: 5 } })
+      await expect(line).toHaveAttribute('aria-expanded', 'true')
+      await expect(thread.locator('.commentReplyContent').first()).toBeVisible()
+      const replyCount = await thread.locator('.commentReplyContent').count()
+
+      const connector = thread.locator('.commentReplyConnectorToggle').first()
+      await connector.hover()
+      await expect(connector).toHaveCSS('cursor', 'pointer')
+      await expect.poll(() => connector.evaluate(element => getComputedStyle(element).borderInlineStartColor)).not.toBe(restingColor)
+      await connector.click()
+      await expect(thread.locator('.commentReplyContent')).toHaveCount(0)
+      await line.focus()
+      await line.press('Enter')
+      await expect(thread.locator('.commentReplyContent')).toHaveCount(replyCount)
+      await line.press('Space')
+      await expect(thread.locator('.commentReplyContent')).toHaveCount(0)
+      await line.press('Enter')
+
+      // Give one loaded reply children so the same controls are exercised at a
+      // second depth without relying on YouTube's changing reply structure.
+      const branch = thread.locator('.commentReplyBranchRoot').first()
+      await branch.evaluate(element => {
+        const find = vnode => {
+          if (vnode?.component?.subTree?.el === element) return vnode.component
+          if (vnode?.component?.subTree) {
+            const match = find(vnode.component.subTree)
+            if (match) return match
+          }
+          for (const child of Array.isArray(vnode?.children) ? vnode.children : []) {
+            const match = find(child)
+            if (match) return match
+          }
+          return null
+        }
+        const component = find(document.querySelector('#app').__vue_app__._container._vnode)
+        const reply = component.props.node.reply
+        reply.replies = Array.from({ length: 8 }, (_, index) => ({
+          ...reply,
+          id: `thread-line-child-${index}`,
+          text: `Nested reply ${index}`,
+          replies: [],
+          numReplies: 0,
+          hasReplyToken: false,
+        }))
+        reply.numReplies = 8
+        reply.hasReplyToken = false
+      })
+      const nestedLine = branch.locator(':scope > .commentReplyLineToggle')
+      const children = branch.locator('.commentReplyChildren .commentReplyContent')
+      await expect(children).toHaveCount(8)
+      await line.evaluate(element => element.blur())
+      await nestedLine.hover({ position: { x: 10, y: 5 } })
+      await expect(nestedLine).toHaveCSS('cursor', 'pointer')
+      await expect.poll(() => branch.locator('.commentReplyChildStem').evaluate(element => getComputedStyle(element).borderInlineStartColor)).not.toBe(restingColor)
+      await attachScreenshot(`comment thread line hover at ${scale}%`)
+      await nestedLine.click({ position: { x: 10, y: 5 } })
+      await expect(children).toHaveCount(0)
+      await expect(thread.locator('.commentReplyContent')).toHaveCount(replyCount)
+      await nestedLine.focus()
+      await nestedLine.press('Space')
+      await expect(children).toHaveCount(8)
+      await branch.locator('.commentReplyChildren .commentReplyConnectorToggle').first().click()
+      await expect(children).toHaveCount(0)
+      await branch.locator(':scope > .commentReplyChildren > .commentReplyContinuation button').click()
+      await expect(children).toHaveCount(8)
+
+      await setPlayerFullscreen(page, true)
+      await page.locator('.fullscreenCommentsToggle').click({ force: true })
+      const scroller = page.locator('.fullscreenCommentsOverlay.open .commentsContentWrapper')
+      for (const toggle of [nestedLine, line]) {
+        await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
+        const previousScrollTop = await scroller.evaluate(element => element.scrollTop)
+        expect(previousScrollTop).toBeGreaterThan(0)
+        await toggle.evaluate(element => element.click())
+        await expect.poll(() => scroller.evaluate((element, previousScrollTop) => {
+          const content = element.querySelector(':scope > div')
+          const maximumScrollTop = Math.max(0, element.scrollTop +
+            content.getBoundingClientRect().bottom - element.getBoundingClientRect().bottom)
+          const scrollbar = element.querySelector(':scope > .os-scrollbar-vertical')
+          return {
+            reduced: element.scrollTop < previousScrollTop,
+            scrollbarMatchesOverflow: scrollbar.classList.contains('os-scrollbar-visible') === (maximumScrollTop > 1),
+          }
+        }, previousScrollTop)).toEqual({ reduced: true, scrollbarMatchesOverflow: true })
+        await expect.poll(() => scroller.evaluate(element => {
+          const content = element.querySelector(':scope > div')
+          return element.getBoundingClientRect().bottom - content.getBoundingClientRect().bottom
+        // The clamp uses integer layout offsets and heights; their rounding
+        // can add up to more than one CSS pixel at fractional Electron zoom.
+        })).toBeLessThanOrEqual(2)
+      }
+    })
+  }
 
   test('searches the comments loaded for the current video', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)

--- a/src/renderer/components/CommentSection/CommentReply.css
+++ b/src/renderer/components/CommentSection/CommentReply.css
@@ -7,7 +7,7 @@
   position: absolute;
   inset-block: 0;
   inset-inline-start: 0;
-  border-inline-start: 1px solid var(--comment-thread-line-color);
+  border-inline-start: 1px solid var(--comment-parent-thread-line-color, var(--comment-thread-line-color));
   pointer-events: none;
 }
 
@@ -26,7 +26,7 @@
   inset-block-start: 0;
   inset-inline-start: 0;
   block-size: calc(30px + var(--highlighted-comment-offset));
-  border-inline-start: 1px solid var(--comment-thread-line-color);
+  border-inline-start: 1px solid var(--comment-parent-thread-line-color, var(--comment-thread-line-color));
   pointer-events: none;
 }
 
@@ -37,10 +37,41 @@
   inset-inline-start: 0;
   inline-size: 15px;
   block-size: 15px;
-  border-block-end: 1px solid var(--comment-thread-line-color);
-  border-inline-start: 1px solid var(--comment-thread-line-color);
+  border-block-end: 1px solid var(--comment-parent-thread-line-color, var(--comment-thread-line-color));
+  border-inline-start: 1px solid var(--comment-parent-thread-line-color, var(--comment-thread-line-color));
   border-end-start-radius: calc(12px * var(--ui-roundness));
   pointer-events: none;
+}
+
+.commentReplyConnectorToggle {
+  z-index: 2;
+  box-sizing: content-box;
+  padding: 0;
+  border-block-start: 0;
+  border-inline-end: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.commentReplyConnectorToggle::after {
+  content: '';
+  position: absolute;
+  inset: -6px;
+}
+
+.commentReplyConnectorToggle:hover,
+.commentReplyConnectorToggle:focus-visible {
+  border-color: currentcolor;
+}
+
+.commentReplyLineToggle {
+  inset-block-end: 30px;
+}
+
+.highlightedCommentBranch > .commentReplyLineToggle {
+  inset-block-start: calc(75px + var(--highlighted-comment-offset));
 }
 
 .highlightedCommentBranch > .commentReplyConnector {
@@ -70,5 +101,15 @@
 }
 
 .commentReplyChildren {
+  --comment-parent-thread-line-color: var(--comment-thread-line-color);
+
   margin-inline-start: 45px;
+}
+
+.commentReplyLineToggle:is(:hover, :focus-visible) ~ .commentReplyContent > .commentReplyChildStem {
+  border-color: currentcolor;
+}
+
+.commentReplyLineToggle:is(:hover, :focus-visible) ~ .commentReplyChildren {
+  --comment-parent-thread-line-color: currentcolor;
 }

--- a/src/renderer/components/CommentSection/CommentReply.vue
+++ b/src/renderer/components/CommentSection/CommentReply.vue
@@ -7,9 +7,27 @@
       highlightedCommentBranch: reply.id === highlightedCommentId
     }"
   >
-    <span
+    <component
+      :is="canToggleParent ? 'button' : 'span'"
       class="commentReplyConnector"
-      aria-hidden="true"
+      :class="{ commentReplyConnectorToggle: canToggleParent }"
+      :type="canToggleParent ? 'button' : undefined"
+      :aria-hidden="canToggleParent ? undefined : true"
+      :aria-label="canToggleParent ? parentToggleLabel : undefined"
+      :tabindex="canToggleParent ? -1 : undefined"
+      @click="canToggleParent && emit('toggle-parent')"
+      @keydown.space.stop
+      @keyup.space.stop
+    />
+    <button
+      v-if="hasReplyChildren && !filtering"
+      type="button"
+      class="commentThreadLineToggle commentReplyLineToggle"
+      :aria-label="replyToggleLabel"
+      :aria-expanded="showReplyChildren"
+      @click="toggleReplyChildren"
+      @keydown.space.stop
+      @keyup.space.stop
     />
     <div
       class="comment commentReplyContent"
@@ -22,7 +40,7 @@
         {{ $t('Comments.Highlighted reply') }}
       </p>
       <span
-        v-if="showReplyChildren"
+        v-if="hasReplyChildren"
         class="commentReplyChildStem"
         aria-hidden="true"
       />
@@ -160,61 +178,86 @@
       </p>
     </div>
     <div
-      v-if="showReplyChildren"
+      v-if="hasReplyChildren"
       class="commentReplyChildren"
     >
-      <CommentReply
-        v-for="child in node.children"
-        :key="child.reply.id"
-        :node="child"
-        :thread-index="threadIndex"
-        :enable-channel-links="enableChannelLinks"
-        :hide-comment-likes="hideCommentLikes"
-        :hide-comment-photos="hideCommentPhotos"
-        :subscribed-channel-ids="subscribedChannelIds"
-        :channel-thumbnail="channelThumbnail"
-        :loading-reply-ids="loadingReplyIds"
-        :loading-translation-ids="loadingTranslationIds"
-        :translation-enabled="translationEnabled"
-        :translation-language="translationLanguage"
-        :translation-language-name="translationLanguageName"
-        :comment-translation-ignored-languages="commentTranslationIgnoredLanguages"
-        :highlighted-comment-id="highlightedCommentId"
-        :highlight="highlight"
-        :personal-pinned-comment-ids="personalPinnedCommentIds"
-        :filtering="filtering"
-        :shorten-view-counts="shortenViewCounts"
-        @copy-youtube-link="emit('copy-youtube-link', $event)"
-        @get-more-replies="emit('get-more-replies', $event)"
-        @toggle-personal-pin="emit('toggle-personal-pin', $event)"
-        @timestamp-event="emit('timestamp-event', $event)"
-        @translate-comment="emit('translate-comment', $event)"
-        @translation-unavailable="emit('translation-unavailable', $event)"
-      />
+      <template v-if="showReplyChildren">
+        <CommentReply
+          v-for="child in node.children"
+          :key="child.reply.id"
+          :node="child"
+          :thread-index="threadIndex"
+          :enable-channel-links="enableChannelLinks"
+          :hide-comment-likes="hideCommentLikes"
+          :hide-comment-photos="hideCommentPhotos"
+          :subscribed-channel-ids="subscribedChannelIds"
+          :channel-thumbnail="channelThumbnail"
+          :loading-reply-ids="loadingReplyIds"
+          :loading-translation-ids="loadingTranslationIds"
+          :translation-enabled="translationEnabled"
+          :translation-language="translationLanguage"
+          :translation-language-name="translationLanguageName"
+          :comment-translation-ignored-languages="commentTranslationIgnoredLanguages"
+          :highlighted-comment-id="highlightedCommentId"
+          :highlight="highlight"
+          :personal-pinned-comment-ids="personalPinnedCommentIds"
+          :filtering="filtering"
+          :shorten-view-counts="shortenViewCounts"
+          :parent-toggle-label="replyToggleLabel"
+          :can-toggle-parent="!filtering"
+          @toggle-parent="toggleReplyChildren"
+          @replies-toggled="emit('replies-toggled')"
+          @copy-youtube-link="emit('copy-youtube-link', $event)"
+          @get-more-replies="emit('get-more-replies', $event)"
+          @toggle-personal-pin="emit('toggle-personal-pin', $event)"
+          @timestamp-event="emit('timestamp-event', $event)"
+          @translate-comment="emit('translate-comment', $event)"
+          @translation-unavailable="emit('translation-unavailable', $event)"
+        />
+        <div
+          v-if="!filtering && (loadingReplyIds.has(reply.id) || (reply.dataType === 'local' && reply.hasReplyToken))"
+          class="commentReplyContinuation"
+        >
+          <button
+            type="button"
+            class="commentReplyContinuationButton"
+            :disabled="loadingReplyIds.has(reply.id)"
+            @click="emit('get-more-replies', reply.id)"
+          >
+            <FtSpinner
+              v-if="loadingReplyIds.has(reply.id)"
+              inline
+              size="18px"
+              border-width="2px"
+              :label="$t('Comments.Getting comment replies, please wait')"
+            />
+            <template v-else>
+              <span>{{ $t("Comments.Show More Replies") }}</span>
+              <FtIcon
+                :icon="['fas', 'angle-down']"
+                aria-hidden="true"
+              />
+            </template>
+          </button>
+        </div>
+      </template>
       <div
-        v-if="!filtering && (loadingReplyIds.has(reply.id) || (reply.dataType === 'local' && reply.hasReplyToken))"
+        v-if="!filtering"
         class="commentReplyContinuation"
       >
         <button
           type="button"
           class="commentReplyContinuationButton"
-          :disabled="loadingReplyIds.has(reply.id)"
-          @click="emit('get-more-replies', reply.id)"
+          :aria-expanded="showReplyChildren"
+          @click="toggleReplyChildren"
+          @keydown.space.stop
+          @keyup.space.stop
         >
-          <FtSpinner
-            v-if="loadingReplyIds.has(reply.id)"
-            inline
-            size="18px"
-            border-width="2px"
-            :label="$t('Comments.Getting comment replies, please wait')"
+          <span>{{ replyToggleLabel }}</span>
+          <FtIcon
+            :icon="['fas', showReplyChildren ? 'angle-up' : 'angle-down']"
+            aria-hidden="true"
           />
-          <template v-else>
-            <span>{{ $t("Comments.Show More Replies") }}</span>
-            <FtIcon
-              :icon="['fas', 'angle-down']"
-              aria-hidden="true"
-            />
-          </template>
         </button>
       </div>
     </div>
@@ -223,7 +266,7 @@
 
 <script setup>
 import { FtIcon } from '@opentubex/icons'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import FtTimestampCatcher from '../FtTimestampCatcher.vue'
@@ -232,6 +275,7 @@ import FtRetryImage from '../FtRetryImage.vue'
 import FtSpinner from '../FtSpinner/FtSpinner.vue'
 import { useRelativeTimeClock } from '../../composables/useRelativeTimeClock'
 import { formatViewCount, getRelativeTimeFromDate } from '../../helpers/utils'
+import { getCommentReplyCount } from '../../helpers/comment-replies'
 
 const { t } = useI18n()
 
@@ -247,6 +291,14 @@ const props = defineProps({
   rootLevel: {
     type: Boolean,
     default: false
+  },
+  parentToggleLabel: {
+    type: String,
+    required: true
+  },
+  canToggleParent: {
+    type: Boolean,
+    required: true
   },
   enableChannelLinks: {
     type: Boolean,
@@ -323,13 +375,26 @@ function formatCommentTime(comment) {
 }
 
 const reply = props.node.reply
-const showReplyChildren = computed(() => {
+const childrenCollapsed = ref(false)
+const hasReplyChildren = computed(() => {
   return props.node.children.length > 0 ||
     (!props.filtering && (
       (reply.dataType === 'local' && reply.hasReplyToken) ||
       props.loadingReplyIds.has(reply.id)
     ))
 })
+const showReplyChildren = computed(() => hasReplyChildren.value && (!childrenCollapsed.value || props.filtering))
+const replyToggleLabel = computed(() => {
+  const replyCount = getCommentReplyCount(reply)
+  return showReplyChildren.value
+    ? t('Comments.Hide {replyCount} replies', { replyCount }, replyCount)
+    : t('Comments.Reply Count', { replyCount }, replyCount)
+})
+
+function toggleReplyChildren() {
+  childrenCollapsed.value = !childrenCollapsed.value
+  emit('replies-toggled')
+}
 const isPersonallyPinned = computed(() => props.personalPinnedCommentIds.has(reply.id))
 const personalPinActionLabel = computed(() => {
   return isPersonallyPinned.value
@@ -367,6 +432,8 @@ const authorSearchSegments = computed(() => {
 })
 
 const emit = defineEmits([
+  'toggle-parent',
+  'replies-toggled',
   'copy-youtube-link',
   'get-more-replies',
   'timestamp-event',

--- a/src/renderer/components/CommentSection/CommentSection.css
+++ b/src/renderer/components/CommentSection/CommentSection.css
@@ -458,6 +458,33 @@
   inset-block-start: calc(75px + var(--highlighted-comment-offset));
 }
 
+.commentThreadLineToggle {
+  position: absolute;
+  z-index: 1;
+  inset-block: 75px 45px;
+  inset-inline-start: 35px;
+  inline-size: 26px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.highlightedComment > .commentThreadLineToggle {
+  inset-block-start: calc(75px + var(--highlighted-comment-offset));
+}
+
+.commentThreadLineToggle:disabled {
+  cursor: default;
+}
+
+.commentThreadLineToggle:focus-visible {
+  outline: 2px solid currentcolor;
+  outline-offset: 2px;
+}
+
 .commentTitleAction {
   font-size: 13px;
   text-decoration: underline;
@@ -696,8 +723,8 @@
   inset-inline-start: 0;
   inline-size: 15px;
   block-size: 26px;
-  border-block-end: 1px solid var(--comment-thread-line-color);
-  border-inline-start: 1px solid var(--comment-thread-line-color);
+  border-block-end: 1px solid var(--comment-parent-thread-line-color, var(--comment-thread-line-color));
+  border-inline-start: 1px solid var(--comment-parent-thread-line-color, var(--comment-thread-line-color));
   border-end-start-radius: calc(12px * var(--ui-roundness));
   pointer-events: none;
 }
@@ -765,4 +792,13 @@
   text-decoration: underline;
   cursor: pointer;
   color: var(--title-color);
+}
+
+.commentThread:has(> .commentThreadLineToggle:enabled:is(:hover, :focus-visible))::before,
+.commentThreadLineToggle:enabled:is(:hover, :focus-visible) ~ .commentReplyRootToggle::before {
+  border-color: currentcolor;
+}
+
+.commentThreadLineToggle:enabled:is(:hover, :focus-visible) ~ .commentReplies {
+  --comment-parent-thread-line-color: currentcolor;
 }

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -204,6 +204,17 @@
             highlightedComment: comment.id === highlightedCommentId
           }"
         >
+          <button
+            v-if="index !== null && !hasActiveCommentFilters && (shouldShowCommentReplies(comment, replyNodes) || shouldShowCommentReplyToggle(comment, replyNodes))"
+            type="button"
+            class="commentThreadLineToggle"
+            :aria-label="commentReplyAccessibleLabel(comment)"
+            :aria-expanded="!!comment.showReplies"
+            :disabled="isReplyLoading(comment.id)"
+            @click="toggleCommentReplies(index)"
+            @keydown.space.stop
+            @keyup.space.stop
+          />
           <p
             v-if="comment.id === highlightedCommentId"
             class="highlightedCommentBadge"
@@ -436,6 +447,10 @@
               :personal-pinned-comment-ids="personalPinnedCommentIds"
               :filtering="hasActiveCommentFilters"
               :shorten-view-counts="shortenViewCounts"
+              :parent-toggle-label="commentReplyAccessibleLabel(comment)"
+              :can-toggle-parent="index !== null && !hasActiveCommentFilters && !isReplyLoading(comment.id)"
+              @toggle-parent="toggleCommentReplies(index)"
+              @replies-toggled="clampCommentsScrollAfterRender"
               @copy-youtube-link="copyCommentYoutubeLink"
               @get-more-replies="getCommentReplies(index, $event)"
               @toggle-personal-pin="togglePersonalCommentPin($event, comment)"
@@ -1576,6 +1591,7 @@ function commentReplyAccessibleLabel(comment) {
 function toggleCommentReplies(index) {
   if (commentData.value[index].showReplies || commentData.value[index].replies.length > 0) {
     commentData.value[index].showReplies = !commentData.value[index].showReplies
+    clampCommentsScrollAfterRender()
   } else {
     getCommentReplies(index)
   }


### PR DESCRIPTION
Comment thread lines were decorative. They now highlight on hover and let you expand or collapse replies by clicking them.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Adds pointer cursors and hover highlighting to thread lines and reply connectors. Root threads and nested reply branches can be toggled from their lines, with Enter/Space support and scroll clamping after collapse.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Click comment thread lines to expand or collapse replies, with hover highlighting to show which thread you control.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a video with replies and hover over the line below a comment avatar. The line highlights and the cursor becomes a pointer. Click it to open replies, then click the line or a reply connector to collapse them.
2. Open a reply with nested replies. Its line should toggle only that branch. Tab to a line control and use Enter or Space; Space should toggle replies without pausing the video.
3. Repeat in dark and light themes and at 125% UI scale. In fullscreen comments, scroll to the bottom and collapse a long thread. The scroll position and scrollbar should adjust without leaving empty space.
4. Enable a comment filter and verify that matching replies remain visible and their thread connections stay intact.

## Additional context
<!-- Add any other context about the pull request here. -->
