### PR TITLE
fix(android): use native pairing scanner and require Android 8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
     allow:
       - dependency-name: "@capacitor/android"
       - dependency-name: "@capacitor/app"
+      - dependency-name: "@capacitor/barcode-scanner"
       - dependency-name: "@capacitor/browser"
       - dependency-name: "@capacitor/cli"
       - dependency-name: "@capacitor/core"

--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ RedirectTube, doesn’t automatically open YouTube links in OpenTubeX (although 
 * openSUSE: [RPM repository](https://rpm.opentubex.org/)
 * Flatpak: [OpenTubeX remote](https://flatpak.opentubex.org/), [Flatpark](https://flatpark.org/apps/org.opentubex.OpenTubeX/), and [source code](https://github.com/OpenTubeX/flatpak)
 * Arch User Repository (AUR): [Download](https://aur.archlinux.org/packages/opentubex-bin/)
-* Android preview: requires Android 7.0 or newer (API 24). Current APKs compile and target Android 16 (API 36). Install and update through the [OpenTubeX F-Droid repository](https://fdroid.opentubex.org/) or [Obtainium](https://apps.obtainium.imranr.dev/redirect?r=obtainium://add/https://github.com/OpenTubeX/OpenTubeX).
+* Android preview: requires Android 8.0 or newer (API 26). Current APKs compile and target Android 16 (API 36). Install and update through the [OpenTubeX F-Droid repository](https://fdroid.opentubex.org/) or [Obtainium](https://apps.obtainium.imranr.dev/redirect?r=obtainium://add/https://github.com/OpenTubeX/OpenTubeX).
 
 iOS support is planned. The first iOS builds will be downloadable `.ipa` files.
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -76,6 +76,11 @@ android {
     }
 }
 
+// Pairing uses ZXing; exclude the plugin's unused proprietary ML Kit dependency.
+configurations.configureEach {
+    exclude group: 'com.google.mlkit', module: 'barcode-scanning'
+}
+
 repositories {
     flatDir{
         dirs '../capacitor-cordova-android-plugins/src/main/libs', 'libs'

--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -10,6 +10,7 @@ android {
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
     implementation project(':capacitor-app')
+    implementation project(':capacitor-barcode-scanner')
     implementation project(':capacitor-browser')
     implementation project(':capacitor-local-notifications')
 

--- a/android/app/src/androidTest/java/org/opentubex/app/PairingCameraTest.java
+++ b/android/app/src/androidTest/java/org/opentubex/app/PairingCameraTest.java
@@ -1,0 +1,103 @@
+package org.opentubex.app;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.pm.PackageManager;
+import android.os.ParcelFileDescriptor;
+import android.view.KeyEvent;
+import android.webkit.WebView;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
+import androidx.test.runner.lifecycle.Stage;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+@RunWith(AndroidJUnit4.class)
+public class PairingCameraTest {
+    @Test
+    public void nativePairingDoesNotBundleMlKit() {
+        assertThrows(ClassNotFoundException.class,
+            () -> Class.forName("com.google.mlkit.vision.barcode.BarcodeScanning"));
+    }
+
+    @Test
+    public void nativePairingScannerOpensAndReturnsCancellationWithoutCrashing() throws Exception {
+        String packageName = InstrumentationRegistry.getInstrumentation().getTargetContext().getPackageName();
+        try (ParcelFileDescriptor.AutoCloseInputStream output = new ParcelFileDescriptor.AutoCloseInputStream(
+                InstrumentationRegistry.getInstrumentation().getUiAutomation()
+                    .executeShellCommand("pm grant " + packageName + " " + Manifest.permission.CAMERA))) {
+            while (output.read() != -1) {}
+        }
+        assertEquals("Android must be able to grant camera access for pairing", PackageManager.PERMISSION_GRANTED,
+            InstrumentationRegistry.getInstrumentation().getTargetContext().checkSelfPermission(Manifest.permission.CAMERA));
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            AtomicReference<WebView> view = new AtomicReference<>();
+            scenario.onActivity(activity -> view.set(activity.getBridge().getWebView()));
+            awaitValue(view.get(), "location.protocol === 'https:' && document.readyState === 'complete'", "true");
+            evaluate(view.get(),
+                "window.pairingCameraResult = 'pending';" +
+                "window.Capacitor.nativePromise('CapacitorBarcodeScanner', 'scanBarcode', {" +
+                "hint: 0, cameraDirection: 1, scanOrientation: 3, scanButton: false," +
+                "android: {scanningLibrary: 'zxing'}, cancelButtonAccessibilityLabel: 'Cancel'" +
+                "}).then(function() { window.pairingCameraResult = 'scanned'; }," +
+                "function(error) { window.pairingCameraResult = error.code; });"
+            );
+            awaitNativeScanner();
+            InstrumentationRegistry.getInstrumentation().sendKeyDownUpSync(KeyEvent.KEYCODE_BACK);
+            awaitValue(view.get(), "window.pairingCameraResult", "\"OS-PLUG-BARC-0006\"");
+        }
+    }
+
+    private static void awaitNativeScanner() throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(15);
+        AtomicReference<Boolean> opened = new AtomicReference<>(false);
+        do {
+            InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> {
+                for (Activity activity : ActivityLifecycleMonitorRegistry.getInstance().getActivitiesInStage(Stage.RESUMED)) {
+                    if (activity.getClass().getName().equals("com.outsystems.plugins.barcode.view.OSBARCScannerActivity")) {
+                        opened.set(true);
+                    }
+                }
+            });
+            if (opened.get()) return;
+            Thread.sleep(100);
+        } while (System.nanoTime() < deadline);
+        assertTrue("Native QR scanner opens", opened.get());
+    }
+
+    private static void awaitValue(WebView view, String script, String expected) throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(15);
+        String actual;
+        do {
+            actual = evaluate(view, script);
+            if (expected.equals(actual)) return;
+            Thread.sleep(100);
+        } while (System.nanoTime() < deadline);
+        assertEquals(expected, actual);
+    }
+
+    private static String evaluate(WebView view, String script) throws Exception {
+        CountDownLatch evaluated = new CountDownLatch(1);
+        AtomicReference<String> result = new AtomicReference<>();
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(() ->
+            view.evaluateJavascript(script, value -> {
+                result.set(value);
+                evaluated.countDown();
+            })
+        );
+        assertTrue("WebView responds", evaluated.await(5, TimeUnit.SECONDS));
+        return result.get();
+    }
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- Pairing can also use a text code on devices without a camera. -->
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -68,6 +72,7 @@
     <!-- Permissions -->
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -5,6 +5,9 @@ project(':capacitor-android').projectDir = new File('../node_modules/.pnpm/@capa
 include ':capacitor-app'
 project(':capacitor-app').projectDir = new File('../node_modules/.pnpm/@capacitor+app@8.1.1_@capacitor+core@8.5.0/node_modules/@capacitor/app/android')
 
+include ':capacitor-barcode-scanner'
+project(':capacitor-barcode-scanner').projectDir = new File('../node_modules/.pnpm/@capacitor+barcode-scanner@3.1.2_@capacitor+core@8.5.0/node_modules/@capacitor/barcode-scanner/android')
+
 include ':capacitor-browser'
 project(':capacitor-browser').projectDir = new File('../node_modules/.pnpm/@capacitor+browser@8.0.4_@capacitor+core@8.5.0/node_modules/@capacitor/browser/android')
 

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -1,5 +1,5 @@
 ext {
-    minSdkVersion = 24
+    minSdkVersion = 26
     compileSdkVersion = 36
     targetSdkVersion = 36
     androidxActivityVersion = '1.11.0'

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   "dependencies": {
     "@capacitor/android": "^8.5.0",
     "@capacitor/app": "^8.1.1",
+    "@capacitor/barcode-scanner": "^3.1.2",
     "@capacitor/browser": "^8.0.4",
     "@capacitor/core": "^8.5.0",
     "@capacitor/local-notifications": "^8.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@capacitor/app':
         specifier: ^8.1.1
         version: 8.1.1(@capacitor/core@8.5.0)
+      '@capacitor/barcode-scanner':
+        specifier: ^3.1.2
+        version: 3.1.2(@capacitor/core@8.5.0)
       '@capacitor/browser':
         specifier: ^8.0.4
         version: 8.0.4(@capacitor/core@8.5.0)
@@ -797,6 +800,11 @@ packages:
 
   '@capacitor/app@8.1.1':
     resolution: {integrity: sha512-xM2ZTX5jK60tFtmjsmJv+Cdj1Qsb6NcavkqmdEnCPQBeya9oKhamZJxYOnQNj1ZvcJM7sWfG6BEtSLx42pisbA==}
+    peerDependencies:
+      '@capacitor/core': '>=8.0.0'
+
+  '@capacitor/barcode-scanner@3.1.2':
+    resolution: {integrity: sha512-8OdOFfHgxo22TQAGghk+BuSu66RROWPxkHChQpbIttzdomvgKkwJUi8tfNUYqlG2RT9HEy40yyAzxFhxN22lLg==}
     peerDependencies:
       '@capacitor/core': '>=8.0.0'
 
@@ -3300,6 +3308,9 @@ packages:
         optional: true
       webpack:
         optional: true
+
+  html5-qrcode@2.3.8:
+    resolution: {integrity: sha512-jsr4vafJhwoLVEDW3n1KvPnCCXWaQfRng0/EEYk1vNcQGcG/htAdhJX0be8YyqMoSz7+hZvOZSTAepsabiuhiQ==}
 
   htmlparser2@6.1.0:
     resolution: {integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==}
@@ -6250,6 +6261,11 @@ snapshots:
     dependencies:
       '@capacitor/core': 8.5.0
 
+  '@capacitor/barcode-scanner@3.1.2(@capacitor/core@8.5.0)':
+    dependencies:
+      '@capacitor/core': 8.5.0
+      html5-qrcode: 2.3.8
+
   '@capacitor/browser@8.0.4(@capacitor/core@8.5.0)':
     dependencies:
       '@capacitor/core': 8.5.0
@@ -9129,6 +9145,8 @@ snapshots:
       tapable: 2.3.3
     optionalDependencies:
       webpack: 5.110.3(postcss@8.5.26)(webpack-cli@7.2.3)
+
+  html5-qrcode@2.3.8: {}
 
   htmlparser2@6.1.0:
     dependencies:

--- a/src/renderer/components/SyncSettings/SyncPairing.vue
+++ b/src/renderer/components/SyncSettings/SyncPairing.vue
@@ -645,7 +645,8 @@ async function startScanner() {
   stopScanner()
   scannerHandled = false
   try {
-    if (usingNativeScanner) {
+    // Keep the build flag here so Webpack excludes native scanner chunks on desktop/web.
+    if (process.env.IS_CAPACITOR) {
       const { scanNativePairingCode } = await import('../../helpers/nativePairingScanner')
       if (sequence !== approveSequence || !approvePromptOpen.value) return
       const code = await scanNativePairingCode({

--- a/src/renderer/components/SyncSettings/SyncPairing.vue
+++ b/src/renderer/components/SyncSettings/SyncPairing.vue
@@ -154,7 +154,11 @@
     <div class="pairingContent">
       <template v-if="approveStage === 'scanning'">
         <p>{{ t('Settings.Sync Settings.Pairing Scan Hint') }}</p>
-        <div class="scannerFrame">
+        <FtLoader v-if="usingNativeScanner" />
+        <div
+          v-else
+          class="scannerFrame"
+        >
           <video
             ref="scannerVideo"
             class="scannerVideo"
@@ -352,6 +356,7 @@ const props = defineProps({
 
 const emit = defineEmits(['paired'])
 const { locale, t } = useI18n()
+const usingNativeScanner = Boolean(process.env.IS_CAPACITOR)
 const timeFormat = computed(() => store.getters.getTimeFormat)
 
 const receivePromptOpen = ref(false)
@@ -640,6 +645,23 @@ async function startScanner() {
   stopScanner()
   scannerHandled = false
   try {
+    if (usingNativeScanner) {
+      const { scanNativePairingCode } = await import('../../helpers/nativePairingScanner')
+      if (sequence !== approveSequence || !approvePromptOpen.value) return
+      const code = await scanNativePairingCode({
+        instructions: t('Settings.Sync Settings.Pairing Scan Hint'),
+        cancelLabel: t('Cancel'),
+        torchOnLabel: t('Settings.Sync Settings.Turn Flashlight Off'),
+        torchOffLabel: t('Settings.Sync Settings.Turn Flashlight On'),
+      })
+      if (sequence !== approveSequence || !approvePromptOpen.value) return
+      if (code === null) {
+        await openManualEntry()
+      } else {
+        await handleScan({ data: code })
+      }
+      return
+    }
     scanner = new QrScanner(scannerVideo.value, handleScan, {
       highlightScanRegion: true,
       highlightCodeOutline: true,
@@ -649,10 +671,11 @@ async function startScanner() {
     })
     await scanner.start()
   } catch {
-    stopScanner()
     if (sequence !== approveSequence || !approvePromptOpen.value) return
+    stopScanner()
+    if (usingNativeScanner) await openManualEntry()
     approveError.value = t('Settings.Sync Settings.Camera Unavailable')
-    approveStage.value = 'error'
+    if (!usingNativeScanner) approveStage.value = 'error'
   }
 }
 

--- a/src/renderer/helpers/nativePairingScanner.js
+++ b/src/renderer/helpers/nativePairingScanner.js
@@ -1,0 +1,35 @@
+import {
+  CapacitorBarcodeScanner,
+  CapacitorBarcodeScannerAndroidScanningLibrary,
+  CapacitorBarcodeScannerCameraDirection,
+  CapacitorBarcodeScannerScanOrientation,
+  CapacitorBarcodeScannerTypeHint,
+} from '@capacitor/barcode-scanner'
+
+let scanning = false
+
+export async function scanNativePairingCode({ instructions, cancelLabel, torchOnLabel, torchOffLabel }) {
+  // Native scanning owns a separate screen and cannot be stopped from JS.
+  // Keep ownership until it returns, including when the pairing view unmounts.
+  if (scanning) throw new Error('A native pairing scan is already active')
+  scanning = true
+  try {
+    const result = await CapacitorBarcodeScanner.scanBarcode({
+      hint: CapacitorBarcodeScannerTypeHint.QR_CODE,
+      cameraDirection: CapacitorBarcodeScannerCameraDirection.BACK,
+      scanOrientation: CapacitorBarcodeScannerScanOrientation.ADAPTIVE,
+      scanInstructions: instructions,
+      scanButton: false,
+      cancelButtonAccessibilityLabel: cancelLabel,
+      torchButtonOnAccessibilityLabel: torchOnLabel,
+      torchButtonOffAccessibilityLabel: torchOffLabel,
+      android: { scanningLibrary: CapacitorBarcodeScannerAndroidScanningLibrary.ZXING },
+    })
+    return result.ScanResult
+  } catch (error) {
+    if (error?.code === 'OS-PLUG-BARC-0006') return null
+    throw error
+  } finally {
+    scanning = false
+  }
+}

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -811,6 +811,8 @@ Settings:
     Import playlists formats: 'التنسيقات المدعومة: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'التنسيقات المدعومة: OpenTubeX / FreeTube (.db)، YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: تشغيل المصباح
+    Turn Flashlight Off: إيقاف المصباح
     Devices: "الأجهزة"
     Devices Hint: "راجع الأجهزة التي يمكنها الوصول إلى حساب المزامنة هذا."
     Change Password: "تغيير كلمة المرور"

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -839,6 +839,8 @@ Settings:
     Import playlists formats: 'Фарматы, якія падтрымліваюцца: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Фарматы, якія падтрымліваюцца: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Уключыць ліхтарык
+    Turn Flashlight Off: Выключыць ліхтарык
     Devices: "Прылады"
     Devices Hint: "Праверце прылады, якія маюць доступ да гэтага ўліковага запісу сінхранізацыі."
     Change Password: "Змяніць пароль"

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -796,6 +796,8 @@ Settings:
     Import playlists formats: 'Поддържани формати: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Поддържани формати: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Включване на фенерчето
+    Turn Flashlight Off: Изключване на фенерчето
     Devices: "Устройства"
     Devices Hint: "Прегледайте устройствата, които имат достъп до този акаунт за синхронизиране."
     Change Password: "Промяна на паролата"

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -792,6 +792,8 @@ Settings:
     Import playlists formats: "Mentrezhioù skoret: OpenTubeX / FreeTube (.db)"
     Import search history formats: "Mentrezhioù skoret: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)"
   Sync Settings:
+    Turn Flashlight On: Enaouiñ al lamp-tredan
+    Turn Flashlight Off: Lazhañ al lamp-tredan
     Devices: "Trobarzhelloù"
     Devices Hint: "Gwiriañ an trobarzhelloù a c’hall haeziñ ar gont sinkronelaat-mañ."
     Change Password: "Cheñch ar ger-tremen"

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -1114,6 +1114,8 @@ Settings:
     Import playlists formats: 'Formats admesos: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Formats admesos: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Activa la llanterna
+    Turn Flashlight Off: Desactiva la llanterna
     Devices: "Dispositius"
     Devices Hint: "Revisa els dispositius que poden accedir a aquest compte de sincronització."
     Change Password: "Canvia la contrasenya"

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -792,6 +792,8 @@ Settings:
     Import playlists formats: 'Podporované formáty: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Podporované formáty: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Zapnout svítilnu
+    Turn Flashlight Off: Vypnout svítilnu
     Devices: "Zařízení"
     Devices Hint: "Zkontrolujte zařízení, která mají přístup k tomuto synchronizačnímu účtu."
     Change Password: "Změnit heslo"

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -796,6 +796,8 @@ Settings:
     Import playlists formats: 'Fformatau a gynhelir: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Fformatau a gynhelir: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Troi’r fflachlamp ymlaen
+    Turn Flashlight Off: Diffodd y fflachlamp
     Devices: "Dyfeisiau"
     Devices Hint: "Adolygwch y dyfeisiau sy’n gallu cyrchu’r cyfrif cysoni hwn."
     Change Password: "Newid cyfrinair"

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -835,6 +835,8 @@ Settings:
     Import playlists formats: 'Understøttede formater: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Understøttede formater: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Tænd lommelygten
+    Turn Flashlight Off: Sluk lommelygten
     Devices: "Enheder"
     Devices Hint: "Gennemse de enheder, der har adgang til denne synkroniseringskonto."
     Change Password: "Skift adgangskode"

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -816,6 +816,8 @@ Settings:
     Import playlists formats: 'Υποστηριζόμενες μορφές: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Υποστηριζόμενες μορφές: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Ενεργοποίηση φακού
+    Turn Flashlight Off: Απενεργοποίηση φακού
     Devices: "Συσκευές"
     Devices Hint: "Ελέγξτε τις συσκευές που έχουν πρόσβαση σε αυτόν τον λογαριασμό συγχρονισμού."
     Change Password: "Αλλαγή κωδικού πρόσβασης"

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -773,6 +773,8 @@ Settings:
     Import playlists formats: 'Supported formats: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Supported formats: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Turn torch on
+    Turn Flashlight Off: Turn torch off
     Devices: "Devices"
     Devices Hint: "Review the devices that can access this sync account."
     Change Password: "Change password"

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -895,6 +895,8 @@ Settings:
     Import playlists formats: 'Formatos compatibles: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Formatos compatibles: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Encender la linterna
+    Turn Flashlight Off: Apagar la linterna
     Devices: "Dispositivos"
     Devices Hint: "Revisá los dispositivos que pueden acceder a esta cuenta de sincronización."
     Change Password: "Cambiar contraseña"

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -966,6 +966,8 @@ Settings:
     Import playlists formats: 'Formatos compatibles: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Formatos compatibles: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Encender la linterna
+    Turn Flashlight Off: Apagar la linterna
     Devices: "Dispositivos"
     Devices Hint: "Revisa los dispositivos que pueden acceder a esta cuenta de sincronización."
     Change Password: "Cambiar contraseña"

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -809,6 +809,8 @@ Settings:
     Import playlists formats: 'Formatos compatibles: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Formatos compatibles: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Encender la linterna
+    Turn Flashlight Off: Apagar la linterna
     Devices: "Dispositivos"
     Devices Hint: "Revisa los dispositivos que pueden acceder a esta cuenta de sincronización."
     Change Password: "Cambiar contraseña"

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -794,6 +794,8 @@ Settings:
     Import playlists formats: 'Toetatud vormingud: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Toetatud vormingud: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Lülita taskulamp sisse
+    Turn Flashlight Off: Lülita taskulamp välja
     Devices: "Seadmed"
     Devices Hint: "Vaata üle seadmed, millel on juurdepääs sellele sünkroonimiskontole."
     Change Password: "Muuda parooli"

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -796,6 +796,8 @@ Settings:
     Import playlists formats: 'Onartutako formatuak: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Onartutako formatuak: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Piztu linterna
+    Turn Flashlight Off: Itzali linterna
     Devices: "Gailuak"
     Devices Hint: "Berrikusi sinkronizazio-kontu hau atzi dezaketen gailuak."
     Change Password: "Aldatu pasahitza"

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -839,6 +839,8 @@ Settings:
     Import playlists formats: 'قالب‌های پشتیبانی‌شده: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'قالب‌های پشتیبانی‌شده: OpenTubeX / FreeTube (.db)، YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: روشن کردن چراغ‌قوه
+    Turn Flashlight Off: خاموش کردن چراغ‌قوه
     Devices: "دستگاه‌ها"
     Devices Hint: "دستگاه‌هایی را که می‌توانند به این حساب همگام‌سازی دسترسی داشته باشند بررسی کنید."
     Change Password: "تغییر گذرواژه"

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -816,6 +816,8 @@ Settings:
     Import playlists formats: 'Tuetut muodot: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Tuetut muodot: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Sytytä taskulamppu
+    Turn Flashlight Off: Sammuta taskulamppu
     Devices: "Laitteet"
     Devices Hint: "Tarkista laitteet, joilla on tämän synkronointitilin käyttöoikeus."
     Change Password: "Vaihda salasana"

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -792,6 +792,8 @@ Settings:
     Import playlists formats: 'Formats pris en charge : OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Formats pris en charge : OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Allumer la lampe torche
+    Turn Flashlight Off: Éteindre la lampe torche
     Devices: "Appareils"
     Devices Hint: "Vérifiez les appareils qui peuvent accéder à ce compte de synchronisation."
     Change Password: "Modifier le mot de passe"

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -811,6 +811,8 @@ Settings:
     Import playlists formats: 'Formatos compatibles: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Formatos compatibles: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Acender a lanterna
+    Turn Flashlight Off: Apagar a lanterna
     Devices: "Dispositivos"
     Devices Hint: "Revisa os dispositivos que poden acceder a esta conta de sincronización."
     Change Password: "Cambiar o contrasinal"

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -816,6 +816,8 @@ Settings:
     Import playlists formats: 'תבניות נתמכות: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'תבניות נתמכות: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: הפעלת הפנס
+    Turn Flashlight Off: כיבוי הפנס
     Devices: "מכשירים"
     Devices Hint: "בדקו אילו מכשירים יכולים לגשת לחשבון הסנכרון הזה."
     Change Password: "שינוי סיסמה"

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -796,6 +796,8 @@ Settings:
     Import playlists formats: 'Podržani formati: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Podržani formati: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Uključi svjetiljku
+    Turn Flashlight Off: Isključi svjetiljku
     Devices: "Uređaji"
     Devices Hint: "Pregledajte uređaje koji mogu pristupiti ovom računu za sinkronizaciju."
     Change Password: "Promijeni lozinku"

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -794,6 +794,8 @@ Settings:
     Import playlists formats: 'Támogatott formátumok: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Támogatott formátumok: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Zseblámpa bekapcsolása
+    Turn Flashlight Off: Zseblámpa kikapcsolása
     Devices: "Eszközök"
     Devices Hint: "Tekintse át azokat az eszközöket, amelyek hozzáférhetnek ehhez a szinkronizálási fiókhoz."
     Change Password: "Jelszó módosítása"

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -811,6 +811,8 @@ Settings:
     Import playlists formats: 'Format yang didukung: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Format yang didukung: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Nyalakan senter
+    Turn Flashlight Off: Matikan senter
     Devices: "Perangkat"
     Devices Hint: "Tinjau perangkat yang dapat mengakses akun sinkronisasi ini."
     Change Password: "Ubah kata sandi"

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -811,6 +811,8 @@ Settings:
     Import playlists formats: 'Studd snið: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Studd snið: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Kveikja á vasaljósi
+    Turn Flashlight Off: Slökkva á vasaljósi
     Devices: "Tæki"
     Devices Hint: "Farðu yfir tækin sem hafa aðgang að þessum samstillingarreikningi."
     Change Password: "Breyta lykilorði"

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -792,6 +792,8 @@ Settings:
     Import playlists formats: 'Formati supportati: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Formati supportati: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Accendi la torcia
+    Turn Flashlight Off: Spegni la torcia
     Devices: "Dispositivi"
     Devices Hint: "Controlla i dispositivi che possono accedere a questo account di sincronizzazione."
     Change Password: "Cambia password"

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -792,6 +792,8 @@ Settings:
     Import playlists formats: '対応形式: OpenTubeX / FreeTube（.db）'
     Import search history formats: '対応形式: OpenTubeX / FreeTube（.db）、YouTube Takeout（.json）'
   Sync Settings:
+    Turn Flashlight On: ライトをオンにする
+    Turn Flashlight Off: ライトをオフにする
     Devices: "デバイス"
     Devices Hint: "この同期アカウントにアクセスできるデバイスを確認します。"
     Change Password: "パスワードを変更"

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -1028,6 +1028,8 @@ Settings:
     Import playlists formats: '지원 형식: OpenTubeX / FreeTube (.db)'
     Import search history formats: '지원 형식: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: 손전등 켜기
+    Turn Flashlight Off: 손전등 끄기
     Devices: "기기"
     Devices Hint: "이 동기화 계정에 접근할 수 있는 기기를 확인합니다."
     Change Password: "비밀번호 변경"

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -1045,6 +1045,8 @@ Settings:
     Import playlists formats: 'Palaikomi formatai: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Palaikomi formatai: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Įjungti žibintuvėlį
+    Turn Flashlight Off: Išjungti žibintuvėlį
     Devices: "Įrenginiai"
     Devices Hint: "Peržiūrėkite įrenginius, galinčius pasiekti šią sinchronizavimo paskyrą."
     Change Password: "Keisti slaptažodį"

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -794,6 +794,8 @@ Settings:
     Import playlists formats: 'Støttede formater: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Støttede formater: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Slå på lommelykten
+    Turn Flashlight Off: Slå av lommelykten
     Devices: "Enheter"
     Devices Hint: "Se gjennom enhetene som har tilgang til denne synkroniseringskontoen."
     Change Password: "Endre passord"

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -816,6 +816,8 @@ Settings:
     Import playlists formats: 'Ondersteunde indelingen: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Ondersteunde indelingen: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Zaklamp inschakelen
+    Turn Flashlight Off: Zaklamp uitschakelen
     Devices: "Apparaten"
     Devices Hint: "Bekijk de apparaten die toegang hebben tot dit synchronisatieaccount."
     Change Password: "Wachtwoord wijzigen"

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -995,6 +995,8 @@ Settings:
     Import playlists formats: 'Støtta format: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Støtta format: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Slå på lommelykta
+    Turn Flashlight Off: Slå av lommelykta
     Devices: "Einingar"
     Devices Hint: "Sjå gjennom einingane som har tilgang til denne synkroniseringskontoen."
     Change Password: "Endre passord"

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -338,6 +338,8 @@ Settings:
     Open Profile Directory: Otwórz katalog profilu
     Invalid JSON row, skipping item: Nieprawidłowy JSON w wierszu {row}. Element zostanie pominięty
   Sync Settings:
+    Turn Flashlight On: Włącz latarkę
+    Turn Flashlight Off: Wyłącz latarkę
     Devices: "Urządzenia"
     Devices Hint: "Sprawdź urządzenia, które mają dostęp do tego konta synchronizacji."
     Change Password: "Zmień hasło"

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -794,6 +794,8 @@ Settings:
     Import playlists formats: 'Formatos suportados: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Formatos suportados: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Ligar a lanterna
+    Turn Flashlight Off: Desligar a lanterna
     Devices: "Dispositivos"
     Devices Hint: "Confira os dispositivos que podem acessar esta conta de sincronização."
     Change Password: "Alterar senha"

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -811,6 +811,8 @@ Settings:
     Import playlists formats: 'Formatos suportados: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Formatos suportados: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Ligar a lanterna
+    Turn Flashlight Off: Desligar a lanterna
     Devices: "Dispositivos"
     Devices Hint: "Reveja os dispositivos que podem aceder a esta conta de sincronização."
     Change Password: "Alterar palavra-passe"

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -819,6 +819,8 @@ Settings:
     Import playlists formats: 'Formatos suportados: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Formatos suportados: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Ligar a lanterna
+    Turn Flashlight Off: Desligar a lanterna
     Devices: "Dispositivos"
     Devices Hint: "Reveja os dispositivos que podem aceder a esta conta de sincronização."
     Change Password: "Alterar palavra-passe"

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -805,6 +805,8 @@ Settings:
     Import playlists formats: 'Formate acceptate: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Formate acceptate: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Aprinde lanterna
+    Turn Flashlight Off: Stinge lanterna
     Devices: "Dispozitive"
     Devices Hint: "Verificați dispozitivele care pot accesa acest cont de sincronizare."
     Change Password: "Schimbați parola"

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -788,6 +788,8 @@ Settings:
     Import playlists formats: 'Поддерживаемые форматы: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Поддерживаемые форматы: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Включить фонарик
+    Turn Flashlight Off: Выключить фонарик
     Devices: "Устройства"
     Devices Hint: "Проверьте устройства, у которых есть доступ к этой учётной записи синхронизации."
     Change Password: "Изменить пароль"

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -794,6 +794,8 @@ Settings:
     Import playlists formats: 'Podporované formáty: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Podporované formáty: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Zapnúť baterku
+    Turn Flashlight Off: Vypnúť baterku
     Devices: "Zariadenia"
     Devices Hint: "Skontrolujte zariadenia, ktoré majú prístup k tomuto synchronizačnému účtu."
     Change Password: "Zmeniť heslo"

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -1078,6 +1078,8 @@ Settings:
     Import playlists formats: 'Podprte oblike: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Podprte oblike: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Vklopi svetilko
+    Turn Flashlight Off: Izklopi svetilko
     Devices: "Naprave"
     Devices Hint: "Preglejte naprave, ki lahko dostopajo do tega računa za sinhronizacijo."
     Change Password: "Spremeni geslo"

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -832,6 +832,8 @@ Settings:
     Import playlists formats: 'Подржани формати: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Подржани формати: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Укључи батеријску лампу
+    Turn Flashlight Off: Искључи батеријску лампу
     Devices: "Уређаји"
     Devices Hint: "Прегледајте уређаје који могу да приступе овом налогу за синхронизацију."
     Change Password: "Промени лозинку"

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -796,6 +796,8 @@ Settings:
     Import playlists formats: 'Format som stöds: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Format som stöds: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Slå på ficklampan
+    Turn Flashlight Off: Slå av ficklampan
     Devices: "Enheter"
     Devices Hint: "Granska enheterna som har åtkomst till det här synkroniseringskontot."
     Change Password: "Byt lösenord"

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -815,6 +815,8 @@ Settings:
     Import playlists formats: 'ஆதரிக்கப்படும் வடிவங்கள்: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'ஆதரிக்கப்படும் வடிவங்கள்: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: கைவிளக்கை இயக்கு
+    Turn Flashlight Off: கைவிளக்கை அணை
     Devices: "சாதனங்கள்"
     Devices Hint: "இந்த ஒத்திசைவு கணக்கை அணுகக்கூடிய சாதனங்களை மதிப்பாய்வு செய்யவும்."
     Change Password: "கடவுச்சொல்லை மாற்று"

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -792,6 +792,8 @@ Settings:
     Import playlists formats: 'Desteklenen biçimler: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Desteklenen biçimler: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: El fenerini aç
+    Turn Flashlight Off: El fenerini kapat
     Devices: "Cihazlar"
     Devices Hint: "Bu eşitleme hesabına erişebilen cihazları inceleyin."
     Change Password: "Parolayı değiştir"

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -811,6 +811,8 @@ Settings:
     Import playlists formats: 'Підтримувані формати: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Підтримувані формати: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Увімкнути ліхтарик
+    Turn Flashlight Off: Вимкнути ліхтарик
     Devices: "Пристрої"
     Devices Hint: "Перегляньте пристрої, які мають доступ до цього облікового запису синхронізації."
     Change Password: "Змінити пароль"

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -811,6 +811,8 @@ Settings:
     Import playlists formats: 'Định dạng được hỗ trợ: OpenTubeX / FreeTube (.db)'
     Import search history formats: 'Định dạng được hỗ trợ: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: Bật đèn pin
+    Turn Flashlight Off: Tắt đèn pin
     Devices: "Thiết bị"
     Devices Hint: "Xem lại các thiết bị có thể truy cập tài khoản đồng bộ này."
     Change Password: "Đổi mật khẩu"

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -792,6 +792,8 @@ Settings:
     Import playlists formats: '支持的格式：OpenTubeX / FreeTube (.db)'
     Import search history formats: '支持的格式：OpenTubeX / FreeTube (.db)、YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: 打开手电筒
+    Turn Flashlight Off: 关闭手电筒
     Devices: "设备"
     Devices Hint: "查看可访问此同步账户的设备。"
     Change Password: "更改密码"

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -794,6 +794,8 @@ Settings:
     Import playlists formats: '支援的格式：OpenTubeX / FreeTube (.db)'
     Import search history formats: '支援的格式：OpenTubeX / FreeTube (.db)、YouTube Takeout (.json)'
   Sync Settings:
+    Turn Flashlight On: 開啟手電筒
+    Turn Flashlight Off: 關閉手電筒
     Devices: "裝置"
     Devices Hint: "檢視可存取此同步帳戶的裝置。"
     Change Password: "變更密碼"

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -1379,6 +1379,8 @@ Settings:
     Subtitles Enabled: Untertitel aktiviert
     Volume: Lautstärke
   Sync Settings:
+    Turn Flashlight On: Taschenlampe einschalten
+    Turn Flashlight Off: Taschenlampe ausschalten
     Sync Settings: Synchronisierung
     Enable Sync: Synchronisierung aktivieren
     Privacy Passphrase: Datenschutz-Passphrase

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1429,6 +1429,8 @@ Settings:
     Import search history formats: 'Supported formats: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
     Manage Subscriptions: Manage Subscriptions
   Sync Settings:
+    Turn Flashlight On: Turn flashlight on
+    Turn Flashlight Off: Turn flashlight off
     Sync Settings: Sync
     Enable Sync: Enable Sync
     Privacy Passphrase: Privacy passphrase

--- a/tests/unit/native-pairing-scanner.test.mjs
+++ b/tests/unit/native-pairing-scanner.test.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { CapacitorBarcodeScanner } from '@capacitor/barcode-scanner'
+
+import { scanNativePairingCode } from '../../src/renderer/helpers/nativePairingScanner.js'
+
+const labels = {
+  instructions: 'Scan the pairing code',
+  cancelLabel: 'Cancel',
+  torchOnLabel: 'Turn flashlight off',
+  torchOffLabel: 'Turn flashlight on',
+}
+
+test('native pairing scans QR codes with the rear camera and returns the code unchanged', async t => {
+  const scan = t.mock.method(CapacitorBarcodeScanner, 'scanBarcode', async () => ({
+    ScanResult: 'opentubex-pairing:encrypted-request', format: 0,
+  }))
+
+  assert.equal(await scanNativePairingCode(labels), 'opentubex-pairing:encrypted-request')
+  assert.deepEqual(scan.mock.calls[0].arguments, [{
+    hint: 0,
+    cameraDirection: 1,
+    scanOrientation: 3,
+    scanInstructions: labels.instructions,
+    scanButton: false,
+    cancelButtonAccessibilityLabel: labels.cancelLabel,
+    torchButtonOnAccessibilityLabel: labels.torchOnLabel,
+    torchButtonOffAccessibilityLabel: labels.torchOffLabel,
+    android: { scanningLibrary: 'zxing' },
+  }])
+})
+
+test('native cancellation returns to manual entry without reporting a camera failure', async t => {
+  t.mock.method(CapacitorBarcodeScanner, 'scanBarcode', async () => {
+    throw Object.assign(new Error('Canceled'), { code: 'OS-PLUG-BARC-0006' })
+  })
+  assert.equal(await scanNativePairingCode(labels), null)
+})
+
+test('camera denial and scanner failures remain errors and release the scanner for retry', async t => {
+  for (const code of ['OS-PLUG-BARC-0007', 'OS-PLUG-BARC-0004']) {
+    const error = Object.assign(new Error('Camera unavailable'), { code })
+    const scan = t.mock.method(CapacitorBarcodeScanner, 'scanBarcode', async () => { throw error })
+    await assert.rejects(scanNativePairingCode(labels), error)
+    scan.mock.restore()
+  }
+  t.mock.method(CapacitorBarcodeScanner, 'scanBarcode', async () => ({ ScanResult: 'retry', format: 0 }))
+  assert.equal(await scanNativePairingCode(labels), 'retry')
+})
+
+test('a pending native scan keeps exclusive ownership until it returns', async t => {
+  let complete
+  const scan = t.mock.method(CapacitorBarcodeScanner, 'scanBarcode', () => new Promise(resolve => { complete = resolve }))
+  const pending = scanNativePairingCode(labels)
+  try {
+    await assert.rejects(scanNativePairingCode(labels), /already active/)
+    assert.equal(scan.mock.callCount(), 1)
+  } finally {
+    complete({ ScanResult: 'first', format: 0 })
+  }
+  assert.equal(await pending, 'first')
+  const retry = scanNativePairingCode(labels)
+  complete({ ScanResult: 'second', format: 0 })
+  assert.equal(await retry, 'second')
+})

--- a/tests/unit/sync-pairing-scanner.test.mjs
+++ b/tests/unit/sync-pairing-scanner.test.mjs
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import { runInNewContext } from 'node:vm'
+import { compileScript, parse } from 'vue/compiler-sfc'
+
+const { descriptor } = parse(await readFile(new URL('../../src/renderer/components/SyncSettings/SyncPairing.vue', import.meta.url), 'utf8'))
+const source = compileScript(descriptor, { id: 'pairing-scanner-test' }).content
+  .replace(/^import[\s\S]*?from ['"][^'"]+['"]\n/gm, '')
+  .replace('export default', 'const Pairing =')
+  .replace("import('../../helpers/nativePairingScanner')", 'loadNativeScanner()')
+
+function setup({ native = true } = {}) {
+  let resolveScan
+  let rejectScan
+  let unmount
+  let nativeLoads = 0
+  let browserStarts = 0
+  let browserStops = 0
+  const parsedCodes = []
+  const scan = new Promise((resolve, reject) => { resolveScan = resolve; rejectScan = reject })
+  const ref = value => ({ value })
+  const component = runInNewContext(source + '; Pairing', {
+    process: { env: { IS_CAPACITOR: native } },
+    FtButton: {}, FtFlexBox: {}, FtInput: {}, FtLoader: {}, FtPrompt: {},
+    ref,
+    computed: fn => ({ get value() { return fn() } }),
+    useTemplateRef: () => ref({ focus() {} }),
+    nextTick: async () => {},
+    onBeforeUnmount: fn => { unmount = fn },
+    useI18n: () => ({ locale: ref('en-US'), t: key => key }),
+    getCurrentSyncServerDeviceInfo: async () => ({ name: '' }),
+    store: { getters: {} },
+    loadNativeScanner: async () => {
+      nativeLoads++
+      return { scanNativePairingCode: () => scan }
+    },
+    QrScanner: class {
+      async start() { browserStarts++ }
+      destroy() { browserStops++ }
+    },
+    parsePairingQrPayload: code => {
+      parsedCodes.push(code)
+      throw new Error('Invalid pairing code')
+    },
+    clearTimeout,
+  })
+  const state = component.setup({ serverUrl: 'https://sync.example.test' }, { expose() {}, emit() {} })
+  return {
+    state, resolveScan, rejectScan, parsedCodes,
+    unmount: () => unmount(),
+    counts: () => ({ nativeLoads, browserStarts, browserStops }),
+  }
+}
+
+async function flush() {
+  // Settle the lazy import, scan promise, and Vue nextTick continuations.
+  for (let i = 0; i < 8; i++) await Promise.resolve()
+}
+
+test('Capacitor uses native scanning and validates its result through the existing pairing flow', async () => {
+  const f = setup()
+  await f.state.openScanner()
+  f.resolveScan('invalid-code')
+  await flush()
+  assert.deepEqual(f.counts(), { nativeLoads: 1, browserStarts: 0, browserStops: 0 })
+  assert.deepEqual(f.parsedCodes, ['invalid-code'])
+  assert.equal(f.state.approveError.value, 'Invalid pairing code')
+})
+
+test('native cancellation and denied camera access both leave text pairing available', async () => {
+  for (const denied of [false, true]) {
+    const f = setup()
+    await f.state.openScanner()
+    if (denied) f.rejectScan(new Error('Permission denied'))
+    else f.resolveScan(null)
+    await flush()
+    assert.equal(f.state.approveStage.value, 'manual')
+    assert.equal(f.state.approvePromptOpen.value, true)
+    assert.equal(f.state.approveError.value, denied ? 'Settings.Sync Settings.Camera Unavailable' : '')
+  }
+})
+
+test('closing, unmounting, or switching to text entry invalidates a pending native scan', async () => {
+  for (const action of ['closeScanner', 'openManualEntry', 'unmount']) {
+    for (const rejected of [false, true]) {
+      const f = setup()
+      await f.state.openScanner()
+      await flush()
+      if (action === 'unmount') f.unmount()
+      else await f.state[action]()
+      if (rejected) f.rejectScan(new Error('Camera failed'))
+      else f.resolveScan('stale-code')
+      await flush()
+      assert.deepEqual(f.parsedCodes, [])
+      assert.equal(f.state.approveError.value, '')
+      if (action === 'openManualEntry') assert.equal(f.state.approveStage.value, 'manual')
+      if (action === 'closeScanner') assert.equal(f.state.approvePromptOpen.value, false)
+    }
+  }
+})
+
+test('desktop and web retain the embedded scanner and stop it when pairing closes', async () => {
+  const f = setup({ native: false })
+  await f.state.openScanner()
+  await flush()
+  f.state.closeScanner()
+  assert.deepEqual(f.counts(), { nativeLoads: 0, browserStarts: 1, browserStops: 1 })
+})

--- a/tests/unit/sync-pairing-scanner.test.mjs
+++ b/tests/unit/sync-pairing-scanner.test.mjs
@@ -1,11 +1,16 @@
 import assert from 'node:assert/strict'
-import { readFile } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import test from 'node:test'
 import { runInNewContext } from 'node:vm'
 import { compileScript, parse } from 'vue/compiler-sfc'
+import webpack from 'webpack'
 
 const { descriptor } = parse(await readFile(new URL('../../src/renderer/components/SyncSettings/SyncPairing.vue', import.meta.url), 'utf8'))
-const source = compileScript(descriptor, { id: 'pairing-scanner-test' }).content
+const compiledSource = compileScript(descriptor, { id: 'pairing-scanner-test' }).content
+const source = compiledSource
   .replace(/^import[\s\S]*?from ['"][^'"]+['"]\n/gm, '')
   .replace('export default', 'const Pairing =')
   .replace("import('../../helpers/nativePairingScanner')", 'loadNativeScanner()')
@@ -106,4 +111,34 @@ test('desktop and web retain the embedded scanner and stop it when pairing close
   await flush()
   f.state.closeScanner()
   assert.deepEqual(f.counts(), { nativeLoads: 0, browserStarts: 1, browserStops: 1 })
+})
+
+test('desktop bundles exclude the native scanner while Capacitor bundles include it', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'pairing-bundle-'))
+  const helper = fileURLToPath(new URL('../../src/renderer/helpers/nativePairingScanner.js', import.meta.url))
+  try {
+    const entry = join(directory, 'pairing.js')
+    await writeFile(entry, compiledSource.replace("'../../helpers/nativePairingScanner'", JSON.stringify(helper)))
+    for (const native of [false, true]) {
+      const stats = await new Promise((resolve, reject) => {
+        webpack({
+          mode: 'production',
+          entry,
+          output: { path: join(directory, String(native)) },
+          // Only inspect pairing's native import; other component dependencies are unrelated.
+          externals: [({ request }, callback) => {
+            if (request === entry || request === helper) callback()
+            else callback(null, `commonjs ${request}`)
+          }],
+          plugins: [new webpack.DefinePlugin({ 'process.env.IS_CAPACITOR': JSON.stringify(native) })],
+        }, (error, result) => error ? reject(error) : resolve(result))
+      })
+      assert.equal(stats.hasErrors(), false, stats.toString({ all: false, errors: true }))
+      const modules = stats.toJson({ all: false, modules: true }).modules
+      assert.equal(modules.some(module => module.name?.includes('nativePairingScanner')), native,
+        native ? 'Capacitor must include its native scanner' : 'Desktop must not emit the native scanner chunk')
+    }
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Tapping "Pair Another Device" on Android could crash immediately without a camera permission prompt. Use the official Capacitor barcode scanner with ZXing and declare the camera permission so Android can request access. Cancellation and camera errors leave manual pairing available, and desktop/web scanning stays supported. Desktop and web builds exclude the native plugin chunks.

The plugin requires Android 8 or newer, so this raises the minimum from Android 7. Exclude its unused proprietary ML Kit dependency from Android packaging.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fix the Android crash when pairing another device by using a native QR scanner. Android 8 or newer is now required.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. On Android, open Settings → Sync and choose "Pair Another Device". Grant camera access when asked; the native scanner should open without closing the app.
2. Scan the pairing QR from another OpenTubeX device and continue the existing approval flow. Scanning an unrelated QR should show the invalid pairing code message.
3. Open the scanner again and press Back. Manual pairing entry should appear. Denying camera permission should also leave manual entry available with a camera error.
4. On desktop, open the same pairing flow and confirm that the embedded scanner and manual entry still work.

## Additional context
<!-- Add any other context about the pull request here. -->

The official plugin also supports a future iOS target; this PR does not add an iOS app.
