### PR TITLE
fix(android): preserve yt-dlp playback cache across restarts

### DIFF
--- a/android/YTDLP.md
+++ b/android/YTDLP.md
@@ -31,3 +31,25 @@ pnpm run capacitor:sync:android
 ```
 
 For a single-ABI test APK, add `-PtestAbi=arm64-v8a`. Normal APKs retain all bundled ABIs. The test document provider exists only in the instrumentation APK.
+
+### Playback cache across APK replacement
+
+`YtDlpPlaybackCacheTest` checks cache persistence, Android cache eviction, migration and explicit cleanup. Its default `playbackCachePhase=both` writes and reads the replacement fixture within one test process; it does not replace the APK. To test replacement, run the `seed` and `verify` phases in separate processes with an APK install between them.
+
+After building the app and instrumentation APKs above, run these commands from the repository root on the selected test device. Replace `DEVICE_SERIAL` with its ADB serial. The app must use the same package identity and signing key across both installs.
+
+```sh
+playback_test_device=DEVICE_SERIAL
+playback_test_class='org.opentubex.app.YtDlpPlaybackCacheTest#playbackSurvivesAppReplacement'
+playback_test_runner=org.opentubex.app.nightly.test/androidx.test.runner.AndroidJUnitRunner
+
+adb -s "$playback_test_device" install --user 0 -r android/app/build/outputs/apk/debug/app-debug.apk
+adb -s "$playback_test_device" install --user 0 -r android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
+adb -s "$playback_test_device" shell am instrument --user 0 -w \
+  -e class "$playback_test_class" -e playbackCachePhase seed "$playback_test_runner"
+adb -s "$playback_test_device" install --user 0 -r android/app/build/outputs/apk/debug/app-debug.apk
+adb -s "$playback_test_device" shell am instrument --user 0 -w \
+  -e class "$playback_test_class" -e playbackCachePhase verify "$playback_test_runner"
+```
+
+Both instrumentation runs must print `OK (1 test)` and each install must report `Success`. Check the instrumentation output even when ADB exits successfully. Keep the device's app data intact between phases and run `verify` within one hour, before the fixture expires. The `verify` phase removes its fixture afterward.

--- a/android/app/src/androidTest/java/org/opentubex/app/YtDlpPlaybackCacheTest.java
+++ b/android/app/src/androidTest/java/org/opentubex/app/YtDlpPlaybackCacheTest.java
@@ -115,7 +115,8 @@ public class YtDlpPlaybackCacheTest {
             @Override public File getCacheDir() { return cache; }
             @Override public File getNoBackupFilesDir() { return root; }
         };
-        // Run with -e playbackCachePhase seed, install -r, then run with verify.
+        // The default "both" checks persistence without replacing the APK.
+        // See android/YTDLP.md for the separate seed -> install -r -> verify flow.
         String phase = InstrumentationRegistry.getArguments().getString("playbackCachePhase", "both");
         try {
             if (!phase.equals("verify")) {

--- a/android/app/src/androidTest/java/org/opentubex/app/YtDlpPlaybackCacheTest.java
+++ b/android/app/src/androidTest/java/org/opentubex/app/YtDlpPlaybackCacheTest.java
@@ -1,0 +1,137 @@
+package org.opentubex.app;
+
+import android.content.Context;
+import android.content.ContextWrapper;
+import androidx.test.platform.app.InstrumentationRegistry;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.PluginCall;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class YtDlpPlaybackCacheTest {
+    private static final String VIDEO = "___________";
+
+    private JSObject call(Context context, JSObject data) throws Exception {
+        // Each request uses a new plugin, with no state retained from the writer.
+        YtDlpPlugin plugin = new YtDlpPlugin();
+        CompletableFuture<JSObject> response = new CompletableFuture<>();
+        PluginCall call = new PluginCall(null, "YtDlp", "test", "cache", data) {
+            @Override public void resolve(JSObject result) { response.complete(result); }
+            @Override public void reject(String message) { response.completeExceptionally(new AssertionError(message)); }
+        };
+        var executor = YtDlpPlugin.class.getDeclaredField("executor");
+        executor.setAccessible(true);
+        try {
+            plugin.cache(context, call);
+            return response.get(5, TimeUnit.SECONDS);
+        } finally { ((ExecutorService) executor.get(plugin)).shutdownNow(); }
+    }
+
+    private JSObject request(String action) {
+        return new JSObject().put("action", action).put("videoId", VIDEO).put("cacheKey", "settings");
+    }
+
+    private Context isolatedContext(Context app, File root) {
+        return new ContextWrapper(app) {
+            @Override public File getDataDir() { return root; }
+            @Override public File getCacheDir() { return new File(root, "cache"); }
+            @Override public File getCodeCacheDir() { return new File(root, "code_cache"); }
+            @Override public File getNoBackupFilesDir() { return new File(root, "no_backup"); }
+        };
+    }
+
+    @Test public void playbackSurvivesPluginRestartAndAndroidCacheEviction() throws Exception {
+        Context app = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        File root = new File(app.getCacheDir(), "playback-test-" + UUID.randomUUID());
+        Context context = isolatedContext(app, root);
+        try {
+            long expiry = System.currentTimeMillis() + 3600000;
+            JSObject source = new JSObject().put("manifestSrc", "<MPD/>").put("isLive", false);
+            call(context, request("set").put("expiryTime", expiry).put("source", source));
+            assertEquals("<MPD/>", call(context, request("get")).getJSONObject("entry").getJSONObject("source").getString("manifestSrc"));
+
+            // Android may reclaim cache files while the app is stopped.
+            YtDlpFiles.deleteTree(context.getCacheDir());
+            JSObject restored = call(context, request("get"));
+            assertTrue("Playback cache was lost after Android cache eviction", restored.has("entry"));
+            assertEquals(expiry, restored.getJSONObject("entry").getLong("expiryTime"));
+            assertEquals("<MPD/>", restored.getJSONObject("entry").getJSONObject("source").getString("manifestSrc"));
+
+            call(context, request("clear"));
+            assertFalse(call(context, request("get")).has("entry"));
+        } finally { YtDlpFiles.deleteTree(root); }
+    }
+
+    @Test public void existingCacheMovesToPersistentStorage() throws Exception {
+        Context app = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        File root = new File(app.getCacheDir(), "playback-test-" + UUID.randomUUID());
+        Context context = isolatedContext(app, root);
+        try {
+            File oldDirectory = new File(context.getCacheDir(), "yt-dlp-playback");
+            assertTrue(oldDirectory.mkdirs());
+            JSObject entry = request("set").put("expiryTime", System.currentTimeMillis() + 3600000)
+                .put("source", new JSObject().put("manifestSrc", "<MPD/>"));
+            YtDlpFiles.write(new File(oldDirectory, VIDEO + ".json"), entry.toString().getBytes(StandardCharsets.UTF_8));
+            assertTrue(call(context, request("get")).has("entry"));
+            assertFalse("Old cache directory should be moved", oldDirectory.exists());
+            YtDlpFiles.deleteTree(context.getCacheDir());
+            assertTrue(call(context, request("get")).has("entry"));
+            call(context, request("delete"));
+            assertFalse(call(context, request("get")).has("entry"));
+        } finally { YtDlpFiles.deleteTree(root); }
+    }
+
+    @Test public void storageSettingsMeasuresAndClearsPersistentPlaybackCache() throws Exception {
+        Context app = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        File root = new File(app.getCacheDir(), "playback-test-" + UUID.randomUUID());
+        Context context = isolatedContext(app, root);
+        try {
+            call(context, request("set").put("expiryTime", System.currentTimeMillis() + 3600000)
+                .put("source", new JSObject().put("manifestSrc", "<MPD/>")));
+            File preferences = new File(context.getNoBackupFilesDir(), "preferences.json");
+            YtDlpFiles.write(preferences, "{}".getBytes(StandardCharsets.UTF_8));
+
+            AndroidStorage.Usage usage = AndroidStoragePlugin.getUsage(context);
+            assertTrue("Storage Settings must count playback entries as clearable cache", usage.cacheBytes > 0);
+            assertEquals(preferences.length(), usage.appDataBytes);
+            assertTrue(AndroidStoragePlugin.clearCacheFiles(context));
+            assertFalse("Clear Cache must remove persistent playback entries", call(context, request("get")).has("entry"));
+            assertEquals(0, AndroidStoragePlugin.getUsage(context).cacheBytes);
+            assertTrue("Clear Cache must preserve other app data", preferences.isFile());
+        } finally { YtDlpFiles.deleteTree(root); }
+    }
+
+    @Test public void playbackSurvivesAppReplacement() throws Exception {
+        Context app = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        File root = new File(app.getNoBackupFilesDir(), "playback-replacement-test");
+        File cache = new File(app.getCacheDir(), "playback-replacement-test");
+        Context context = new ContextWrapper(app) {
+            @Override public File getCacheDir() { return cache; }
+            @Override public File getNoBackupFilesDir() { return root; }
+        };
+        // Run with -e playbackCachePhase seed, install -r, then run with verify.
+        String phase = InstrumentationRegistry.getArguments().getString("playbackCachePhase", "both");
+        try {
+            if (!phase.equals("verify")) {
+                YtDlpFiles.deleteTree(root);
+                YtDlpFiles.deleteTree(cache);
+                call(context, request("set").put("expiryTime", System.currentTimeMillis() + 3600000)
+                    .put("source", new JSObject().put("manifestSrc", "<MPD/>")));
+            }
+            if (!phase.equals("seed")) {
+                assertEquals("<MPD/>", call(context, request("get")).getJSONObject("entry").getJSONObject("source").getString("manifestSrc"));
+            }
+        } finally {
+            if (!phase.equals("seed")) {
+                YtDlpFiles.deleteTree(root);
+                YtDlpFiles.deleteTree(cache);
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/org/opentubex/app/AndroidStoragePlugin.java
+++ b/android/app/src/main/java/org/opentubex/app/AndroidStoragePlugin.java
@@ -1,5 +1,6 @@
 package org.opentubex.app;
 
+import android.content.Context;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
@@ -14,11 +15,7 @@ import java.util.concurrent.TimeUnit;
 public class AndroidStoragePlugin extends Plugin {
     @PluginMethod
     public void getUsage(PluginCall call) {
-        AndroidStorage.Usage usage = AndroidStorage.measure(
-            getContext().getDataDir(),
-            getContext().getCacheDir(),
-            getContext().getCodeCacheDir()
-        );
+        AndroidStorage.Usage usage = getUsage(getContext());
         JSObject result = new JSObject();
         result.put("appDataBytes", usage.appDataBytes);
         result.put("cacheBytes", usage.cacheBytes);
@@ -28,8 +25,6 @@ public class AndroidStoragePlugin extends Plugin {
 
     @PluginMethod
     public void clearCache(PluginCall call) {
-        File cacheDirectory = getContext().getCacheDir();
-        File codeCacheDirectory = getContext().getCodeCacheDir();
         CountDownLatch webViewCacheCleared = new CountDownLatch(1);
 
         getActivity().runOnUiThread(() -> {
@@ -48,11 +43,30 @@ public class AndroidStoragePlugin extends Plugin {
             return;
         }
 
-        boolean cleared = AndroidStorage.clearDirectory(cacheDirectory);
-        cleared &= AndroidStorage.clearDirectory(codeCacheDirectory);
+        boolean cleared = clearCacheFiles(getContext());
 
         JSObject result = new JSObject();
         result.put("cleared", cleared);
         call.resolve(result);
+    }
+
+    static AndroidStorage.Usage getUsage(Context context) {
+        return AndroidStorage.measure(context.getDataDir(), cacheDirectories(context));
+    }
+
+    static boolean clearCacheFiles(Context context) {
+        synchronized (YtDlpPlugin.PLAYBACK_CACHE_LOCK) {
+            boolean cleared = true;
+            for (File directory : cacheDirectories(context)) cleared &= AndroidStorage.clearDirectory(directory);
+            return cleared;
+        }
+    }
+
+    private static File[] cacheDirectories(Context context) {
+        return new File[] {
+            context.getCacheDir(),
+            context.getCodeCacheDir(),
+            YtDlpPlugin.playbackCacheDirectory(context)
+        };
     }
 }

--- a/android/app/src/main/java/org/opentubex/app/YtDlpPlugin.java
+++ b/android/app/src/main/java/org/opentubex/app/YtDlpPlugin.java
@@ -4,6 +4,7 @@ import static java.util.Arrays.asList;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.content.Context;
 import android.net.Uri;
 import androidx.activity.result.ActivityResult;
 import com.getcapacitor.*;
@@ -33,7 +34,7 @@ public final class YtDlpPlugin extends Plugin {
     private volatile String version;
     private String ffmpegVersion;
     private String ffprobeVersion;
-    private final Object cacheLock = new Object();
+    static final Object PLAYBACK_CACHE_LOCK = new Object();
 
     @Override public void load() {
         downloads = YtDlpDownloads.get(getContext());
@@ -199,9 +200,26 @@ public final class YtDlpPlugin extends Plugin {
         });
     }
     @PluginMethod public void cache(PluginCall call) {
+        cache(getContext(), call);
+    }
+
+    static File playbackCacheDirectory(Context context) {
+        return new File(context.getNoBackupFilesDir(), "yt-dlp-playback");
+    }
+
+    void cache(Context context, PluginCall call) {
         run(call, () -> {
-            synchronized (cacheLock) {
-            File directory = new File(getContext().getCacheDir(), "yt-dlp-playback");
+            synchronized (PLAYBACK_CACHE_LOCK) {
+            // Keep signed playback URLs across restarts and APK replacements,
+            // outside Android's reclaimable cache and device backups.
+            File directory = playbackCacheDirectory(context);
+            if (!directory.exists()) {
+                File previousDirectory = new File(context.getCacheDir(), "yt-dlp-playback");
+                directory.getParentFile().mkdirs();
+                if (previousDirectory.isDirectory() && !previousDirectory.renameTo(directory)) {
+                    throw new IOException("Unable to preserve the existing playback cache");
+                }
+            }
             directory.mkdirs();
             String action = call.getString("action", "");
             if (action.equals("clear")) { YtDlpFiles.deleteTree(directory); return new JSONObject(); }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Reported during mobile playback testing; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Mobile playback can fetch streams with yt-dlp again after Android reclaims cached playback URLs. Store these entries in persistent, backup-excluded app storage and move existing entries there, while retaining their expiry and size limits.

Keep playback entries in Storage Settings’ cache total and explicit Clear Cache action. Share the playback lock with cleanup so it cannot race writes or the directory move.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Play a video using yt-dlp, then close and reopen the Android app. Replay it before its stream URLs expire and confirm the cached streams are reused.
2. Replace the APK while preserving app data, then replay the same video and confirm its cached streams remain available.
3. Use Clear Cache in Storage Settings. Confirm the cache total drops and replaying the video fetches fresh streams after reopening the app. Other app data should remain intact.

## Additional context
<!-- Add any other context about the pull request here. -->

Native regression coverage includes cache eviction, migration, explicit storage cleanup, and APK replacement between separate test processes. Ordinary restart and APK replacement alone did not establish the original cause; cache eviction was the reproduced failure.
