### PR TITLE
fix(home): stabilize recommendations, center messages, and hide disabled sections

### DIFF
--- a/e2e/tests/offline/home-recommendations.spec.mjs
+++ b/e2e/tests/offline/home-recommendations.spec.mjs
@@ -119,20 +119,26 @@ async function mockCandidates(page) {
     failures: new Set(),
     channelVideos: [channelCandidate, ...excludedCandidates],
     searchVideos: [searchCandidate, channelCandidate, ...excludedCandidates],
-    holdResponses() {
+    holdResponses(source = null) {
       let release
+      heldSource = source
       gate = new Promise(resolve => { release = resolve })
       return () => {
         gate = null
         release()
       }
     },
-    async settled() {
-      await expect.poll(() => requests.length > 0 && finished.size === requests.length).toBe(true)
+    async settled(source = null) {
+      await expect.poll(() => {
+        const started = source ? requests.filter(request => request.source === source).length : requests.length
+        const completed = source ? [...finished].filter(request => candidateSource(new URL(request.url())) === source).length : finished.size
+        return started > 0 && completed === started
+      }).toBe(true)
       await renderTurn(page)
     },
   }
   let gate = null
+  let heldSource = null
   const recordFinished = request => {
     if (candidateSource(new URL(request.url()))) finished.add(request)
   }
@@ -163,7 +169,7 @@ async function mockCandidates(page) {
         : source === 'channel'
           ? { videos: backend.channelVideos, continuation: null }
           : backend.searchVideos)
-    if (gate) await gate
+    if (gate && (heldSource === null || heldSource === source)) await gate
     const wasAborted = () => /abort|cancel/i.test(route.request().failure()?.errorText ?? '')
     if (wasAborted()) return
     try {
@@ -288,6 +294,173 @@ test('reuses recommendations when revisiting Home and bypasses the cache with Re
   await expect(recommendations(page).locator('.recommendationFeed .ft-list-video')).toHaveCount(1)
 })
 
+test('keeps the open recommendation feed unchanged when watch history updates until Refresh', async ({ page }) => {
+  const backend = await mockCandidates(page)
+  await goTo(page, 'home')
+  await setEnabled(page, true)
+  await backend.settled()
+  const titles = recommendations(page).locator('.ft-list-video .title')
+  const originalTitles = await titles.allTextContents()
+  expect(originalTitles.length).toBeGreaterThan(0)
+  const requestCount = backend.requests.length
+  backend.channelVideos = [video('recfresh001', 'Linux desktop fresh results')]
+  backend.searchVideos = []
+
+  for (let update = 1; update <= 3; update++) {
+    await page.evaluate(record => document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      .dispatch('updateHistory', record), { ...historyEntry(), timeWatched: now + update * 1000 })
+    await renderTurn(page)
+    await expect(titles).toHaveText(originalTitles)
+    expect(backend.requests).toHaveLength(requestCount)
+  }
+
+  await recommendations(page).getByRole('button', { name: REFRESH, exact: true }).click()
+  await backend.settled()
+  await expect(titles).toHaveText(['Linux desktop fresh results'])
+  expect(backend.requests.length).toBeGreaterThan(requestCount)
+})
+
+test.describe('history clearing with saved recommendation seeds', () => {
+  test.use({ seed: { settings, history, playlists: [{ _id: 'favorites', playlistName: 'Favorites', protected: true, videos: [historyEntry('recfavorite')] }] } })
+
+  test('discards the loaded feed when history is cleared and waits for Refresh', async ({ page }) => {
+    const backend = await mockCandidates(page)
+    await goTo(page, 'home')
+    await setEnabled(page, true)
+    await backend.settled()
+    const section = recommendations(page)
+    await expect(section.locator('.recommendationEntry')).toHaveCount(2)
+    const requestCount = backend.requests.length
+    backend.channelVideos = [video('recfresh001', 'Linux desktop fresh results')]
+    backend.searchVideos = []
+
+    await clearHistory(page)
+    await expect(section.locator('.recommendationEntry')).toHaveCount(0)
+    await renderTurn(page)
+    expect(backend.requests).toHaveLength(requestCount)
+    await section.getByRole('button', { name: REFRESH, exact: true }).click()
+    await backend.settled()
+    await expect(section.getByRole('link', { name: /Linux desktop fresh results/ })).toBeVisible()
+  })
+})
+
+test('publishes recommendations once after all discovery sources settle', async ({ page }) => {
+  const backend = await mockCandidates(page)
+  const release = backend.holdResponses('search')
+  try {
+    await goTo(page, 'home')
+    await setEnabled(page, true)
+    await backend.settled('channel')
+    const section = recommendations(page)
+    await expect(section).toHaveAttribute('aria-busy', 'true')
+    await expect(section.locator('.recommendationEntry')).toHaveCount(0, { timeout: 1000 })
+    release()
+    await backend.settled()
+    await expect(section).toHaveAttribute('aria-busy', 'false')
+    await expect(section.locator('.recommendationEntry')).toHaveCount(2)
+  } finally {
+    release()
+  }
+})
+
+test('preserves the loaded Home tab across background learning updates and cache expiry', async ({ page }) => {
+  const backend = await mockCandidates(page)
+  await goTo(page, 'home')
+  await setEnabled(page, true)
+  await backend.settled()
+  const originalTitles = await recommendations(page).locator('.ft-list-video .title').allTextContents()
+  const requestCount = backend.requests.length
+  const homeTabId = await page.locator('.tab.active').getAttribute('data-tab-id')
+  const otherTab = await page.evaluate(() => window.ftElectron.tabs.create({ route: '/history', makeActive: true }))
+  await expect(page).toHaveURL(/#\/history$/)
+  backend.channelVideos = [video('recfresh001', 'Linux desktop fresh results')]
+  backend.searchVideos = []
+  await page.evaluate(record => document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    .dispatch('updateHistory', record), historyEntry('rechist0002'))
+  // Cache expiry may affect a newly opened Home page, but not a tab's existing feed.
+  const restoreClock = await page.evaluateHandle(() => {
+    const original = Date.now
+    Date.now = () => original() + 16 * 60 * 1000
+    return () => { Date.now = original }
+  })
+  try {
+    await page.locator(`.tab[data-tab-id="${homeTabId}"]`).click()
+    await expect(page).toHaveURL(/#\/home$/)
+    await renderTurn(page)
+    await expect(recommendations(page).locator('.ft-list-video .title')).toHaveText(originalTitles)
+    expect(backend.requests).toHaveLength(requestCount)
+  } finally {
+    await restoreClock.evaluate(restore => restore())
+    await restoreClock.dispose()
+  }
+  await expect(page.locator(`.tab[data-tab-id="${otherTab.id}"]`)).toBeVisible()
+})
+
+test('keeps existing suggestions through new watches and learning updates', async ({ page }) => {
+  const backend = await mockCandidates(page)
+  await goTo(page, 'home')
+  await setEnabled(page, true)
+  await backend.settled()
+  const titles = recommendations(page).locator('.ft-list-video .title')
+  const originalTitles = await titles.allTextContents()
+  const requestCount = backend.requests.length
+  backend.channelVideos = [video('recfresh001', 'Linux desktop fresh results')]
+  backend.searchVideos = []
+  await page.evaluate(async record => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    await store.dispatch('updateHistory', record)
+    await store.dispatch('recordRecommendationEvent', { type: 'positive', video: record })
+    await store.dispatch('removeFromHistory', 'recseen0001')
+  }, { ...historyEntry('recchan0001'), title: channelCandidate.title })
+  await renderTurn(page)
+  await expect(titles).toHaveText(originalTitles)
+  expect(backend.requests).toHaveLength(requestCount)
+  await recommendations(page).getByRole('button', { name: REFRESH, exact: true }).click()
+  await backend.settled()
+  await expect(titles).toHaveText(['Linux desktop fresh results'])
+})
+
+test('keeps the loaded feed stable while loading more and when cancelling that load', async ({ page }) => {
+  const backend = await mockCandidates(page)
+  await goTo(page, 'home')
+  await setEnabled(page, true)
+  await backend.settled()
+  const section = recommendations(page)
+  const titles = section.locator('.ft-list-video .title')
+  const originalTitles = await titles.allTextContents()
+  const homeTabId = await page.locator('.tab.active').getAttribute('data-tab-id')
+  backend.searchVideos = [video('recextra001', 'Linux desktop extra suggestions', DISCOVERY_CHANNEL_ID)]
+  let release = backend.holdResponses('search')
+  try {
+    const requestCount = backend.requests.length
+    await section.getByRole('button', { name: 'Load more videos', exact: true }).click()
+    await expectBothSources(backend, requestCount)
+    await backend.settled('channel')
+    await expect(titles).toHaveText(originalTitles)
+    release()
+    await backend.settled()
+    await expect(section.getByRole('link', { name: /Linux desktop extra suggestions/ })).toBeVisible()
+    const loadedTitles = await titles.allTextContents()
+
+    release = backend.holdResponses()
+    const nextRequestCount = backend.requests.length
+    await section.getByRole('button', { name: 'Load more videos', exact: true }).click()
+    await expectBothSources(backend, nextRequestCount)
+    await page.evaluate(() => window.ftElectron.tabs.create({ route: '/history', makeActive: true }))
+    await expect(page).toHaveURL(/#\/history$/)
+    release()
+    await backend.settled()
+    const finalRequestCount = backend.requests.length
+    await page.locator(`.tab[data-tab-id="${homeTabId}"]`).click()
+    await expect(page).toHaveURL(/#\/home$/)
+    await renderTurn(page)
+    await expect(titles).toHaveText(loadedTitles)
+    expect(backend.requests).toHaveLength(finalRequestCount)
+  } finally {
+    release()
+  }
+})
+
 test('hiding through Customize invalidates pending results and stops requests until shown again', async ({ page }) => {
   const backend = await mockCandidates(page)
   const release = backend.holdResponses()
@@ -398,8 +571,81 @@ test.describe('watch-page recommendations hidden', () => {
   })
 })
 
+test('hides disabled recommendations persistently and restores them through Home customization', async ({ app, page }, testInfo) => {
+  const backend = await mockCandidates(page)
+  await goTo(page, 'home')
+  await setWindowSize(app, page, { width: 375, height: 700 })
+  const hide = recommendations(page).getByRole('button', { name: 'Keep disabled and hide this section', exact: true })
+  await expect(hide.locator('.ft-icon')).toBeVisible()
+  await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth)).toBeLessThanOrEqual(1)
+  await hide.evaluate(element => element.scrollIntoView({ block: 'center' }))
+  await page.screenshot({ path: testInfo.outputPath('hide-disabled-recommendations.png'), animations: 'disabled' })
+  await hide.click()
+  await expect(recommendations(page)).toHaveCount(0)
+  expect(backend.requests).toEqual([])
+
+  const relaunched = await app.relaunch()
+  page = relaunched.page
+  const restoredBackend = await mockCandidates(page)
+  await goTo(page, 'home')
+  await expect(recommendations(page)).toHaveCount(0)
+  await page.getByRole('button', { name: 'Customize Home', exact: true }).click()
+  const toggle = page.getByRole('checkbox', { name: 'Recommended for you', exact: true })
+  await expect(toggle).not.toBeChecked()
+  await page.getByRole('region', { name: 'Customize Home' }).getByText('Recommended for you', { exact: true }).click()
+  await expect(toggle).toBeChecked()
+  await expect(recommendations(page).getByRole('button', { name: 'Enable recommendations', exact: true })).toBeVisible()
+  expect(restoredBackend.requests).toEqual([])
+})
+
+for (const state of ['no history', 'empty', 'error']) {
+  test(`centers the ${state} recommendation message at 95% scale`, async ({ app, page }, testInfo) => {
+    const backend = await mockCandidates(page)
+    backend.channelVideos = []
+    backend.searchVideos = []
+    if (state === 'error') backend.failures = new Set(['channel', 'search', 'related'])
+    if (state === 'no history') await clearHistory(page)
+    await goTo(page, 'home')
+    const section = recommendations(page)
+    await expect(section.locator('.recommendationIntroduction p')).toHaveCSS('text-align', 'center')
+    await setEnabled(page, true)
+    const message = section.getByRole('status')
+    await expect(message).toHaveText(state === 'no history'
+      ? NO_HISTORY
+      : state === 'error' ? UNAVAILABLE : 'No recommendations found. Try refreshing after watching more videos.')
+
+    for (const size of [{ width: 1100, height: 800 }, { width: 375, height: 700 }]) {
+      await setWindowSize(app, page, size)
+      await expect(message).toHaveCSS('text-align', 'center')
+      await expect.poll(() => message.evaluate(element => {
+        const range = document.createRange()
+        range.selectNodeContents(element)
+        const text = range.getBoundingClientRect()
+        const section = element.closest('[data-home-section]').getBoundingClientRect()
+        return Math.abs(text.left + text.width / 2 - section.left - section.width / 2)
+      })).toBeLessThanOrEqual(1)
+      await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth)).toBeLessThanOrEqual(1)
+      await section.scrollIntoViewIfNeeded()
+      await page.screenshot({ path: testInfo.outputPath(`recommendation-${state}-${size.width}.png`), animations: 'disabled' })
+    }
+  })
+}
+
 test.describe('without watch history', () => {
   test.use({ seed: { settings, history: [] } })
+
+  test('loads saved positive feedback before checking for recommendation seeds after restart', async ({ app, page }) => {
+    await page.evaluate(async record => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateEnableHomeRecommendations', true)
+      await store.dispatch('recordRecommendationEvent', { type: 'positive', video: record })
+    }, historyEntry())
+    const relaunched = await app.relaunch()
+    page = relaunched.page
+    await mockCandidates(page)
+    await goTo(page, 'home')
+    await expect(recommendations(page).getByRole('link', { name: /Linux desktop shortcuts/ })).toBeVisible()
+  })
 
   test('explains how to get recommendations without making candidate requests', async ({ page }) => {
     const backend = await mockCandidates(page)

--- a/e2e/tests/offline/home-recommendations.spec.mjs
+++ b/e2e/tests/offline/home-recommendations.spec.mjs
@@ -420,6 +420,54 @@ test('keeps existing suggestions through new watches and learning updates', asyn
   await expect(titles).toHaveText(['Linux desktop fresh results'])
 })
 
+for (const change of ['backend setting', 'learning reset']) {
+  test(`restarts an interrupted initial feed but preserves a completed feed after ${change}`, async ({ page }) => {
+    const backend = await mockCandidates(page)
+    const changeContext = () => page.evaluate(async change => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      if (change === 'learning reset') await store.dispatch('resetRecommendations')
+      else await store.dispatch('updateShowFamilyFriendlyOnly', !store.getters.getShowFamilyFriendlyOnly)
+    }, change)
+    let release = backend.holdResponses()
+    try {
+      await goTo(page, 'home')
+      await setEnabled(page, true)
+      await expectBothSources(backend)
+      const requestCount = backend.requests.length
+      backend.channelVideos = [video('recfresh001', 'Linux desktop fresh results')]
+      backend.searchVideos = []
+      await changeContext()
+      await expect.poll(() => backend.aborted.length).toBeGreaterThan(0)
+      await expectBothSources(backend, requestCount)
+      release()
+      await backend.settled()
+      const section = recommendations(page)
+      const titles = section.locator('.ft-list-video .title')
+      await expect(titles).toHaveText(['Linux desktop fresh results'])
+
+      backend.channelVideos = [video('recextra001', 'Linux desktop extra suggestions')]
+      release = backend.holdResponses()
+      const completedRequestCount = backend.requests.length
+      await section.getByRole('button', { name: 'Load more videos', exact: true }).click()
+      await expectBothSources(backend, completedRequestCount)
+      const pendingRequestCount = backend.requests.length
+      const abortedCount = backend.aborted.length
+      await changeContext()
+      await expect.poll(() => backend.aborted.length).toBeGreaterThan(abortedCount)
+      release()
+      await backend.settled()
+      await expect(titles).toHaveText(['Linux desktop fresh results'])
+      expect(backend.requests).toHaveLength(pendingRequestCount)
+
+      await section.getByRole('button', { name: REFRESH, exact: true }).click()
+      await backend.settled()
+      await expect(titles).toHaveText(['Linux desktop extra suggestions'])
+    } finally {
+      release()
+    }
+  })
+}
+
 test('keeps the loaded feed stable while loading more and when cancelling that load', async ({ page }) => {
   const backend = await mockCandidates(page)
   await goTo(page, 'home')

--- a/e2e/tests/offline/home-recommendations.spec.mjs
+++ b/e2e/tests/offline/home-recommendations.spec.mjs
@@ -574,8 +574,15 @@ test.describe('watch-page recommendations hidden', () => {
 test('hides disabled recommendations persistently and restores them through Home customization', async ({ app, page }, testInfo) => {
   const backend = await mockCandidates(page)
   await goTo(page, 'home')
-  await setWindowSize(app, page, { width: 375, height: 700 })
   const hide = recommendations(page).getByRole('button', { name: 'Keep disabled and hide this section', exact: true })
+  const enable = recommendations(page).getByRole('button', { name: 'Enable recommendations', exact: true })
+  for (const size of [{ width: 1100, height: 800 }, { width: 375, height: 700 }]) {
+    await setWindowSize(app, page, size)
+    await expect.poll(async () => Math.abs(
+      await enable.evaluate(element => element.getBoundingClientRect().width) -
+      await hide.evaluate(element => element.getBoundingClientRect().width)
+    )).toBeLessThanOrEqual(1)
+  }
   await expect(hide.locator('.ft-icon')).toBeVisible()
   await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth)).toBeLessThanOrEqual(1)
   await hide.evaluate(element => element.scrollIntoView({ block: 'center' }))

--- a/src/renderer/composables/useHomeRecommendations.js
+++ b/src/renderer/composables/useHomeRecommendations.js
@@ -16,6 +16,7 @@ export function useHomeRecommendations(visible) {
   let candidates = []
   let generation = 0
   let requestController = null
+  let initialized = false
   let round = 0
   let limit = 24
   let feedId = crypto.randomUUID()
@@ -40,7 +41,7 @@ export function useHomeRecommendations(visible) {
   const recommendations = computed(() => enabled.value && hasHistory.value
     ? ranked.value.filter(video => {
         const record = store.state.recommendations.recommendationRecords[video.videoId]
-        return isVisible(video) && !store.getters.getHistoryCacheById[video.videoId] &&
+        return isVisible(video) &&
       !['dismiss', 'blockChannel'].includes(record?.feedback) &&
       !records.value.some(record => record.feedback === 'blockChannel' && record.authorId === video.authorId)
       })
@@ -74,7 +75,8 @@ export function useHomeRecommendations(visible) {
       .map(item => ({ ...item.video, recommendationReason: item.reason }))
   }
   const sourceIdentity = videos => videos.map(video => [video.videoId, video.timeWatched, video.title])
-  // Do not restart discovery on every playback tick or viewport impression.
+  // This identifies reusable candidates when opening Home, not a reason to
+  // replace a feed that is already on screen.
   const context = computed(() => JSON.stringify({
     visible: visible.value,
     enabled: enabled.value,
@@ -93,28 +95,27 @@ export function useHomeRecommendations(visible) {
   }))
 
   async function refresh(useCache = false, append = false) {
-    const requestGeneration = ++generation
-    requestController?.abort()
-    requestController = null
+    cancelRequest()
+    const requestGeneration = generation
     hasError.value = false
-    isLoading.value = false
     if (!visible.value || !enabled.value || !store.getters.getRememberHistory) {
-      candidates = []; ranked.value = []; cachedCandidates = null
+      clearFeed()
       return
     }
     if (!presented.value) return
+    if (!append) initialized = false
     if (!store.getters.getRecommendationEpoch) {
       try { await store.dispatch('loadRecommendations') } catch { hasError.value = true }
-      // The epoch update schedules a fresh generation with the loaded evidence.
-      return
+      if (requestGeneration !== generation || !store.getters.getRecommendationEpoch) return
     }
-    if (!hasHistory.value) { ranked.value = []; candidates = []; cachedCandidates = null; return }
+    if (!hasHistory.value) { clearFeed(); return }
     const requestContext = context.value
     if (!append) {
       limit = 24
       if (useCache && cachedCandidates?.context === requestContext && Date.now() - cachedCandidates.at < CACHE_LIFETIME) {
         candidates = cachedCandidates.videos; feedId = cachedCandidates.feedId; round = cachedCandidates.round
         rerank()
+        initialized = true
         return
       }
       candidates = []; ranked.value = []; feedId = crypto.randomUUID(); feedVersion.value++
@@ -129,7 +130,6 @@ export function useHomeRecommendations(visible) {
       .toSorted(([a], [b]) => (learned.channelWeights.get(b) ?? 0) - (learned.channelWeights.get(a) ?? 0))
       .slice(0, 12).flatMap(([id, entry]) => (entry.videos ?? []).slice(0, 30)
         .map(video => ({ ...video, recommendationSources: [{ type: 'subscription', id }] })))])
-    rerank(learned)
     isLoading.value = true
     requestController = new AbortController()
     const signal = requestController.signal
@@ -147,14 +147,15 @@ export function useHomeRecommendations(visible) {
         async () => (await getLocalSearchResults(query, searchSettings, familyFriendly, signal)).results,
         () => getInvidiousSearchResults(query, 1, searchSettings, signal), signal
       ),
-      onCandidates: videos => {
-        if (generation !== requestGeneration) return
-        candidates = mergeRecommendationCandidates([...candidates, ...videos]).slice(0, 1600); rerank(learned)
-      },
       isCancelled: () => generation !== requestGeneration,
       signal,
     })
     if (generation !== requestGeneration) return
+    // Publish one completed ranking so each source response cannot reshuffle
+    // cards while the user is choosing a video.
+    candidates = mergeRecommendationCandidates([...candidates, ...result.videos]).slice(0, 1600)
+    rerank(learned)
+    initialized = true
     hasError.value = result.failedSources > 0
     isLoading.value = false
     if (!hasError.value) cachedCandidates = { context: requestContext, videos: candidates, feedId, round, at: Date.now() }
@@ -166,16 +167,62 @@ export function useHomeRecommendations(visible) {
   async function feedback(video, type) {
     try {
       await store.dispatch('recordRecommendationEvent', { video, type })
-      rerank()
     } catch { hasError.value = true }
   }
   function recordImpression(video, visible, entry) {
     if (!visible || !presented.value || !enabled.value || entry?.target.closest('[aria-hidden="true"]')) return
     store.dispatch('recordRecommendationEvent', { type: 'impression', video, feedId }).catch(() => { hasError.value = true })
   }
-  watch([context, presented], () => refresh(true), { immediate: true })
+  function cancelRequest() {
+    generation++
+    requestController?.abort()
+    requestController = null
+    isLoading.value = false
+  }
+  function clearFeed() {
+    initialized = false
+    candidates = []; ranked.value = []; cachedCandidates = null
+  }
+  // Load persisted feedback before deciding whether there are any seeds.
+  const available = computed(() => visible.value && enabled.value && store.getters.getRememberHistory &&
+    (hasHistory.value || !store.getters.getRecommendationEpoch))
+  watch([available, presented], () => {
+    if (!available.value) {
+      cancelRequest()
+      clearFeed()
+    } else if (!presented.value) {
+      cancelRequest()
+    } else if (!initialized) {
+      refresh(true)
+    }
+  }, { immediate: true })
+  // Revoking learning or changing the backend cancels obsolete requests.
+  // A completed feed stays put; the next explicit refresh uses the new context.
+  watch([
+    () => store.getters.getRecommendationEpoch,
+    () => store.getters.getBackendPreference,
+    () => store.getters.getBackendFallback,
+    () => store.getters.getCurrentInvidiousInstanceUrl,
+    () => store.getters.getCurrentInvidiousInstanceAuthorization,
+    () => store.getters.getShowFamilyFriendlyOnly,
+  ], () => {
+    cachedCandidates = null
+    if (isLoading.value) {
+      cancelRequest()
+      initialized = true
+    }
+  })
+  watch([() => history.value.length === 0, () => store.getters.getRecommendationEpoch],
+    ([empty, epoch], [wasEmpty, previousEpoch]) => {
+      if (!empty || (wasEmpty && (!previousEpoch || epoch === previousEpoch))) return
+      // Clearing history also discards its visible suggestions when favorites
+      // or subscriptions still supply seeds. Only Refresh should replace them.
+      cancelRequest()
+      clearFeed()
+      initialized = available.value
+    })
   watch(exploration, () => rerank())
-  onBeforeUnmount(() => { generation++; requestController?.abort() })
+  onBeforeUnmount(cancelRequest)
   return {
     enabled,
     hasHistory,
@@ -189,7 +236,7 @@ export function useHomeRecommendations(visible) {
     feedback,
     recordImpression,
     setExploration: value => store.dispatch('updateRecommendationExploration', Number(value)),
-    reset: () => store.dispatch('resetRecommendations'),
+    reset: async () => { await store.dispatch('resetRecommendations'); await refresh() },
     setEnabled: value => store.dispatch('updateEnableHomeRecommendations', value),
   }
 }

--- a/src/renderer/composables/useHomeRecommendations.js
+++ b/src/renderer/composables/useHomeRecommendations.js
@@ -209,7 +209,7 @@ export function useHomeRecommendations(visible) {
     cachedCandidates = null
     if (isLoading.value) {
       cancelRequest()
-      initialized = true
+      if (!initialized) refresh(true)
     }
   })
   watch([() => history.value.length === 0, () => store.getters.getRecommendationEpoch],

--- a/src/renderer/views/Home/Home.css
+++ b/src/renderer/views/Home/Home.css
@@ -37,8 +37,13 @@
   font-size: 1.25rem;
 }
 
-.recommendationHide {
-  max-inline-size: calc(100% - 10px);
+.recommendationIntroductionActions {
+  display: flex;
+  flex-direction: column;
+  max-inline-size: 100%;
+}
+
+.recommendationIntroductionActions :deep(.btn) {
   white-space: normal;
 }
 

--- a/src/renderer/views/Home/Home.css
+++ b/src/renderer/views/Home/Home.css
@@ -26,11 +26,20 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+}
+
+.recommendationIntroduction,
+.recommendationStatus {
   text-align: center;
 }
 
 .recommendationIntroduction :deep(.ft-icon) {
   font-size: 1.25rem;
+}
+
+.recommendationHide {
+  max-inline-size: calc(100% - 10px);
+  white-space: normal;
 }
 
 .recommendationEntry {

--- a/src/renderer/views/Home/Home.vue
+++ b/src/renderer/views/Home/Home.vue
@@ -186,19 +186,20 @@
           class="recommendationIntroduction"
         >
           <p>{{ recommendationDescription }}</p>
-          <FtButton
-            :label="t('Home Page.Enable recommendations')"
-            :icon="['fas', 'power-off']"
-            @click="setRecommendationsEnabled(true)"
-          />
-          <FtButton
-            class="recommendationHide"
-            :label="t('Home Page.Keep disabled and hide this section')"
-            :icon="['fas', 'eye-slash']"
-            background-color="var(--secondary-card-bg-color)"
-            text-color="var(--primary-text-color)"
-            @click="setSectionVisibility('recommendations', false)"
-          />
+          <div class="recommendationIntroductionActions">
+            <FtButton
+              :label="t('Home Page.Enable recommendations')"
+              :icon="['fas', 'power-off']"
+              @click="setRecommendationsEnabled(true)"
+            />
+            <FtButton
+              :label="t('Home Page.Keep disabled and hide this section')"
+              :icon="['fas', 'eye-slash']"
+              background-color="var(--secondary-card-bg-color)"
+              text-color="var(--primary-text-color)"
+              @click="setSectionVisibility('recommendations', false)"
+            />
+          </div>
         </div>
         <template v-if="recommendationsEnabled">
           <p

--- a/src/renderer/views/Home/Home.vue
+++ b/src/renderer/views/Home/Home.vue
@@ -191,10 +191,19 @@
             :icon="['fas', 'power-off']"
             @click="setRecommendationsEnabled(true)"
           />
+          <FtButton
+            class="recommendationHide"
+            :label="t('Home Page.Keep disabled and hide this section')"
+            :icon="['fas', 'eye-slash']"
+            background-color="var(--secondary-card-bg-color)"
+            text-color="var(--primary-text-color)"
+            @click="setSectionVisibility('recommendations', false)"
+          />
         </div>
         <template v-if="recommendationsEnabled">
           <p
             v-if="!recommendationsHaveHistory"
+            class="recommendationStatus"
             role="status"
           >
             {{ t('Home Page.Recommendations need history') }}
@@ -202,6 +211,7 @@
           <FtLoader v-else-if="recommendationsLoading && recommendations.length === 0" />
           <p
             v-else-if="recommendations.length === 0"
+            class="recommendationStatus"
             role="status"
           >
             {{ recommendationsError ? t('Home Page.Recommendations unavailable') : t('Home Page.No recommendations') }}

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} ساعة'
   Hours and minutes: '{hours} ساعة {minutes} دقيقة'
 Home Page:
+  Keep disabled and hide this section: "إبقاء الاقتراحات معطلة وإخفاء هذا القسم"
   Familiar description: "فضّل الفيديوهات التي لم تشاهدها من قنوات تستمتع بها بالفعل."
   Balanced description: "امزج القنوات المألوفة بقنوات جديدة تناسب اهتماماتك."
   Explore description: "امنح مساحة أكبر لقنوات جديدة مرتبطة باهتماماتك."

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -101,6 +101,7 @@ Stats:
   Hours: '{hours} гад'
   Hours and minutes: '{hours} гад {minutes} хв'
 Home Page:
+  Keep disabled and hide this section: "Пакінуць выключаным і схаваць гэты раздзел"
   Familiar description: "Аддавайце перавагу непрагледжаным відэа з каналаў, якія вам ужо падабаюцца."
   Balanced description: "Спалучайце знаёмыя каналы з новымі, што адпавядаюць вашым інтарэсам."
   Explore description: "Давайце больш месца новым каналам, звязаным з вашымі інтарэсамі."

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} ч'
   Hours and minutes: '{hours} ч {minutes} мин'
 Home Page:
+  Keep disabled and hide this section: "Оставяне изключено и скриване на този раздел"
   Familiar description: "Предпочитане на негледани видеоклипове от канали, които вече харесвате."
   Balanced description: "Смесване на познати канали с нови, които отговарят на интересите ви."
   Explore description: "Повече място за нови канали, свързани с интересите ви."

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: "{hours} e"
   Hours and minutes: "{hours} e {minutes} min"
 Home Page:
+  Keep disabled and hide this section: "Lezel diweredekaet ha kuzhat ar rann-mañ"
   Familiar description: "Roit ar c'hentañ plas d'ar videoioù n'ho peus ket gwelet eus chadennoù a blij deoc'h dija."
   Balanced description: "Meskit chadennoù anavezet gant re nevez a glot gant ho tec'hoù."
   Explore description: "Roit muioc'h a blas da chadennoù nevez liammet ouzh ho tec'hoù."

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -125,6 +125,7 @@ Stats:
   Hours: '{hours} h'
   Hours and minutes: '{hours} h {minutes} min'
 Home Page:
+  Keep disabled and hide this section: "Mantén les recomanacions desactivades i amaga aquesta secció"
   Familiar description: "Prioritza vídeos no vistos de canals que ja t’agraden."
   Balanced description: "Combina canals coneguts amb altres de nous que coincideixin amb els teus interessos."
   Explore description: "Dona més espai a canals nous relacionats amb els teus interessos."

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} h'
   Hours and minutes: '{hours} h {minutes} min'
 Home Page:
+  Keep disabled and hide this section: "Ponechat vypnuté a skrýt tuto sekci"
   Familiar description: "Upřednostnit nezhlédnutá videa z kanálů, které už máte rádi."
   Balanced description: "Kombinovat známé kanály s novými, které odpovídají vašim zájmům."
   Explore description: "Dát více prostoru novým kanálům souvisejícím s vašimi zájmy."

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} awr'
   Hours and minutes: '{hours} awr {minutes} mun'
 Home Page:
+  Keep disabled and hide this section: "Cadw wedi ei analluogi a chuddio’r adran hon"
   Familiar description: "Ffafrio fideos heb eu gwylio o sianeli rydych eisoes yn eu mwynhau."
   Balanced description: "Cymysgu sianeli cyfarwydd â rhai newydd sy’n cyd-fynd â’ch diddordebau."
   Explore description: "Rhoi mwy o le i sianeli newydd sy’n gysylltiedig â’ch diddordebau."

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -97,6 +97,7 @@ Stats:
   Hours: '{hours} t.'
   Hours and minutes: '{hours} t. {minutes} min.'
 Home Page:
+  Keep disabled and hide this section: "Behold deaktiveret, og skjul denne sektion"
   Familiar description: "Foretræk videoer, du ikke har set, fra kanaler, du allerede kan lide."
   Balanced description: "Bland kendte kanaler med nye, der matcher dine interesser."
   Explore description: "Giv mere plads til nye kanaler med relation til dine interesser."

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} ώρες'
   Hours and minutes: '{hours} ώρες {minutes} λεπτά'
 Home Page:
+  Keep disabled and hide this section: "Διατήρηση απενεργοποίησης και απόκρυψη αυτής της ενότητας"
   Familiar description: "Προτίμηση σε βίντεο που δεν έχετε δει από κανάλια που ήδη σας αρέσουν."
   Balanced description: "Συνδυασμός γνωστών καναλιών με νέα που ταιριάζουν στα ενδιαφέροντά σας."
   Explore description: "Περισσότερος χώρος για νέα κανάλια σχετικά με τα ενδιαφέροντά σας."

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -94,6 +94,7 @@ Stats:
   Hours: "{hours} hr"
   Hours and minutes: "{hours} hr {minutes} min"
 Home Page:
+  Keep disabled and hide this section: "Keep disabled and hide this section"
   Familiar description: "Favour unwatched videos from channels you already enjoy."
   Balanced description: "Mix familiar channels with new ones that match your interests."
   Explore description: "Give more space to new channels related to your interests."

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -103,6 +103,7 @@ Stats:
   Hours: '{hours} h'
   Hours and minutes: '{hours} h {minutes} min'
 Home Page:
+  Keep disabled and hide this section: "Mantener desactivadas y ocultar esta sección"
   Familiar description: "Priorizá videos que no viste de canales que ya te gustan."
   Balanced description: "Combiná canales conocidos con otros nuevos que coincidan con tus intereses."
   Explore description: "Dale más espacio a canales nuevos relacionados con tus intereses."

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -101,6 +101,7 @@ Stats:
   Hours: '{hours} h'
   Hours and minutes: '{hours} h {minutes} min'
 Home Page:
+  Keep disabled and hide this section: "Mantener desactivadas y ocultar esta sección"
   Familiar description: "Prioriza videos que no has visto de canales que ya te gustan."
   Balanced description: "Combina canales conocidos con otros nuevos que coincidan con tus intereses."
   Explore description: "Da más espacio a canales nuevos relacionados con tus intereses."

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} h'
   Hours and minutes: '{hours} h {minutes} min'
 Home Page:
+  Keep disabled and hide this section: "Mantener desactivadas y ocultar esta sección"
   Familiar description: "Prioriza vídeos que no has visto de canales que ya te gustan."
   Balanced description: "Combina canales conocidos con otros nuevos que coincidan con tus intereses."
   Explore description: "Da más espacio a canales nuevos relacionados con tus intereses."

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} t'
   Hours and minutes: '{hours} t {minutes} min'
 Home Page:
+  Keep disabled and hide this section: "Jäta keelatuks ja peida see jaotis"
   Familiar description: "Eelista vaatamata videoid kanalitelt, mis sulle juba meeldivad."
   Balanced description: "Sega tuttavaid kanaleid uutega, mis vastavad sinu huvidele."
   Explore description: "Anna rohkem ruumi uutele kanalitele, mis on seotud sinu huvidega."

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} h'
   Hours and minutes: '{hours} h {minutes} min'
 Home Page:
+  Keep disabled and hide this section: "Mantendu desgaituta eta ezkutatu atal hau"
   Familiar description: "Lehenetsi ikusi gabeko bideoak dagoeneko gustuko dituzun kanaletatik."
   Balanced description: "Nahastu kanal ezagunak zure interesekin bat datozen kanal berriekin."
   Explore description: "Eman leku gehiago zure interesekin lotutako kanal berriei."

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -105,6 +105,7 @@ Stats:
   Hours: '{hours} ساعت'
   Hours and minutes: '{hours} ساعت و {minutes} دقیقه'
 Home Page:
+  Keep disabled and hide this section: "غیرفعال بماند و این بخش پنهان شود"
   Familiar description: "ویدیوهای ندیده از کانال‌هایی را ترجیح دهید که از قبل دوست دارید."
   Balanced description: "کانال‌های آشنا را با کانال‌های جدید متناسب با علایقتان ترکیب کنید."
   Explore description: "فضای بیشتری به کانال‌های جدید مرتبط با علایقتان بدهید."

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} t'
   Hours and minutes: '{hours} t {minutes} min'
 Home Page:
+  Keep disabled and hide this section: "Pidä poissa käytöstä ja piilota tämä osio"
   Familiar description: "Suosi katsomattomia videoita kanavilta, joista jo pidät."
   Balanced description: "Yhdistä tuttuja kanavia uusiin, kiinnostuksenkohteitasi vastaaviin kanaviin."
   Explore description: "Anna enemmän tilaa uusille kanaville, jotka liittyvät kiinnostuksenkohteisiisi."

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} h'
   Hours and minutes: '{hours} h {minutes} min'
 Home Page:
+  Keep disabled and hide this section: "Garder les recommandations désactivées et masquer cette section"
   Familiar description: "Privilégier les vidéos non vues de chaînes que vous appréciez déjà."
   Balanced description: "Mélanger des chaînes connues et de nouvelles chaînes correspondant à vos centres d’intérêt."
   Explore description: "Accorder plus de place aux nouvelles chaînes liées à vos centres d’intérêt."

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} h'
   Hours and minutes: '{hours} h {minutes} min'
 Home Page:
+  Keep disabled and hide this section: "Manter desactivadas e agochar esta sección"
   Familiar description: "Prioriza vídeos sen ver de canles que xa che gustan."
   Balanced description: "Combina canles coñecidas con outras novas que coincidan cos teus intereses."
   Explore description: "Dá máis espazo a canles novas relacionadas cos teus intereses."

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} שע׳'
   Hours and minutes: '{hours} שע׳ {minutes} דק׳'
 Home Page:
+  Keep disabled and hide this section: "להשאיר מושבת ולהסתיר את המקטע הזה"
   Familiar description: "העדפת סרטונים שטרם נצפו מערוצים שכבר אהבת."
   Balanced description: "שילוב ערוצים מוכרים עם ערוצים חדשים שתואמים לתחומי העניין שלך."
   Explore description: "מתן יותר מקום לערוצים חדשים הקשורים לתחומי העניין שלך."

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} h'
   Hours and minutes: '{hours} h {minutes} min'
 Home Page:
+  Keep disabled and hide this section: "Ostavi isključeno i sakrij ovaj odjeljak"
   Familiar description: "Daj prednost nepogledanim videozapisima s kanala koje već voliš."
   Balanced description: "Kombiniraj poznate kanale s novima koji odgovaraju tvojim interesima."
   Explore description: "Daj više prostora novim kanalima povezanima s tvojim interesima."

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} óra'
   Hours and minutes: '{hours} óra {minutes} perc'
 Home Page:
+  Keep disabled and hide this section: "Maradjon kikapcsolva, és rejtse el ezt a szakaszt"
   Familiar description: "Még nem látott videók előnyben részesítése már kedvelt csatornákról."
   Balanced description: "Ismert csatornák keverése az érdeklődésedhez illő újakkal."
   Explore description: "Több hely az érdeklődésedhez kapcsolódó új csatornáknak."

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} jam'
   Hours and minutes: '{hours} jam {minutes} mnt'
 Home Page:
+  Keep disabled and hide this section: "Tetap nonaktifkan dan sembunyikan bagian ini"
   Familiar description: "Utamakan video yang belum ditonton dari channel yang sudah Anda sukai."
   Balanced description: "Padukan channel yang dikenal dengan channel baru yang sesuai minat Anda."
   Explore description: "Beri lebih banyak ruang untuk channel baru yang terkait dengan minat Anda."

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} klst.'
   Hours and minutes: '{hours} klst. {minutes} mín.'
 Home Page:
+  Keep disabled and hide this section: "Halda óvirku og fela þennan hluta"
   Familiar description: "Veldu frekar óséð myndskeið frá rásum sem þér líkar þegar við."
   Balanced description: "Blandaðu kunnuglegum rásum við nýjar sem passa við áhugamál þín."
   Explore description: "Gefðu nýjum rásum sem tengjast áhugamálum þínum meira vægi."

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} h'
   Hours and minutes: '{hours} h {minutes} min'
 Home Page:
+  Keep disabled and hide this section: "Mantieni disattivati i consigli e nascondi questa sezione"
   Familiar description: "Preferisci video non ancora visti da canali che già ti piacciono."
   Balanced description: "Combina canali conosciuti con nuovi canali in linea con i tuoi interessi."
   Explore description: "Dai più spazio a nuovi canali legati ai tuoi interessi."

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours}時間'
   Hours and minutes: '{hours}時間{minutes}分'
 Home Page:
+  Keep disabled and hide this section: "無効のままこのセクションを非表示にする"
   Familiar description: "すでに気に入っているチャンネルの未視聴の動画を優先します。"
   Balanced description: "なじみのあるチャンネルと、興味に合う新しいチャンネルを組み合わせます。"
   Explore description: "興味に関連する新しいチャンネルをより多く表示します。"

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -102,6 +102,7 @@ Stats:
   Hours: '{hours}시간'
   Hours and minutes: '{hours}시간 {minutes}분'
 Home Page:
+  Keep disabled and hide this section: "비활성화 상태를 유지하고 이 섹션 숨기기"
   Familiar description: "이미 좋아하는 채널의 아직 보지 않은 동영상을 우선합니다."
   Balanced description: "익숙한 채널과 관심사에 맞는 새로운 채널을 섞어 추천합니다."
   Explore description: "관심사와 관련된 새로운 채널을 더 많이 추천합니다."

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -117,6 +117,7 @@ Stats:
   Hours: '{hours} val.'
   Hours and minutes: '{hours} val. {minutes} min.'
 Home Page:
+  Keep disabled and hide this section: "Palikti išjungtą ir slėpti šią skiltį"
   Familiar description: "Teikti pirmenybę nežiūrėtiems vaizdo įrašams iš jau mėgstamų kanalų."
   Balanced description: "Derinti pažįstamus kanalus su naujais, atitinkančiais jūsų pomėgius."
   Explore description: "Skirti daugiau vietos naujiems kanalams, susijusiems su jūsų pomėgiais."

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} t'
   Hours and minutes: '{hours} t {minutes} min'
 Home Page:
+  Keep disabled and hide this section: "Behold deaktivert og skjul denne delen"
   Familiar description: "Foretrekk videoer du ikke har sett, fra kanaler du allerede liker."
   Balanced description: "Bland kjente kanaler med nye som passer interessene dine."
   Explore description: "Gi mer plass til nye kanaler knyttet til interessene dine."

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} uur'
   Hours and minutes: '{hours} uur {minutes} min'
 Home Page:
+  Keep disabled and hide this section: "Uitgeschakeld houden en deze sectie verbergen"
   Familiar description: "Geef voorrang aan onbekeken video’s van kanalen die je al leuk vindt."
   Balanced description: "Combineer vertrouwde kanalen met nieuwe die bij je interesses passen."
   Explore description: "Geef meer ruimte aan nieuwe kanalen die aansluiten bij je interesses."

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -101,6 +101,7 @@ Stats:
   Hours: '{hours} t'
   Hours and minutes: '{hours} t {minutes} min'
 Home Page:
+  Keep disabled and hide this section: "Hald deaktivert og gøym denne delen"
   Familiar description: "Føretrekk videoar du ikkje har sett, frå kanalar du allereie likar."
   Balanced description: "Bland kjende kanalar med nye som passar interessene dine."
   Explore description: "Gje meir plass til nye kanalar knytte til interessene dine."

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -8,6 +8,7 @@ Search Listing:
   Label:
     Members Only: Tylko dla wspierających
 Home Page:
+  Keep disabled and hide this section: "Pozostaw wyłączone i ukryj tę sekcję"
   Familiar description: "Preferuj nieobejrzane filmy z kanałów, które już lubisz."
   Balanced description: "Łącz znane kanały z nowymi, pasującymi do Twoich zainteresowań."
   Explore description: "Daj więcej miejsca nowym kanałom związanym z Twoimi zainteresowaniami."

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} h'
   Hours and minutes: '{hours} h {minutes} min'
 Home Page:
+  Keep disabled and hide this section: "Manter desativadas e ocultar esta seção"
   Familiar description: "Priorize vídeos não assistidos de canais que você já gosta."
   Balanced description: "Misture canais conhecidos com novos que correspondam aos seus interesses."
   Explore description: "Dê mais espaço a novos canais relacionados aos seus interesses."

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} h'
   Hours and minutes: '{hours} h {minutes} min'
 Home Page:
+  Keep disabled and hide this section: "Manter desativadas e ocultar esta secção"
   Familiar description: "Dá prioridade a vídeos por ver de canais de que já gostas."
   Balanced description: "Combina canais conhecidos com novos que correspondam aos teus interesses."
   Explore description: "Dá mais espaço a novos canais relacionados com os teus interesses."

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} h'
   Hours and minutes: '{hours} h {minutes} min'
 Home Page:
+  Keep disabled and hide this section: "Manter desativadas e ocultar esta secção"
   Familiar description: "Dá prioridade a vídeos por ver de canais de que já gostas."
   Balanced description: "Combina canais conhecidos com novos que correspondam aos teus interesses."
   Explore description: "Dá mais espaço a novos canais relacionados com os teus interesses."

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} h'
   Hours and minutes: '{hours} h {minutes} min'
 Home Page:
+  Keep disabled and hide this section: "Păstrează dezactivat și ascunde această secțiune"
   Familiar description: "Preferă videoclipuri nevizionate de la canale care îți plac deja."
   Balanced description: "Combină canale cunoscute cu unele noi care corespund intereselor tale."
   Explore description: "Oferă mai mult spațiu canalelor noi legate de interesele tale."

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -70,6 +70,7 @@ Stats:
   Hours: '{hours} ч'
   Hours and minutes: '{hours} ч {minutes} мин'
 Home Page:
+  Keep disabled and hide this section: "Оставить выключенным и скрыть этот раздел"
   Familiar description: "Отдавайте предпочтение непросмотренным видео с каналов, которые вам уже нравятся."
   Balanced description: "Сочетайте знакомые каналы с новыми, соответствующими вашим интересам."
   Explore description: "Давайте больше места новым каналам, связанным с вашими интересами."

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} h'
   Hours and minutes: '{hours} h {minutes} min'
 Home Page:
+  Keep disabled and hide this section: "Ponechať vypnuté a skryť túto sekciu"
   Familiar description: "Uprednostniť nepozreté videá z kanálov, ktoré už máte radi."
   Balanced description: "Kombinovať známe kanály s novými, ktoré zodpovedajú vašim záujmom."
   Explore description: "Dať viac priestoru novým kanálom súvisiacim s vašimi záujmami."

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -124,6 +124,7 @@ Stats:
   Hours: '{hours} h'
   Hours and minutes: '{hours} h {minutes} min'
 Home Page:
+  Keep disabled and hide this section: "Pusti onemogočeno in skrij ta razdelek"
   Familiar description: "Daj prednost neogledanim videoposnetkom s kanalov, ki so ti že všeč."
   Balanced description: "Združi znane kanale z novimi, ki ustrezajo tvojim zanimanjem."
   Explore description: "Nameni več prostora novim kanalom, povezanim s tvojimi zanimanji."

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -97,6 +97,7 @@ Stats:
   Hours: '{hours} ч'
   Hours and minutes: '{hours} ч {minutes} мин'
 Home Page:
+  Keep disabled and hide this section: "Остави искључено и сакриј овај одељак"
   Familiar description: "Дај предност непогледаним видео-снимцима са канала које већ волиш."
   Balanced description: "Комбинуј познате канале са новим који одговарају твојим интересовањима."
   Explore description: "Дај више простора новим каналима повезаним са твојим интересовањима."

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} tim'
   Hours and minutes: '{hours} tim {minutes} min'
 Home Page:
+  Keep disabled and hide this section: "Behåll inaktiverat och dölj det här avsnittet"
   Familiar description: "Prioritera osedda videor från kanaler du redan gillar."
   Balanced description: "Blanda bekanta kanaler med nya som matchar dina intressen."
   Explore description: "Ge mer plats åt nya kanaler som är kopplade till dina intressen."

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -98,6 +98,7 @@ Stats:
   Hours: '{hours} மணி'
   Hours and minutes: '{hours} மணி {minutes} நிமி.'
 Home Page:
+  Keep disabled and hide this section: "முடக்கப்பட்ட நிலையிலேயே வைத்து இந்தப் பகுதியை மறை"
   Familiar description: "நீங்கள் ஏற்கனவே விரும்பும் சேனல்களில் பார்க்காத காணொளிகளுக்கு முன்னுரிமை அளிக்கவும்."
   Balanced description: "பழக்கமான சேனல்களுடன் உங்கள் ஆர்வங்களுக்கு ஏற்ற புதிய சேனல்களைக் கலக்கவும்."
   Explore description: "உங்கள் ஆர்வங்களுடன் தொடர்புடைய புதிய சேனல்களுக்கு அதிக இடம் அளிக்கவும்."

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} sa'
   Hours and minutes: '{hours} sa {minutes} dk'
 Home Page:
+  Keep disabled and hide this section: "Devre dışı bırakılmış olarak tut ve bu bölümü gizle"
   Familiar description: "Zaten sevdiğiniz kanallardan izlemediğiniz videolara öncelik verin."
   Balanced description: "Tanıdık kanalları ilgi alanlarınıza uyan yeni kanallarla harmanlayın."
   Explore description: "İlgi alanlarınızla ilgili yeni kanallara daha fazla yer verin."

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} год'
   Hours and minutes: '{hours} год {minutes} хв'
 Home Page:
+  Keep disabled and hide this section: "Залишити вимкненим і приховати цей розділ"
   Familiar description: "Надавайте перевагу непереглянутим відео з каналів, які вам уже подобаються."
   Balanced description: "Поєднуйте знайомі канали з новими, що відповідають вашим інтересам."
   Explore description: "Давайте більше місця новим каналам, пов’язаним із вашими інтересами."

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} giờ'
   Hours and minutes: '{hours} giờ {minutes} phút'
 Home Page:
+  Keep disabled and hide this section: "Giữ trạng thái tắt và ẩn mục này"
   Familiar description: "Ưu tiên video chưa xem từ các kênh bạn đã yêu thích."
   Balanced description: "Kết hợp các kênh quen thuộc với kênh mới phù hợp với sở thích của bạn."
   Explore description: "Dành thêm chỗ cho các kênh mới liên quan đến sở thích của bạn."

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} 小时'
   Hours and minutes: '{hours} 小时 {minutes} 分钟'
 Home Page:
+  Keep disabled and hide this section: "保持禁用并隐藏此部分"
   Familiar description: "优先推荐你已喜欢的频道中尚未观看的视频。"
   Balanced description: "混合推荐熟悉的频道和符合你兴趣的新频道。"
   Explore description: "为与你兴趣相关的新频道提供更多推荐机会。"

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -95,6 +95,7 @@ Stats:
   Hours: '{hours} 小時'
   Hours and minutes: '{hours} 小時 {minutes} 分鐘'
 Home Page:
+  Keep disabled and hide this section: "保持停用並隱藏此區塊"
   Familiar description: "優先推薦你已喜歡的頻道中尚未觀看的影片。"
   Balanced description: "混合推薦熟悉的頻道和符合你興趣的新頻道。"
   Explore description: "為與你興趣相關的新頻道提供更多推薦機會。"

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -93,6 +93,7 @@ Search Filters:
     Location: Region
   Clear Filters: Suchfilter zurücksetzen
 Home Page:
+  Keep disabled and hide this section: "Deaktiviert lassen und diesen Abschnitt ausblenden"
   Familiar description: "Bevorzuge ungesehene Videos von Kanälen, die du bereits magst."
   Balanced description: "Mische vertraute Kanäle mit neuen, die zu deinen Interessen passen."
   Explore description: "Gib neuen Kanälen, die zu deinen Interessen passen, mehr Raum."

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -211,6 +211,7 @@ Stats:
   Hours and minutes: '{hours} hr {minutes} min'
 
 Home Page:
+  Keep disabled and hide this section: "Keep disabled and hide this section"
   Familiar description: "Favor unwatched videos from channels you already enjoy."
   Balanced description: "Mix familiar channels with new ones that match your interests."
   Explore description: "Give more space to new channels related to your interests."


### PR DESCRIPTION
Home recommendations could replace visible suggestions repeatedly while a video was being chosen. Empty messages were left-aligned, and disabling recommendations left the section on Home.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Requested directly in a Codex task; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
- Keep loaded suggestions stable through history and learning updates, tab switches, and cancelled loading of more videos. Publish a completed ranking once per requested load.
- Discard stale suggestions when history is cleared, including when favorites still provide recommendation seeds.
- Center empty and error messages, and add "Keep disabled and hide this section" with translations. Both disabled-state buttons share the same width and wrap on narrow windows. The section can be restored through Customize Home.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/f9c61b89-1f4f-41de-9579-180b58acd843">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/fe2da4c8-36cf-4e89-98b3-48ca017060a6">
  <img alt="Centered Home recommendation controls with equal-width enable and hide buttons" src="https://github.com/user-attachments/assets/f9c61b89-1f4f-41de-9579-180b58acd843">
</picture>

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Home with recommendations disabled. Check that the explanation and both buttons are centered and the buttons have equal widths, including in a narrow window. Choose "Keep disabled and hide this section", restart the app, and restore the section through Customize Home. Recommendations should remain disabled.
2. Enable recommendations with some watch history. Once videos appear, watch another video in a different tab or window and return to Home. The existing suggestions should stay in place. Refresh should fetch a new list.
3. Load more videos, switch tabs before the request finishes, then return. The loaded list should remain intact. Check that dismissing a video or hiding its channel still removes it immediately.
4. Keep a favorite saved, clear all watch history, and return to Home. Old suggestions should be gone; Refresh should generate suggestions from the remaining saved videos.
5. Check the empty, missing-history, and error messages at normal and narrow window widths, including a non-100% UI scale.

## Additional context
<!-- Add any other context about the pull request here. -->

Home recommendations were introduced after the latest stable release, v0.34.0-beta, so these changes are marked Not noteworthy.



