### PR TITLE
fix(history): preserve resume position when leaving videos during startup

### DIFF
--- a/e2e/tests/offline/history-quick-exit.spec.mjs
+++ b/e2e/tests/offline/history-quick-exit.spec.mjs
@@ -1,0 +1,88 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { test, expect, sel } from '../../helpers/app.mjs'
+import { openMockedVideo } from '../../helpers/player.mjs'
+import { mockPlayableWatchPage, watchHistoryEntry } from '../../helpers/watch.mjs'
+
+test.use({
+  seed: {
+    settings: {
+      videoPlaybackEngine: 'built-in',
+      ytDlpPlaybackEngineDefaultMigration: true,
+      defaultVideoFormat: 'legacy',
+      rememberHistory: true,
+      watchedProgressSavingMode: 'auto',
+      useSponsorBlock: false,
+    },
+    history: [{ ...watchHistoryEntry, watchProgress: 10, lengthSeconds: 19 }],
+  },
+})
+
+async function savedProgress(app) {
+  const contents = await readFile(path.join(app.userDataDir, 'history.db'), 'utf8')
+  return contents.trim().split('\n').map(line => JSON.parse(line))
+    .filter(record => record.videoId === 'jNQXAC9IVRw').at(-1)?.watchProgress
+}
+
+for (const phase of ['metadata pending', 'media pending', 'first loaded data']) {
+  test(`preserves the resume position when leaving with ${phase}`, async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await page.locator(sel.sideNavLink('history')).first().evaluate(element => element.click())
+    await expect(page).toHaveURL(/#\/history/)
+    let release
+    const pending = new Promise(resolve => { release = resolve })
+    let reached
+    const requested = new Promise(resolve => { reached = resolve })
+    if (phase !== 'first loaded data') {
+      await page.route(phase === 'metadata pending' ? '**/youtubei/v1/player**' : /googlevideo\.com\/videoplayback/, async route => {
+        reached()
+        await pending
+        await route.fallback()
+      })
+    } else {
+      await page.evaluate(backSelector => {
+        document.addEventListener('loadeddata', () => {
+          document.querySelector(backSelector).click()
+        }, { capture: true, once: true })
+      }, sel.backButton)
+    }
+
+    try {
+      await page.locator(sel.searchInput).fill('https://www.youtube.com/watch?v=jNQXAC9IVRw')
+      await page.locator(sel.searchInput).press('Enter')
+      if (phase !== 'first loaded data') {
+        await requested
+        await page.locator(sel.backButton).click()
+        release()
+      }
+      await expect(page).toHaveURL(/#\/history/)
+      release()
+      expect(await savedProgress(app)).toBeGreaterThanOrEqual(10)
+      await page.reload()
+      await expect(page.getByRole('heading', { name: 'History', exact: true })).toBeVisible()
+      expect(await savedProgress(app)).toBeGreaterThanOrEqual(10)
+    } finally {
+      release()
+    }
+  })
+}
+
+for (const position of [0, 12]) {
+  test(`saves a deliberate seek to ${position} seconds after resuming`, async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await page.locator(sel.sideNavLink('history')).first().evaluate(element => element.click())
+    await expect(page).toHaveURL(/#\/history/)
+    const video = await openMockedVideo(page)
+    await expect.poll(() => video.evaluate(element => element.currentTime)).toBeGreaterThanOrEqual(10)
+    await video.evaluate((element, seconds) => {
+      element.pause()
+      return new Promise(resolve => {
+        element.addEventListener('seeked', resolve, { once: true })
+        element.currentTime = seconds
+      })
+    }, position)
+    await page.locator(sel.backButton).click()
+    await expect(page).toHaveURL(/#\/history/)
+    await expect.poll(() => savedProgress(app)).toBe(position)
+  })
+}

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1095,6 +1095,7 @@ export default defineComponent({
     }
 
     const hasLoaded = ref(false)
+    const hasPlaybackPosition = ref(false)
     const videoLayoutReady = ref(false)
     const annotationCurrentTime = ref(0)
     const annotationVideoAspectRatio = ref(null)
@@ -5922,6 +5923,7 @@ export default defineComponent({
     }
 
     function handlePlaying() {
+      hasPlaybackPosition.value = true
       // Chromium can briefly paint a video's poster across the compositor
       // surface while detaching it into native PiP on Windows. Once a real
       // frame is available the poster is no longer needed, so remove it before
@@ -6011,6 +6013,7 @@ export default defineComponent({
     }
 
     function handleSeeking() {
+      hasPlaybackPosition.value = true
       shortsEnded.value = false
       cancelSponsorBlockSkipSchedule()
       clearAbRepeatBoundarySchedule()
@@ -10228,6 +10231,7 @@ export default defineComponent({
       player.addEventListener('loading', () => {
         silenceSkipping.reset()
         hasLoaded.value = false
+        hasPlaybackPosition.value = false
         videoLayoutReady.value = false
         annotationVideoAspectRatio.value = null
         if (props.shortsPlayer) {
@@ -11002,6 +11006,7 @@ export default defineComponent({
 
     expose({
       hasLoaded,
+      hasPlaybackPosition,
 
       isPaused,
       play,

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -4178,6 +4178,9 @@ export default defineComponent({
       // for tabs the user has actually presented.
       if (!this.isCurrentlyPresented() || !this.hasBeenPresented) { return }
       if (!this.$refs.player?.hasLoaded) { return }
+      // Shaka can finish loading before it seeks to the resume point. Saving
+      // the media element's initial zero in that gap would erase progress.
+      if (!this.$refs.player.hasPlaybackPosition) { return }
 
       const currentTime = this.shortsPlaybackCompleted && this.watchedProgressSavingEnabled
         ? this.videoLengthSeconds


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Resolves https://gitlab.com/opentubex/OpenTubeX/-/work_items/530

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Opening a partially watched video and immediately going back can replace its saved playback position with zero. Shaka reports the stream loaded before restoring the initial position. Wait until playback starts or a seek establishes the position before saving progress; deliberate seeks back to zero still save normally.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed saved playback positions resetting when leaving a video during startup.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Set the preferred video format to Legacy and enable automatic watch-progress saving.
2. Watch part of a video, then return to History.
3. Reopen it and immediately go back while it is loading. Repeat a few times, then reopen it normally. It should resume from the saved position.
4. After playback resumes, pause and seek to the beginning or another position. Go back and reopen the video; the deliberately selected position should be saved.

## Additional context
<!-- Add any other context about the pull request here. -->

Implemented with GPT-6 in the Codex desktop app.
