### PR TITLE
feat(android): show icons for tabs from other devices

### DIFF
--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -297,6 +297,70 @@ test('fits synced-device tabs in the phone tab organizer', async ({ app, page })
   ))).toBe(true)
 })
 
+for (const iconPack of ['material', 'remix']) {
+  test(`shows synced tab avatars and page icons in the phone organizer with ${iconPack}`, async ({ app, page }, testInfo) => {
+    await setWindowSize(app, page, { width: 375, height: 760 })
+    await enablePhoneTabSwitcher(page)
+    const avatar = 'data:image/svg+xml,' + encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><rect width="24" height="24" fill="green"/></svg>')
+    await page.route('https://example.com/retry-avatar.svg*', route => route.fulfill({
+      contentType: 'image/svg+xml',
+      body: route.request().url().includes('opentubex_retry=')
+        ? decodeURIComponent(avatar.split(',')[1])
+        : 'invalid image',
+    }))
+    await page.evaluate(async ({ pack, avatarUrl }) => {
+      const store = document.querySelector('#app')._vnode.component.appContext.config.globalProperties.$store
+      await store.dispatch('updateIconPack', pack)
+      store.commit('setSyncServerEnabled', true)
+      store.commit('setSyncServerToken', 'e2e-token')
+      store.commit('setSyncServerPrivacyMode', 'enhanced')
+      store.commit('setSyncServerSyncSessions', true)
+      store.commit('setChannelThumbnail', { channelId: 'cached-channel', thumbnail: avatarUrl })
+      store.commit('setVideoAvatar', { videoId: 'cached-video', avatar: avatarUrl })
+      store.commit('setSyncServerOtherDeviceSessions', [{
+        syncDeviceId: 'desktop-e2e',
+        syncPlatform: 'desktop',
+        sessionId: 'desktop-session',
+        tabs: [
+          { id: 'history', title: 'History', url: 'app://bundle/index.html#/history?search=test' },
+          { id: 'subscriptions', title: 'Subscriptions', url: 'https://localhost/subscriptions' },
+          { id: 'channel', title: 'Cached channel', url: 'app://bundle/index.html#/channel/cached-channel' },
+          { id: 'video', title: 'Cached video', url: '/watch/cached-video?t=30' },
+          { id: 'avatar', title: 'Saved avatar', url: '/watch/saved-avatar', avatarUrl },
+          { id: 'broken', title: 'Broken avatar', url: '/watch/broken', avatarUrl: 'data:image/png;base64,invalid' },
+          { id: 'retry', title: 'Retry avatar', url: '/watch/retry', avatarUrl: 'https://example.com/retry-avatar.svg' },
+          { id: 'unknown', title: 'Unknown page', url: '/unknown' },
+        ],
+      }])
+    }, { pack: iconPack, avatarUrl: avatar })
+
+    await page.locator('.capacitorPhoneTabSwitcherButton').click()
+    const organizer = page.locator('.capacitorPhoneTabDialog')
+    await organizer.getByRole('tab', { name: 'Tabs from other devices' }).click()
+    const row = title => organizer.getByRole('button', { name: title, exact: true })
+    for (const [title, icon] of [['History', 'clock-rotate-left'], ['Subscriptions', 'rss'], ['Broken avatar', 'clapperboard'], ['Unknown page', 'display']]) {
+      const glyph = row(title).locator(`[data-icon="${icon}"]`)
+      await expect(glyph).toBeVisible()
+      await expect(glyph).toHaveAttribute('data-icon-pack', iconPack)
+    }
+    for (const title of ['Cached channel', 'Cached video', 'Saved avatar']) {
+      await expect(row(title).locator('img')).toHaveAttribute('src', avatar)
+      await expect.poll(() => row(title).locator('img').evaluate(image => image.naturalWidth)).toBe(24)
+    }
+    await expect(row('Broken avatar').locator('img')).toBeHidden()
+    await expect(row('Retry avatar').locator('[data-icon="clapperboard"]')).toBeVisible()
+    await expect(row('Retry avatar').locator('img')).toBeVisible()
+    await expect.poll(() => row('Retry avatar').locator('img').evaluate(image => image.naturalWidth)).toBe(24)
+    await expect(row('Retry avatar').locator('[data-icon="clapperboard"]')).toHaveCount(0)
+
+    const screenshot = testInfo.outputPath(`phone-synced-tab-icons-${iconPack}.png`)
+    await organizer.screenshot({ path: screenshot })
+    await testInfo.attach('Phone synced tab icons', { path: screenshot, contentType: 'image/png' })
+    await setWindowSize(app, page, { width: 760, height: 375 })
+    await expect.poll(() => organizer.evaluate(element => element.scrollWidth <= element.clientWidth + 1)).toBe(true)
+  })
+}
+
 test('shows remote tab sets as tabs and confirms deletion in the phone organizer', async ({ app, page }) => {
   await setWindowSize(app, page, { width: 375, height: 760 })
   await page.evaluate(() => window.ftElectron.setZoomFactor(0.95))

--- a/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.css
+++ b/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.css
@@ -513,6 +513,18 @@
   inline-size: 100%;
 }
 
+.capacitorPhoneSyncedTabIcon {
+  display: grid;
+  place-items: center;
+  inline-size: 24px;
+  block-size: 24px;
+}
+
+.capacitorPhoneSyncedTabIcon .capacitorPhoneTabAvatar {
+  inline-size: 24px;
+  block-size: 24px;
+}
+
 .capacitorPhoneSyncedTabList span {
   min-inline-size: 0;
   overflow: hidden;

--- a/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.vue
+++ b/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.vue
@@ -299,16 +299,27 @@
                     </header>
                     <div class="capacitorPhoneSyncedTabList">
                       <button
-                        v-for="tab in activeOtherDeviceSession.tabs"
+                        v-for="tab in activeOtherDeviceTabs"
                         :key="tab.id"
                         type="button"
                         class="capacitorPhoneSyncedTabButton capacitorPhoneSyncedTabTarget"
                         @click="openOtherDeviceSession({ ...activeOtherDeviceSession, tabs: [tab] })"
                       >
-                        <FtIcon
-                          :icon="['fas', 'arrow-up-right-from-square']"
-                          aria-hidden="true"
-                        />
+                        <span class="capacitorPhoneSyncedTabIcon">
+                          <FtRetryImage
+                            v-if="getTabAvatarUrl(tab)"
+                            v-show="!failedSyncedTabAvatarUrls.has(getTabAvatarUrl(tab))"
+                            :src="getTabAvatarUrl(tab)"
+                            class="capacitorPhoneTabAvatar"
+                            @error="failedSyncedTabAvatarUrls.add(getTabAvatarUrl(tab))"
+                            @load="failedSyncedTabAvatarUrls.delete(getTabAvatarUrl(tab))"
+                          />
+                          <FtIcon
+                            v-if="!getTabAvatarUrl(tab) || failedSyncedTabAvatarUrls.has(getTabAvatarUrl(tab))"
+                            :icon="getTabPageIcon(tab) || ['fas', 'display']"
+                            aria-hidden="true"
+                          />
+                        </span>
                         <span dir="auto">{{ tab.title || tab.url }}</span>
                       </button>
                     </div>
@@ -372,7 +383,7 @@ import { clampOverlayScrollTop, restoreOverlayScrollTop } from '../../helpers/ov
 import { formatDeviceSessionLabel, shouldShowOtherDeviceSessions } from '../../helpers/sync-sessions'
 import { showToast } from '../../helpers/utils'
 import { getCapacitorTabService } from '../../tabs/CapacitorTabService'
-import { getTabAvatarUrl, getTabPageIcon } from '../../tabs/tabPreview'
+import { getSyncedTabPreview, getTabAvatarUrl, getTabPageIcon } from '../../tabs/tabPreview'
 import FtPrompt from '../FtPrompt/FtPrompt.vue'
 import FtRetryImage from '../FtRetryImage.vue'
 import { lockBodyScroll, unlockBodyScroll } from '../FtPrompt/scrollLock'
@@ -394,6 +405,7 @@ const syncedSessionIdPrefix = `capacitor-phone-synced-session-${useId().replaceA
 const syncedSessionPanelId = `${syncedSessionIdPrefix}-panel`
 const selectedOtherDeviceSessionKey = ref(null)
 const sessionToDelete = ref(null)
+const failedSyncedTabAvatarUrls = ref(new Set())
 const triggerRef = useTemplateRef('triggerRef')
 const dialogRef = useTemplateRef('dialogRef')
 const openTabsScrollRef = useTemplateRef('openTabsScrollRef')
@@ -412,6 +424,9 @@ const activeOtherDeviceSession = computed(() => (
   otherDeviceSessions.value.find(session => (
     otherDeviceSessionKey(session) === selectedOtherDeviceSessionKey.value
   )) ?? otherDeviceSessions.value[0] ?? null
+))
+const activeOtherDeviceTabs = computed(() => (
+  activeOtherDeviceSession.value?.tabs.map(getSyncedTabPreview) ?? []
 ))
 const activeOtherDeviceSessionKey = computed(() => (
   activeOtherDeviceSession.value ? otherDeviceSessionKey(activeOtherDeviceSession.value) : null

--- a/src/renderer/components/TabOrganizer/TabOrganizer.vue
+++ b/src/renderer/components/TabOrganizer/TabOrganizer.vue
@@ -626,7 +626,7 @@ import { clampOverlayScrollTop, restoreOverlayScrollTop } from '../../helpers/ov
 import { formatDeviceSessionLabel, getSyncTabRoute, shouldShowOtherDeviceSessions } from '../../helpers/sync-sessions'
 import { showToast } from '../../helpers/utils'
 import store from '../../store/index'
-import { getTabAvatarUrl, getTabPageIcon } from '../../tabs/tabPreview'
+import { getSyncedTabPreview as syncedTabPreview, getTabAvatarUrl, getTabPageIcon } from '../../tabs/tabPreview'
 import { formatTabTitle } from '../../tabs/tabTitle'
 import FtCheckboxList from '../FtCheckboxList/FtCheckboxList.vue'
 import FtPrompt from '../FtPrompt/FtPrompt.vue'
@@ -834,15 +834,6 @@ function handleTabAvatarError(tab) {
   failedTabAvatarUrls.value = {
     ...failedTabAvatarUrls.value,
     [tab.id]: getTabAvatarUrl(tab)
-  }
-}
-
-function syncedTabPreview(tab) {
-  try {
-    const url = new URL(getSyncTabRoute(tab.url), window.location.origin)
-    return { ...tab, route: { path: url.pathname } }
-  } catch {
-    return tab
   }
 }
 

--- a/src/renderer/tabs/tabPreview.js
+++ b/src/renderer/tabs/tabPreview.js
@@ -1,6 +1,16 @@
 import store from '../store/index'
+import { getSyncTabRoute } from '../helpers/sync-sessions'
 
 export { getTabPageIcon } from './tabPageIcon'
+
+export function getSyncedTabPreview(tab) {
+  try {
+    const url = new URL(getSyncTabRoute(tab.url), window.location.origin)
+    return { ...tab, route: { path: url.pathname } }
+  } catch {
+    return tab
+  }
+}
 
 /**
  * Resolve the fallback preview image for a tab when no screenshot has been


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Requested directly by the maintainer; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Android showed the same open arrow for every tab from another device, while desktop displayed page icons and available avatars. Reuse desktop's route resolver in the Android organizer and display the matching page icon or avatar, retaining Android's image retries and an icon fallback if loading fails.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Android's tab organizer now shows page icons and available channel avatars for tabs from other devices.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/74a7feb1-96c6-4507-8968-0bb891c47865">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/e3d9dd4f-7bee-49c1-b3be-179be3ffe50b">
  <img alt="Android tab organizer showing page icons and channel avatars for tabs from another device" src="https://github.com/user-attachments/assets/74a7feb1-96c6-4507-8968-0bb891c47865">
</picture>
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run this branch in Android dev mode with tab synchronization enabled and tabs from another device available.
2. Open the tab organizer and select **Tabs from other devices**. Confirm History, Subscriptions, and other pages show their matching icons.
3. Confirm channels and videos with supplied or locally cached avatars show those images. Uncached channels should show the generic channel icon.
4. Check both Material and Remix icon packs and rotate between portrait and landscape. Labels should remain readable and rows should fit the panel.
5. Open a synced tab and switch device sessions to confirm the existing actions still work.

## Additional context
<!-- Add any other context about the pull request here. -->

The accepted desktop behavior is preserved: missing channel-avatar metadata is not fetched automatically.


