### PR TITLE
feat(tabs): preview tab groups in custom tooltips

### DIFF
--- a/e2e/tests/offline/tab-preview.spec.mjs
+++ b/e2e/tests/offline/tab-preview.spec.mjs
@@ -311,6 +311,8 @@ test.describe('tab group previews', () => {
     ])
     await expect(tooltip.locator('.tabTooltipPreview img').first()).toHaveAttribute('src', /^data:image\/jpeg/)
     await expect(tooltip.locator('.tabTooltipPreviewFallback')).toHaveCount(3)
+    await expect(tooltip.locator('.tabTooltipGridTitleIcon[data-icon="rss"]')).toHaveCount(1)
+    await expect(tooltip.locator('.tabTooltipGridTitleIcon[data-icon="clapperboard"]')).toHaveCount(3)
     await expect(trigger).toHaveAttribute('aria-describedby', await tooltip.getAttribute('id'))
 
     const positions = await tooltip.locator('.tabTooltipGridItem').evaluateAll(items => ({
@@ -365,9 +367,51 @@ test.describe('tab group previews', () => {
           .every(child => child.getBoundingClientRect().bottom <= bounds.bottom - 7)
         return { besideRail, inside, childrenFit }
       }, position)).toEqual({ besideRail: true, inside: true, childrenFit: true })
+      const titlesAligned = await tooltip.locator('.tabTooltipGridTitle').evaluateAll(titles => titles.every(title => {
+        const icon = title.querySelector('.tabTooltipGridTitleIcon').getBoundingClientRect()
+        const text = title.querySelector('.tabTooltipGridTitleText').getBoundingClientRect()
+        return icon.right < text.left && Math.abs(icon.top + icon.height / 2 - text.top - text.height / 2) <= 1
+      }))
+      expect(titlesAligned).toBe(true)
       await attachScreenshot(`group previews ${position} fractional scale`)
     })
   }
+
+  test('uses channel avatars beside titles, handles failed images, and respects the icon setting', async ({ page }) => {
+    const { tabIds, groupId } = await createCollapsedPreviewGroup(page)
+    const avatarTabId = await page.evaluate(async groupId => {
+      const route = '/channel/UCgroupPreviewAvatar'
+      const tab = await window.ftElectron.tabs.create({ route, title: 'Channel avatar', makeActive: false, lazyLoad: true })
+      const image = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+      const bytes = Uint8Array.from(atob(image), character => character.charCodeAt(0))
+      await window.ftElectron.tabs.updateAvatar(bytes.buffer, tab.id, route)
+      await window.ftElectron.tabs.setGroup([tab.id], groupId)
+      return tab.id
+    }, groupId)
+    await page.locator('.collapsedTabGroup').hover()
+    const item = page.locator('.tabTooltipGridItem').filter({ hasText: 'Channel avatar' })
+    const avatar = item.locator('.tabTooltipGridTitleAvatar')
+    await expect(avatar).toBeVisible()
+    await expect.poll(() => avatar.evaluate(image => image.complete && image.naturalWidth > 0)).toBe(true)
+    await avatar.dispatchEvent('error')
+    await expect(avatar).toHaveCount(0)
+    await expect(item.locator('.tabTooltipGridTitleIcon')).toHaveAttribute('data-icon', 'circle-user')
+
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateShowTabIcons', false)
+    })
+    await expect(page.locator('.tabTooltipGridTitleIcon, .tabTooltipGridTitleAvatar')).toHaveCount(0)
+    await expect(page.locator('.tabTooltipGridTitleText')).toHaveCount(5)
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateShowTabIcons', true)
+    })
+    await expect(page.locator('.tabTooltipGridTitleIcon')).toHaveCount(5)
+    const state = await page.evaluate(() => window.ftElectron.tabs.getState())
+    expect(state.activeTabId).toBe(tabIds[0])
+    expect(state.tabs.find(tab => tab.id === avatarTabId).isUnloaded).toBe(true)
+  })
 
   test('keeps the custom title and count when previews are disabled', async ({ page, attachScreenshot }) => {
     await page.evaluate(async () => {

--- a/e2e/tests/offline/tab-preview.spec.mjs
+++ b/e2e/tests/offline/tab-preview.spec.mjs
@@ -274,6 +274,13 @@ test.describe('tab previews disabled', () => {
   })
 })
 
+/**
+ * Groups the active tab with unloaded tabs so previews cover both captured pages
+ * and fallbacks without fetching remote content.
+ * @param {import('@playwright/test').Page} page
+ * @param {number} count total tabs in the collapsed group, including the active tab
+ * @returns {Promise<{groupId: string, tabIds: string[]}>}
+ */
 async function createCollapsedPreviewGroup(page, count = 4) {
   return page.evaluate(async count => {
     const state = await window.ftElectron.tabs.getState()

--- a/e2e/tests/offline/tab-preview.spec.mjs
+++ b/e2e/tests/offline/tab-preview.spec.mjs
@@ -273,3 +273,129 @@ test.describe('tab previews disabled', () => {
     }
   })
 })
+
+async function createCollapsedPreviewGroup(page, count = 4) {
+  return page.evaluate(async count => {
+    const state = await window.ftElectron.tabs.getState()
+    const ids = [state.tabs.find(tab => tab.isActive).id]
+    for (let index = 1; index < count; index++) {
+      const tab = await window.ftElectron.tabs.create({
+        route: `/watch/group-preview-${index}`,
+        title: `Group preview ${index}`,
+        makeActive: false,
+        lazyLoad: true
+      })
+      ids.push(tab.id)
+    }
+    const group = await window.ftElectron.tabs.createGroup({ name: 'Research', color: 'blue' })
+    await window.ftElectron.tabs.setGroup(ids, group.id)
+    await window.ftElectron.tabs.updateGroup(group.id, { isCollapsed: true })
+    return { groupId: group.id, tabIds: ids }
+  }, count)
+}
+
+test.describe('tab group previews', () => {
+  test('shows captured pages and unloaded fallbacks in a titled grid', async ({ page, attachScreenshot }) => {
+    const { tabIds } = await createCollapsedPreviewGroup(page)
+    const trigger = page.locator('.collapsedTabGroup')
+    await expect(trigger).not.toHaveAttribute('title')
+    await trigger.hover()
+
+    const tooltip = page.locator('.tabGroupTooltip')
+    await expect(tooltip).toBeVisible()
+    await expect(tooltip.locator('.tabTooltipTitle')).toHaveText('Research')
+    await expect(tooltip.locator('.tabTooltipCount')).toHaveText('4 tabs')
+    await expect(tooltip.locator('.tabTooltipGridItem')).toHaveCount(4)
+    await expect(tooltip.locator('.tabTooltipGridTitle')).toHaveText([
+      /.+/, 'Group preview 1', 'Group preview 2', 'Group preview 3'
+    ])
+    await expect(tooltip.locator('.tabTooltipPreview img').first()).toHaveAttribute('src', /^data:image\/jpeg/)
+    await expect(tooltip.locator('.tabTooltipPreviewFallback')).toHaveCount(3)
+    await expect(trigger).toHaveAttribute('aria-describedby', await tooltip.getAttribute('id'))
+
+    const positions = await tooltip.locator('.tabTooltipGridItem').evaluateAll(items => ({
+      rows: new Set(items.map(item => Math.round(item.getBoundingClientRect().top))).size,
+      columns: new Set(items.map(item => Math.round(item.getBoundingClientRect().left))).size
+    }))
+    expect(positions).toEqual({ rows: 2, columns: 2 })
+    const state = await page.evaluate(() => window.ftElectron.tabs.getState())
+    expect(state.tabs.filter(tab => tabIds.slice(1).includes(tab.id)).every(tab => tab.isUnloaded)).toBe(true)
+    await attachScreenshot('collapsed tab group preview grid')
+
+    await page.keyboard.press('Escape')
+    await expect(tooltip).toBeHidden()
+    await trigger.focus()
+    await expect(tooltip).toBeVisible()
+    await page.locator(sel.newTabButton).focus()
+    await expect(tooltip).toBeHidden()
+    await page.locator(sel.newTabButton).hover()
+    await trigger.hover()
+    await expect(tooltip).toBeVisible()
+    await trigger.click()
+    await expect(tooltip).toBeHidden()
+    await expect(page.locator(sel.tabs)).toHaveCount(4)
+  })
+
+  for (const position of ['top', 'bottom', 'left', 'right']) {
+    test(`fits a large group beside ${position} tabs at fractional UI scale`, async ({ page, attachScreenshot }) => {
+      await page.setViewportSize({ width: 800, height: 450 })
+      await page.evaluate(async position => {
+        await window.ftElectron.setZoomFactor(0.95)
+        const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+        store.commit('setTabBarPosition', position)
+      }, position)
+      await createCollapsedPreviewGroup(page, 8)
+      await page.locator('.collapsedTabGroup').hover()
+      const tooltip = page.locator('.tabGroupTooltip')
+      await expect(tooltip).toBeVisible()
+      await expect(tooltip.locator('.tabTooltipGridItem')).toHaveCount(6)
+      await expect(tooltip.locator('.tabTooltipRemaining')).toHaveText('+2')
+      await expect.poll(() => tooltip.evaluate((element, position) => {
+        const bounds = element.getBoundingClientRect()
+        const rail = document.querySelector('.tabBar').getBoundingClientRect()
+        const besideRail = {
+          top: bounds.top >= rail.bottom + 5,
+          bottom: bounds.bottom <= rail.top - 5,
+          left: bounds.left >= rail.right + 5,
+          right: bounds.right <= rail.left - 5
+        }[position]
+        const inside = bounds.left >= 7 && bounds.top >= 7 &&
+          bounds.right <= window.innerWidth - 7 && bounds.bottom <= window.innerHeight - 7
+        const childrenFit = [...element.querySelectorAll('.tabTooltipGridItem, .tabTooltipRemaining')]
+          .every(child => child.getBoundingClientRect().bottom <= bounds.bottom - 7)
+        return { besideRail, inside, childrenFit }
+      }, position)).toEqual({ besideRail: true, inside: true, childrenFit: true })
+      await attachScreenshot(`group previews ${position} fractional scale`)
+    })
+  }
+
+  test('keeps the custom title and count when previews are disabled', async ({ page, attachScreenshot }) => {
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateBaseTheme', 'dark')
+    })
+    await createCollapsedPreviewGroup(page)
+    const trigger = page.locator('.collapsedTabGroup')
+    await trigger.hover()
+    const tooltip = page.locator('.tabGroupTooltip')
+    await expect(tooltip.locator('.tabTooltipGridItem')).toHaveCount(4)
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateShowTabPreviews', false)
+    })
+    await expect(tooltip).toBeVisible()
+    await expect(tooltip.locator('.tabTooltipGrid')).toHaveCount(0)
+    await expect(tooltip.locator('.tabTooltipTitle')).toHaveText('Research')
+    await expect(tooltip.locator('.tabTooltipCount')).toHaveText('4 tabs')
+    expect((await tooltip.boundingBox()).width).toBeLessThan(200)
+    await attachScreenshot('group tooltip without previews in dark theme')
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateShowTabPreviews', true)
+    })
+    await expect(tooltip.locator('.tabTooltipGridItem')).toHaveCount(4)
+    await expect(tooltip.locator('.tabTooltipPreview img').first()).toHaveAttribute('src', /^data:image\/jpeg/)
+    await expect(tooltip).toHaveCSS('visibility', 'visible')
+    await attachScreenshot('group preview grid in dark theme')
+  })
+})

--- a/src/renderer/components/TabBar/SortableTab.vue
+++ b/src/renderer/components/TabBar/SortableTab.vue
@@ -1,147 +1,95 @@
 <template>
-  <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events -->
-  <div
-    ref="tabRef"
-    class="tab tabBarReorderItem"
-    :data-tab-id="tab.id"
-    :data-reorder-id="tab.id"
-    :class="tabClasses"
-    :style="tabStyle"
-    :aria-label="displayTitle"
-    :aria-describedby="isTooltipVisible ? tooltipId : undefined"
-    :aria-pressed="isSelected"
-    role="button"
-    tabindex="-1"
-    @click="handleClick"
-    @pointerenter="handlePointerEnter"
-    @pointerleave="handlePointerLeave"
-    @focusin="showTooltip"
-    @focusout="hideTooltip"
-    @pointerdown="handlePointerDown"
-    @mousedown.middle.prevent
-    @auxclick.prevent="handleAuxClick"
+  <TabTooltip
+    :title="displayTitle"
+    :tabs="[tab]"
+    :group="group"
+    :is-active="tab.isActive"
+    :tab-bar-position="tabBarPosition"
+    :disable-tooltips="disableTooltips || isDragging"
+    :close-tooltips-signal="closeTooltipsSignal"
+    :show-preview="showPreview"
   >
-    <FtIcon
-      v-if="tab.isPinned"
-      :icon="['fas', 'thumbtack']"
-      class="pinBadge"
-      aria-hidden="true"
-    />
-    <span class="tabTitle">
-      <FtIcon
-        v-if="group"
-        :icon="['fas', 'layer-group']"
-        class="groupBadge"
-        aria-hidden="true"
-      />
-      <span
-        v-if="tab.isLoading"
-        class="loadingDot"
-        aria-hidden="true"
-      />
-      <FtIcon
-        v-else-if="tab.isPlaying"
-        :icon="['fas', 'play']"
-        class="playingIcon"
-        aria-hidden="true"
-      />
-      <img
-        v-else-if="showIcon && usableTabAvatarUrl"
-        :src="tabAvatarUrl"
-        class="tabAvatar"
-        alt=""
-        draggable="false"
-        @error="handleAvatarError"
-      >
-      <FtIcon
-        v-else-if="showIcon && tabPageIcon"
-        :icon="tabPageIcon"
-        class="tabPageIcon"
-        aria-hidden="true"
-      />
-      <span class="tabTitleText">{{ displayTitle }}</span>
-    </span>
-    <button
-      class="closeButton"
-      :aria-label="closeLabel"
-      :title="closeLabel"
-      @click.stop="$emit('close', tab.id)"
-      @pointerdown.stop
-    >
-      <FtIcon
-        :icon="['fas', 'times']"
-        class="closeIcon"
-      />
-    </button>
-  </div>
-  <Teleport to="body">
-    <Transition name="tab-tooltip">
+    <template #anchor="{ bindings }">
+      <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events -->
       <div
-        v-if="isTooltipVisible"
-        :id="tooltipId"
-        ref="tooltipRef"
-        class="tabTooltip"
-        :class="{ withPreview: showPreview }"
-        data-tab-preview-overlay
-        :style="tooltipStyle"
-        role="tooltip"
+        v-bind="bindings"
+        class="tab tabBarReorderItem"
+        :data-tab-id="tab.id"
+        :data-reorder-id="tab.id"
+        :class="tabClasses"
+        :style="tabStyle"
+        :aria-label="displayTitle"
+        :aria-pressed="isSelected"
+        role="button"
+        tabindex="-1"
+        @click="handleClick"
+        @mousedown.middle.prevent
+        @auxclick.prevent="handleAuxClick"
       >
-        <div class="tabTooltipTitle">
-          {{ displayTitle }}
-        </div>
-        <div
-          v-if="group"
-          class="tabTooltipGroup"
-          :style="{ '--tab-group-color': groupColor || 'var(--secondary-text-color)' }"
-        >
+        <FtIcon
+          v-if="tab.isPinned"
+          :icon="['fas', 'thumbtack']"
+          class="pinBadge"
+          aria-hidden="true"
+        />
+        <span class="tabTitle">
           <FtIcon
+            v-if="group"
             :icon="['fas', 'layer-group']"
-            class="tabTooltipGroupIcon"
+            class="groupBadge"
             aria-hidden="true"
           />
-          {{ group.name }}
-        </div>
-        <div
-          v-if="showPreview"
-          class="tabTooltipPreview"
-        >
+          <span
+            v-if="tab.isLoading"
+            class="loadingDot"
+            aria-hidden="true"
+          />
+          <FtIcon
+            v-else-if="tab.isPlaying"
+            :icon="['fas', 'play']"
+            class="playingIcon"
+            aria-hidden="true"
+          />
           <img
-            v-if="tooltipPreviewUrl"
-            :src="tooltipPreviewUrl"
-            :alt="tooltipPreviewAlt"
-            draggable="false"
-            @error="handleTooltipPreviewError"
-          >
-          <img
-            v-else-if="usableTabAvatarUrl"
-            :src="usableTabAvatarUrl"
-            :alt="tooltipPreviewAlt"
-            class="tabTooltipPreviewAvatar"
+            v-else-if="showIcon && usableTabAvatarUrl"
+            :src="tabAvatarUrl"
+            class="tabAvatar"
+            alt=""
             draggable="false"
             @error="handleAvatarError"
           >
-          <div
-            v-else
-            class="tabTooltipPreviewFallback"
+          <FtIcon
+            v-else-if="showIcon && tabPageIcon"
+            :icon="tabPageIcon"
+            class="tabPageIcon"
             aria-hidden="true"
-          >
-            <FtIcon
-              :icon="tabPageIcon || ['fas', 'display']"
-              class="tabTooltipFallbackIcon"
-            />
-          </div>
-        </div>
+          />
+          <span class="tabTitleText">{{ displayTitle }}</span>
+        </span>
+        <button
+          class="closeButton"
+          :aria-label="closeLabel"
+          :title="closeLabel"
+          @click.stop="$emit('close', tab.id)"
+          @pointerdown.stop
+        >
+          <FtIcon
+            :icon="['fas', 'times']"
+            class="closeIcon"
+          />
+        </button>
       </div>
-    </Transition>
-  </Teleport>
+    </template>
+  </TabTooltip>
 </template>
 
 <script setup>
 import { FtIcon } from '@opentubex/icons'
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { getTabAccentColor } from '../../constants/tabColors'
 import { getTabAvatarUrl, getTabPageIcon, getTabPreviewFallbackUrl } from '../../tabs/tabPreview'
 import { formatTabTitle } from '../../tabs/tabTitle'
+import TabTooltip from './TabTooltip.vue'
 
 const props = defineProps({
   tab: {
@@ -209,22 +157,7 @@ const props = defineProps({
 
 const emit = defineEmits(['activate', 'close', 'middleClick'])
 
-const TOOLTIP_MAX_WIDTH_PX = 340
-const TOOLTIP_ESTIMATED_HEIGHT_PX = 240
-const TOOLTIP_TITLE_ONLY_ESTIMATED_HEIGHT_PX = 35
-const TOOLTIP_MARGIN_PX = 8
-const TOOLTIP_OFFSET_PX = 6
-const TOOLTIP_SHOW_DELAY_MS = 80
-
-const tabRef = useTemplateRef('tabRef')
-const tooltipRef = useTemplateRef('tooltipRef')
-const isTooltipVisible = ref(false)
-const tooltipPreviewUrl = ref(null)
 const failedAvatarUrl = ref(null)
-const tooltipStyle = ref({})
-const tooltipRequestId = ref(0)
-let showTooltipTimeoutId = null
-let suppressTooltipUntilPointerLeave = false
 
 const tabColor = computed(() => getTabAccentColor(props.tab.color))
 const groupColor = computed(() => getTabAccentColor(props.group?.color))
@@ -259,12 +192,6 @@ const tabStyle = computed(() => {
 
 const displayTitle = computed(() => formatTabTitle(props.tab.title))
 
-const tooltipId = computed(() => `tab-tooltip-${props.tab.id}`)
-const tooltipPreviewAlt = computed(() => `${displayTitle.value} preview`)
-const tooltipEstimatedHeight = computed(() => props.showPreview
-  ? TOOLTIP_ESTIMATED_HEIGHT_PX
-  : TOOLTIP_TITLE_ONLY_ESTIMATED_HEIGHT_PX)
-
 // When a tab points at a channel page and no screenshot has been captured yet,
 // fall back to the channel's profile picture (cached by the Channel view).
 const tabAvatarUrl = computed(() => getTabAvatarUrl(props.tab))
@@ -279,10 +206,6 @@ function handleAvatarError() {
   failedAvatarUrl.value = usableTabAvatarUrl.value
 }
 
-function handleTooltipPreviewError() {
-  tooltipPreviewUrl.value = null
-}
-
 function handleClick(event) {
   emit('activate', event, props.tab.id)
 }
@@ -295,234 +218,6 @@ function handleAuxClick(event) {
     emit('middleClick', event, props.tab.id)
   }
 }
-
-function showTooltip() {
-  if (props.disableTooltips || props.isDragging || suppressTooltipUntilPointerLeave) {
-    return
-  }
-
-  clearShowTooltipTimeout()
-  showTooltipTimeoutId = window.setTimeout(() => {
-    showTooltipTimeoutId = null
-    if (props.disableTooltips || props.isDragging || suppressTooltipUntilPointerLeave) {
-      return
-    }
-
-    updateTooltipPosition()
-    isTooltipVisible.value = true
-    nextTick(updateTooltipPosition)
-    addTooltipDismissListeners()
-    window.addEventListener('resize', updateTooltipPosition)
-    loadTooltipPreview()
-  }, TOOLTIP_SHOW_DELAY_MS)
-}
-
-function handlePointerEnter() {
-  suppressTooltipUntilPointerLeave = false
-  showTooltip()
-}
-
-function handlePointerLeave() {
-  if (document.hasFocus()) {
-    suppressTooltipUntilPointerLeave = false
-  }
-  hideTooltip()
-}
-
-function handlePointerDown() {
-  suppressTooltipUntilPointerLeave = true
-  hideTooltip()
-}
-
-function handleWindowBlur() {
-  suppressTooltipUntilPointerLeave = true
-  hideTooltip()
-}
-
-function hideTooltip() {
-  clearShowTooltipTimeout()
-  isTooltipVisible.value = false
-  tooltipPreviewUrl.value = null
-  tooltipRequestId.value++
-  removeTooltipDismissListeners()
-  window.removeEventListener('resize', updateTooltipPosition)
-}
-
-function clearShowTooltipTimeout() {
-  if (showTooltipTimeoutId != null) {
-    clearTimeout(showTooltipTimeoutId)
-    showTooltipTimeoutId = null
-  }
-}
-
-function addTooltipDismissListeners() {
-  document.addEventListener('pointerdown', hideTooltip, true)
-  document.addEventListener('wheel', hideTooltip, true)
-  document.addEventListener('visibilitychange', hideTooltip, true)
-  document.addEventListener('keydown', handleTooltipKeydown, true)
-}
-
-function removeTooltipDismissListeners() {
-  document.removeEventListener('pointerdown', hideTooltip, true)
-  document.removeEventListener('wheel', hideTooltip, true)
-  document.removeEventListener('visibilitychange', hideTooltip, true)
-  document.removeEventListener('keydown', handleTooltipKeydown, true)
-}
-
-/**
- * @param {KeyboardEvent} event
- */
-function handleTooltipKeydown(event) {
-  if (event.key === 'Escape') {
-    hideTooltip()
-  }
-}
-
-function updateTooltipPosition() {
-  const element = tabRef.value
-  if (!(element instanceof HTMLElement)) {
-    return
-  }
-
-  const rect = element.getBoundingClientRect()
-  const maxTooltipWidth = Math.min(
-    TOOLTIP_MAX_WIDTH_PX,
-    Math.max(120, window.innerWidth - TOOLTIP_MARGIN_PX * 2)
-  )
-  const renderedTooltipWidth = tooltipRef.value?.getBoundingClientRect().width
-  const tooltipWidth = !props.showPreview && renderedTooltipWidth > 0
-    ? Math.min(renderedTooltipWidth, maxTooltipWidth)
-    : maxTooltipWidth
-  if (props.vertical) {
-    // Place the tooltip beside the tab, keeping it inside the viewport.
-    const top = Math.max(
-      TOOLTIP_MARGIN_PX,
-      Math.min(window.innerHeight - tooltipEstimatedHeight.value, rect.top)
-    )
-    const tabBarRect = element.closest('.tabBar')?.getBoundingClientRect()
-    let adjacentEdge = props.tabBarPosition === 'right'
-      ? (tabBarRect?.left ?? rect.left)
-      : (tabBarRect?.right ?? rect.right)
-    if (props.tabBarPosition === 'right') {
-      const pageScrollbar = document.querySelector(
-        'body > .os-scrollbar-vertical:not(.os-scrollbar-unusable)'
-      )
-      if (pageScrollbar instanceof HTMLElement) {
-        adjacentEdge = Math.min(adjacentEdge, pageScrollbar.getBoundingClientRect().left)
-      }
-    }
-
-    const availableWidth = props.tabBarPosition === 'right'
-      ? adjacentEdge - TOOLTIP_OFFSET_PX - TOOLTIP_MARGIN_PX
-      : window.innerWidth - adjacentEdge - TOOLTIP_OFFSET_PX - TOOLTIP_MARGIN_PX
-    const constrainedWidth = Math.min(tooltipWidth, Math.max(120, availableWidth))
-    const horizontalPosition = props.tabBarPosition === 'right'
-      ? {
-          left: 'auto',
-          // Anchor the outer tooltip edge directly to the rail. Calculating a
-          // left position from its width drifts when preview content changes
-          // the tooltip's final box size after the first render.
-          right: `${Math.round(window.innerWidth - adjacentEdge + TOOLTIP_OFFSET_PX)}px`,
-          transformOrigin: 'right top'
-        }
-      : {
-          left: `${Math.round(adjacentEdge + TOOLTIP_OFFSET_PX)}px`,
-          right: 'auto',
-          transformOrigin: 'left top'
-        }
-    tooltipStyle.value = {
-      ...horizontalPosition,
-      maxInlineSize: `${Math.round(constrainedWidth)}px`,
-      top: `${Math.round(top)}px`
-    }
-    return
-  }
-
-  const left = Math.max(
-    TOOLTIP_MARGIN_PX,
-    Math.min(
-      window.innerWidth - tooltipWidth - TOOLTIP_MARGIN_PX,
-      rect.left + rect.width / 2 - tooltipWidth / 2
-    )
-  )
-
-  const top = props.tabBarPosition === 'bottom'
-    ? rect.top - tooltipEstimatedHeight.value - TOOLTIP_OFFSET_PX
-    : rect.bottom + TOOLTIP_OFFSET_PX
-  tooltipStyle.value = {
-    left: `${Math.round(left)}px`,
-    top: `${Math.round(Math.max(TOOLTIP_MARGIN_PX, top))}px`
-  }
-}
-
-async function loadTooltipPreview() {
-  const requestId = ++tooltipRequestId.value
-  tooltipPreviewUrl.value = null
-
-  if (
-    !props.showPreview ||
-    !process.env.IS_ELECTRON ||
-    typeof window.ftElectron?.tabs?.capturePreview !== 'function'
-  ) {
-    return
-  }
-
-  try {
-    const dataUrl = await window.ftElectron.tabs.capturePreview(props.tab.id)
-    if (requestId !== tooltipRequestId.value || !isTooltipVisible.value) {
-      return
-    }
-    tooltipPreviewUrl.value = typeof dataUrl === 'string' && dataUrl.length > 0
-      ? dataUrl
-      : null
-  } catch {
-    if (requestId === tooltipRequestId.value) {
-      tooltipPreviewUrl.value = null
-    }
-  }
-}
-
-onMounted(() => {
-  window.addEventListener('blur', handleWindowBlur)
-})
-
-onBeforeUnmount(() => {
-  window.removeEventListener('blur', handleWindowBlur)
-  hideTooltip()
-})
-
-watch(() => props.closeTooltipsSignal, () => {
-  hideTooltip()
-})
-
-watch(() => props.tab.isActive, (isActive) => {
-  if (isActive) {
-    hideTooltip()
-  }
-})
-
-watch(() => props.isDragging, (isDragging) => {
-  if (isDragging) {
-    hideTooltip()
-  }
-})
-
-watch(() => props.disableTooltips, (disableTooltips) => {
-  if (disableTooltips) {
-    hideTooltip()
-  }
-})
-
-watch(() => props.showPreview, (showPreview) => {
-  tooltipPreviewUrl.value = null
-  tooltipRequestId.value++
-  if (isTooltipVisible.value) {
-    nextTick(updateTooltipPosition)
-    if (showPreview) {
-      loadTooltipPreview()
-    }
-  }
-})
 
 watch(tabAvatarUrl, (avatarUrl) => {
   if (avatarUrl !== failedAvatarUrl.value) {
@@ -800,111 +495,4 @@ watch(tabAvatarUrl, (avatarUrl) => {
   font-size: 10px;
 }
 
-.tabTooltip {
-  box-sizing: border-box;
-  position: fixed;
-  z-index: 10000;
-  inline-size: max-content;
-  max-inline-size: min(340px, calc(100vw - 16px));
-  padding: 8px;
-  border: 1px solid var(--border-color);
-  border-radius: calc(8px * var(--ui-roundness));
-  background-color: var(--card-bg-color);
-  backdrop-filter: var(--card-bg-blur, none);
-  box-shadow: 0 8px 26px rgb(0 0 0 / 32%);
-  color: var(--primary-text-color);
-  font-family: var(--app-font-family);
-  font-weight: 400;
-  letter-spacing: 0;
-  pointer-events: none;
-  -webkit-app-region: no-drag;
-}
-
-.tabTooltip.withPreview {
-  inline-size: min(340px, calc(100vw - 16px));
-}
-
-.tabTooltipGroup {
-  align-items: center;
-  color: var(--secondary-text-color);
-  display: flex;
-  font-size: 11px;
-  gap: 6px;
-  margin-block-start: 3px;
-}
-
-.tabTooltip.withPreview .tabTooltipGroup {
-  margin-block-end: 7px;
-}
-
-.tabTooltipGroupIcon {
-  color: var(--tab-group-color);
-  flex: 0 0 auto;
-  font-size: 10px;
-}
-
-.tab-tooltip-enter-active,
-.tab-tooltip-leave-active {
-  transition: opacity 0.14s ease, transform 0.14s ease;
-}
-
-.tab-tooltip-enter-from,
-.tab-tooltip-leave-to {
-  opacity: 0;
-  transform: translateY(-4px) scale(0.985);
-}
-
-.tabTooltipPreview {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  aspect-ratio: 16 / 9;
-  inline-size: 100%;
-  overflow: hidden;
-  border-radius: calc(5px * var(--ui-roundness));
-  background-color: var(--secondary-card-bg-color);
-  backdrop-filter: var(--secondary-card-bg-blur, none);
-}
-
-.tabTooltipPreview img {
-  display: block;
-  inline-size: 100%;
-  block-size: 100%;
-  object-fit: contain;
-}
-
-.tabTooltipPreview .tabTooltipPreviewAvatar {
-  inline-size: auto;
-  block-size: 72%;
-  aspect-ratio: 1;
-  object-fit: cover;
-  border-radius: 50%;
-}
-
-.tabTooltipPreviewFallback {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  inline-size: 100%;
-  block-size: 100%;
-  color: var(--tertiary-text-color);
-}
-
-.tabTooltipFallbackIcon {
-  font-size: 24px;
-  opacity: 0.72;
-}
-
-.tabTooltipTitle {
-  margin-block-end: 7px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 12px;
-  line-height: 1.35;
-}
-
-.tabTooltipTitle:only-child {
-  margin-block-end: 0;
-}
 </style>

--- a/src/renderer/components/TabBar/TabBar.vue
+++ b/src/renderer/components/TabBar/TabBar.vue
@@ -47,31 +47,43 @@
             @close="closeTab"
             @middle-click="handleMiddleClick"
           />
-          <button
+          <TabTooltip
             v-else
-            class="tabBarReorderItem collapsedTabGroup"
-            :class="{
-              active: item.isActive,
-              bottom: tabBarPosition === 'bottom',
-              noTransition: suppressTransitions,
-              vertical
-            }"
-            :data-reorder-id="item.id"
-            :data-group-id="item.group.id"
-            :style="collapsedGroupStyle(item)"
-            :aria-label="collapsedGroupLabel(item)"
-            :title="collapsedGroupLabel(item)"
-            :aria-expanded="false"
-            @click="expandTabGroup(item.group.id)"
+            :title="item.group.name"
+            :tabs="item.tabs"
+            is-group
+            :tab-bar-position="tabBarPosition"
+            :disable-tooltips="draggingTabIds.size > 0"
+            :close-tooltips-signal="closeTooltipsSignal"
+            :show-preview="showTabPreviews"
           >
-            <FtIcon
-              :icon="['fas', 'layer-group']"
-              aria-hidden="true"
-            />
-            <span class="collapsedTabGroupName">
-              {{ item.group.name }}
-            </span>
-          </button>
+            <template #anchor="{ bindings }">
+              <button
+                v-bind="bindings"
+                class="tabBarReorderItem collapsedTabGroup"
+                :class="{
+                  active: item.isActive,
+                  bottom: tabBarPosition === 'bottom',
+                  noTransition: suppressTransitions,
+                  vertical
+                }"
+                :data-reorder-id="item.id"
+                :data-group-id="item.group.id"
+                :style="collapsedGroupStyle(item)"
+                :aria-label="collapsedGroupLabel(item)"
+                :aria-expanded="false"
+                @click="expandTabGroup(item.group.id)"
+              >
+                <FtIcon
+                  :icon="['fas', 'layer-group']"
+                  aria-hidden="true"
+                />
+                <span class="collapsedTabGroupName">
+                  {{ item.group.name }}
+                </span>
+              </button>
+            </template>
+          </TabTooltip>
         </template>
       </div>
       <div
@@ -143,6 +155,7 @@ import { fetchTabAvatarBytes } from '../../helpers/tabAvatar'
 import { loadMissingTabAvatars } from '../../helpers/loadTabAvatars'
 import { clampOverlayScrollTop } from '../../helpers/overlayScrollbars'
 import SortableTab from './SortableTab.vue'
+import TabTooltip from './TabTooltip.vue'
 import {
   buildCurrentShiftedTabIds,
   buildShiftedTabIds,
@@ -203,6 +216,7 @@ function buildStripItems(currentTabs) {
       id: `group:${group.id}`,
       type: 'group',
       group,
+      tabs: groupTabs,
       tabIds: groupTabs.map(groupTab => groupTab.id),
       isPinned: tab.isPinned,
       isActive: groupTabs.some(groupTab => groupTab.isActive)

--- a/src/renderer/components/TabBar/TabBar.vue
+++ b/src/renderer/components/TabBar/TabBar.vue
@@ -51,6 +51,7 @@
             v-else
             :title="item.group.name"
             :tabs="item.tabs"
+            :show-icon="showTabIcons"
             is-group
             :tab-bar-position="tabBarPosition"
             :disable-tooltips="draggingTabIds.size > 0"

--- a/src/renderer/components/TabBar/TabTooltip.vue
+++ b/src/renderer/components/TabBar/TabTooltip.vue
@@ -1,0 +1,423 @@
+<template>
+  <slot
+    name="anchor"
+    :bindings="triggerBindings"
+  />
+  <Teleport to="body">
+    <Transition name="tab-tooltip">
+      <div
+        v-if="isTooltipVisible"
+        :id="tooltipId"
+        ref="tooltipRef"
+        class="tabTooltip"
+        :class="{ withPreview: showPreview, tabGroupTooltip: isGroup }"
+        data-tab-preview-overlay
+        :style="tooltipStyle"
+        role="tooltip"
+      >
+        <div class="tabTooltipTitle">
+          {{ title }}
+        </div>
+        <div
+          v-if="isGroup"
+          class="tabTooltipCount"
+        >
+          {{ t('Tab Organizer.Tab Count', { count: tabs.length }, tabs.length) }}
+        </div>
+        <div
+          v-else-if="group"
+          class="tabTooltipGroup"
+          :style="{ '--tab-group-color': getTabAccentColor(group.color) || 'var(--secondary-text-color)' }"
+        >
+          <FtIcon
+            :icon="['fas', 'layer-group']"
+            class="tabTooltipGroupIcon"
+            aria-hidden="true"
+          />
+          {{ group.name }}
+        </div>
+        <template v-if="showPreview">
+          <div
+            v-if="isGroup"
+            class="tabTooltipGrid"
+          >
+            <div
+              v-for="tab in previewTabs"
+              :key="tab.id"
+              class="tabTooltipGridItem"
+            >
+              <TabTooltipPreview :tab="tab" />
+              <div class="tabTooltipGridTitle">
+                {{ formatTabTitle(tab.title) }}
+              </div>
+            </div>
+          </div>
+          <TabTooltipPreview
+            v-else-if="tabs[0]"
+            :tab="tabs[0]"
+          />
+          <div
+            v-if="isGroup && tabs.length > previewTabs.length"
+            class="tabTooltipCount tabTooltipRemaining"
+          >
+            {{ `+${tabs.length - previewTabs.length}` }}
+          </div>
+        </template>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup>
+import { FtIcon } from '@opentubex/icons'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, useTemplateRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { getTabAccentColor } from '../../constants/tabColors'
+import { formatTabTitle } from '../../tabs/tabTitle'
+import TabTooltipPreview from './TabTooltipPreview.vue'
+
+const props = defineProps({
+  title: { type: String, required: true },
+  tabs: { type: Array, required: true },
+  group: { type: Object, default: null },
+  isGroup: { type: Boolean, default: false },
+  isActive: { type: Boolean, default: false },
+  tabBarPosition: { type: String, default: 'top' },
+  disableTooltips: { type: Boolean, default: false },
+  closeTooltipsSignal: { type: Number, default: 0 },
+  showPreview: { type: Boolean, default: true }
+})
+
+const { t } = useI18n()
+const TOOLTIP_MAX_WIDTH_PX = 340
+const TOOLTIP_MARGIN_PX = 8
+const TOOLTIP_OFFSET_PX = 6
+const TOOLTIP_SHOW_DELAY_MS = 80
+const tabRef = ref(null)
+const tooltipRef = useTemplateRef('tooltipRef')
+const tooltipId = useId()
+const isTooltipVisible = ref(false)
+const tooltipStyle = ref({})
+// Keep large groups quick to inspect without turning a hover tooltip into a scroller.
+const previewTabs = computed(() => props.tabs.slice(0, 6))
+const resizeObserver = new ResizeObserver(updateTooltipPosition)
+let showTooltipTimeoutId = null
+let suppressTooltipUntilPointerLeave = false
+
+const triggerBindings = computed(() => ({
+  ref: element => { tabRef.value = element },
+  'aria-describedby': isTooltipVisible.value ? tooltipId : undefined,
+  onPointerenter: handlePointerEnter,
+  onPointerleave: handlePointerLeave,
+  onFocusin: showTooltip,
+  onFocusout: hideTooltip,
+  onPointerdown: handlePointerDown
+}))
+
+function showTooltip() {
+  if (props.disableTooltips || suppressTooltipUntilPointerLeave) {
+    return
+  }
+
+  clearShowTooltipTimeout()
+  showTooltipTimeoutId = window.setTimeout(() => {
+    showTooltipTimeoutId = null
+    if (props.disableTooltips || suppressTooltipUntilPointerLeave) {
+      return
+    }
+
+    updateTooltipPosition()
+    isTooltipVisible.value = true
+    nextTick(updateTooltipPosition)
+    addTooltipDismissListeners()
+    window.addEventListener('resize', updateTooltipPosition)
+    nextTick(() => {
+      if (isTooltipVisible.value && tooltipRef.value) resizeObserver.observe(tooltipRef.value)
+    })
+  }, TOOLTIP_SHOW_DELAY_MS)
+}
+
+function handlePointerEnter() {
+  suppressTooltipUntilPointerLeave = false
+  showTooltip()
+}
+
+function handlePointerLeave() {
+  if (document.hasFocus()) {
+    suppressTooltipUntilPointerLeave = false
+  }
+  hideTooltip()
+}
+
+function handlePointerDown() {
+  suppressTooltipUntilPointerLeave = true
+  hideTooltip()
+}
+
+function handleWindowBlur() {
+  suppressTooltipUntilPointerLeave = true
+  hideTooltip()
+}
+
+function hideTooltip() {
+  clearShowTooltipTimeout()
+  isTooltipVisible.value = false
+  resizeObserver.disconnect()
+  removeTooltipDismissListeners()
+  window.removeEventListener('resize', updateTooltipPosition)
+}
+
+function clearShowTooltipTimeout() {
+  if (showTooltipTimeoutId != null) {
+    clearTimeout(showTooltipTimeoutId)
+    showTooltipTimeoutId = null
+  }
+}
+
+function addTooltipDismissListeners() {
+  document.addEventListener('pointerdown', hideTooltip, true)
+  document.addEventListener('wheel', hideTooltip, true)
+  document.addEventListener('visibilitychange', hideTooltip, true)
+  document.addEventListener('keydown', handleTooltipKeydown, true)
+}
+
+function removeTooltipDismissListeners() {
+  document.removeEventListener('pointerdown', hideTooltip, true)
+  document.removeEventListener('wheel', hideTooltip, true)
+  document.removeEventListener('visibilitychange', hideTooltip, true)
+  document.removeEventListener('keydown', handleTooltipKeydown, true)
+}
+
+/**
+ * @param {KeyboardEvent} event
+ */
+function handleTooltipKeydown(event) {
+  if (event.key === 'Escape') {
+    hideTooltip()
+  }
+}
+
+function updateTooltipPosition() {
+  const element = tabRef.value
+  if (!(element instanceof HTMLElement)) {
+    return
+  }
+
+  const rect = element.getBoundingClientRect()
+  const tabBarRect = element.closest('.tabBar')?.getBoundingClientRect()
+  const maxTooltipWidth = Math.min(
+    props.isGroup ? 420 : TOOLTIP_MAX_WIDTH_PX,
+    Math.max(120, window.innerWidth - TOOLTIP_MARGIN_PX * 2)
+  )
+  const tooltipHeight = tooltipRef.value?.offsetHeight ?? 240
+  const renderedTooltipWidth = tooltipRef.value?.offsetWidth
+  const tooltipWidth = !props.showPreview && renderedTooltipWidth > 0
+    ? Math.min(renderedTooltipWidth, maxTooltipWidth)
+    : maxTooltipWidth
+  if (['left', 'right'].includes(props.tabBarPosition)) {
+    // Place the tooltip beside the tab, keeping it inside the viewport.
+    const top = Math.max(
+      TOOLTIP_MARGIN_PX,
+      Math.min(window.innerHeight - tooltipHeight - TOOLTIP_MARGIN_PX, rect.top)
+    )
+    let adjacentEdge = props.tabBarPosition === 'right'
+      ? (tabBarRect?.left ?? rect.left)
+      : (tabBarRect?.right ?? rect.right)
+    if (props.tabBarPosition === 'right') {
+      const pageScrollbar = document.querySelector(
+        'body > .os-scrollbar-vertical:not(.os-scrollbar-unusable)'
+      )
+      if (pageScrollbar instanceof HTMLElement) {
+        adjacentEdge = Math.min(adjacentEdge, pageScrollbar.getBoundingClientRect().left)
+      }
+    }
+
+    const availableWidth = props.tabBarPosition === 'right'
+      ? adjacentEdge - TOOLTIP_OFFSET_PX - TOOLTIP_MARGIN_PX
+      : window.innerWidth - adjacentEdge - TOOLTIP_OFFSET_PX - TOOLTIP_MARGIN_PX
+    const constrainedWidth = Math.min(tooltipWidth, Math.max(120, availableWidth))
+    const horizontalPosition = props.tabBarPosition === 'right'
+      ? {
+          left: 'auto',
+          // Anchor the outer tooltip edge directly to the rail. Calculating a
+          // left position from its width drifts when preview content changes
+          // the tooltip's final box size after the first render.
+          right: `${Math.round(window.innerWidth - adjacentEdge + TOOLTIP_OFFSET_PX)}px`,
+          transformOrigin: 'right top'
+        }
+      : {
+          left: `${Math.round(adjacentEdge + TOOLTIP_OFFSET_PX)}px`,
+          right: 'auto',
+          transformOrigin: 'left top'
+        }
+    tooltipStyle.value = {
+      ...horizontalPosition,
+      maxInlineSize: `${Math.round(constrainedWidth)}px`,
+      top: `${Math.round(top)}px`
+    }
+    return
+  }
+
+  const left = Math.max(
+    TOOLTIP_MARGIN_PX,
+    Math.min(
+      window.innerWidth - tooltipWidth - TOOLTIP_MARGIN_PX,
+      rect.left + rect.width / 2 - tooltipWidth / 2
+    )
+  )
+
+  const anchorEdge = props.tabBarPosition === 'bottom'
+    ? (tabBarRect?.top ?? rect.top)
+    : (tabBarRect?.bottom ?? rect.bottom)
+  const availableHeight = Math.max(0, (props.tabBarPosition === 'bottom'
+    ? anchorEdge
+    : window.innerHeight - anchorEdge) - TOOLTIP_OFFSET_PX - TOOLTIP_MARGIN_PX)
+  const height = props.isGroup ? Math.min(tooltipHeight, availableHeight) : tooltipHeight
+  const top = props.tabBarPosition === 'bottom'
+    ? anchorEdge - height - TOOLTIP_OFFSET_PX
+    : anchorEdge + TOOLTIP_OFFSET_PX
+  tooltipStyle.value = {
+    left: `${Math.round(left)}px`,
+    maxBlockSize: props.isGroup ? `${availableHeight}px` : undefined,
+    top: `${Math.round(Math.max(TOOLTIP_MARGIN_PX, Math.min(top, window.innerHeight - height - TOOLTIP_MARGIN_PX)))}px`
+  }
+}
+
+onMounted(() => window.addEventListener('blur', handleWindowBlur))
+onBeforeUnmount(() => {
+  window.removeEventListener('blur', handleWindowBlur)
+  hideTooltip()
+})
+
+watch(() => props.closeTooltipsSignal, hideTooltip)
+watch(() => props.isActive, active => { if (active) hideTooltip() })
+watch(() => props.disableTooltips, disabled => { if (disabled) hideTooltip() })
+watch(() => props.tabBarPosition, hideTooltip)
+watch(() => props.showPreview, () => nextTick(updateTooltipPosition))
+</script>
+
+<style scoped>
+.tabTooltip {
+  box-sizing: border-box;
+  position: fixed;
+  z-index: 10000;
+  inline-size: max-content;
+  max-inline-size: min(340px, calc(100vw - 16px));
+  padding: 8px;
+  border: 1px solid var(--border-color);
+  border-radius: calc(8px * var(--ui-roundness));
+  background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
+  box-shadow: 0 8px 26px rgb(0 0 0 / 32%);
+  color: var(--primary-text-color);
+  font-family: var(--app-font-family);
+  font-weight: 400;
+  letter-spacing: 0;
+  pointer-events: none;
+  -webkit-app-region: no-drag;
+}
+
+.tabTooltip.withPreview {
+  inline-size: min(340px, calc(100vw - 16px));
+}
+
+.tabTooltipGroup {
+  align-items: center;
+  color: var(--secondary-text-color);
+  display: flex;
+  font-size: 11px;
+  gap: 6px;
+  margin-block-start: 3px;
+}
+
+.tabTooltip.withPreview .tabTooltipGroup {
+  margin-block-end: 7px;
+}
+
+.tabTooltipGroupIcon {
+  color: var(--tab-group-color);
+  flex: 0 0 auto;
+  font-size: 10px;
+}
+
+.tab-tooltip-enter-active,
+.tab-tooltip-leave-active {
+  transition: opacity 0.14s ease, transform 0.14s ease;
+}
+
+.tab-tooltip-enter-from,
+.tab-tooltip-leave-to {
+  opacity: 0;
+  transform: translateY(-4px) scale(0.985);
+}
+
+.tabTooltipTitle {
+  margin-block-end: 7px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.tabTooltipTitle:only-child {
+  margin-block-end: 0;
+}
+
+.tabTooltip.tabGroupTooltip.withPreview {
+  inline-size: min(420px, calc(100vw - 16px));
+  max-inline-size: min(420px, calc(100vw - 16px));
+  max-block-size: calc(100vh - 16px);
+  display: flex;
+  flex-direction: column;
+}
+
+.tabTooltipCount {
+  color: var(--secondary-text-color);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.tabTooltipGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-auto-rows: minmax(0, 1fr);
+  gap: 10px;
+  margin-block-start: 8px;
+  min-block-size: 0;
+}
+
+.tabTooltipGridItem {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-inline-size: 0;
+  min-block-size: 0;
+}
+
+.tabTooltipGridItem :deep(.tabTooltipPreview) {
+  min-block-size: 0;
+  flex-shrink: 1;
+}
+
+.tabTooltipGridTitle {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: 12px;
+  line-height: 1.35;
+  flex-shrink: 0;
+}
+
+.tabTooltipRemaining {
+  margin-block-start: 8px;
+  text-align: end;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tab-tooltip-enter-active,
+  .tab-tooltip-leave-active {
+    transition: none;
+  }
+}
+</style>

--- a/src/renderer/components/TabBar/TabTooltip.vue
+++ b/src/renderer/components/TabBar/TabTooltip.vue
@@ -46,10 +46,11 @@
               :key="tab.id"
               class="tabTooltipGridItem"
             >
-              <TabTooltipPreview :tab="tab" />
-              <div class="tabTooltipGridTitle">
-                {{ formatTabTitle(tab.title) }}
-              </div>
+              <TabTooltipPreview
+                :tab="tab"
+                show-title
+                :show-icon="showIcon"
+              />
             </div>
           </div>
           <TabTooltipPreview
@@ -73,7 +74,6 @@ import { FtIcon } from '@opentubex/icons'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { getTabAccentColor } from '../../constants/tabColors'
-import { formatTabTitle } from '../../tabs/tabTitle'
 import TabTooltipPreview from './TabTooltipPreview.vue'
 
 const props = defineProps({
@@ -85,7 +85,8 @@ const props = defineProps({
   tabBarPosition: { type: String, default: 'top' },
   disableTooltips: { type: Boolean, default: false },
   closeTooltipsSignal: { type: Number, default: 0 },
-  showPreview: { type: Boolean, default: true }
+  showPreview: { type: Boolean, default: true },
+  showIcon: { type: Boolean, default: true }
 })
 
 const { t } = useI18n()
@@ -398,15 +399,6 @@ watch(() => props.showPreview, () => nextTick(updateTooltipPosition))
 .tabTooltipGridItem :deep(.tabTooltipPreview) {
   min-block-size: 0;
   flex-shrink: 1;
-}
-
-.tabTooltipGridTitle {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  font-size: 12px;
-  line-height: 1.35;
-  flex-shrink: 0;
 }
 
 .tabTooltipRemaining {

--- a/src/renderer/components/TabBar/TabTooltipPreview.vue
+++ b/src/renderer/components/TabBar/TabTooltipPreview.vue
@@ -21,10 +21,30 @@
       aria-hidden="true"
     >
       <FtIcon
-        :icon="getTabPageIcon(tab) || ['fas', 'display']"
+        :icon="pageIcon || ['fas', 'display']"
         class="tabTooltipFallbackIcon"
       />
     </div>
+  </div>
+  <div
+    v-if="showTitle"
+    class="tabTooltipGridTitle"
+  >
+    <img
+      v-if="showIcon && avatarUrl && avatarUrl !== failedAvatarUrl"
+      :src="avatarUrl"
+      class="tabTooltipGridTitleAvatar"
+      alt=""
+      draggable="false"
+      @error="failedAvatarUrl = avatarUrl"
+    >
+    <FtIcon
+      v-else-if="showIcon && pageIcon"
+      :icon="pageIcon"
+      class="tabTooltipGridTitleIcon"
+      aria-hidden="true"
+    />
+    <span class="tabTooltipGridTitleText">{{ formatTabTitle(tab.title) }}</span>
   </div>
 </template>
 
@@ -32,11 +52,17 @@
 import { FtIcon } from '@opentubex/icons'
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import { getTabAvatarUrl, getTabPageIcon, getTabPreviewFallbackUrl } from '../../tabs/tabPreview'
+import { formatTabTitle } from '../../tabs/tabTitle'
 
-const props = defineProps({ tab: { type: Object, required: true } })
+const props = defineProps({
+  tab: { type: Object, required: true },
+  showTitle: { type: Boolean, default: false },
+  showIcon: { type: Boolean, default: true }
+})
 const previewUrl = ref(null)
 const failedAvatarUrl = ref(null)
 const avatarUrl = computed(() => getTabAvatarUrl(props.tab) || getTabPreviewFallbackUrl(props.tab))
+const pageIcon = computed(() => getTabPageIcon(props.tab))
 let requestId = 0
 
 watch(() => props.tab.id, async tabId => {
@@ -98,4 +124,36 @@ onBeforeUnmount(() => { requestId++ })
   opacity: 0.72;
 }
 
+.tabTooltipGridTitle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-inline-size: 0;
+  font-size: 12px;
+  line-height: 1.35;
+  flex-shrink: 0;
+}
+
+.tabTooltipGridTitleText {
+  min-inline-size: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.tabTooltipGridTitleAvatar,
+.tabTooltipGridTitleIcon {
+  inline-size: 14px;
+  block-size: 14px;
+  flex-shrink: 0;
+}
+
+.tabTooltipGridTitleAvatar {
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.tabTooltipGridTitleIcon {
+  color: var(--secondary-text-color);
+}
 </style>

--- a/src/renderer/components/TabBar/TabTooltipPreview.vue
+++ b/src/renderer/components/TabBar/TabTooltipPreview.vue
@@ -1,0 +1,101 @@
+<template>
+  <div class="tabTooltipPreview">
+    <img
+      v-if="previewUrl"
+      :src="previewUrl"
+      alt=""
+      draggable="false"
+      @error="previewUrl = null"
+    >
+    <img
+      v-else-if="avatarUrl && avatarUrl !== failedAvatarUrl"
+      :src="avatarUrl"
+      alt=""
+      class="tabTooltipPreviewAvatar"
+      draggable="false"
+      @error="failedAvatarUrl = avatarUrl"
+    >
+    <div
+      v-else
+      class="tabTooltipPreviewFallback"
+      aria-hidden="true"
+    >
+      <FtIcon
+        :icon="getTabPageIcon(tab) || ['fas', 'display']"
+        class="tabTooltipFallbackIcon"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { FtIcon } from '@opentubex/icons'
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { getTabAvatarUrl, getTabPageIcon, getTabPreviewFallbackUrl } from '../../tabs/tabPreview'
+
+const props = defineProps({ tab: { type: Object, required: true } })
+const previewUrl = ref(null)
+const failedAvatarUrl = ref(null)
+const avatarUrl = computed(() => getTabAvatarUrl(props.tab) || getTabPreviewFallbackUrl(props.tab))
+let requestId = 0
+
+watch(() => props.tab.id, async tabId => {
+  const currentRequestId = ++requestId
+  previewUrl.value = null
+  if (!process.env.IS_ELECTRON || typeof window.ftElectron?.tabs?.capturePreview !== 'function') return
+  try {
+    const dataUrl = await window.ftElectron.tabs.capturePreview(tabId)
+    if (currentRequestId === requestId) {
+      previewUrl.value = typeof dataUrl === 'string' && dataUrl.length > 0 ? dataUrl : null
+    }
+  } catch {
+    // Unloaded tabs or failed captures keep their avatar or page icon.
+  }
+}, { immediate: true })
+
+onBeforeUnmount(() => { requestId++ })
+</script>
+
+<style scoped>
+.tabTooltipPreview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 16 / 9;
+  inline-size: 100%;
+  overflow: hidden;
+  border-radius: calc(5px * var(--ui-roundness));
+  background-color: var(--secondary-card-bg-color);
+  backdrop-filter: var(--secondary-card-bg-blur, none);
+}
+
+.tabTooltipPreview img {
+  display: block;
+  inline-size: 100%;
+  block-size: 100%;
+  object-fit: contain;
+}
+
+.tabTooltipPreview .tabTooltipPreviewAvatar {
+  inline-size: auto;
+  block-size: 72%;
+  aspect-ratio: 1;
+  object-fit: cover;
+  border-radius: 50%;
+}
+
+.tabTooltipPreviewFallback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  inline-size: 100%;
+  block-size: 100%;
+  color: var(--tertiary-text-color);
+}
+
+.tabTooltipFallbackIcon {
+  font-size: 24px;
+  opacity: 0.72;
+}
+
+</style>


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Requested directly in the task; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Collapsed tab groups only showed a native text tooltip, making it hard to see which tabs they contained. They now share the custom tooltip used by normal tabs and show a grid of up to six previews with tab icons and titles, the total tab count, and a count for additional tabs.

The grid respects the preview setting, uses fallback icons or avatars when screenshots are unavailable, and fits all four tab-bar positions, including fractional UI scales.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Tab groups now show tab previews with titles and icons in a custom tooltip.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/a4b0d1ae-9b3b-45cd-89b0-063437f2a2aa">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/17e137f3-7c59-4d8b-a81a-2418fc17bbb6">
  <img alt="A collapsed tab group showing previews with each tab icon beside its title" src="https://github.com/user-attachments/assets/a4b0d1ae-9b3b-45cd-89b0-063437f2a2aa">
</picture>
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open several tabs, put them in a group, and collapse the group in Tab Organizer. Hover or keyboard-focus the group in the tab bar. A custom tooltip should show its name, tab count, and previews with each tab’s icon to the left of its title.
2. Add more than six tabs to the group. The tooltip should show six previews and a count for the remaining tabs. Unloaded tabs should use fallback images or icons without being loaded.
3. Disable “Show tab previews” in Settings. The tooltip should retain its name and count while hiding the grid. Re-enable the setting to restore previews. Turn “Show tab icons” off and on to verify that title icons follow the setting.
4. Try top, bottom, left, and right tab bars at 95% UI scale, including a short window. The tooltip should fit beside the bar and stay inside the window. Check both light and dark themes.
5. Press Escape, move focus away, or click the group. The tooltip should close. Normal-tab tooltips should still show previews and dismiss as before.


## Additional context
<!-- Add any other context about the pull request here. -->
Implemented and reviewed with Codex.



