### PR TITLE
feat: add light and dark theme selectors to quick settings

### DIFF
--- a/e2e/tests/offline/quick-settings.spec.mjs
+++ b/e2e/tests/offline/quick-settings.spec.mjs
@@ -1,8 +1,9 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { test, expect, goToSettingsSection, latestSettings } from '../../helpers/app.mjs'
+import { test, expect, expectScrollAtRenderedEnd, goToSettingsSection, latestSettings } from '../../helpers/app.mjs'
 import { DEFAULT_QUICK_SETTINGS } from '../../../src/renderer/helpers/quickSettings.js'
+import { DEFAULT_CUSTOM_THEME } from '../../../src/customTheme.js'
 
 const ALL_QUICK_SETTINGS = [
   ...DEFAULT_QUICK_SETTINGS,
@@ -28,6 +29,121 @@ const ADDITIONAL_QUICK_SETTINGS = [
   ['enableCaptionTranslations', 'Enable Caption Translations', 'Language and region'],
   ['enableCommentTranslations', 'Enable comment translations', 'Language and region'],
 ]
+
+test.describe('quick system themes', () => {
+  test.use({ seed: { settings: { quickSettings: ['baseTheme'], baseTheme: 'system', currentLocale: 'en-US', uiScale: 125 } } })
+
+  test('adds light and dark selectors and persists their choices across restart', async ({ app, page }, testInfo) => {
+    const appearance = await goToSettingsSection(page, 'appearance')
+    await appearance.getByRole('button', { name: 'Customize quick settings' }).click()
+    await page.getByRole('button', { name: 'Add setting' }).click()
+    const search = page.getByPlaceholder('Search settings')
+    for (const label of ['Light theme', 'Dark theme']) {
+      await search.fill(label)
+      await page.locator('.settingPicker .optionWrapper').getByText(label, { exact: true }).click()
+    }
+    await search.press('Escape')
+    await page.locator('.settingsCloseButton').click()
+    await page.locator('.profileTrigger').click()
+    const menu = page.getByRole('dialog', { name: 'Quick settings' })
+
+    for (const [scheme, label, choice, value] of [
+      ['light', 'Light theme', 'Solarized Light', 'solarizedLight'],
+      ['dark', 'Dark theme', 'Solarized Dark', 'solarizedDark'],
+    ]) {
+      await page.emulateMedia({ colorScheme: scheme })
+      await menu.getByRole('combobox', { name: label }).click()
+      await page.getByRole('option', { name: choice, exact: true }).click()
+      await expect(page.locator('body')).toHaveClass(new RegExp(value))
+      await expect(menu).toBeVisible()
+    }
+    await expect.poll(async () => {
+      const saved = latestSettings(await readFile(path.join(app.userDataDir, 'settings.db'), 'utf8'))
+      return [saved.quickSettings, saved.systemLightTheme, saved.systemDarkTheme]
+    }).toEqual([['baseTheme', 'systemLightTheme', 'systemDarkTheme'], 'solarizedLight', 'solarizedDark'])
+
+    ;({ page } = await app.relaunch())
+    await page.locator('.profileTrigger').click()
+    const reopened = page.getByRole('dialog', { name: 'Quick settings' })
+    await expect(reopened.getByRole('combobox', { name: 'Light theme' })).toHaveText('Solarized Light')
+    await expect(reopened.getByRole('combobox', { name: 'Dark theme' })).toHaveText('Solarized Dark')
+    await expect(reopened).not.toHaveClass(/quick-settings-menu-enter-active/)
+    // Electron capturePage includes the entire window at non-100% zoom.
+    const screenshot = await app.electronApp.evaluate(async ({ BrowserWindow }) => (
+      (await BrowserWindow.getAllWindows()[0].webContents.capturePage()).toDataURL()
+    ))
+    await testInfo.attach('light and dark quick theme selectors', {
+      body: Buffer.from(screenshot.split(',')[1], 'base64'), contentType: 'image/png',
+    })
+
+    await reopened.getByRole('combobox', { name: 'Base Theme' }).click()
+    await page.getByRole('option', { name: 'Light', exact: true }).click()
+    await expect(reopened.locator('[data-setting-id="systemLightTheme"]')).toHaveCount(0)
+    await expect(reopened.locator('[data-setting-id="systemDarkTheme"]')).toHaveCount(0)
+    await reopened.getByRole('combobox', { name: 'Base Theme' }).click()
+    await page.getByRole('option', { name: /System default/i }).click()
+    for (const [id, label] of [['systemLightTheme', 'Light'], ['systemDarkTheme', 'Dark']]) {
+      const control = reopened.locator(`[data-setting-id="${id}"]`)
+      await control.getByRole('button', { name: 'Reset this setting to its default' }).click()
+      await expect(control.getByRole('combobox')).toHaveText(label)
+    }
+  })
+
+  test('clamps the menu after hiding system theme selectors at the bottom', async ({ app, page }) => {
+    await app.electronApp.evaluate(({ BrowserWindow }) => {
+      BrowserWindow.getAllWindows()[0].setBounds({ x: 0, y: 0, width: 1000, height: 600 })
+    })
+    await page.evaluate(async ids => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateQuickSettings', [...ids, 'systemLightTheme', 'systemDarkTheme'])
+    }, DEFAULT_QUICK_SETTINGS)
+    await page.locator('.profileTrigger').click()
+    const menu = page.getByRole('dialog', { name: 'Quick settings' })
+    const scroller = menu.locator('.quickSettingsScroll')
+    const scrollbar = scroller.locator('.os-scrollbar-vertical')
+    const thumb = scrollbar.locator('.os-scrollbar-handle')
+    await scroller.evaluate(element => element.scrollTo(0, element.scrollHeight))
+    await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+    await expectScrollAtRenderedEnd(scroller)
+    const originalThumbHeight = await thumb.evaluate(element => element.getBoundingClientRect().height)
+
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateBaseTheme', 'dark')
+    })
+    await expect(menu.locator('[data-setting-id="systemLightTheme"]')).toHaveCount(0)
+    await expect(menu.locator('[data-setting-id="systemDarkTheme"]')).toHaveCount(0)
+    await expectScrollAtRenderedEnd(scroller)
+    await expect(scrollbar).toHaveClass(/os-scrollbar-visible/)
+    await expect.poll(() => thumb.evaluate(element => element.getBoundingClientRect().height))
+      .toBeGreaterThan(originalThumbHeight)
+  })
+
+  test('offers only matching built-in and custom themes', async ({ page }) => {
+    await page.evaluate(async (defaultTheme) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setCustomThemes', [
+        { ...defaultTheme, id: 'paper', name: 'Paper', isDark: false },
+        { ...defaultTheme, id: 'midnight', name: 'Midnight', isDark: true },
+      ])
+      await store.dispatch('updateQuickSettings', ['systemLightTheme', 'systemDarkTheme'])
+    }, DEFAULT_CUSTOM_THEME)
+    await page.locator('.profileTrigger').click()
+    const menu = page.getByRole('dialog', { name: 'Quick settings' })
+    for (const [label, included, excluded] of [
+      ['Light theme', ['Light', 'Solarized Light', 'Paper'], ['Dark', 'Solarized Dark', 'Midnight']],
+      ['Dark theme', ['Dark', 'Solarized Dark', 'Midnight'], ['Light', 'Solarized Light', 'Paper']],
+    ]) {
+      const select = menu.getByRole('combobox', { name: label })
+      await select.click()
+      const options = page.locator(`#${await select.getAttribute('aria-controls')}`)
+      for (const name of included) await expect(options.getByRole('option', { name, exact: true })).toHaveCount(1)
+      for (const name of [...excluded, 'System default']) await expect(options.getByRole('option', { name, exact: true })).toHaveCount(0)
+      await options.getByRole('option', { name: included[2], exact: true }).click()
+      await expect(select).toHaveText(included[2])
+    }
+  })
+})
 
 test.describe('additional quick settings', () => {
   test.use({ seed: { settings: { quickSettings: [], uiScale: 125 } } })

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
@@ -185,6 +185,18 @@
                     @change="updateSetting('BaseTheme', $event)"
                   />
                   <FtSelect
+                    v-else-if="setting.id === 'systemLightTheme' || setting.id === 'systemDarkTheme'"
+                    class="quickSelect"
+                    :placeholder="setting.label"
+                    :value="store.state.settings[setting.id]"
+                    :setting-key="setting.id"
+                    :select-names="systemThemeOptions[setting.id].map(({ name }) => name)"
+                    :select-values="systemThemeOptions[setting.id].map(({ value }) => value)"
+                    :disabled="customThemeEditorOpen"
+                    :icon="setting.icon"
+                    @change="updateBasicQuickSetting(setting.id, $event)"
+                  />
+                  <FtSelect
                     v-else-if="setting.id === 'mainColor'"
                     class="quickSelect"
                     :placeholder="t('Settings.Theme Settings.Main Color Theme.Main Color Theme')"
@@ -411,6 +423,7 @@ import {
 import { defaultUpdaterId } from '../../store/modules/settings'
 import { switchActiveProfile, translateProfileName as getTranslatedProfileName } from '../../helpers/profileSwitching'
 import { customThemeValue, isCustomThemeValue } from '../../../customTheme'
+import { getThemeClassification } from '../../../appearanceSettings'
 
 const { locale, t } = useI18n()
 const id = useId()
@@ -482,6 +495,16 @@ const baseThemeNames = computed(() => [
   ...builtInBaseThemeNames.value,
   ...customThemes.value.map(({ name }) => name)
 ])
+const systemThemeOptions = computed(() => {
+  const options = { systemLightTheme: [], systemDarkTheme: [] }
+  baseThemeValues.value.forEach((value, index) => {
+    const classification = getThemeClassification(value, customThemes.value)
+    if (classification === null) return
+    const settingId = classification === 'light' ? 'systemLightTheme' : 'systemDarkTheme'
+    options[settingId].push({ name: baseThemeNames.value[index], value })
+  })
+  return options
+})
 
 const COLOR_VALUES = colors.map(color => color.name)
 const COLOR_SWATCHES = colors.map(color => color.value)
@@ -546,6 +569,7 @@ const orderedQuickSettingSections = computed(() => {
     .map(settingId => catalogById.get(settingId))
     .filter(setting => setting != null && (
       (setting.id !== 'mainColor' || mainColorAvailable.value) &&
+      (!['systemLightTheme', 'systemDarkTheme'].includes(setting.id) || baseTheme.value === 'system') &&
       (setting.id !== 'region' || regionValues.value.length > 0)
     ))
 

--- a/src/renderer/helpers/quickSettings.js
+++ b/src/renderer/helpers/quickSettings.js
@@ -1,5 +1,7 @@
 const CORE_QUICK_SETTINGS = [
   ['baseTheme', 'appearance', 'Settings.Theme Settings.Base Theme.Base Theme', { control: 'select', icon: ['fas', 'palette'] }],
+  ['systemLightTheme', 'appearance', 'Settings.Theme Settings.Light Theme', { control: 'select', icon: ['fas', 'sun'] }],
+  ['systemDarkTheme', 'appearance', 'Settings.Theme Settings.Dark Theme', { control: 'select', icon: ['fas', 'moon'] }],
   ['mainColor', 'appearance', 'Settings.Theme Settings.Main Color Theme.Main Color Theme', { control: 'select', icon: ['fas', 'palette'] }],
   ['uiScale', 'appearance', 'Settings.Theme Settings.UI Scale', { control: 'slider', electronOnly: true, icon: ['fas', 'sliders-h'] }],
   ['thumbnailSize', 'appearance', 'Settings.Theme Settings.Thumbnail Size', { control: 'slider', icon: ['fas', 'photo-film'] }],


### PR DESCRIPTION
Quick settings cannot currently show the separate light and dark theme selectors used by System Default. This adds both to the customizer and hides them whenever a fixed base theme is selected, preserving their saved choices.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Requested directly in Codex; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Both selectors offer matching built-in and custom themes and reuse the existing persistence and reset controls. Hiding them also updates the menu layout and scroll range.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
You can now add optional light and dark theme selectors through the Quick Settings customizer. They appear when using System Default and are not added by default.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/9e7d66ed-73c1-417b-85ff-67bcdb6ce271">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/ad7bc204-1122-45c7-b3e0-0fb8ad7e4e4d">
  <img alt="Light and dark theme selectors in Quick Settings" src="https://github.com/user-attachments/assets/9e7d66ed-73c1-417b-85ff-67bcdb6ce271">
</picture>

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. In Appearance settings, open Customize quick settings and add Light theme and Dark theme.
2. Set Base Theme to System Default, open Quick Settings, and choose a light and dark theme. Each selector should only offer matching themes, including custom themes.
3. Change Base Theme to a fixed theme. Both selectors should disappear. Switch back to System Default and confirm their choices return.
4. Restart the app to confirm the choices persist, then use each reset button to restore Light and Dark.
5. At 125% UI scale in a short window, scroll a long Quick Settings menu to the bottom and switch away from System Default. The menu should have no obsolete scroll offset or empty space.

## Additional context
<!-- Add any other context about the pull request here. -->

