### PR TITLE
fix(subscriptions): refresh premiere viewers and completed videos

### DIFF
--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -191,6 +191,90 @@ test.describe('subscriptions feed from cache', () => {
     await expect(premiere.locator('.videoDuration')).toHaveText('Premiere')
   })
 
+  test('polls a started premiere for watching counts and its completed video state', async ({ page }) => {
+    await goTo(page, 'trending')
+    await page.clock.install({ time: now + 30 * 24 * HOUR - 30_000 })
+    let ended = false
+    let watching = 2500
+    let failRequests = false
+    const requests = []
+    await page.route('https://www.youtube.com/watch?*', async route => {
+      const videoId = new URL(route.request().url()).searchParams.get('v')
+      requests.push(videoId)
+      if (failRequests) {
+        await route.abort()
+        return
+      }
+      const player = {
+        playabilityStatus: { status: 'OK' },
+        videoDetails: {
+          videoId,
+          isLive: !ended,
+          isLiveContent: false,
+          viewCount: '9000',
+          lengthSeconds: '702'
+        },
+        microformat: {
+          playerMicroformatRenderer: {
+            liveBroadcastDetails: {
+              isLiveNow: !ended,
+              ...(ended ? { endTimestamp: new Date().toISOString() } : {})
+            }
+          }
+        }
+      }
+      const initialData = {
+        contents: {
+          videoViewCountRenderer: {
+            viewCount: { runs: [{ text: String(watching) }, { text: ' watching now' }] },
+            isLive: true
+          }
+        }
+      }
+      await route.fulfill({
+        contentType: 'text/html',
+        body:
+        `<script>var ytInitialPlayerResponse = ${JSON.stringify(player)}; var ytInitialData = ${JSON.stringify(initialData)};</script>`
+      })
+    })
+    await goTo(page, 'subscriptions')
+    await expect(page.getByText('Upcoming premiere video')).toHaveCount(0)
+    await page.clock.fastForward(61_000)
+    await page.clock.runFor(200)
+
+    const premiere = page.locator('.ft-list-video').filter({ hasText: 'Upcoming premiere video' })
+    await expect(premiere.locator('.viewCount')).toContainText('2.5k watching')
+    failRequests = true
+    await page.clock.fastForward(61_000)
+    await page.clock.runFor(200)
+    await expect(premiere.locator('.viewCount')).toContainText('2.5k watching')
+    await expect(premiere.locator('.videoDuration')).toHaveText('Premiere')
+    failRequests = false
+    watching = 3700
+    await page.clock.fastForward(61_000)
+    await page.clock.runFor(200)
+    await expect(premiere.locator('.viewCount')).toContainText('3.7k watching')
+
+    await goTo(page, 'trending')
+    const inactiveRequestCount = requests.length
+    await page.clock.fastForward(121_000)
+    expect(requests).toHaveLength(inactiveRequestCount)
+    await goTo(page, 'subscriptions')
+
+    ended = true
+    await page.clock.fastForward(61_000)
+    await page.clock.runFor(200)
+    await expect(premiere.locator('.videoDuration')).toHaveText('11:42')
+    await expect(premiere.locator('.viewCount')).toContainText('9k views')
+    await expect(premiere).not.toHaveClass(/premiereVideo/)
+
+    const completedRequestCount = requests.length
+    await page.clock.fastForward(121_000)
+    expect(requests).toHaveLength(completedRequestCount)
+    expect(requests).not.toContain('aaaaaaaaaa1')
+    expect(requests).not.toContain('bbbbbbbbbb1')
+  })
+
   test('an open video menu does not lift feed content over the sticky header', async ({ page }) => {
     await goTo(page, 'subscriptions')
 

--- a/src/renderer/composables/useSubscriptionPremiereUpdates.js
+++ b/src/renderer/composables/useSubscriptionPremiereUpdates.js
@@ -1,0 +1,55 @@
+import { onActivated, onBeforeUnmount, onDeactivated, onMounted, watch } from 'vue'
+
+import { refreshSubscriptionPremieres } from '../helpers/subscriptions'
+import { useTabContext } from '../tabs/TabContext'
+
+const POLL_INTERVAL_MS = 60_000
+
+export function useSubscriptionPremiereUpdates() {
+  const { isTabPresented } = useTabContext()
+  let active = false
+  let timer = null
+  let generation = 0
+
+  function stop() {
+    generation++
+    clearTimeout(timer)
+    timer = null
+  }
+
+  function schedule() {
+    stop()
+    if (!active || isTabPresented?.value === false || document.hidden) return
+    const currentGeneration = generation
+    const isCurrent = () => active && generation === currentGeneration
+    timer = setTimeout(async () => {
+      timer = null
+      try {
+        await refreshSubscriptionPremieres(isCurrent)
+      } finally {
+        if (isCurrent()) schedule()
+      }
+    }, POLL_INTERVAL_MS)
+  }
+
+  function start() {
+    active = true
+    schedule()
+  }
+
+  onMounted(() => {
+    document.addEventListener('visibilitychange', schedule)
+    start()
+  })
+  onActivated(start)
+  onDeactivated(() => {
+    active = false
+    stop()
+  })
+  if (isTabPresented !== null) watch(isTabPresented, schedule)
+  onBeforeUnmount(() => {
+    active = false
+    stop()
+    document.removeEventListener('visibilitychange', schedule)
+  })
+}

--- a/src/renderer/helpers/subscription-premieres.js
+++ b/src/renderer/helpers/subscription-premieres.js
@@ -1,0 +1,93 @@
+import { extractAssignedJsonObject } from './assigned-json.js'
+import { getUpcomingPremiereTimestamp, updateUpcomingPremiereState } from './subscription-entries.js'
+
+/** @param {object} video @param {number} now */
+export function shouldRefreshSubscriptionPremiere(video, now) {
+  const scheduled = getUpcomingPremiereTimestamp(video)
+  if (scheduled > now) return false
+  return video.isPremiere === true ||
+    updateUpcomingPremiereState(video, now) !== video ||
+    ((video.isUpcoming === true || video.premiere === true) && (scheduled == null || scheduled <= now)) ||
+    (scheduled > 0 && (video.liveNow === true || video.isLive === true))
+}
+
+/** @param {unknown} value */
+function numericCount(value) {
+  if (value == null || value === '') return undefined
+  const count = Number(value)
+  return Number.isFinite(count) && count >= 0 ? count : undefined
+}
+
+/** @param {object} data */
+function findWatchingCount(data) {
+  if (data == null || typeof data !== 'object') return undefined
+  const renderer = data.videoViewCountRenderer
+  if (renderer?.isLive === true) {
+    const text = renderer.viewCount?.simpleText ?? renderer.viewCount?.runs?.map(run => run.text).join('')
+    const digits = text?.match(/[\d, .\u00a0\u202f]+/)?.[0].replaceAll(/\D/g, '')
+    return numericCount(digits)
+  }
+  for (const value of Object.values(data)) {
+    const count = findWatchingCount(value)
+    if (count !== undefined) return count
+  }
+  return undefined
+}
+
+/** @param {boolean} liveNow @param {boolean} isUpcoming */
+function stateUpdate(liveNow, isUpcoming) {
+  return {
+    liveNow,
+    isLive: liveNow,
+    isUpcoming,
+    premiere: isUpcoming,
+    ...(!liveNow && !isUpcoming
+      ? { isPremiere: false, premiereDate: null, premiereTimestamp: 0 }
+      : {})
+  }
+}
+
+/** @param {string} html @param {string} videoId */
+export function getLocalSubscriptionPremiereUpdate(html, videoId) {
+  try {
+    const player = JSON.parse(extractAssignedJsonObject(html, 'ytInitialPlayerResponse') ?? 'null')
+    const details = player?.videoDetails
+    if (details?.videoId !== videoId) return null
+    const isUpcoming = details.isUpcoming === true
+    if (player.playabilityStatus?.status !== 'OK' && !isUpcoming) return null
+    const broadcast = player.microformat?.playerMicroformatRenderer?.liveBroadcastDetails
+    // Finished premieres can omit isLive entirely once they become VODs.
+    const live = broadcast?.isLiveNow ?? details.isLive ??
+      (numericCount(details.lengthSeconds) > 0 ? false : undefined)
+    if (typeof live !== 'boolean') return null
+    const liveNow = live && !isUpcoming
+    const update = stateUpdate(liveNow, isUpcoming)
+    if ((liveNow || isUpcoming) && typeof details.isLiveContent === 'boolean') {
+      update.isPremiere = !details.isLiveContent
+    }
+    let viewCount
+    if (liveNow) {
+      const data = JSON.parse(extractAssignedJsonObject(html, 'ytInitialData') ?? 'null')
+      viewCount = findWatchingCount(data)
+    } else {
+      viewCount = numericCount(details.viewCount)
+    }
+    if (viewCount !== undefined) update.viewCount = viewCount
+    const lengthSeconds = numericCount(details.lengthSeconds)
+    if (lengthSeconds !== undefined) update.lengthSeconds = lengthSeconds
+    return update
+  } catch {
+    return null
+  }
+}
+
+/** @param {object} video @param {string} videoId */
+export function getInvidiousSubscriptionPremiereUpdate(video, videoId) {
+  if (video?.error || video?.videoId !== videoId || typeof video.liveNow !== 'boolean') return null
+  const update = stateUpdate(video.liveNow, video.isUpcoming === true)
+  const viewCount = numericCount(video.viewCount)
+  const lengthSeconds = numericCount(video.lengthSeconds)
+  if (viewCount !== undefined) update.viewCount = viewCount
+  if (lengthSeconds !== undefined) update.lengthSeconds = lengthSeconds
+  return update
+}

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -34,6 +34,7 @@ import { mapConcurrently } from './concurrent-map'
 import { includeAutomaticDownloadChannels, startAutomaticDownloadsForChannel } from './automaticDownloads'
 import { extractAssignedJsonObject } from './assigned-json'
 import { getLocalPremiereState } from './premiere'
+import { getInvidiousSubscriptionPremiereUpdate, getLocalSubscriptionPremiereUpdate, shouldRefreshSubscriptionPremiere } from './subscription-premieres'
 import { shouldShowProgressStartToast } from './progressPresentation'
 import { isAndroidSubscriptionRefreshActive } from './androidSubscriptionRefresh'
 import { createSubscriptionNetworkRecovery, SubscriptionNetworkError } from './subscriptionNetworkRecovery'
@@ -72,6 +73,58 @@ const SUBSCRIPTION_FETCH_BATCH_DELAY_MS = 2000
 const SUBSCRIPTION_FETCH_CONCURRENCY = 8
 const RSS_ENRICHMENT_CONCURRENCY = 3
 const RSS_ENRICHMENT_TIMEOUT_MS = 15_000
+
+/**
+ * Refresh only due premieres, preserving the channel's full-refresh timestamp
+ * and any newer cache data written while the request was in flight.
+ * @param {() => boolean} isActive
+ */
+export async function refreshSubscriptionPremieres(isActive) {
+  if (!store.getters.getSubscriptionCacheReady || store.getters.getSubscriptionFeedRefreshInProgress) return
+  const profile = store.getters.getActiveProfile
+  const channels = getSubscriptionsForFeed(profile.subscriptions, 'videos')
+  for (const channel of channels) {
+    if (!isActive() || store.getters.getActiveProfile._id !== profile._id) return
+    const cache = store.getters.getVideoCache[channel.id]
+    const entries = cache?.videos
+    const candidates = entries?.filter(video => shouldRefreshSubscriptionPremiere(video, Date.now())) ?? []
+    if (candidates.length === 0) continue
+    const updates = new Map()
+    await mapConcurrently(candidates, RSS_ENRICHMENT_CONCURRENCY, async video => {
+      if (!isActive()) return
+      try {
+        const options = { signal: AbortSignal.timeout(RSS_ENRICHMENT_TIMEOUT_MS) }
+        let update
+        if (!process.env.SUPPORTS_LOCAL_API || store.getters.getBackendPreference === 'invidious') {
+          const url = `${store.getters.getCurrentInvidiousInstanceUrl}/api/v1/videos/${encodeURIComponent(video.videoId)}`
+          const response = await invidiousFetch(url, options.signal)
+          if (!response.ok) return
+          update = getInvidiousSubscriptionPremiereUpdate(await response.json(), video.videoId)
+        } else {
+          const response = await localApiFetch(`https://www.youtube.com/watch?v=${encodeURIComponent(video.videoId)}`, {
+            ...options,
+            headers: { 'Accept-Language': 'en-US' },
+            nativeTimeoutMs: RSS_ENRICHMENT_TIMEOUT_MS
+          })
+          if (!response.ok) return
+          update = getLocalSubscriptionPremiereUpdate(await response.text(), video.videoId)
+        }
+        if (update !== null) updates.set(video.videoId, update)
+      } catch {
+        // Keep the last known state and retry on the next poll.
+      }
+    })
+    if (!isActive() || store.getters.getActiveProfile._id !== profile._id) return
+    if (updates.size === 0 || store.getters.getVideoCache[channel.id]?.videos !== entries ||
+      store.getters.getSubscriptionFeedRefreshInProgress) continue
+    await store.dispatch('updateSubscriptionVideosCacheByChannel', {
+      channelId: channel.id,
+      videos: entries.map(video => updates.has(video.videoId) ? { ...video, ...updates.get(video.videoId) } : video),
+      timestamp: cache.timestamp
+    })
+    notifySubscriptionChannelRefreshed('videos')
+  }
+}
 
 /**
  * Stops the refresh running in this renderer after the channels that are

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -369,6 +369,7 @@ import store from '../../store/index'
 import { useTabContext, useTabLifecycle } from '../../tabs/TabContext'
 import { getTabNavigationService } from '../../tabs/TabNavigationService'
 import { useRefreshAllSubscriptionFeeds } from '../../composables/useRefreshAllSubscriptionFeeds'
+import { useSubscriptionPremiereUpdates } from '../../composables/useSubscriptionPremiereUpdates'
 import {
   requestSubscriptionRefreshCancellation,
   refreshSubscriptionLiveFromRemote,
@@ -385,6 +386,7 @@ const usesLogicalTabs = process.env.IS_ELECTRON || process.env.IS_CAPACITOR
 const hasHorizontalTabBar = computed(() => isElectron && store.getters.getTabBarPosition === 'top')
 
 const { tabId, isTabPresented } = useTabContext()
+useSubscriptionPremiereUpdates()
 const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()

--- a/tests/unit/subscription-cache-writes.test.mjs
+++ b/tests/unit/subscription-cache-writes.test.mjs
@@ -3,12 +3,16 @@ import { readFile } from 'node:fs/promises'
 import test from 'node:test'
 import vm from 'node:vm'
 import Datastore from '@seald-io/nedb'
+import { ensureSubscriptionFeedEntryState } from '../../src/renderer/helpers/subscription-entries.js'
 
 // The handlers module imports the platform datastore singleton through webpack.
 // Run the actual cache class with an isolated real NeDB for each interleaving.
 const source = await readFile(new URL('../../src/datastores/handlers/base.js', import.meta.url), 'utf8')
 const start = source.indexOf('class SubscriptionCache {')
 const cacheSource = source.slice(start, source.indexOf('\nclass ', start + 1))
+const storeSource = await readFile(new URL('../../src/renderer/store/modules/subscription-cache.js', import.meta.url), 'utf8')
+const moduleSource = storeSource.slice(storeSource.indexOf('const MAX_CONCURRENT_CACHE_WRITES'))
+  .replace('export default', 'globalThis.cacheModule =')
 
 for (const enrichmentFirst of [false, true]) {
   test(`Shorts refresh preserves new entries when enrichment starts ${enrichmentFirst ? 'first' : 'second'}`, async () => {
@@ -34,5 +38,71 @@ for (const enrichmentFirst of [false, true]) {
     assert.deepEqual(result.shorts.map(video => video.videoId), ['old', 'new'])
     assert.equal(new Date(result.shortsTimestamp).getTime(), 2000)
     assert.equal(result.shorts[0].title, enrichmentFirst ? 'Refreshed title' : 'Enriched title')
+  })
+}
+
+for (const delayDatabaseReply of [false, true]) {
+  test(`a premiere update cannot overwrite a full refresh when its database ${delayDatabaseReply ? 'reply' : 'write'} arrives late`, async () => {
+    const db = { subscriptionCache: new Datastore({ inMemoryOnly: true }) }
+    const Cache = vm.runInNewContext(`${cacheSource}\nSubscriptionCache`, { db })
+    const cachedVideos = [{ videoId: 'premiere', viewCount: 1000, isNewInSubscriptionFeed: false }]
+    await Cache.updateVideosByChannelId('channel', cachedVideos, new Date(1000))
+
+    let releasePremiere
+    let signalWaiting
+    const waiting = new Promise(resolve => { signalWaiting = resolve })
+    const resume = new Promise(resolve => { releasePremiere = resolve })
+    const context = vm.createContext({
+      console,
+      ensureSubscriptionFeedEntryState,
+      DBSubscriptionCacheHandlers: {
+        async updateVideosByChannelId(channelId, videos, timestamp) {
+          if (timestamp.getTime() !== 1000) {
+            return Cache.updateVideosByChannelId(channelId, videos, timestamp)
+          }
+          // Model an IPC acknowledgement delayed until after a newer refresh,
+          // and the inverse order where the old write itself reaches NeDB late.
+          if (delayDatabaseReply) {
+            const result = await Cache.updateVideosByChannelId(channelId, videos, timestamp)
+            signalWaiting()
+            await resume
+            return result
+          }
+          signalWaiting()
+          await resume
+          return Cache.updateVideosByChannelId(channelId, videos, timestamp)
+        }
+      }
+    })
+    vm.runInContext(moduleSource, context)
+    const { actions, mutations, state } = context.cacheModule
+    state.videoCache.channel = { videos: cachedVideos, timestamp: new Date(1000) }
+    const actionContext = {
+      state,
+      rootGetters: { getHistoryCacheById: {} },
+      commit(type, payload) { mutations[type](state, payload) }
+    }
+    const premiereUpdate = actions.updateSubscriptionVideosCacheByChannel(actionContext, {
+      channelId: 'channel',
+      videos: [{ ...cachedVideos[0], viewCount: 2500 }],
+      timestamp: new Date(1000)
+    })
+    await waiting
+
+    const refreshedVideos = [
+      { videoId: 'premiere', viewCount: 3000, isNewInSubscriptionFeed: false },
+      { videoId: 'new-video', isNewInSubscriptionFeed: true }
+    ]
+    await actions.updateSubscriptionVideosCacheByChannel(actionContext, {
+      channelId: 'channel', videos: refreshedVideos, timestamp: new Date(2000)
+    })
+    releasePremiere()
+    await premiereUpdate
+
+    assert.equal(state.videoCache.channel.videos, refreshedVideos)
+    assert.equal(state.videoCache.channel.timestamp.getTime(), 2000)
+    const persisted = await db.subscriptionCache.findOneAsync({ _id: 'channel' })
+    assert.deepEqual(persisted.videos, refreshedVideos)
+    assert.equal(new Date(persisted.videosTimestamp).getTime(), 2000)
   })
 }

--- a/tests/unit/subscription-premieres.test.mjs
+++ b/tests/unit/subscription-premieres.test.mjs
@@ -1,0 +1,175 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import vm from 'node:vm'
+
+import { getLocalSubscriptionPremiereUpdate, getInvidiousSubscriptionPremiereUpdate, shouldRefreshSubscriptionPremiere } from '../../src/renderer/helpers/subscription-premieres.js'
+import { mapConcurrently } from '../../src/renderer/helpers/concurrent-map.js'
+import { getSubscriptionsForFeed } from '../../src/renderer/helpers/subscription-channels.js'
+
+const videoId = 'premiere123'
+function html({ live = true, upcoming = false, watching = '2,500', status = 'OK' } = {}) {
+  return `<script>var ytInitialPlayerResponse = ${JSON.stringify({
+    playabilityStatus: { status },
+    videoDetails: { videoId, isLive: live, isLiveContent: false, isUpcoming: upcoming, viewCount: '9000', lengthSeconds: '702' },
+    microformat: { playerMicroformatRenderer: { liveBroadcastDetails: { isLiveNow: live && !upcoming } } }
+  })}; var ytInitialData = ${JSON.stringify({ contents: { videoViewCountRenderer: {
+    viewCount: { runs: [{ text: watching }, { text: ' watching now' }] }, isLive: true
+  } } })};</script>`
+}
+
+test('polls due and running premieres, excluding ordinary videos and future premieres', () => {
+  assert.equal(shouldRefreshSubscriptionPremiere({ isUpcoming: true, premiereDate: new Date(1000) }, 999), false)
+  assert.equal(shouldRefreshSubscriptionPremiere({ isUpcoming: true, premiereDate: new Date(1000) }, 1000), true)
+  assert.equal(shouldRefreshSubscriptionPremiere({ isPremiere: true, liveNow: true }, 1000), true)
+  assert.equal(shouldRefreshSubscriptionPremiere({ premiereTimestamp: 0, liveNow: false }, 1000), false)
+  assert.equal(shouldRefreshSubscriptionPremiere({ isLive: true, isPremiere: false }, 1000), false)
+})
+
+test('polls supported cached premieres that only have a scheduled date', () => {
+  const premiere = { premiereDate: new Date(1000) }
+  assert.equal(shouldRefreshSubscriptionPremiere(premiere, 999), false)
+  assert.equal(shouldRefreshSubscriptionPremiere(premiere, 1000), true)
+  assert.equal(shouldRefreshSubscriptionPremiere({ ...premiere, isUpcoming: false, premiere: false }, 1000), false)
+})
+
+test('uses the concurrent audience rather than total views while a premiere runs', () => {
+  const update = getLocalSubscriptionPremiereUpdate(html(), videoId)
+  assert.equal(update.viewCount, 2500)
+  assert.equal(update.liveNow, true)
+  assert.equal(update.isPremiere, true)
+  assert.equal(update.isUpcoming, false)
+  assert.equal(getLocalSubscriptionPremiereUpdate(html({ watching: '0' }), videoId).viewCount, 0)
+})
+
+test('clears premiere flags and scheduled dates when the video ends', () => {
+  const update = getLocalSubscriptionPremiereUpdate(html({ live: false }), videoId)
+  assert.equal(update.viewCount, 9000)
+  assert.equal(update.lengthSeconds, 702)
+  assert.equal(update.liveNow, false)
+  assert.equal(update.isLive, false)
+  assert.equal(update.isPremiere, false)
+  assert.equal(update.isUpcoming, false)
+  assert.equal(update.premiere, false)
+  assert.equal(update.premiereDate, null)
+  assert.equal(update.premiereTimestamp, 0)
+  assert.equal(shouldRefreshSubscriptionPremiere(update, 1000), false)
+})
+
+test('unavailable or malformed responses cannot complete a premiere', () => {
+  assert.equal(getLocalSubscriptionPremiereUpdate('<html>Consent required</html>', videoId), null)
+  assert.equal(getLocalSubscriptionPremiereUpdate(html({ status: 'ERROR' }), videoId), null)
+  assert.equal(getLocalSubscriptionPremiereUpdate(html(), 'different-id'), null)
+})
+
+test('completed premieres can omit the live flags entirely', () => {
+  const response = `<script>var ytInitialPlayerResponse = ${JSON.stringify({
+    playabilityStatus: { status: 'OK' },
+    videoDetails: { videoId, isLiveContent: false, viewCount: '9000', lengthSeconds: '702' }
+  })};</script>`
+  assert.equal(getLocalSubscriptionPremiereUpdate(response, videoId).isPremiere, false)
+})
+
+test('delayed premieres remain eligible for subsequent checks', () => {
+  const update = getLocalSubscriptionPremiereUpdate(html({ upcoming: true, status: 'LIVE_STREAM_OFFLINE' }), videoId)
+  assert.equal(update.isUpcoming, true)
+  assert.equal(update.liveNow, false)
+  assert.equal(update.isPremiere, true)
+  assert.equal(shouldRefreshSubscriptionPremiere({ ...update, premiereDate: new Date(1000) }, 2000), true)
+})
+
+test('Invidious live and completed responses update the same cached fields', () => {
+  const live = getInvidiousSubscriptionPremiereUpdate({ videoId, liveNow: true, isUpcoming: false, viewCount: 1234, lengthSeconds: 0 }, videoId)
+  assert.equal(live.liveNow, true)
+  assert.equal(live.viewCount, 1234)
+  assert.equal(live.isPremiere, undefined)
+  const ended = getInvidiousSubscriptionPremiereUpdate({ videoId, liveNow: false, isUpcoming: false, viewCount: 9000, lengthSeconds: 702 }, videoId)
+  assert.equal(ended.isPremiere, false)
+  assert.equal(ended.lengthSeconds, 702)
+  assert.equal(ended.premiereDate, null)
+  assert.equal(getInvidiousSubscriptionPremiereUpdate({ error: 'Unavailable' }, videoId), null)
+})
+
+test('a missing concurrent count keeps the cached audience instead of using total views', () => {
+  const response = html().replace('videoViewCountRenderer', 'unrelatedRenderer')
+  assert.equal(getLocalSubscriptionPremiereUpdate(response, videoId).viewCount, undefined)
+})
+
+// Run the real refresh function without the renderer's platform singletons.
+const source = await readFile(new URL('../../src/renderer/helpers/subscriptions.js', import.meta.url), 'utf8')
+const start = source.indexOf('export async function refreshSubscriptionPremieres(')
+const refreshSource = source.slice(start, source.indexOf('\n/**', start)).replace('export ', '')
+
+function createRefresh(fetch) {
+  const video = { videoId, isPremiere: true, liveNow: true, viewCount: 1000, isNewInSubscriptionFeed: false }
+  const getters = {
+    getSubscriptionCacheReady: true,
+    getSubscriptionFeedRefreshInProgress: false,
+    getBackendPreference: 'local',
+    getCurrentInvidiousInstanceUrl: 'https://invidious.example',
+    getActiveProfile: { _id: 'profile', subscriptions: [{ id: 'channel' }] },
+    getVideoCache: { channel: { videos: [video], timestamp: new Date(1000) } }
+  }
+  const writes = []
+  const refresh = vm.runInNewContext(`${refreshSource}\nrefreshSubscriptionPremieres`, {
+    store: { getters, dispatch: async (action, payload) => writes.push(payload) },
+    process: { env: { SUPPORTS_LOCAL_API: true } },
+    AbortSignal,
+    RSS_ENRICHMENT_TIMEOUT_MS: 15_000,
+    RSS_ENRICHMENT_CONCURRENCY: 3,
+    getSubscriptionsForFeed,
+    shouldRefreshSubscriptionPremiere,
+    mapConcurrently,
+    localApiFetch: fetch,
+    invidiousFetch: fetch,
+    getLocalSubscriptionPremiereUpdate,
+    getInvidiousSubscriptionPremiereUpdate,
+    notifySubscriptionChannelRefreshed() {}
+  })
+  return { refresh, getters, writes }
+}
+
+test('polling preserves seen state and the last full channel refresh timestamp', async () => {
+  const { refresh, writes } = createRefresh(async () => new Response(html()))
+  await refresh(() => true)
+  assert.equal(writes.length, 1)
+  assert.equal(writes[0].videos[0].viewCount, 2500)
+  assert.equal(writes[0].videos[0].isNewInSubscriptionFeed, false)
+  assert.equal(writes[0].timestamp.getTime(), 1000)
+})
+
+test('requests English watch-page counts when the system locale uses other digits', async () => {
+  const { refresh, writes } = createRefresh(async (url, options) => new Response(html({
+    watching: options.headers?.['Accept-Language'] === 'en-US' ? '2,500' : '٢٬٥٠٠'
+  })))
+  await refresh(() => true)
+  assert.equal(writes[0].videos[0].viewCount, 2500)
+})
+
+test('polling uses the selected Invidious backend with a request timeout', async () => {
+  const { refresh, getters, writes } = createRefresh(async (url, signal) => {
+    assert.equal(url, `https://invidious.example/api/v1/videos/${videoId}`)
+    assert.ok(signal instanceof AbortSignal)
+    return Response.json({ videoId, liveNow: false, isUpcoming: false, viewCount: 9000, lengthSeconds: 702 })
+  })
+  getters.getBackendPreference = 'invidious'
+  await refresh(() => true)
+  assert.equal(writes[0].videos[0].isPremiere, false)
+  assert.equal(writes[0].videos[0].viewCount, 9000)
+})
+
+for (const change of ['cache', 'profile', 'inactive']) {
+  test(`ignores a response after the ${change} changes while fetching`, async () => {
+    let finish
+    const response = new Promise(resolve => { finish = resolve })
+    const { refresh, getters, writes } = createRefresh(() => response)
+    let active = true
+    const pending = refresh(() => active)
+    if (change === 'cache') getters.getVideoCache.channel.videos = [{ videoId: 'newer-video' }]
+    if (change === 'profile') getters.getActiveProfile = { _id: 'another-profile', subscriptions: [] }
+    if (change === 'inactive') active = false
+    finish(new Response(html()))
+    await pending
+    assert.equal(writes.length, 0)
+  })
+}


### PR DESCRIPTION
Premieres that started from an upcoming subscription entry kept stale watching counts and could remain marked live after ending. This change checks active premieres about once a minute and automatically shows completed premieres as normal videos.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

Requested directly in Codex; no linked issue.

<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description

Refresh only due or running premieres through the selected Local or Invidious backend while subscriptions is visible. Update the watching count in place, then clear the live/premiere state and show the duration and total views when the premiere finishes. Failed checks retry quietly; stale responses cannot overwrite newer feed data.

<!-- Please write a clear and concise description of what the pull request does. -->

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Subscription premieres now refresh their watching count and automatically become normal videos when they finish.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing

1. With this branch running in dev mode, open Subscriptions with an upcoming premiere in the feed. Keep the page visible as it starts.
2. Wait about a minute between audience changes. The card should update its watching count without a manual feed refresh.
3. When the premiere finishes, its card should show the normal video duration and total views instead of the premiere/live state.
4. Leave the subscriptions page and confirm in the Network panel that premiere checks stop. Return to resume checking.
5. Repeat with the Local and Invidious backends. A failed request should retain the last known state and retry on the next check.

<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

## Additional context
<!-- Add any other context about the pull request here. -->
