### PR TITLE
fix: remove fractional seconds from history duration badges

### DIFF
--- a/e2e/tests/offline/history.spec.mjs
+++ b/e2e/tests/offline/history.spec.mjs
@@ -341,6 +341,33 @@ test.describe('watch history', () => {
   })
 })
 
+test.describe('fractional history durations', () => {
+  const examples = [
+    { videoId: 'fraction001', lengthSeconds: 4125.721, timestamp: '1:08:45' },
+    { videoId: 'fraction002', lengthSeconds: 153.839, timestamp: '2:33' },
+    { videoId: 'fraction003', lengthSeconds: 125.109, timestamp: '2:05' },
+    { videoId: 'fraction004', lengthSeconds: 116.889, timestamp: '1:56' },
+    { videoId: 'fraction005', lengthSeconds: 104.768, timestamp: '1:44' }
+  ]
+
+  test.use({
+    seed: {
+      history: examples.map(({ videoId, lengthSeconds }, index) => historyEntry(
+        videoId, `Fractional duration ${index}`, now - index, false, { lengthSeconds }
+      ))
+    }
+  })
+
+  test('shows whole-second duration badges for persisted fractional durations', async ({ page }) => {
+    await goTo(page, 'history')
+
+    for (const [index, { timestamp }] of examples.entries()) {
+      const video = page.locator('.ft-list-video').filter({ hasText: `Fractional duration ${index}` })
+      await expect(video.locator('.videoDuration')).toHaveText(timestamp)
+    }
+  })
+})
+
 test.describe('history search pagination', () => {
   test.use({
     seed: {

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -714,6 +714,9 @@ export function formatDurationAsTimestamp(lengthSeconds) {
     return lengthSeconds
   }
 
+  // Media durations can include milliseconds; timestamps display whole seconds.
+  lengthSeconds = Math.floor(lengthSeconds)
+
   if (lengthSeconds === 0) {
     return '0:00'
   }

--- a/tests/unit/duration-timestamp.test.mjs
+++ b/tests/unit/duration-timestamp.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// Load the actual formatter without the renderer's router and native dependencies.
+const source = await readFile(new URL('../../src/renderer/helpers/utils.js', import.meta.url), 'utf8')
+const formatter = source.match(/export function formatDurationAsTimestamp\([^]*?\n\}/)[0].replace('export ', '')
+const formatDurationAsTimestamp = vm.runInNewContext(`${formatter}\nformatDurationAsTimestamp`)
+
+test('formats fractional history durations as whole-second timestamps', () => {
+  const examples = [
+    [4125.721, '1:08:45'],
+    [153.839, '2:33'],
+    [125.109, '2:05'],
+    [116.889, '1:56'],
+    [104.768, '1:44'],
+  ]
+
+  for (const [duration, expected] of examples) {
+    assert.equal(formatDurationAsTimestamp(duration), expected)
+  }
+})
+
+test('does not round fractional durations into the next second, minute, or hour', () => {
+  for (const [duration, expected] of [
+    [0.999, '0:00'],
+    [9.999, '0:09'],
+    [59.999, '0:59'],
+    [60.001, '1:00'],
+    [3599.999, '59:59'],
+    [3600.001, '1:00:00'],
+  ]) {
+    assert.equal(formatDurationAsTimestamp(duration), expected)
+  }
+})
+
+test('preserves whole-second timestamps and string labels', () => {
+  for (const [duration, expected] of [
+    [0, '0:00'],
+    [5, '0:05'],
+    [60, '1:00'],
+    [3600, '1:00:00'],
+    [3661, '1:01:01'],
+    ['LIVE', 'LIVE'],
+    ['UPCOMING', 'UPCOMING'],
+    ['1:23', '1:23'],
+    ['', ''],
+  ]) {
+    assert.equal(formatDurationAsTimestamp(duration), expected)
+  }
+})


### PR DESCRIPTION
History cards can show long decimal fragments such as `1:08:45.72099999999955` when a saved duration includes fractional seconds. This change displays `1:08:45`, consistent with the player.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #1191

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Floor numeric durations before calculating hours, minutes, and seconds. Existing history entries display correctly without changing stored data. Unit and Electron regression tests cover the reported examples.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed history duration badges showing fractional seconds and long decimal fragments.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Play a video using yt-dlp long enough to save it in History, then open History. Existing affected entries can also be used.
2. Confirm the duration badge contains whole seconds and matches the player, for example `2:33` instead of `2:33.839`.
3. Check a video longer than an hour and confirm its badge uses `H:MM:SS` with no decimals.

## Additional context
<!-- Add any other context about the pull request here. -->
