### PR TITLE
fix(android): maximize Settings, Downloads, About, and profile windows

### DIFF
--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -180,7 +180,7 @@
           <FtIcon :icon="['fas', 'angle-down']" />
         </button>
         <button
-          v-if="!isNarrowLayout"
+          v-if="!isMaximizationForced"
           type="button"
           class="settingsHeaderButton"
           :aria-label="maximizeButtonLabel"
@@ -517,7 +517,8 @@ let restoreBounds = null
 let preservedScrollPositions = []
 
 const windowBounds = ref(getInitialBounds())
-const isWindowMaximized = computed(() => isMaximized.value || isNarrowLayout.value)
+const isMaximizationForced = computed(() => IS_CAPACITOR || isNarrowLayout.value)
+const isWindowMaximized = computed(() => isMaximized.value || isMaximizationForced.value)
 const windowStyle = computed(() => isWindowMaximized.value
   ? {
       left: '0',
@@ -1247,7 +1248,7 @@ function restorePreservedScrollPositions() {
 }
 
 async function toggleMaximized() {
-  if (isNarrowLayout.value) return
+  if (isMaximizationForced.value) return
   cancelBoundsAnimation()
   const element = settingsWindowRef.value
   const from = getWindowAnimationState(element)
@@ -1322,7 +1323,7 @@ function handleSettingsEscape(event) {
 
 function handleHeaderDoubleClick(event) {
   if (
-    isNarrowLayout.value ||
+    isMaximizationForced.value ||
     event.button !== 0 ||
     event.target.closest('button, input, .settingsSearch')
   ) return
@@ -1331,7 +1332,7 @@ function handleHeaderDoubleClick(event) {
 
 function startDragging(event) {
   if (
-    isNarrowLayout.value ||
+    isMaximizationForced.value ||
     event.button !== 0 ||
     event.target.closest('button, input, .settingsSearch')
   ) return

--- a/tests/unit/settings-window-layout.test.mjs
+++ b/tests/unit/settings-window-layout.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import vm from 'node:vm'
+import { computed, ref } from 'vue'
+
+const component = await readFile(new URL('../../src/renderer/views/Settings/Settings.vue', import.meta.url), 'utf8')
+
+function componentFunction(name) {
+  const start = component.search(new RegExp(`(?:async )?function ${name}\\(`))
+  assert.notEqual(start, -1)
+  return component.slice(start, component.indexOf('\n}', start) + 2)
+}
+
+// Run the real window sizing and interaction logic without the settings pages'
+// browser-only imports. Vue refs keep viewport changes reactive in this harness.
+function settingsWindow(isCapacitor, width) {
+  const window = { innerWidth: width }
+  const initialState = component.slice(component.indexOf('const isMaximized ='), component.indexOf('const activeSection ='))
+  const windowState = component.slice(component.indexOf('const windowBounds ='), component.indexOf('const settingsWindowMorphing ='))
+  const functions = ['updateNarrowLayout', 'toggleMaximized', 'handleHeaderDoubleClick', 'startDragging', 'startResizing']
+    .map(componentFunction).join('\n')
+  const api = vm.runInNewContext(`${initialState}\n${windowState}\n${functions}\n;({
+    isWindowMaximized, windowStyle, updateNarrowLayout,
+    toggleMaximized, handleHeaderDoubleClick, startDragging, startResizing
+  })`, {
+    computed,
+    ref,
+    window,
+    IS_CAPACITOR: isCapacitor,
+    SETTINGS_DESKTOP_WIDTH_THRESHOLD: 760,
+    getInitialBounds: () => ({ x: 24, y: 40, width: 720, height: 600 }),
+    t: key => key,
+    cancelBoundsAnimation: () => assert.fail('Forced maximization must reject window gestures')
+  })
+  return {
+    ...api,
+    resize(width) {
+      window.innerWidth = width
+      api.updateNarrowLayout()
+    }
+  }
+}
+
+function assertMaximized(settings) {
+  assert.equal(settings.isWindowMaximized.value, true)
+  assert.equal(settings.windowStyle.value.left, '0')
+  assert.equal(settings.windowStyle.value.top, 'var(--app-safe-area-inset-top, 0px)')
+  assert.equal(settings.windowStyle.value.inlineSize, '100vw')
+  assert.equal(settings.windowStyle.value.blockSize, 'calc(100dvh - var(--app-safe-area-inset-top, 0px))')
+}
+
+test('mobile settings open maximized on landscape phones and tablets', () => {
+  for (const width of [375, 844, 1024, 1366, 1092.8]) {
+    assertMaximized(settingsWindow(true, width))
+  }
+})
+
+test('mobile settings stay maximized when rotating across the compact breakpoint', () => {
+  const settings = settingsWindow(true, 375)
+  for (const width of [844, 375, 1024, 1366]) {
+    settings.resize(width)
+    assertMaximized(settings)
+  }
+})
+
+test('mobile settings cannot be restored, dragged, or resized on tablets', async () => {
+  const settings = settingsWindow(true, 1024)
+  const event = { button: 0, target: { closest: () => null } }
+  await settings.toggleMaximized()
+  settings.handleHeaderDoubleClick(event)
+  settings.startDragging(event)
+  settings.startResizing(event, 'se')
+  assertMaximized(settings)
+})
+
+test('desktop settings float at wide widths and maximize only at narrow widths', () => {
+  const settings = settingsWindow(false, 1280)
+  assert.equal(settings.isWindowMaximized.value, false)
+  assert.equal(settings.windowStyle.value.inlineSize, '720px')
+  settings.resize(375)
+  assertMaximized(settings)
+  settings.resize(1280)
+  assert.equal(settings.isWindowMaximized.value, false)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Settings opened as a floating window when a phone rotated into tablet layout, and on wider tablets. Force the shared window used by Settings, Downloads, About, and the profile manager to stay maximized at every Android viewport width, with restore and window-drag gestures disabled. Desktop window behavior and standalone confirmation dialogs stay the same.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Settings, Downloads, About, and the profile manager now stay maximized on phones in landscape and on tablets.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. On Android, open Settings with the phone in portrait, rotate to landscape, then close and reopen Settings. It should fill the available app area below the status bar in both orientations.
2. Repeat on a tablet. Settings should have no maximize or restore button, and dragging or double-tapping its header should not make it float.
3. Open Downloads, About, and the profile manager on Android. Each should use the same maximized window behavior.
4. On desktop, open Settings in a wide window. Maximize, restore, drag, and resize should still work. Narrowing the app window should still force Settings to fill it.

## Additional context
<!-- Add any other context about the pull request here. -->
