### PR TITLE
fix(mobile): restore page scrolling and feed tab menus

### DIFF
--- a/e2e/tests/offline/subscriptions-context-menu.spec.mjs
+++ b/e2e/tests/offline/subscriptions-context-menu.spec.mjs
@@ -71,6 +71,86 @@ test('subscription tabs expose feed-specific reload actions', async ({ page }) =
   await page.evaluate(() => window.__removeSubscriptionFeedReloadListener())
 })
 
+test('holding a subscription tab opens its mobile bottom menu without selecting it', async ({ page }) => {
+  await goTo(page, 'subscriptions')
+  const videos = page.locator('[data-subscription-feed-tab="videos"]')
+  const shorts = page.locator('[data-subscription-feed-tab="shorts"]')
+  await expect(videos).toHaveAttribute('aria-selected', 'true')
+  const session = await page.context().newCDPSession(page)
+  await session.send('Emulation.setTouchEmulationEnabled', { enabled: true })
+  const bounds = await shorts.boundingBox()
+  await session.send('Input.dispatchTouchEvent', {
+    type: 'touchStart',
+    touchPoints: [{ x: bounds.x + bounds.width / 2, y: bounds.y + bounds.height / 2 }]
+  })
+  const menu = page.locator('.mobileLinkActions')
+  await expect(menu).toBeVisible({ timeout: 3000 })
+  await session.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] })
+  await expect(menu.getByRole('menuitem', { name: 'Reload Shorts', exact: true })).toBeVisible()
+  await expect(videos).toHaveAttribute('aria-selected', 'true')
+  await expect(shorts).toHaveAttribute('aria-selected', 'false')
+  await page.keyboard.press('Escape')
+  await expect(menu).toHaveCount(0)
+  await shorts.evaluate(element => element.dispatchEvent(new PointerEvent('contextmenu', {
+    bubbles: true, cancelable: true, pointerType: 'touch'
+  })))
+  await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    window.__mobileFeedRefreshStarted = false
+    store.watch(state => state.subscriptionCache.subscriptionFeedRefreshInProgress, refreshing => {
+      if (refreshing) window.__mobileFeedRefreshStarted = true
+    })
+  })
+  await page.route(/^https?:\/\//, route => route.abort())
+  await menu.getByRole('menuitem', { name: 'Reload Shorts', exact: true }).click()
+  await expect(menu).toHaveCount(0)
+  await expect.poll(() => page.evaluate(() => window.__mobileFeedRefreshStarted)).toBe(true)
+  await session.detach()
+})
+
+test('a mobile Cancel Refresh action never reloads after the refresh finishes', async ({ app, page }) => {
+  await goTo(page, 'subscriptions')
+  await page.route(/^https?:\/\//, route => route.abort())
+  await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    store.commit('setSubscriptionFeedRefreshInProgress', true)
+  })
+  await app.electronApp.evaluate(({ ipcMain }) => {
+    globalThis.__mobileCancelRequested = false
+    ipcMain.on('subscription-auto-refresh-cancel', () => {
+      globalThis.__mobileCancelRequested = true
+    })
+  })
+  await page.locator('[data-subscription-feed-tab="shorts"]').evaluate(element => {
+    element.dispatchEvent(new PointerEvent('contextmenu', {
+      bubbles: true, cancelable: true, pointerType: 'touch'
+    }))
+  })
+  const cancel = page.locator('.mobileLinkActions').getByRole('menuitem', { name: 'Cancel Refresh', exact: true })
+  await expect(cancel).toBeVisible()
+  await page.evaluate(() => {
+    document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      .commit('setSubscriptionFeedRefreshInProgress', false)
+  })
+  await cancel.click()
+  await expect.poll(() => app.electronApp.evaluate(() => globalThis.__mobileCancelRequested)).toBe(true)
+})
+
+test('moving or cancelling a touch on feed tabs does not open a menu', async ({ page }) => {
+  await goTo(page, 'subscriptions')
+  const shorts = page.locator('[data-subscription-feed-tab="shorts"]')
+  for (const event of ['pointermove', 'pointercancel', 'pointerup']) {
+    await shorts.dispatchEvent('pointerdown', {
+      pointerType: 'touch', isPrimary: true, clientX: 100, clientY: 100
+    })
+    await shorts.dispatchEvent(event, {
+      pointerType: 'touch', isPrimary: true, clientX: 120, clientY: 100
+    })
+    await page.waitForTimeout(600)
+    await expect(page.locator('.mobileLinkActions')).toHaveCount(0)
+  }
+})
+
 test('disabled context menu actions cannot execute through IPC', async ({ page }) => {
   const searchInput = page.locator('.searchInput input')
   await searchInput.fill('selection')

--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -299,6 +299,36 @@ test.describe('new subscriptions feed', () => {
     await expect(menu.getByRole('menuitem', { name: 'Mark all as seen' })).toHaveCount(0)
   })
 
+  test('the mobile feed menu marks an inactive new category as seen', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+    await page.locator('[data-subscription-feed-tab="all"]').click()
+    await page.getByRole('button', { name: 'Show tabbed view' }).click()
+    const videos = page.locator('[data-new-feed-tab="videos"]')
+    const shorts = page.locator('[data-new-feed-tab="shorts"]')
+    const session = await page.context().newCDPSession(page)
+    await session.send('Emulation.setTouchEmulationEnabled', { enabled: true })
+    const bounds = await shorts.boundingBox()
+    await session.send('Input.dispatchTouchEvent', {
+      type: 'touchStart',
+      touchPoints: [{ x: bounds.x + bounds.width / 2, y: bounds.y + bounds.height / 2 }]
+    })
+    const menu = page.locator('.mobileLinkActions')
+    await expect(menu).toBeVisible()
+    await session.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] })
+    await expect(menu.getByRole('menuitem', { name: 'Reload Shorts', exact: true })).toBeVisible()
+    await menu.getByRole('menuitem', { name: 'Mark all as seen', exact: true }).click()
+    await expect(menu).toHaveCount(0)
+    await expect(videos).toHaveAttribute('aria-selected', 'true')
+    await expect(videos.locator('.newContentDot')).toBeVisible()
+    await expect(shorts.locator('.newContentDot')).toHaveCount(0)
+    await shorts.evaluate(element => element.dispatchEvent(new PointerEvent('contextmenu', {
+      bubbles: true, cancelable: true, pointerType: 'touch'
+    })))
+    await expect(menu).toBeVisible()
+    await expect(menu.getByRole('menuitem', { name: 'Mark all as seen', exact: true })).toHaveCount(0)
+    await session.detach()
+  })
+
   test('shows Shorts as portrait cards with their duration and upload time', async ({ page }) => {
     await goTo(page, 'subscriptions')
     await page.locator('[data-subscription-feed-tab="shorts"]').click()

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -85,6 +85,80 @@ async function expectSponsorBlockContentClamp(content, previousScrollTop) {
 
 test.use({ seed: { settings: WATCH_PAGE_SEED } })
 
+async function swipeVertically(session, bounds, distance) {
+  const x = bounds.x + bounds.width / 2
+  const y = bounds.y + bounds.height / 2
+  await session.send('Input.dispatchTouchEvent', {
+    type: 'touchStart', touchPoints: [{ x, y }]
+  })
+  for (let step = 1; step <= 10; step++) {
+    await session.send('Input.dispatchTouchEvent', {
+      type: 'touchMove', touchPoints: [{ x, y: y + distance * step / 10 }]
+    })
+  }
+  // Hold before releasing so momentum cannot race the next boundary check.
+  await new Promise(resolve => setTimeout(resolve, 200))
+  await session.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] })
+}
+
+for (const zoom of [1, 1.25]) {
+  for (const chapterCount of [1, 30]) {
+    test(`touch scrolling chains from sidebar chapters to the page (${chapterCount} chapters, ${zoom} scale)`, async ({ app, page }) => {
+      await mockPlayableWatchPage(app, page)
+      await openMockedVideo(page)
+      await page.locator(`${activeTab} .ftVideoPlayer video`).evaluate(video => video.pause())
+      await setWindowSize(app, page, { width: 500, height: 850 })
+      await page.evaluate(zoom => window.ftElectron.setZoomFactor(zoom), zoom)
+      const session = await page.context().newCDPSession(page)
+      const view = await watchViewHandle(page)
+      await view.evaluate(async (view, count) => {
+        view.videoChapters = Array.from({ length: count }, (_, index) => ({
+          title: `Test chapter ${index + 1}`,
+          timestamp: `${index}:00`,
+          startSeconds: index * 60
+        }))
+        view.videoCurrentChapterIndex = count - 1
+        view.showSidebarChapters = true
+        await view.$nextTick()
+      }, chapterCount)
+      const panel = page.locator(`${activeTab} .watchVideoChaptersPanel`)
+      const chapters = panel.locator('.chaptersWrapper')
+      await expect(panel).toBeVisible()
+      await expect(panel).not.toHaveClass(/chapters-panel-enter-active/)
+      await expect(chapters).toHaveCSS('overscroll-behavior-y', 'contain')
+      await session.send('Emulation.setTouchEmulationEnabled', { enabled: true })
+      await expect.poll(() => page.evaluate(() => matchMedia('(pointer: coarse)').matches)).toBe(true)
+      await expect(chapters).toHaveCSS('overscroll-behavior-y', 'auto')
+      await chapters.evaluate(element => {
+        element.scrollIntoView({ block: 'center' })
+        element.scrollTop = element.scrollHeight
+      })
+      await expect.poll(() => chapters.evaluate(element =>
+        Math.abs(element.scrollHeight - element.clientHeight - element.scrollTop)
+      )).toBeLessThanOrEqual(1)
+      const initialPageScroll = await page.evaluate(() => window.scrollY)
+      expect(await page.evaluate(() =>
+        document.scrollingElement.scrollHeight - innerHeight - scrollY
+      )).toBeGreaterThan(100)
+      const bounds = await chapters.boundingBox()
+      await swipeVertically(session, bounds, -150)
+      await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(initialPageScroll + 50)
+
+      await chapters.evaluate(element => {
+        element.scrollIntoView({ block: 'center' })
+        element.scrollTop = 0
+      })
+      const pageScrollAtTop = await page.evaluate(() => window.scrollY)
+      expect(pageScrollAtTop).toBeGreaterThan(100)
+      const topBounds = await chapters.boundingBox()
+      await swipeVertically(session, topBounds, 150)
+      await expect.poll(() => page.evaluate(() => window.scrollY)).toBeLessThan(pageScrollAtTop - 50)
+      await session.detach()
+      await view.dispose()
+    })
+  }
+}
+
 test('reserves the player height when Shaka loads before video metadata', async ({ app, page }) => {
   await mockPlayableWatchPage(app, page)
   await page.evaluate(() => window.ftElectron.setZoomFactor(1.25))

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -178,7 +178,7 @@
     <FtContextMenu v-if="isElectron" />
     <Teleport to="body">
       <div
-        v-if="mobileContextLink"
+        v-if="mobileContextLink || mobileContextActions"
         class="mobileLinkActionsBackdrop"
         @pointerdown.self.stop
         @click.self.stop="closeMobileLinkActions"
@@ -194,6 +194,20 @@
         >
           <strong dir="auto">{{ mobileContextLinkLabel }}</strong>
           <button
+            v-for="action in mobileContextActions?.actions ?? []"
+            :key="action.label"
+            type="button"
+            role="menuitem"
+            @click="runMobileContextAction(action)"
+          >
+            <FtIcon
+              :icon="action.icon"
+              aria-hidden="true"
+            />
+            {{ action.label }}
+          </button>
+          <button
+            v-if="mobileContextLink"
             type="button"
             role="menuitem"
             @click="openMobileContextLink(false)"
@@ -733,10 +747,18 @@ const commandPaletteOpen = ref(false)
 const hardwareKeyboardAttached = ref(!isCapacitor)
 provide('hardwareKeyboardAttached', hardwareKeyboardAttached)
 const mobileContextLink = ref(null)
+const mobileContextActions = ref(null)
+provide('openMobileContextActions', async (menu) => {
+  mobileContextLink.value = null
+  mobileContextActions.value = menu
+  await nextTick()
+  mobileLinkActionsRef.value?.focus({ preventScroll: true })
+})
 const mobileLinkActionsPromptId = useId()
 const mobileLinkActionsRef = useTemplateRef('mobileLinkActionsRef')
 let mobileLinkActionsLocked = false
 const mobileContextLinkLabel = computed(() => {
+  if (mobileContextActions.value) return mobileContextActions.value.title
   const link = mobileContextLink.value
   if (!link) return ''
 
@@ -758,7 +780,7 @@ const mobileContextLinkCopyUrl = computed(() => {
     ? resolveMobileContextLinkCopyUrl(href, window.location.href.split('#')[0])
     : null
 })
-watch(() => mobileContextLink.value !== null, (isOpen) => {
+watch(() => mobileContextLink.value !== null || mobileContextActions.value !== null, (isOpen) => {
   if (isOpen && !mobileLinkActionsLocked) {
     lockBodyScroll()
     store.commit('addOpenPrompt', mobileLinkActionsPromptId)
@@ -2746,7 +2768,7 @@ async function handleAndroidExitPromptAnswer(option) {
 }
 
 async function handleAndroidBack() {
-  if (mobileContextLink.value !== null) {
+  if (mobileContextLink.value !== null || mobileContextActions.value !== null) {
     closeMobileLinkActions()
     return
   }
@@ -2883,6 +2905,12 @@ function handleGamepadBack() {
  */
 function handleKeyboardShortcuts(event) {
   if (showTutorial.value) return
+
+  if (event.key === 'Escape' && (mobileContextLink.value || mobileContextActions.value)) {
+    event.preventDefault()
+    closeMobileLinkActions()
+    return
+  }
 
   const shortcuts = KeyboardShortcuts.APP.GENERAL
 
@@ -3731,6 +3759,7 @@ async function handleMobileLinkContextMenu(event) {
 
   event.preventDefault()
   event.stopPropagation()
+  mobileContextActions.value = null
   mobileContextLink.value = link
   await nextTick()
   mobileLinkActionsRef.value?.focus({ preventScroll: true })
@@ -3738,6 +3767,12 @@ async function handleMobileLinkContextMenu(event) {
 
 function closeMobileLinkActions() {
   mobileContextLink.value = null
+  mobileContextActions.value = null
+}
+
+function runMobileContextAction(action) {
+  closeMobileLinkActions()
+  return action.run()
 }
 
 async function copyMobileContextLink() {

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -2,6 +2,11 @@
   <div
     class="subscriptionsPage"
     :class="{ hasTabBar: hasHorizontalTabBar }"
+    @contextmenu="handleFeedContextMenu"
+    @pointerdown="startFeedTabHold"
+    @pointermove="moveFeedTabHold"
+    @pointerup="cancelFeedTabHold"
+    @pointercancel="cancelFeedTabHold"
   >
     <FtCard class="card">
       <div
@@ -345,7 +350,7 @@
 
 <script setup>
 import { FtIcon } from '@opentubex/icons'
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue'
+import { computed, inject, nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 
@@ -381,6 +386,92 @@ import { getSubscriptionsForFeed } from '../../helpers/subscription-channels'
 
 const isElectron = process.env.IS_ELECTRON
 const usesLogicalTabs = process.env.IS_ELECTRON || process.env.IS_CAPACITOR
+const openMobileContextActions = inject('openMobileContextActions')
+let feedTabHold = null
+
+function cancelFeedTabHold() {
+  clearTimeout(feedTabHold?.timer)
+  feedTabHold = null
+}
+
+function startFeedTabHold(event) {
+  resetFeedTabHold()
+  if (event.pointerType !== 'touch' || !event.isPrimary) return
+  const tab = event.target.closest('[data-subscription-feed-tab], [data-new-feed-tab]')
+  if (!tab) return
+
+  feedTabHold = {
+    x: event.clientX,
+    y: event.clientY,
+    timer: setTimeout(() => {
+      cancelFeedTabHold()
+      tab.dispatchEvent(new PointerEvent('contextmenu', {
+        bubbles: true,
+        cancelable: true,
+        pointerType: 'touch'
+      }))
+    }, 500)
+  }
+}
+
+function moveFeedTabHold(event) {
+  if (feedTabHold && Math.hypot(event.clientX - feedTabHold.x, event.clientY - feedTabHold.y) > 10) {
+    cancelFeedTabHold()
+  }
+}
+
+function resetFeedTabHold() {
+  cancelFeedTabHold()
+  document.removeEventListener('click', suppressFeedTabHoldClick, true)
+  document.removeEventListener('pointerdown', resetFeedTabHold, true)
+  document.removeEventListener('keydown', resetFeedTabHold, true)
+}
+
+function suppressFeedTabHoldClick(event) {
+  event.preventDefault()
+  event.stopImmediatePropagation()
+  resetFeedTabHold()
+}
+
+function handleFeedContextMenu(event) {
+  if (!process.env.IS_CAPACITOR && event.pointerType !== 'touch') return
+  const tab = event.target.closest('[data-subscription-feed-tab], [data-new-feed-tab]')
+  if (!tab) return
+
+  event.preventDefault()
+  event.stopPropagation()
+  cancelFeedTabHold()
+  if (event.pointerType === 'touch') {
+    // The sheet can become the release target. Suppress the opening touch's
+    // click globally, but let the next pointer or keyboard interaction through.
+    document.addEventListener('click', suppressFeedTabHoldClick, true)
+    document.addEventListener('pointerdown', resetFeedTabHold, true)
+    document.addEventListener('keydown', resetFeedTabHold, true)
+  }
+  const feedTab = tab.dataset.subscriptionFeedTab ?? tab.dataset.newFeedTab
+  const reloadLabels = {
+    videos: t('Context Menu.Reload Videos'),
+    shorts: t('Context Menu.Reload Shorts'),
+    live: t('Context Menu.Reload Live'),
+    posts: t('Context Menu.Reload Posts'),
+    all: t('Context Menu.Reload All Feeds')
+  }
+  const actions = [{
+    label: subscriptionFeedRefreshInProgress.value ? t('Context Menu.Cancel Refresh') : reloadLabels[feedTab],
+    icon: subscriptionFeedRefreshInProgress.value ? ['fas', 'xmark'] : ['fas', 'sync'],
+    run: subscriptionFeedRefreshInProgress.value
+      ? cancelRefresh
+      : () => handleFeedReloadRequest({ tabId, feedTab })
+  }]
+  if (tab.dataset.newFeedTab && newFeedTabHasNewContent(feedTab)) {
+    actions.push({
+      label: t('Subscriptions.Mark All as Seen'),
+      icon: ['fas', 'check'],
+      run: () => markAllAsSeen('new', feedTab)
+    })
+  }
+  openMobileContextActions({ title: tab.textContent.trim(), actions })
+}
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const hasHorizontalTabBar = computed(() => isElectron && store.getters.getTabBarPosition === 'top')
@@ -501,6 +592,7 @@ let scrollPositionOwnerTab = currentTab.value
 let restoreScrollOnActivate = false
 
 useTabLifecycle({
+  deactivate: resetFeedTabHold,
   activate: () => {
     if (!restoreScrollOnActivate) {
       return
@@ -583,6 +675,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   isMounted = false
+  resetFeedTabHold()
   tabChangeSequence++
   document.removeEventListener('keydown', handlePanelTabNavigation)
   removeFeedReloadRequestListener?.()

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -1188,6 +1188,11 @@
     :deep(.chaptersWrapper) {
       max-block-size: 480px;
 
+      @media (pointer: coarse) {
+        // Let swipes at the list's edges continue scrolling the watch page.
+        overscroll-behavior-y: auto;
+      }
+
       // In the sidebar the chapters sit on a card rather than above the video,
       // so drop the light handle and take the theme's colour again
       --scrollbar-color: inherit;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

Touch scrolling stopped at the chapters panel, and holding subscription feed tabs did not open their mobile actions. This fixes both while preserving desktop scroll containment.

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

Reported in the Codex task; no linked issue.
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description

Allow vertical scrolling to continue from sidebar chapters onto the page on touch devices. Holding subscription tabs or New-feed categories now opens the existing bottom sheet with reload/cancel and applicable mark-as-seen actions. Movement cancels a pending hold, and releasing a hold does not select a tab or dismiss the menu.
<!-- Please write a clear and concise description of what the pull request does. -->

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed mobile page scrolling around the chapters panel and added long-press actions to subscription feed tabs.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing

1. On a touch device, open chapters on a watch page. Swipe down at the end of the chapter list and up at its start. The page should continue scrolling. Also check a short list and 125% UI scale. Desktop mouse scrolling should remain contained.
2. Hold a subscription tab, then a category under the tabbed New feed. The bottom sheet should open without selecting the tab, and remain open when you release your finger. Swipe or release early to confirm no menu opens.
3. Use Reload, Cancel Refresh, and Mark all as seen where available. Marking an inactive New-feed category should leave the selected category unchanged. Cancel must never start a new refresh if the current refresh finishes while the menu is open.
4. Dismiss the sheet with the backdrop, Escape, or Android Back and confirm page scrolling works again.
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

## Additional context
<!-- Add any other context about the pull request here. -->
