### PR TITLE
fix: prevent profile sync from failing on a second device

### DIFF
--- a/src/renderer/helpers/sync-server.js
+++ b/src/renderer/helpers/sync-server.js
@@ -1009,7 +1009,7 @@ export async function syncProfiles(client, store, previous = {}, options = {}) {
     const oldMetadata = previous[id]?.metadata
     const localMetadata = local ? profileMetadata(local, oldMetadata) : null
     const remoteMetadata = remote
-      ? remoteProfileMetadata(remote.group, oldMetadata ?? localMetadata)
+      ? remoteProfileMetadata(remote.group, oldMetadata ?? localMetadata ?? {})
       : null
     const localChanged = localMetadata && !metadataEquals(localMetadata, oldMetadata)
     const remoteChanged = remoteMetadata && !metadataEquals(remoteMetadata, oldMetadata)

--- a/tests/unit/sync-server-profiles.test.mjs
+++ b/tests/unit/sync-server-profiles.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import vm from 'node:vm'
+
+import { MAIN_PROFILE_ID } from '../../src/constants.js'
+import * as profileSync from '../../src/renderer/helpers/profile-sync.js'
+
+// Run the real sync code, replacing webpack imports with its profile dependencies.
+const source = await readFile(new URL('../../src/renderer/helpers/sync-server.js', import.meta.url), 'utf8')
+const context = vm.createContext({ MAIN_PROFILE_ID, ...profileSync })
+vm.runInContext(source
+  .replace(/^import[\s\S]*? from ['"][^'"]+['"]\n/gm, '')
+  .replace(/^export \{[\s\S]*?\}\n/gm, '')
+  .replace(/^export (?=(async )?(function|class|const))/gm, '') + '\nglobalThis.syncProfiles = syncProfiles', context)
+
+for (const colors of [
+  { bg_color: '#123456', text_color: '#abcdef' },
+  { bg_color: null, text_color: null },
+  {},
+]) {
+  test(`first sync imports a remote profile with colors ${JSON.stringify(colors)}`, async () => {
+    const channel = { id: 'channel-1', name: 'Subscribed channel' }
+    const profileList = [{ _id: MAIN_PROFILE_ID, subscriptions: [channel] }]
+    const group = { id: 'remote-profile', local_id: 'profile-1', title: 'Music', ...colors }
+    const client = {
+      getSubscriptionGroups: async () => [{ group, channels: [{ id: channel.id }] }],
+    }
+    const store = {
+      state: { profiles: { profileList } },
+      dispatch: async (action, profile) => {
+        assert.equal(action, 'updateProfile')
+        profileList.push(structuredClone(profile))
+      },
+    }
+
+    const snapshot = await context.syncProfiles(client, store)
+
+    assert.deepEqual(profileList[1], {
+      _id: 'profile-1',
+      name: 'Music',
+      bgColor: colors.bg_color ?? '#000000',
+      textColor: colors.text_color ?? '#FFFFFF',
+      subscriptions: [channel],
+    })
+    assert.deepEqual(structuredClone(snapshot), {
+      'profile-1': {
+        remoteId: 'remote-profile',
+        metadata: {
+          title: 'Music',
+          bgColor: colors.bg_color ?? '#000000',
+          textColor: colors.text_color ?? '#FFFFFF',
+        },
+        channels: [channel.id],
+      },
+    })
+
+    // A later sync uploads edits made on the second device to the same server group.
+    profileList[1].name = 'Renamed on second device'
+    const uploads = []
+    client.updateSubscriptionGroup = async (id, payload) => uploads.push([id, structuredClone(payload)])
+    await context.syncProfiles(client, store, snapshot)
+    assert.deepEqual(uploads, [['remote-profile', {
+      id: 'profile-1',
+      local_id: 'profile-1',
+      title: 'Renamed on second device',
+      bg_color: colors.bg_color ?? '#000000',
+      text_color: colors.text_color ?? '#FFFFFF',
+    }]])
+  })
+}


### PR DESCRIPTION
Syncing a second device can stop with `Cannot read properties of null (reading bgColor)` when importing a profile for the first time. Supply an empty metadata fallback so synchronization can complete.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #1171

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

When neither a local profile nor previous sync metadata exists, pass an empty fallback to the remote profile metadata helper. Regression coverage imports remote profiles with supplied, null, and omitted colors, then uploads edits made on the second device.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed a profile sync error that could interrupt synchronization when connecting a second device.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. On a first device, create an additional profile and sync it to an account.
2. Connect a second device without that profile to the same account and sync with Profiles enabled. The profile and its subscriptions should appear without a `bgColor` error.
3. Create a playlist on the second device, sync it, then sync the first device. The playlist should appear there.

## Additional context
<!-- Add any other context about the pull request here. -->
