### PR TITLE
fix: keep playlist video counter below the title

### DIFF
--- a/e2e/tests/offline/playlist-skip-buttons.spec.mjs
+++ b/e2e/tests/offline/playlist-skip-buttons.spec.mjs
@@ -109,6 +109,43 @@ function readSkipAvailability(page) {
   })
 }
 
+test('playlist counter stays below the title when expanded and collapsed', async ({ page, attachScreenshot }) => {
+  await page.route(/^https?:\/\//, (route) => route.abort())
+  await goTo(page, 'userplaylists')
+  await page.getByText('Skip button playlist').click()
+  await page.getByText(VIDEO_TITLES[1]).first().click()
+
+  const playlist = page.locator('.watchVideoPlaylist')
+  const counter = playlist.locator('.playlistIndex label')
+  await expect(counter).toHaveText('2 / 3')
+
+  const expectCounterBelowTitle = async () => {
+    await expect.poll(() => playlist.evaluate((element) => {
+      const title = element.querySelector('.playlistTitle').getBoundingClientRect()
+      const counter = element.querySelector('.playlistIndex label').getBoundingClientRect()
+      return counter.top - title.bottom
+    })).toBeGreaterThanOrEqual(0)
+  }
+
+  for (const scale of [1, 0.95, 1.25]) {
+    await page.evaluate(value => window.ftElectron.setZoomFactor(value), scale)
+    for (const width of ['240px', '']) {
+      await playlist.evaluate((element, value) => {
+        element.style.inlineSize = value
+      }, width)
+      await expectCounterBelowTitle()
+      await playlist.getByRole('button', { name: 'Collapse Playlist', exact: true }).click()
+      await expect(playlist.locator('.playlistItemsWrapper')).toBeHidden()
+      await expectCounterBelowTitle()
+      await playlist.getByRole('button', { name: 'Expand Playlist', exact: true }).click()
+      await expect(playlist.locator('.playlistItemsWrapper')).toBeVisible()
+      await expectCounterBelowTitle()
+    }
+  }
+  await playlist.scrollIntoViewIfNeeded()
+  await attachScreenshot('playlist counter below title at 125% UI scale')
+})
+
 test('only offers skipping to playlist videos that exist', async ({ page, attachScreenshot }) => {
   await page.route(/^https?:\/\//, (route) => route.abort())
 

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
@@ -22,19 +22,14 @@
 
 .channelName {
   font-size: 15px;
-  position: relative;
-  inset-block-end: 15px;
 }
 
 .playlistIndex {
-  position: relative;
-  inset-block-end: 15px;
   color: var(--tertiary-text-color);
 }
 
 .playlistIndex.isCollapsed {
   display: block;
-  inset-block-end: 0;
   margin-block-end: -6px;
 }
 
@@ -284,10 +279,6 @@
   font-size: 18px;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.fullscreenPlaylist :is(.channelName, .playlistIndex) {
-  inset-block-end: 0;
 }
 
 .fullscreenPlaylist .playlistItemsWrapper {


### PR DESCRIPTION
The playlist video counter overlapped the playlist title when watching a video from a playlist. This removes the upward CSS offsets so the counter and optional channel name sit below the title.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #1195

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Keep the playlist counter and channel name in normal document flow, and remove the redundant collapsed/fullscreen positioning overrides. Add a layout regression test for expanded and collapsed panels at narrow and default widths and 95%, 100%, and 125% UI scales.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
The playlist video counter now sits below the playlist title without overlapping it.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Play the second video in a playlist containing at least three videos.
2. Check that the title and counter have a clear gap, then collapse and expand the playlist.
3. Repeat with a narrow panel and at 95% and 125% UI scale. The counter should stay below the title.

## Additional context
<!-- Add any other context about the pull request here. -->

Implemented with GPT-6 in the Codex desktop app.

