### PR TITLE
fix(customization): enable mobile reordering and disable redundant resets

### DIFF
--- a/e2e/tests/offline/customization-reset.spec.mjs
+++ b/e2e/tests/offline/customization-reset.spec.mjs
@@ -1,0 +1,47 @@
+import { test, expect, goToSettingsSection } from '../../helpers/app.mjs'
+
+for (const { name, lastItem, addButton, pickerRole } of [
+  { name: 'navigation', lastItem: 'Stats', addButton: 'Add item', pickerRole: 'menu' },
+  { name: 'quick settings', lastItem: 'Region for trending', addButton: 'Add setting', pickerRole: 'dialog' },
+]) {
+  test(`disables ${name} reset only when the default items and order are restored`, async ({ page }) => {
+    const appearance = await goToSettingsSection(page, 'appearance')
+    await appearance.getByRole('button', { name: `Customize ${name}` }).click()
+
+    const reset = page.getByRole('button', { name: 'Reset to defaults', exact: true })
+    const moveUp = page.getByRole('button', { name: `Move ${lastItem} up`, exact: true })
+    const moveDown = page.getByRole('button', { name: `Move ${lastItem} down`, exact: true })
+    const remove = page.getByRole('button', { name: `Remove ${lastItem}`, exact: true })
+    await expect(reset).toBeDisabled()
+
+    await moveUp.click()
+    await expect(reset).toBeEnabled()
+    await moveDown.click()
+    await expect(reset).toBeDisabled()
+
+    await remove.click()
+    await expect(reset).toBeEnabled()
+    await page.getByRole('button', { name: addButton, exact: true }).click()
+    const picker = page.getByRole(pickerRole, { name: addButton, exact: true })
+    if (pickerRole === 'menu') {
+      await picker.getByRole('menuitem', { name: lastItem, exact: true }).click()
+    } else {
+      await picker.getByPlaceholder('Search settings').fill(lastItem)
+      await picker.locator('.optionWrapper').filter({ hasText: lastItem }).click()
+      await picker.getByPlaceholder('Search settings').press('Escape')
+    }
+    await expect(reset).toBeDisabled()
+
+    await moveUp.click()
+    await expect(reset).toBeEnabled()
+    await reset.click()
+    await expect(reset).toBeDisabled()
+    await expect(moveDown).toBeDisabled()
+
+    await remove.click()
+    await expect(reset).toBeEnabled()
+    await reset.click()
+    await expect(reset).toBeDisabled()
+    await expect(remove).toBeVisible()
+  })
+}

--- a/e2e/tests/offline/customization-touch.spec.mjs
+++ b/e2e/tests/offline/customization-touch.spec.mjs
@@ -1,0 +1,109 @@
+import { test, expect, goToSettingsSection } from '../../helpers/app.mjs'
+
+for (const uiScale of [100, 125]) {
+  test.describe(`touch customization at ${uiScale}% UI scale`, () => {
+    test.use({ seed: { settings: { uiScale } } })
+
+    for (const { name, rowSelector, idAttribute } of [
+      { name: 'navigation', rowSelector: '.selectedItem', idAttribute: 'data-navigation-item-id' },
+      { name: 'quick settings', rowSelector: '.selectedSetting', idAttribute: 'data-setting-id' },
+    ]) {
+      test(`scrolls to offscreen ${name} items during a touch drag`, async ({ page }) => {
+        await page.setViewportSize({ width: 375, height: 600 })
+        const appearance = await goToSettingsSection(page, 'appearance')
+        await appearance.getByRole('button', { name: `Customize ${name}` }).click()
+
+        const rows = page.locator(rowSelector)
+        const scroller = page.locator('.settingsSubpageScroll')
+        const itemIds = () => rows.evaluateAll((elements, attribute) => (
+          elements.map(element => element.getAttribute(attribute))
+        ), idAttribute)
+        const original = await itemIds()
+        const session = await page.context().newCDPSession(page)
+        try {
+          for (const down of [true, false]) {
+            const source = await rows.nth(down ? 0 : original.length - 1).locator('.dragHandle').boundingBox()
+            const viewport = await scroller.boundingBox()
+            const x = source.x + source.width / 2
+            const startY = source.y + source.height / 2
+            const endY = down ? viewport.y + viewport.height - 10 : viewport.y + 10
+            await session.send('Input.dispatchTouchEvent', {
+              type: 'touchStart', touchPoints: [{ x, y: startY, id: 1 }],
+            })
+            for (let step = 1; step <= 5; step++) {
+              await session.send('Input.dispatchTouchEvent', {
+                type: 'touchMove', touchPoints: [{ x, y: startY + (endY - startY) * step / 5, id: 1 }],
+              })
+            }
+            await expect.poll(() => scroller.evaluate((element, scrollDown) => (
+              scrollDown
+                ? element.scrollHeight - element.clientHeight - element.scrollTop
+                : element.scrollTop
+            ), down)).toBeLessThanOrEqual(1)
+            const destination = rows.nth(down ? original.length - 1 : 0)
+            const target = await destination.boundingBox()
+            await session.send('Input.dispatchTouchEvent', {
+              type: 'touchMove', touchPoints: [{ x, y: target.y + target.height * (down ? 0.75 : 0.25), id: 1 }],
+            })
+            await expect(destination).toHaveClass(down ? /dropAfter/ : /dropBefore/)
+            await session.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] })
+            await expect.poll(itemIds).toEqual(down ? [...original.slice(1), original[0]] : original)
+            await expect(page.locator(`${rowSelector}.dragging`)).toHaveCount(0)
+          }
+        } finally {
+          await session.detach()
+        }
+      })
+
+      test(`reorders ${name} by touch and cancels interrupted drags`, async ({ page }) => {
+        await page.setViewportSize({ width: 375, height: 812 })
+        const appearance = await goToSettingsSection(page, 'appearance')
+        await appearance.getByRole('button', { name: `Customize ${name}` }).click()
+
+        const rows = page.locator(rowSelector)
+        const itemIds = () => rows.evaluateAll((elements, attribute) => (
+          elements.map(element => element.getAttribute(attribute))
+        ), idAttribute)
+        const original = await itemIds()
+        const session = await page.context().newCDPSession(page)
+
+        async function drag(from, to, after, cancel = false) {
+          const handle = rows.nth(from).locator('.dragHandle')
+          await handle.scrollIntoViewIfNeeded()
+          const source = await handle.boundingBox()
+          const target = await rows.nth(to).boundingBox()
+          const start = { x: source.x + source.width / 2, y: source.y + source.height / 2 }
+          const end = { x: start.x, y: target.y + target.height * (after ? 0.75 : 0.25) }
+          await session.send('Input.dispatchTouchEvent', {
+            type: 'touchStart', touchPoints: [{ ...start, id: 1 }],
+          })
+          for (let step = 1; step <= 5; step++) {
+            await session.send('Input.dispatchTouchEvent', {
+              type: 'touchMove',
+              touchPoints: [{ x: end.x, y: start.y + (end.y - start.y) * step / 5, id: 1 }],
+            })
+          }
+          await expect(rows.nth(to)).toHaveClass(after ? /dropAfter/ : /dropBefore/)
+          await session.send('Input.dispatchTouchEvent', {
+            type: cancel ? 'touchCancel' : 'touchEnd', touchPoints: [],
+          })
+          await expect(page.locator(`${rowSelector}.dragging`)).toHaveCount(0)
+          await expect(page.locator(`${rowSelector}.dropBefore, ${rowSelector}.dropAfter`)).toHaveCount(0)
+        }
+
+        try {
+          await drag(2, 0, false)
+          await expect.poll(itemIds).toEqual([original[2], original[0], original[1], ...original.slice(3)])
+          await expect(page.getByRole('button', { name: 'Reset to defaults' })).toBeEnabled()
+          await drag(0, 2, true)
+          await expect.poll(itemIds).toEqual(original)
+          await expect(page.getByRole('button', { name: 'Reset to defaults' })).toBeDisabled()
+          await drag(2, 0, false, true)
+          await expect.poll(itemIds).toEqual(original)
+        } finally {
+          await session.detach()
+        }
+      })
+    }
+  })
+}

--- a/src/renderer/components/NavigationCustomizer/NavigationCustomizer.vue
+++ b/src/renderer/components/NavigationCustomizer/NavigationCustomizer.vue
@@ -77,6 +77,7 @@
       <FtButton
         :label="t('KeyboardShortcutPrompt.Reset to Defaults')"
         :icon="['fas', 'undo']"
+        :disabled="isDefaultNavigation"
         theme="secondary"
         @click="resetItems"
       />
@@ -105,6 +106,11 @@
           aria-hidden="true"
           @dragstart="startDragging($event, item.id)"
           @dragend="stopDragging"
+          @pointerdown="startPointerDrag($event, item.id)"
+          @pointermove="movePointerDrag"
+          @pointerup="endPointerDrag"
+          @pointercancel="cancelPointerDrag"
+          @lostpointercapture="cancelPointerDrag"
         >
           <FtIcon :icon="['fas', 'grip']" />
         </span>
@@ -213,6 +219,10 @@ const catalog = computed(() => NAVIGATION_ITEM_DEFINITIONS
   })))
 const catalogById = computed(() => new Map(catalog.value.map(item => [item.id, item])))
 const navigationItems = computed(() => store.getters.getNavigationItems)
+const isDefaultNavigation = computed(() => (
+  navigationItems.value.length === DEFAULT_NAVIGATION_ITEMS.length &&
+  navigationItems.value.every((id, index) => id === DEFAULT_NAVIGATION_ITEMS[index])
+))
 const selectedItems = computed(() => navigationItems.value
   .map(id => catalogById.value.get(id))
   .filter(item => item != null))
@@ -347,9 +357,14 @@ const {
   handleDragOver,
   startDragging,
   stopDragging,
+  startPointerDrag,
+  movePointerDrag,
+  endPointerDrag,
+  cancelPointerDrag,
 } = useOrderedItemDrag({
   items: navigationItems,
   rowSelector: '.selectedItem',
+  itemIdAttribute: 'data-navigation-item-id',
   updateItems,
   announceMoved: announceItemMoved,
 })
@@ -480,6 +495,7 @@ function resetItems() {
 }
 
 .dragHandle {
+  touch-action: none;
   align-items: center;
   align-self: stretch;
   color: var(--secondary-text-color);

--- a/src/renderer/components/QuickSettingsCustomizer/QuickSettingsCustomizer.vue
+++ b/src/renderer/components/QuickSettingsCustomizer/QuickSettingsCustomizer.vue
@@ -64,6 +64,7 @@
       <FtButton
         :label="t('KeyboardShortcutPrompt.Reset to Defaults')"
         :icon="['fas', 'undo']"
+        :disabled="isDefaultQuickSettings"
         theme="secondary"
         @click="resetQuickSettings"
       />
@@ -92,6 +93,11 @@
           aria-hidden="true"
           @dragstart="startDragging($event, setting.id)"
           @dragend="stopDragging"
+          @pointerdown="startPointerDrag($event, setting.id)"
+          @pointermove="movePointerDrag"
+          @pointerup="endPointerDrag"
+          @pointercancel="cancelPointerDrag"
+          @lostpointercapture="cancelPointerDrag"
         >
           <FtIcon :icon="['fas', 'grip']" />
         </span>
@@ -192,6 +198,10 @@ const settingPickerRef = useTemplateRef('settingPickerRef')
 const catalog = computed(() => createQuickSettingCatalog(t, process.env.IS_ELECTRON))
 const catalogById = computed(() => new Map(catalog.value.map(setting => [setting.id, setting])))
 const quickSettings = computed(() => store.getters.getQuickSettings)
+const isDefaultQuickSettings = computed(() => (
+  quickSettings.value.length === DEFAULT_QUICK_SETTINGS.length &&
+  quickSettings.value.every((id, index) => id === DEFAULT_QUICK_SETTINGS[index])
+))
 const selectedSettings = computed(() => quickSettings.value
   .map(id => catalogById.value.get(id))
   .filter(setting => setting != null))
@@ -289,9 +299,14 @@ const {
   handleDragOver,
   startDragging,
   stopDragging,
+  startPointerDrag,
+  movePointerDrag,
+  endPointerDrag,
+  cancelPointerDrag,
 } = useOrderedItemDrag({
   items: quickSettings,
   rowSelector: '.selectedSetting',
+  itemIdAttribute: 'data-setting-id',
   updateItems: items => store.dispatch('updateQuickSettings', items),
   announceMoved: announceQuickSettingMoved,
 })
@@ -407,6 +422,7 @@ function resetQuickSettings() {
 }
 
 .dragHandle {
+  touch-action: none;
   align-items: center;
   align-self: stretch;
   color: var(--secondary-text-color);

--- a/src/renderer/composables/useOrderedItemDrag.js
+++ b/src/renderer/composables/useOrderedItemDrag.js
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { onBeforeUnmount, ref } from 'vue'
 
 /**
  * Shares pointer drag reordering between ordered settings lists.
@@ -6,14 +6,26 @@ import { ref } from 'vue'
  * @param {object} options
  * @param {import('vue').ComputedRef<string[]>} options.items
  * @param {string} options.rowSelector
+ * @param {string} options.itemIdAttribute
  * @param {(items: string[]) => unknown} options.updateItems
  * @param {(itemId: string, position: number) => void} options.announceMoved
  */
-export function useOrderedItemDrag({ items, rowSelector, updateItems, announceMoved }) {
+export function useOrderedItemDrag({ items, rowSelector, itemIdAttribute, updateItems, announceMoved }) {
   const draggedItemId = ref(null)
   const dropTarget = ref(null)
+  let pointerId = null
+  let pointerHandle = null
+  let pointerList = null
+  let pointerScroller = null
+  let pointerPosition = null
+  let autoScrollFrame = null
+  let lastScrollTime = 0
 
   function startDragging(event, itemId) {
+    if (pointerId !== null) {
+      event.preventDefault()
+      return
+    }
     draggedItemId.value = itemId
     event.dataTransfer.effectAllowed = 'move'
     event.dataTransfer.setData('text/plain', itemId)
@@ -36,6 +48,11 @@ export function useOrderedItemDrag({ items, rowSelector, updateItems, announceMo
   }
 
   function dropItem(event, itemId) {
+    const bounds = event.currentTarget.getBoundingClientRect()
+    commitDrop(itemId, event.clientY >= bounds.top + bounds.height / 2)
+  }
+
+  function commitDrop(itemId, after) {
     const draggedId = draggedItemId.value
     if (draggedId == null || draggedId === itemId) {
       stopDragging()
@@ -49,8 +66,7 @@ export function useOrderedItemDrag({ items, rowSelector, updateItems, announceMo
       return
     }
 
-    const bounds = event.currentTarget.getBoundingClientRect()
-    let insertIndex = targetIndex + (event.clientY >= bounds.top + bounds.height / 2 ? 1 : 0)
+    let insertIndex = targetIndex + (after ? 1 : 0)
     const reordered = items.value.slice()
     reordered.splice(sourceIndex, 1)
     if (sourceIndex < insertIndex) insertIndex--
@@ -60,10 +76,96 @@ export function useOrderedItemDrag({ items, rowSelector, updateItems, announceMo
     stopDragging()
   }
 
+  function startPointerDrag(event, itemId) {
+    if (event.pointerType === 'mouse' || !event.isPrimary || event.button !== 0) return
+
+    stopDragging()
+    pointerId = event.pointerId
+    pointerHandle = event.currentTarget
+    pointerList = pointerHandle.closest(rowSelector)?.parentElement
+    pointerScroller = pointerList?.parentElement
+    while (pointerScroller && !/auto|scroll/.test(getComputedStyle(pointerScroller).overflowY)) {
+      pointerScroller = pointerScroller.parentElement
+    }
+    draggedItemId.value = itemId
+    pointerHandle.setPointerCapture(pointerId)
+  }
+
+  function movePointerDrag(event) {
+    if (event.pointerId !== pointerId) return
+
+    pointerPosition = { x: event.clientX, y: event.clientY }
+    updatePointerDropTarget()
+    if (pointerScroller && autoScrollFrame === null) {
+      lastScrollTime = performance.now()
+      autoScrollFrame = requestAnimationFrame(scrollNearEdge)
+    }
+  }
+
+  function updatePointerDropTarget() {
+    // Pointer capture keeps events on the grip; hit-test the row under the finger.
+    const row = document.elementFromPoint(pointerPosition.x, pointerPosition.y)?.closest(rowSelector)
+    const itemId = row?.getAttribute(itemIdAttribute)
+    if (row == null || row.parentElement !== pointerList || itemId === draggedItemId.value) {
+      dropTarget.value = null
+      return
+    }
+
+    const bounds = row.getBoundingClientRect()
+    dropTarget.value = { id: itemId, after: pointerPosition.y >= bounds.top + bounds.height / 2 }
+  }
+
+  function scrollNearEdge(time) {
+    autoScrollFrame = null
+    const bounds = pointerScroller.getBoundingClientRect()
+    if (pointerPosition.x < bounds.left || pointerPosition.x > bounds.right) return
+
+    const edgeSize = Math.min(40, bounds.height / 3)
+    const topDistance = pointerPosition.y - bounds.top
+    const bottomDistance = bounds.bottom - pointerPosition.y
+    const direction = topDistance < edgeSize ? -1 : bottomDistance < edgeSize ? 1 : 0
+    if (direction === 0) return
+
+    const distance = direction < 0 ? topDistance : bottomDistance
+    const speed = direction * 600 * Math.min(1, 1 - distance / edgeSize)
+    const elapsed = Math.min(time - lastScrollTime, 32)
+    lastScrollTime = time
+    pointerScroller.scrollBy({ top: speed * elapsed / 1000, behavior: 'instant' })
+    updatePointerDropTarget()
+    autoScrollFrame = requestAnimationFrame(scrollNearEdge)
+  }
+
+  function endPointerDrag(event) {
+    if (event.pointerId !== pointerId) return
+
+    movePointerDrag(event)
+    if (dropTarget.value !== null) {
+      commitDrop(dropTarget.value.id, dropTarget.value.after)
+    } else {
+      stopDragging()
+    }
+  }
+
+  function cancelPointerDrag(event) {
+    if (event.pointerId === pointerId) stopDragging()
+  }
+
   function stopDragging() {
+    if (autoScrollFrame !== null) cancelAnimationFrame(autoScrollFrame)
+    autoScrollFrame = null
+    pointerScroller = null
+    pointerPosition = null
+    const handle = pointerHandle
+    const capturedId = pointerId
+    pointerId = null
+    pointerHandle = null
+    pointerList = null
     draggedItemId.value = null
     dropTarget.value = null
+    if (handle?.hasPointerCapture(capturedId)) handle.releasePointerCapture(capturedId)
   }
+
+  onBeforeUnmount(stopDragging)
 
   return {
     draggedItemId,
@@ -71,6 +173,10 @@ export function useOrderedItemDrag({ items, rowSelector, updateItems, announceMo
     dropItem,
     handleDragOver,
     startDragging,
+    startPointerDrag,
+    movePointerDrag,
+    endPointerDrag,
+    cancelPointerDrag,
     stopDragging,
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Reported directly in this task; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Reset buttons stayed enabled at the default configuration, and navigation and quick settings could not be reordered by touch. Compare each saved item list and its order with the defaults, and support touch dragging from the grips with edge scrolling for offscreen items. Interrupted gestures cancel without changing the order.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed touch reordering in navigation and quick settings customization, including scrolling to offscreen items, and disabled reset buttons when already at defaults.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. In Appearance settings, open each customization panel. With the default items and order, Reset to defaults should be disabled.
2. Add, remove, or reorder an item. Reset should become enabled, then disabled again after restoring the default arrangement manually or with Reset.
3. On a touch device, drag a grip above or below another row. Hold near the top or bottom of the panel to reach offscreen items. Release to save the order; interrupt the gesture to cancel it.
4. Repeat at 125% UI scale, and verify desktop dragging and the move buttons still work.

## Additional context
<!-- Add any other context about the pull request here. -->

Implemented and reviewed with GPT-6 in Codex.
