### PR TITLE
fix(android): report app version to the sync server

### DIFF
--- a/src/renderer/helpers/sync-server.js
+++ b/src/renderer/helpers/sync-server.js
@@ -1,5 +1,6 @@
 import { MAIN_PROFILE_ID } from '../../constants'
 import packageDetails from '../../../package.json'
+import { applySyncServerUserAgent } from '../../syncServerUserAgent'
 import {
   CUSTOM_THEMES_SYNC_KEY,
   customThemeIdFromValue,
@@ -44,7 +45,10 @@ const YOUTUBE_VIDEO_THUMBNAIL_REGEX = /^https?:\/\/i\.ytimg\.com\/vi(?:_webp)?\/
 
 function syncServerFetch(input, init) {
   return process.env.IS_CAPACITOR
-    ? capacitorHttpFetch(input, init)
+    ? capacitorHttpFetch(input, {
+        ...init,
+        headers: applySyncServerUserAgent(Object.fromEntries(new Headers(init.headers))),
+      })
     : fetch(input, init)
 }
 
@@ -104,7 +108,7 @@ export class SyncServerClient {
       hasBody: options.body != null,
       headers: options.headers,
       token: this.token,
-      version: process.env.IS_ELECTRON ? packageDetails.version : '',
+      version: process.env.IS_ELECTRON || process.env.IS_CAPACITOR ? packageDetails.version : '',
     })
 
     try {

--- a/tests/unit/sync-server-request.test.mjs
+++ b/tests/unit/sync-server-request.test.mjs
@@ -1,8 +1,82 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { readFile } from 'node:fs/promises'
+import vm from 'node:vm'
 
 import { applySyncServerUserAgent } from '../../src/syncServerUserAgent.js'
 import { createSyncServerRequestHeaders } from '../../src/renderer/helpers/sync-server-request.js'
+import * as errors from '../../src/renderer/helpers/sync-server-errors.js'
+
+async function loadClient(env, version, requests) {
+  const context = vm.createContext({
+    ...errors,
+    process: { env },
+    packageDetails: { version },
+    createSyncServerRequestHeaders,
+    applySyncServerUserAgent,
+    URL, URLSearchParams, Request, Response, Headers, AbortController, setTimeout, clearTimeout,
+    CapacitorHttp: {
+      request: async options => {
+        requests.push(options)
+        return { status: 200, data: '{}', headers: {} }
+      },
+    },
+    fetch: async (url, options) => {
+      requests.push({ url, ...options })
+      return new Response('{}')
+    },
+  })
+  for (const file of ['api/capacitor-http.js', 'sync-server.js']) {
+    const source = (await readFile(new URL(`../../src/renderer/helpers/${file}`, import.meta.url), 'utf8'))
+      .replace(/^import[\s\S]*? from ['"][^'"]+['"]\n/gm, '')
+      .replace(/^export \{[\s\S]*?\}\n/gm, '')
+      .replace(/^export /gm, '')
+    vm.runInContext(source, context)
+  }
+  return vm.runInContext('new SyncServerClient("https://sync.example")', context)
+}
+
+for (const version of ['0.34.0', '0.34.0-nightly-976']) {
+  test(`Android sync sends ${version} through native HTTP on public and authenticated requests`, async () => {
+    const requests = []
+    const client = await loadClient({ IS_CAPACITOR: true, IS_ELECTRON: false }, version, requests)
+    await client.health()
+    client.token = 'sync-token'
+    await client.request('/subscriptions', { method: 'POST', body: { id: 'channel' } })
+
+    assert.equal(requests.length, 2)
+    for (const request of requests) {
+      const headers = new Headers(request.headers)
+      assert.equal(headers.get('User-Agent'), `OpenTubeX/${version}`)
+      assert.equal(headers.has('OpenTubeX-Client-Version'), false)
+      assert.equal(headers.get('Accept'), 'application/json')
+    }
+    assert.equal(new Headers(requests[0].headers).has('Authorization'), false)
+    assert.equal(new Headers(requests[1].headers).get('Authorization'), 'sync-token')
+    assert.equal(new Headers(requests[1].headers).get('Content-Type'), 'application/json')
+    assert.equal(requests[1].data, '{"id":"channel"}')
+  })
+}
+
+test('browser sync does not send native app version headers', async () => {
+  const requests = []
+  const client = await loadClient({ IS_CAPACITOR: false, IS_ELECTRON: false }, '0.34.0', requests)
+  await client.health()
+
+  const headers = new Headers(requests[0].headers)
+  assert.equal(headers.has('User-Agent'), false)
+  assert.equal(headers.has('OpenTubeX-Client-Version'), false)
+})
+
+test('Electron sync retains its version marker for the main process', async () => {
+  const requests = []
+  const client = await loadClient({ IS_CAPACITOR: false, IS_ELECTRON: true }, '0.34.0', requests)
+  await client.health()
+
+  const headers = new Headers(requests[0].headers)
+  assert.equal(headers.get('OpenTubeX-Client-Version'), '0.34.0')
+  assert.equal(headers.has('User-Agent'), false)
+})
 
 test('unauthenticated sync requests expose the unchanged version through the user agent', () => {
   const requestHeaders = createSyncServerRequestHeaders({


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Requested directly; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Android sync requests sent a generic browser user agent, so the sync server could not identify the app version. Send `OpenTubeX/<version>` through Android native HTTP, matching desktop and preserving nightly version suffixes.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Android now reports its app version to the sync server.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run this branch on Android and connect to a sync server whose request headers you can inspect.
2. Check the user agent on the connection test and an authenticated sync request. Both should be `OpenTubeX/<app version>`, including the nightly suffix when applicable. The internal `OpenTubeX-Client-Version` header should be absent.
3. Confirm that sync still completes successfully.

## Additional context
<!-- Add any other context about the pull request here. -->

Implemented with GPT-6 in the Codex desktop app.
