### PR TITLE
fix: match white button fill size to colored buttons

### DIFF
--- a/e2e/tests/offline/tutorial.spec.mjs
+++ b/e2e/tests/offline/tutorial.spec.mjs
@@ -2,6 +2,46 @@ import { test, expect, setWindowSize } from '../../helpers/app.mjs'
 
 test.use({ showTutorial: true })
 
+for (const zoom of [1, 0.95]) {
+  test(`neutral tutorial buttons have the same visible height as colored buttons at ${zoom} scale`, async ({ page }, testInfo) => {
+    await page.evaluate(() => localStorage.setItem('opentubex.tutorial.audience', 'new'))
+    await page.reload()
+    await page.evaluate(factor => window.ftElectron.setZoomFactor(factor), zoom)
+
+    const tutorial = page.locator('.tutorialCard')
+    await expect(tutorial).toHaveAccessibleName('Welcome to OpenTubeX')
+
+    for (const theme of ['light', 'dark']) {
+      await page.evaluate(async baseTheme => {
+        const store = document.querySelector('#app')._vnode.component.appContext.config.globalProperties.$store
+        await store.dispatch('updateBaseTheme', baseTheme)
+      }, theme)
+
+      // A contrasting border shrinks the visible fill even when the outer
+      // bounds match. Compare both the bounds and the painted background.
+      const buttons = tutorial.locator('.tutorialActions .btn')
+      await expect(buttons).toHaveCount(2)
+      const metrics = await buttons.evaluateAll(elements => elements.map(element => {
+        const style = getComputedStyle(element)
+        const bounds = element.getBoundingClientRect()
+        const borderBlends = style.borderTopColor === style.backgroundColor ||
+          (style.borderTopColor === 'rgba(0, 0, 0, 0)' && style.backgroundClip === 'border-box')
+        const borderHeight = Number.parseFloat(style.borderTopWidth) + Number.parseFloat(style.borderBottomWidth)
+        return {
+          height: bounds.height,
+          visibleHeight: bounds.height - (borderBlends ? 0 : borderHeight)
+        }
+      }))
+      expect(metrics[0].height).toBeCloseTo(metrics[1].height, 1)
+      expect(metrics[0].visibleHeight).toBeCloseTo(metrics[1].visibleHeight, 1)
+      await testInfo.attach(`Tutorial buttons in ${theme} theme at ${zoom} scale`, {
+        body: await tutorial.screenshot({ animations: 'disabled' }),
+        contentType: 'image/png'
+      })
+    }
+  })
+}
+
 async function expectHighlightCenteredOn(page, targetSelector) {
   await expect.poll(async () => {
     const [highlight, target] = await Promise.all([

--- a/src/renderer/components/FtButton/FtButton.css
+++ b/src/renderer/components/FtButton/FtButton.css
@@ -20,7 +20,7 @@
   gap: 10px;
   margin: 5px;
   box-shadow: 0 1px 2px rgb(0 0 0 / 50%);
-  border: 2px solid;
+  border: 2px solid transparent;
 }
 
 .btn:disabled {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Reported directly in the task; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

White secondary buttons, including Skip and Back in onboarding, looked smaller than colored buttons because their contrasting 2 px border reduced the visible fill. Make the shared default border transparent so the fill reaches the same edges while preserving outer dimensions.

Add regression coverage for visible button height in light and dark themes at 100% and 95% UI scale.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
White secondary buttons now match the visible size of colored buttons.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/26ae1661-896e-4c6e-8346-66e120133625">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/c2fb270e-4a65-4729-9c29-199c9b5748d9">
  <img alt="White and colored onboarding buttons with matching visible heights" src="https://github.com/user-attachments/assets/26ae1661-896e-4c6e-8346-66e120133625">
</picture>
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open onboarding and compare Skip with Next, then Back with Next. Their visible fills should have the same height.
2. Repeat in light and dark themes and with UI Scale set to 95%. Check that the buttons stay aligned and keyboard focus remains visible.

## Additional context
<!-- Add any other context about the pull request here. -->

