### PR TITLE
fix(subscriptions): hide settings arrow for unsubscribed channels

### DIFF
--- a/e2e/tests/offline/invidious-thumbnails.spec.mjs
+++ b/e2e/tests/offline/invidious-thumbnails.spec.mjs
@@ -89,14 +89,21 @@ test('loads a channel with one author thumbnail', async ({ page }) => {
   await expect(page.locator('.toast', { hasText: 'Invidious API Error' })).toHaveCount(0)
 })
 
-test('configures subscription options before subscribing', async ({ page }) => {
+test('only offers subscription options while subscribed', async ({ page }) => {
   await page.route(`${INSTANCE_URL}/api/v1/channels/**`, route => route.fulfill({
     json: channelResponse()
   }))
   await openChannel(page)
 
   const channel = page.locator('.channelDetails:visible')
-  await channel.getByRole('button', { name: 'Subscription settings' }).click()
+  const subscribeButton = channel.locator('.subscribeButton')
+  const settingsArrow = channel.getByRole('button', { name: 'Subscription settings' })
+  await expect(subscribeButton).toHaveText('Subscribe')
+  await expect(settingsArrow).toHaveCount(0)
+  await expect(subscribeButton).not.toHaveClass(/hasProfileDropdownToggle/)
+  await subscribeButton.click()
+  await expect(subscribeButton).toContainText('Unsubscribe')
+  await settingsArrow.click()
   const dropdown = page.locator('body > .profileDropdown')
   const shorts = dropdown.getByRole('checkbox', { name: 'Shorts' })
   await expect(shorts).toHaveAttribute('aria-checked', 'true')
@@ -105,7 +112,6 @@ test('configures subscription options before subscribing', async ({ page }) => {
   const dailyLimit = dropdown.getByRole('combobox', { name: 'Videos per day' })
   await dailyLimit.click()
   await page.getByRole('option', { name: '2', exact: true }).click()
-  await channel.getByRole('button', { name: 'Subscribe', exact: true }).click()
 
   await expect(channel.getByRole('button', { name: 'Unsubscribe', exact: true })).toBeVisible()
   await expect.poll(() => page.evaluate(channelId => {
@@ -122,4 +128,28 @@ test('configures subscription options before subscribing', async ({ page }) => {
     feedTypes: ['videos', 'live', 'posts'],
     showMembersOnly: false
   })
+
+  await page.evaluate(async () => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    await store.dispatch('updateUnsubscriptionPopupStatus', false)
+    await store.dispatch('createProfile', {
+      _id: 'empty-profile',
+      name: 'Empty Profile',
+      bgColor: '#000000',
+      textColor: '#FFFFFF',
+      subscriptions: []
+    })
+    await store.dispatch('updateActiveProfile', 'empty-profile')
+  })
+  await expect(settingsArrow).toHaveCount(0)
+  await expect(dropdown).toHaveCount(0)
+
+  await subscribeButton.click()
+  await expect(settingsArrow).toBeVisible()
+  await expect(dropdown).toBeVisible()
+  await dropdown.getByRole('checkbox', { name: 'Empty Profile', exact: true }).click()
+  await expect(subscribeButton).toHaveText('Subscribe')
+  await expect(settingsArrow).toHaveCount(0)
+  await expect(subscribeButton).not.toHaveClass(/hasProfileDropdownToggle/)
+  await expect(dropdown).toHaveCount(0)
 })

--- a/src/renderer/components/FtSubscribeButton/FtSubscribeButton.vue
+++ b/src/renderer/components/FtSubscribeButton/FtSubscribeButton.vue
@@ -320,7 +320,7 @@ const isProfileDropdownEnabled = computed(() => {
 })
 
 const isSubscriptionOptionsEnabled = computed(() => {
-  return !props.hideProfileDropdownToggle
+  return !props.hideProfileDropdownToggle && isSubscribed.value
 })
 
 const isProfileDropdownOpen = ref(false)
@@ -429,7 +429,11 @@ watch(isSubscribed, (subscribed) => {
     justToggled.value = false
   }, 400)
 
-  if (subscribed) optimisticChannelSettings.value = null
+  if (subscribed) {
+    optimisticChannelSettings.value = null
+  } else {
+    isProfileDropdownOpen.value = false
+  }
 })
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
Unsubscribed channels still showed the arrow for subscription feed preferences and daily video limits. Show it only while the active profile is subscribed, and close an open popup when that subscription is removed.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Requested directly; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Use the existing active-profile subscription state for the arrow and split-button styling. Close the popup after unsubscribing or switching to a profile that is not subscribed.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Hide the subscription settings arrow for channels you are not subscribed to in the active profile.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

![Subscribe button without a settings arrow](https://github.com/user-attachments/assets/6d44d40b-3e0d-4f9a-9137-d4f57fe04248)

![Unsubscribe button with a settings arrow](https://github.com/user-attachments/assets/17795c41-77b4-4163-a6b2-b6713481b810)

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a channel that the active profile is not subscribed to. The Subscribe button should have no arrow or split-button edge.
2. Subscribe, open the arrow, and change the feed types and videos-per-day limit. The settings should save.
3. With the popup open, switch to an unsubscribed profile. The popup and arrow should disappear.
4. Subscribe in that profile, then remove its subscription through the popup. The popup and arrow should disappear again.

## Additional context
<!-- Add any other context about the pull request here. -->

