### PR TITLE
feat(themes): discover, preview, install and update community themes

### DIFF
--- a/e2e/tests/offline/theme-discovery.spec.mjs
+++ b/e2e/tests/offline/theme-discovery.spec.mjs
@@ -1,0 +1,407 @@
+import { readFile, readdir } from 'node:fs/promises'
+import path from 'node:path'
+import { cloneDefaultCustomTheme } from '../../../src/customTheme.js'
+import { test, expect, goToSettingsSection } from '../../helpers/app.mjs'
+
+test.use({ seed: { settings: { generalAutoLoadMorePaginatedItemsEnabled: false } } })
+
+const feedUrl = 'https://github.com/OpenTubeX/OpenTubeX/discussions/categories/themes.atom*'
+const screenshot = 'https://github.com/user-attachments/assets/5724b7e8-f82e-4107-835b-a16d12afd0b5'
+const secondScreenshot = 'https://github.com/user-attachments/assets/214fe15d-e6c8-40c0-8e83-c45223bede64'
+const oldRevision = '2026-09-08T07:00:00.000Z'
+const newRevision = '2026-09-08T08:00:00.000Z'
+
+function escape(value) {
+  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;')
+}
+
+function entry(number, { updated = oldRevision, color = '#121212', invalid = false, extra = '', images = [screenshot, secondScreenshot], description = number % 2 === 0 ? 'A longer description with additional details about the colors and the appearance of this community theme, taking several lines in a narrow card.' : 'A community theme.' } = {}) {
+  const theme = cloneDefaultCustomTheme()
+  theme.id = 'shared-export-id'
+  theme.name = `Community theme ${number}`
+  theme.colors.background = color
+  const body = `<h2>Description</h2><p>${escape(description)}</p><h2>Screenshots</h2>
+    ${images.map(src => `<img src="${src}">`).join('')}${extra}
+    <details><summary>Theme JSON</summary><div class="highlight highlight-source-json"
+      data-snippet-clipboard-copy-content="${escape(invalid ? '{}' : JSON.stringify(theme))}"><pre>highlighted code</pre></div></details>`
+  return `<entry><link rel="alternate" href="https://github.com/OpenTubeX/OpenTubeX/discussions/${number}"/>
+    <title>${escape(theme.name)}</title><author><name>ThemeAuthor</name></author>
+    <updated>${updated}</updated><content type="html">${escape(body)}</content></entry>`
+}
+
+function feed(entries) {
+  return `<feed xmlns="http://www.w3.org/2005/Atom">${entries.join('')}</feed>`
+}
+
+async function mockScreenshots(page) {
+  await page.route('https://github.com/user-attachments/assets/*', route => route.fulfill({
+    contentType: 'image/svg+xml',
+    body: '<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900"><rect width="1600" height="900" fill="#202830"/></svg>'
+  }))
+}
+
+async function openDiscovery(page) {
+  const appearance = await goToSettingsSection(page, 'appearance')
+  await appearance.getByRole('button', { name: 'Discover themes', exact: true }).click()
+  await expect(page.locator('.themeDiscovery')).toBeVisible()
+  return page.locator('.themeDiscovery')
+}
+
+async function expectActionsSideBySide(gallery) {
+  await expect.poll(() => gallery.locator('.themeActions').evaluateAll(rows => rows.every(row => {
+    const [install, github] = [...row.children].map(button => button.getBoundingClientRect())
+    const bounds = row.getBoundingClientRect()
+    const card = row.closest('article')
+    const details = row.parentElement
+    const bottom = card.getBoundingClientRect().bottom -
+      Number.parseFloat(getComputedStyle(card).borderBottomWidth) -
+      Number.parseFloat(getComputedStyle(details).paddingBottom)
+    return Math.abs(install.top - github.top) <= 1 &&
+      install.right <= github.left && github.right <= bounds.right + 1 &&
+      Math.abs(bounds.bottom - bottom) <= 1
+  }))).toBe(true)
+}
+
+async function savedThemes(app) {
+  const directory = path.join(app.userDataDir, 'themes')
+  const files = (await readdir(directory)).filter(file => file.endsWith('.json'))
+  return Promise.all(files.map(async file => JSON.parse(await readFile(path.join(directory, file), 'utf8'))))
+}
+
+test('discovers, installs, persists and updates themes without overwriting local edits on refresh', async ({ page, app }) => {
+  let revision = oldRevision
+  let requests = 0
+  const unsafeRequests = []
+  page.on('request', request => {
+    if (request.url().includes('tracker.invalid')) unsafeRequests.push(request.url())
+  })
+  await mockScreenshots(page)
+  const routeFeed = async target => target.route(feedUrl, route => {
+    requests++
+    const secondPage = new URL(route.request().url()).searchParams.get('page') === '2'
+    return route.fulfill({
+      contentType: 'application/atom+xml',
+      body: feed(secondPage
+        ? []
+        : [
+            entry(1197, { updated: revision, color: revision === oldRevision ? '#121212' : '#112233', extra: '<img src="https://tracker.invalid/pixel"><script>window.themeScriptExecuted = true</script><iframe src="https://tracker.invalid/frame"></iframe>' }),
+            entry(1196), entry(1000, { invalid: true })
+          ])
+    })
+  })
+  await routeFeed(page)
+  const appearance = await goToSettingsSection(page, 'appearance')
+  expect(requests).toBe(0)
+  await appearance.getByRole('button', { name: 'Discover themes', exact: true }).click()
+  const gallery = page.locator('.themeDiscovery')
+  await expect(gallery.locator('article')).toHaveCount(2)
+  await expect(gallery.locator('.discoveryToolbar').getByRole('button', { name: 'View on GitHub' })).toHaveCount(0)
+  const refresh = gallery.getByRole('button', { name: 'Refresh', exact: true })
+  await expect(refresh).toHaveText('')
+  const [toolbarBounds, refreshBounds] = await Promise.all([
+    gallery.locator('.discoveryToolbar').boundingBox(), refresh.boundingBox()
+  ])
+  expect(refreshBounds.x).toBeGreaterThan(toolbarBounds.x + toolbarBounds.width / 2)
+  await expect(gallery.locator('article').first().locator('[data-prefix="fab"][data-icon="github"]')).toHaveCount(1)
+  await expectActionsSideBySide(gallery)
+  const first = gallery.locator('article').first()
+  await expect(first.locator('.themePreview img')).toHaveAttribute('src', screenshot)
+  await page.emulateMedia({ reducedMotion: 'no-preference' })
+  await first.locator('.themePreview img').evaluate(image => {
+    window.themeFadeObserved = false
+    image.addEventListener('transitionrun', event => {
+      if (event.propertyName === 'opacity') window.themeFadeObserved = true
+    })
+  })
+  await first.getByRole('button', { name: 'Community theme 1197 (2)', exact: true }).click()
+  await expect(first.locator('.themePreview img')).toHaveAttribute('src', secondScreenshot)
+  expect(await page.evaluate(() => window.themeFadeObserved)).toBe(true)
+  const selectedNumber = first.getByRole('button', { name: 'Community theme 1197 (2)', exact: true })
+  await selectedNumber.hover()
+  await expect.poll(() => selectedNumber.evaluate(button => getComputedStyle(button).backgroundColor)).toMatch(/^oklab/)
+  await expect(selectedNumber).toHaveAttribute('aria-pressed', 'true')
+  const profile = first.getByRole('link', { name: '@ThemeAuthor', exact: true })
+  await expect(profile).toHaveAttribute('href', 'https://github.com/ThemeAuthor')
+  await page.evaluate(() => {
+    window.open = url => { window.openedThemeLink = url; return null }
+  })
+  await profile.click()
+  expect(await page.evaluate(() => window.openedThemeLink)).toBe('https://github.com/ThemeAuthor')
+  const screenshotButton = first.locator('.themePreview button')
+  await screenshotButton.click()
+  const viewer = page.getByRole('dialog', { name: 'Community theme 1197', exact: true })
+  await expect(viewer).toBeVisible()
+  await expect(viewer.locator('img')).toHaveAttribute('src', secondScreenshot)
+  const close = viewer.getByRole('button', { name: 'Close', exact: true })
+  await expect(close).toHaveText('')
+  const [headerBounds, closeBounds] = await Promise.all([
+    viewer.locator('.screenshotHeader').boundingBox(), close.boundingBox()
+  ])
+  expect(Math.abs(closeBounds.x + closeBounds.width - headerBounds.x - headerBounds.width)).toBeLessThanOrEqual(1)
+  await viewer.getByRole('button', { name: 'Previous', exact: true }).click()
+  await expect(viewer.locator('img')).toHaveAttribute('src', screenshot)
+  await expect(viewer.locator('.screenshotNavigation')).toContainText('1 / 2')
+  await viewer.getByRole('button', { name: 'Next', exact: true }).click()
+  await expect(viewer.locator('img')).toHaveAttribute('src', secondScreenshot)
+  await viewer.getByRole('button', { name: 'Next', exact: true }).click()
+  await expect(viewer.locator('img')).toHaveAttribute('src', screenshot)
+  await expect(viewer.locator('.screenshotNavigation')).toContainText('1 / 2')
+  const [thumbnailBounds, fullBounds] = await Promise.all([
+    first.locator('.themePreview img').boundingBox(), viewer.locator('img').boundingBox()
+  ])
+  expect(fullBounds.width).toBeGreaterThan(thumbnailBounds.width)
+  await page.keyboard.press('Escape')
+  await expect(viewer).toHaveCount(0)
+  await expect(gallery).toBeVisible()
+  await expect(screenshotButton).toBeFocused()
+  await screenshotButton.click()
+  await viewer.getByRole('button', { name: 'Close', exact: true }).click()
+  await expect(viewer).toHaveCount(0)
+  await expect(first.getByText('A community theme.', { exact: true })).toBeVisible()
+  expect(unsafeRequests).toEqual([])
+  expect(await page.evaluate(() => window.themeScriptExecuted)).toBeUndefined()
+
+  await first.getByRole('button', { name: 'Install and apply', exact: true }).click()
+  await expect(first.getByRole('button', { name: 'Applied', exact: true })).toBeDisabled()
+  await expect(page.locator('body')).toHaveCSS('background-color', 'rgb(18, 18, 18)')
+  await gallery.locator('article').nth(1).getByRole('button', { name: 'Install and apply', exact: true }).click()
+  await expect.poll(async () => (await savedThemes(app)).length).toBe(2)
+  expect((await savedThemes(app)).map(theme => theme.id).sort()).toEqual(['discussion-1196', 'discussion-1197'])
+  const initialHash = (await savedThemes(app)).find(theme => theme.id === 'discussion-1197').discussionThemeHash
+
+  await page.evaluate(async () => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    const theme = (await window.ftElectron.loadCustomTheme()).find(theme => theme.id === 'discussion-1197')
+    theme.colors.background = '#abcdef'
+    const themes = await window.ftElectron.saveCustomTheme(theme)
+    await store.dispatch('updateCustomThemes', themes)
+  })
+  await gallery.getByRole('button', { name: 'Refresh', exact: true }).click()
+  await expect(first.getByRole('button', { name: 'Apply theme', exact: true })).toBeVisible()
+  await first.getByRole('button', { name: 'Apply theme', exact: true }).click()
+  await expect(page.locator('body')).toHaveCSS('background-color', 'rgb(171, 205, 239)')
+
+  revision = newRevision
+  const relaunched = await app.relaunch()
+  page = relaunched.page
+  await mockScreenshots(page)
+  await routeFeed(page)
+  const reopened = await openDiscovery(page)
+  const updatedCard = reopened.locator('article').first()
+  await expect(updatedCard.getByRole('button', { name: 'Update and apply', exact: true })).toBeVisible()
+  await expect(page.locator('body')).toHaveCSS('background-color', 'rgb(171, 205, 239)')
+  await updatedCard.getByRole('button', { name: 'Update and apply', exact: true }).click()
+  await expect(updatedCard.getByRole('button', { name: 'Applied', exact: true })).toBeDisabled()
+  await expect(page.locator('body')).toHaveCSS('background-color', 'rgb(17, 34, 51)')
+  const saved = await savedThemes(app)
+  expect(saved).toHaveLength(2)
+  expect(saved.find(theme => theme.id === 'discussion-1197').discussionThemeHash).toMatch(/^[\da-f]{64}$/)
+  expect(saved.find(theme => theme.id === 'discussion-1197').discussionThemeHash).not.toBe(initialHash)
+})
+
+test('retries failures, paginates, skips invalid posts and handles empty feeds', async ({ page }) => {
+  let fail = true
+  let empty = false
+  const pages = []
+  await mockScreenshots(page)
+  await page.route(feedUrl, route => {
+    const number = Number(new URL(route.request().url()).searchParams.get('page'))
+    pages.push(number)
+    return route.fulfill({ status: fail ? 503 : 200, contentType: 'application/atom+xml', body: feed(empty || number > 2 ? [] : [entry(number, { invalid: number === 1 })]) })
+  })
+  const gallery = await openDiscovery(page)
+  await expect(gallery.getByRole('alert')).toHaveText('Could not load themes. Try refreshing.')
+  await expect(gallery.getByRole('alert')).toHaveCSS('text-align', 'center')
+  fail = false
+  await gallery.getByRole('button', { name: 'Refresh', exact: true }).click()
+  await expect(gallery.getByText('No installable themes found.')).toBeVisible()
+  await expect(gallery.getByText('No installable themes found.')).toHaveCSS('text-align', 'center')
+  const [loadMoreBounds, scrollerBounds] = await Promise.all([
+    gallery.getByRole('button', { name: 'Load more', exact: true }).boundingBox(),
+    gallery.locator('.discoveryScroller').boundingBox()
+  ])
+  expect(Math.abs(loadMoreBounds.x + loadMoreBounds.width / 2 - scrollerBounds.x - scrollerBounds.width / 2)).toBeLessThanOrEqual(1)
+  await gallery.getByRole('button', { name: 'Load more', exact: true }).click()
+  await expect(gallery.locator('article')).toHaveCount(1)
+  await gallery.getByRole('button', { name: 'Load more', exact: true }).click()
+  await expect(gallery.getByRole('button', { name: 'Load more', exact: true })).toHaveCount(0)
+  expect(pages).toEqual([1, 1, 2, 3])
+  fail = true
+  await gallery.getByRole('button', { name: 'Refresh', exact: true }).click()
+  await expect(gallery.getByRole('alert')).toBeVisible()
+  await expect(gallery.locator('article')).toHaveCount(1)
+  fail = false
+  empty = true
+  await gallery.getByRole('button', { name: 'Refresh', exact: true }).click()
+  await expect(gallery.getByText('No installable themes found.')).toBeVisible()
+  await expect(gallery.locator('article')).toHaveCount(0)
+})
+
+for (const scale of [85, 110]) {
+  test(`clamps the gallery after refresh and resize at ${scale}% scale`, async ({ page, app }) => {
+    let count = 10
+    await mockScreenshots(page)
+    await page.route(feedUrl, route => route.fulfill({ contentType: 'application/atom+xml', body: feed(new URL(route.request().url()).searchParams.get('page') === '1' ? Array.from({ length: count }, (_, i) => entry(i + 1)) : []) }))
+    await page.evaluate(async value => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateUiScale', value)
+    }, scale)
+    const gallery = await openDiscovery(page)
+    await expect(gallery.locator('article')).toHaveCount(10)
+    await expectActionsSideBySide(gallery)
+    await gallery.locator('.themePreview button').first().click()
+    const viewer = page.getByRole('dialog', { name: 'Community theme 1', exact: true })
+    await expect(viewer).toBeVisible()
+    expect(await viewer.locator('img').evaluate(image => {
+      const bounds = image.getBoundingClientRect()
+      return bounds.top >= 0 && bounds.left >= 0 &&
+        bounds.bottom <= window.innerHeight + 1 && bounds.right <= window.innerWidth + 1
+    })).toBe(true)
+    await viewer.getByRole('button', { name: 'Close', exact: true }).click()
+    await expect(viewer).toHaveCount(0)
+    const scroller = gallery.locator('.discoveryScroller')
+    await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
+    await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+    await gallery.getByRole('button', { name: 'Load more', exact: true }).evaluate(element => element.click())
+    await expect(gallery.getByRole('button', { name: 'Load more', exact: true })).toHaveCount(0)
+    await expect.poll(() => scroller.evaluate(element => Math.abs(element.scrollTop - Math.max(0, element.scrollHeight - element.clientHeight)))).toBeLessThanOrEqual(1)
+    await expect(scroller.locator('.os-scrollbar-vertical')).not.toHaveClass(/os-scrollbar-unusable/)
+    await app.electronApp.evaluate(({ BrowserWindow }) => {
+      BrowserWindow.getAllWindows()[0].setBounds({ width: 1900, height: 1200 })
+    })
+    await expect.poll(() => scroller.evaluate(element => Math.abs(element.scrollTop - Math.max(0, element.scrollHeight - element.clientHeight)))).toBeLessThanOrEqual(1)
+    count = 0
+    // DOM activation preserves the obsolete bottom offset until the response.
+    await gallery.getByRole('button', { name: 'Refresh', exact: true }).evaluate(element => element.click())
+    await expect(gallery.locator('article')).toHaveCount(0)
+    await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBe(0)
+    await expect(scroller.locator('.os-scrollbar-vertical')).toHaveClass(/os-scrollbar-unusable/)
+    const toolbar = await gallery.locator('.discoveryToolbar').boundingBox()
+    const viewport = await scroller.boundingBox()
+    expect(viewport.y).toBeGreaterThanOrEqual(toolbar.y + toolbar.height - 1)
+  })
+}
+
+test('automatically loads more at the bottom with a spinner and stops retrying on errors', async ({ page }) => {
+  await mockScreenshots(page)
+  const requests = []
+  let finishSecondPage
+  const secondPage = new Promise(resolve => { finishSecondPage = resolve })
+  await page.route(feedUrl, async route => {
+    const number = Number(new URL(route.request().url()).searchParams.get('page'))
+    requests.push(number)
+    if (number === 2) await secondPage
+    await route.fulfill({
+      status: number > 2 ? 503 : 200,
+      contentType: 'application/atom+xml',
+      body: feed(number === 1 ? Array.from({ length: 9 }, (_, i) => entry(i + 1)) : [entry(10)])
+    })
+  })
+  await page.evaluate(async () => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    await store.dispatch('updateGeneralAutoLoadMorePaginatedItemsEnabled', true)
+  })
+  const gallery = await openDiscovery(page)
+  await expect(gallery.locator('article')).toHaveCount(9)
+  expect(requests).toEqual([1])
+  await expect(gallery.getByRole('button', { name: 'Load more', exact: true })).toHaveCount(0)
+  const scroller = gallery.locator('.discoveryScroller')
+  await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
+  await expect(gallery.locator('.spinnerContainer')).toBeVisible()
+  expect(requests).toEqual([1, 2])
+  finishSecondPage()
+  await expect(gallery.locator('article')).toHaveCount(10)
+  await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
+  await expect(gallery.getByRole('alert')).toBeVisible()
+  await expect(gallery.getByRole('button', { name: 'Load more', exact: true })).toBeVisible()
+  expect(requests).toEqual([1, 2, 3])
+  await expect(gallery.locator('.themeAutoLoadSentinel')).toHaveCount(0)
+  await expect(gallery.locator('.spinnerContainer')).toHaveCount(0)
+})
+
+test('reloads the feed when an already-open gallery is remounted', async ({ page }) => {
+  await mockScreenshots(page)
+  let requests = 0
+  await page.route(feedUrl, route => {
+    requests++
+    return route.fulfill({ contentType: 'application/atom+xml', body: feed([entry(1)]) })
+  })
+  const gallery = await openDiscovery(page)
+  await expect(gallery.locator('article')).toHaveCount(1)
+  expect(requests).toBe(1)
+  await page.evaluate(() => {
+    // A hot reload replaces the child while its parent's open state survives.
+    function find(vnode) {
+      if (vnode?.component?.type?.__name === 'ThemeDiscovery') return vnode.component
+      const nested = vnode?.component?.subTree && find(vnode.component.subTree)
+      if (nested) return nested
+      for (const child of Array.isArray(vnode?.children) ? vnode.children : []) {
+        const match = find(child)
+        if (match) return match
+      }
+      return null
+    }
+    const component = find(document.querySelector('#app').__vue_app__._container._vnode)
+    if (!component) throw new Error('Theme discovery component not found')
+    component.vnode.key = 'before-remount'
+    component.parent.proxy.$forceUpdate()
+  })
+  await expect(gallery).toBeVisible()
+  await expect.poll(() => requests, { timeout: 2000 }).toBe(2)
+  await expect(gallery.locator('article')).toHaveCount(1)
+  await expect(gallery.getByText('No installable themes found.')).toHaveCount(0)
+})
+
+test('only offers updates for changes to the theme JSON', async ({ page, app }) => {
+  await mockScreenshots(page)
+  const options = { updated: oldRevision, description: 'Original description' }
+  await page.route(feedUrl, route => route.fulfill({
+    contentType: 'application/atom+xml', body: feed([entry(1197, options)])
+  }))
+  const gallery = await openDiscovery(page)
+  const card = gallery.locator('article')
+  await card.getByRole('button', { name: 'Install and apply', exact: true }).click()
+  await expect(card.getByRole('button', { name: 'Applied', exact: true })).toBeDisabled()
+
+  options.updated = newRevision
+  options.description = 'Revised description'
+  options.images = [secondScreenshot]
+  await gallery.getByRole('button', { name: 'Refresh', exact: true }).click()
+  await expect(card.getByText('Revised description', { exact: true })).toBeVisible()
+  await expect(card.locator('.themePreview img')).toHaveAttribute('src', secondScreenshot)
+  await expect(card.getByRole('button', { name: 'Applied', exact: true })).toBeDisabled()
+  await expect(card.getByRole('button', { name: 'Update and apply', exact: true })).toHaveCount(0)
+
+  // Actual theme edits must be detected even if the discussion timestamp stays the same.
+  options.color = '#112233'
+  await gallery.getByRole('button', { name: 'Refresh', exact: true }).click()
+  await card.getByRole('button', { name: 'Update and apply', exact: true }).click()
+  await expect(card.getByRole('button', { name: 'Applied', exact: true })).toBeDisabled()
+  expect((await savedThemes(app))[0].colors.background).toBe('#112233')
+  await gallery.getByRole('button', { name: 'Refresh', exact: true }).click()
+  await expect(gallery.getByRole('button', { name: 'Refresh', exact: true })).toHaveAttribute('aria-disabled', 'false')
+  await expect(card.getByRole('button', { name: 'Update and apply', exact: true })).toHaveCount(0)
+})
+
+for (const fullPreview of [false, true]) {
+  test(`keeps the selected screenshot after an outgoing image fails (${fullPreview ? 'full preview' : 'gallery'})`, async ({ page }) => {
+    await mockScreenshots(page)
+    await page.route(feedUrl, route => route.fulfill({ contentType: 'application/atom+xml', body: feed([entry(1)]) }))
+    const gallery = await openDiscovery(page)
+    await page.emulateMedia({ reducedMotion: 'no-preference' })
+    if (fullPreview) await gallery.locator('.themePreview button').click()
+    const container = fullPreview ? page.getByRole('dialog', { name: 'Community theme 1', exact: true }) : gallery
+    await expect(container.locator('img')).toHaveAttribute('src', screenshot)
+    await container.evaluate((element, full) => {
+      const outgoing = element.querySelector('img')
+      outgoing.addEventListener('transitionrun', () => outgoing.dispatchEvent(new Event('error')), { once: true })
+      const next = full
+        ? element.querySelector('.screenshotNavigation button:last-child')
+        : element.querySelector('.screenshotChoices button:last-child')
+      next.click()
+    }, fullPreview)
+    await expect(container.locator('img')).toHaveAttribute('src', secondScreenshot)
+    await expect(container.locator('img')).toBeVisible()
+    await expect.poll(() => container.locator('img').evaluate(image => image.complete && image.naturalWidth > 0)).toBe(true)
+  })
+}

--- a/src/customTheme.js
+++ b/src/customTheme.js
@@ -196,6 +196,11 @@ export function normalizeCustomTheme(value) {
 
   return {
     version: 2,
+    ...(/^discussion-[1-9]\d*$/.test(value.id) &&
+      typeof value.discussionThemeHash === 'string' &&
+      /^[\da-f]{64}$/.test(value.discussionThemeHash)
+      ? { discussionThemeHash: value.discussionThemeHash }
+      : {}),
     id: typeof value.id === 'string' && /^[\w-]{1,80}$/.test(value.id)
       ? value.id
       : 'custom-theme',
@@ -215,6 +220,16 @@ export function normalizeCustomTheme(value) {
     blurs,
     colors
   }
+}
+
+/** Hash the theme's normalized content, excluding local identity and source tracking. */
+export async function customThemeContentHash(value) {
+  const theme = normalizeCustomTheme(value)
+  delete theme.id
+  delete theme.discussionThemeHash
+  const content = new TextEncoder().encode(JSON.stringify(theme))
+  const hash = await globalThis.crypto.subtle.digest('SHA-256', content)
+  return Array.from(new Uint8Array(hash), byte => byte.toString(16).padStart(2, '0')).join('')
 }
 
 function deriveScrollbarActiveColor(hoverColor) {

--- a/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
+++ b/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
@@ -309,6 +309,7 @@ watch(() => store.getters.getIsKeyboardShortcutPromptShown, (open) => {
 }, { flush: 'sync' })
 
 function setDraft(theme) {
+  draft.discussionThemeHash = theme.discussionThemeHash
   draft.version = theme.version
   draft.id = theme.id
   draft.name = theme.name

--- a/src/renderer/components/ThemeDiscovery.vue
+++ b/src/renderer/components/ThemeDiscovery.vue
@@ -1,0 +1,551 @@
+<template>
+  <FtSettingsSubpage
+    :open="open"
+    :title="t('Theme Discovery.Discover Themes')"
+    :icon="['fas', 'search']"
+    flush
+    @close="emit('close')"
+  >
+    <div class="themeDiscovery">
+      <div class="discoveryToolbar">
+        <FtIconButton
+          :title="t('Theme Discovery.Refresh')"
+          :icon="['fas', 'sync']"
+          :disabled="loading"
+          @click="load(true)"
+        />
+      </div>
+      <div
+        ref="scroller"
+        v-overlay-scrollbars
+        class="discoveryScroller"
+        :aria-busy="loading"
+      >
+        <div ref="content">
+          <p
+            v-if="loadFailed"
+            class="discoveryMessage"
+            role="alert"
+          >
+            {{ t('Theme Discovery.Load Error') }}
+          </p>
+          <p
+            v-if="!loading && !loadFailed && entries.length === 0"
+            class="discoveryMessage"
+          >
+            {{ t('Theme Discovery.No Themes') }}
+          </p>
+          <div class="themeGallery">
+            <article
+              v-for="entry in entries"
+              :key="entry.theme.id"
+              class="themeCard"
+            >
+              <div class="themePreview">
+                <button
+                  v-if="entry.screenshots.length && !failedImages.has(currentScreenshot(entry))"
+                  type="button"
+                  @click="preview = entry"
+                >
+                  <Transition
+                    name="themeScreenshot"
+                    mode="out-in"
+                  >
+                    <img
+                      :key="currentScreenshot(entry)"
+                      :src="currentScreenshot(entry)"
+                      :alt="entry.title"
+                      loading="lazy"
+                      referrerpolicy="no-referrer"
+                      @error="failedImages.add($event.currentTarget.src)"
+                    >
+                  </Transition>
+                </button>
+                <span v-else>{{ t('Theme Discovery.No Preview') }}</span>
+              </div>
+              <div
+                v-if="entry.screenshots.length > 1"
+                class="screenshotChoices"
+              >
+                <button
+                  v-for="(screenshot, index) in entry.screenshots"
+                  :key="screenshot"
+                  :aria-label="`${entry.title} (${index + 1})`"
+                  :aria-pressed="currentScreenshot(entry) === screenshot"
+                  @click="selectedScreenshots[entry.theme.id] = screenshot"
+                >
+                  {{ index + 1 }}
+                </button>
+              </div>
+              <div class="themeDetails">
+                <h2>{{ entry.title }}</h2>
+                <a
+                  v-if="entry.author"
+                  :href="`https://github.com/${encodeURIComponent(entry.author)}`"
+                  @click.prevent="openExternalLink(`https://github.com/${encodeURIComponent(entry.author)}`)"
+                >{{ `@${entry.author}` }}</a>
+                <p v-if="entry.description">
+                  {{ entry.description }}
+                </p>
+                <div class="themeActions">
+                  <FtButton
+                    :label="installLabel(entry)"
+                    :icon="['fas', hasUpdate(entry) ? 'sync' : installed(entry) ? 'check' : 'download']"
+                    :disabled="installing !== null || (active(entry) && !hasUpdate(entry))"
+                    @click="install(entry)"
+                  />
+                  <FtButton
+                    :label="t('Theme Discovery.View on GitHub')"
+                    :icon="['fab', 'github']"
+                    @click="openExternalLink(entry.url)"
+                  />
+                </div>
+              </div>
+            </article>
+          </div>
+          <FtSpinner
+            v-if="loading"
+            :label="t('Theme Discovery.Loading')"
+          />
+          <FtButton
+            v-if="!loading && hasMore && (!autoLoad || loadFailed)"
+            class="loadMore"
+            :label="t('Theme Discovery.Load More')"
+            :icon="['fas', 'plus']"
+            :disabled="loading"
+            @click="load(false)"
+          />
+          <div
+            v-if="autoLoad && hasMore && !loading && !loadFailed"
+            v-observe-visibility="autoLoadOptions"
+            class="themeAutoLoadSentinel"
+          />
+        </div>
+      </div>
+    </div>
+  </FtSettingsSubpage>
+  <FtPrompt
+    v-if="preview && open"
+    :label="preview.title"
+    fixed-layout
+    @click="preview = null"
+  >
+    <template #label="{ labelId }">
+      <div class="screenshotHeader">
+        <h2 :id="labelId">
+          {{ preview.title }}
+        </h2>
+        <FtIconButton
+          :title="t('Close')"
+          :icon="['fas', 'xmark']"
+          @click="preview = null"
+        />
+      </div>
+    </template>
+    <div class="fullScreenshotStage">
+      <Transition
+        name="themeScreenshot"
+        mode="out-in"
+      >
+        <img
+          v-if="!failedImages.has(currentScreenshot(preview))"
+          :key="currentScreenshot(preview)"
+          class="fullThemeScreenshot"
+          :src="currentScreenshot(preview)"
+          :alt="preview.title"
+          referrerpolicy="no-referrer"
+          @error="failedImages.add($event.currentTarget.src)"
+        >
+        <p v-else>
+          {{ t('Theme Discovery.No Preview') }}
+        </p>
+      </Transition>
+    </div>
+    <template #footer>
+      <div
+        v-if="preview.screenshots.length > 1"
+        class="screenshotNavigation"
+      >
+        <FtIconButton
+          :title="t('Video.Previous')"
+          :icon="['fas', 'angle-left']"
+          @click="switchPreview(-1)"
+        />
+        <span aria-live="polite">{{ `${preview.screenshots.indexOf(currentScreenshot(preview)) + 1} / ${preview.screenshots.length}` }}</span>
+        <FtIconButton
+          :title="t('Video.Next')"
+          :icon="['fas', 'angle-right']"
+          @click="switchPreview(1)"
+        />
+      </div>
+    </template>
+  </FtPrompt>
+</template>
+
+<script setup>
+import { computed, nextTick, onBeforeUnmount, reactive, ref, useTemplateRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import FtButton from './FtButton/FtButton.vue'
+import FtPrompt from './FtPrompt/FtPrompt.vue'
+import FtIconButton from './FtIconButton/FtIconButton.vue'
+import FtSpinner from './FtSpinner/FtSpinner.vue'
+import FtSettingsSubpage from './FtSettingsSubpage/FtSettingsSubpage.vue'
+import store from '../store/index'
+import { customThemeValue } from '../../customTheme'
+import { saveCustomTheme } from '../helpers/customTheme'
+import { loadThemeFeed } from '../helpers/themeDiscovery'
+import { clampOverlayScrollTop, restoreOverlayScrollTop } from '../helpers/overlayScrollbars'
+import { openExternalLink, showToast } from '../helpers/utils'
+
+const props = defineProps({ open: Boolean })
+const emit = defineEmits(['close'])
+const { t } = useI18n()
+const entries = ref([])
+const loading = ref(false)
+const loadFailed = ref(false)
+const hasMore = ref(false)
+const installing = ref(null)
+const preview = ref(null)
+const scroller = useTemplateRef('scroller')
+const content = useTemplateRef('content')
+const selectedScreenshots = reactive({})
+const failedImages = reactive(new Set())
+const autoLoad = computed(() => store.getters.getGeneralAutoLoadMorePaginatedItemsEnabled)
+const autoLoadOptions = computed(() => ({
+  callback: loadNextIfVisible,
+  intersection: { root: scroller.value },
+}))
+const installedThemes = computed(() => store.getters.getCustomThemes)
+let page = 1
+let controller
+let observer
+
+function clampScroll() {
+  if (scroller.value && content.value) clampOverlayScrollTop(scroller.value, content.value)
+}
+
+watch(() => props.open, async (open) => {
+  controller?.abort()
+  observer?.disconnect()
+  if (!open) {
+    preview.value = null
+    return
+  }
+  loading.value = true
+  await nextTick()
+  if (!props.open) return
+  restoreOverlayScrollTop(scroller.value, 0)
+  observer = new ResizeObserver(clampScroll)
+  observer.observe(content.value)
+  observer.observe(scroller.value)
+  await load(true)
+}, { immediate: true })
+
+onBeforeUnmount(() => {
+  controller?.abort()
+  observer?.disconnect()
+})
+
+function loadNextIfVisible(visible) {
+  if (visible && props.open && autoLoad.value && hasMore.value && !loading.value && !loadFailed.value) {
+    load(false)
+  }
+}
+
+async function load(refresh) {
+  controller?.abort()
+  const request = new AbortController()
+  controller = request
+  loading.value = true
+  loadFailed.value = false
+  try {
+    const result = await loadThemeFeed(refresh ? 1 : page, AbortSignal.any([
+      request.signal, AbortSignal.timeout(20_000)
+    ]))
+    if (request.signal.aborted) return
+    if (refresh) {
+      entries.value = result.themes
+      page = 2
+      failedImages.clear()
+      for (const key of Object.keys(selectedScreenshots)) delete selectedScreenshots[key]
+    } else {
+      const ids = new Set(entries.value.map(entry => entry.theme.id))
+      entries.value.push(...result.themes.filter(entry => !ids.has(entry.theme.id)))
+      page++
+    }
+    hasMore.value = result.hasMore
+  } catch {
+    if (!request.signal.aborted) loadFailed.value = true
+  } finally {
+    if (controller === request) {
+      loading.value = false
+      await nextTick()
+      clampScroll()
+    }
+  }
+}
+
+function currentScreenshot(entry) {
+  return selectedScreenshots[entry.theme.id] ?? entry.screenshots[0]
+}
+
+function switchPreview(direction) {
+  const entry = preview.value
+  const index = entry.screenshots.indexOf(currentScreenshot(entry))
+  selectedScreenshots[entry.theme.id] = entry.screenshots[
+    (index + direction + entry.screenshots.length) % entry.screenshots.length
+  ]
+}
+
+function installed(entry) {
+  return installedThemes.value.some(theme => theme.id === entry.theme.id)
+}
+
+function hasUpdate(entry) {
+  const saved = installedThemes.value.find(theme => theme.id === entry.theme.id)
+  return saved && saved.discussionThemeHash !== entry.theme.discussionThemeHash
+}
+
+function active(entry) {
+  return store.getters.getBaseTheme === customThemeValue(entry.theme.id)
+}
+
+function installLabel(entry) {
+  if (installing.value === entry.theme.id) return t('Theme Discovery.Loading')
+  if (hasUpdate(entry)) return t('Theme Discovery.Update and Apply')
+  if (active(entry)) return t('Theme Discovery.Applied')
+  return installed(entry) ? t('Theme Discovery.Apply Theme') : t('Theme Discovery.Install and Apply')
+}
+
+async function install(entry) {
+  if (installing.value !== null) return
+  installing.value = entry.theme.id
+  try {
+    if (!installed(entry) || hasUpdate(entry)) {
+      const themes = await saveCustomTheme(entry.theme)
+      await store.dispatch('updateCustomThemes', themes)
+    }
+    await store.dispatch('updateBaseTheme', customThemeValue(entry.theme.id))
+    showToast({ message: t('Settings.Theme Settings.Custom Theme.Theme Saved'), icon: ['fas', 'check'] })
+  } catch {
+    showToast({ message: t('Settings.Theme Settings.Custom Theme.Unable to Save'), icon: ['fas', 'triangle-exclamation'] })
+  } finally {
+    installing.value = null
+  }
+}
+</script>
+
+<style scoped>
+.themeDiscovery {
+  display: flex;
+  flex-direction: column;
+  block-size: 100%;
+  min-block-size: 0;
+}
+
+.discoveryToolbar {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.discoveryToolbar {
+  flex-shrink: 0;
+  padding: 16px;
+}
+
+.discoveryMessage {
+  padding-block: 24px;
+  text-align: center;
+}
+
+.discoveryScroller {
+  flex: 1;
+  min-block-size: 0;
+  overflow-y: auto;
+  padding: 0 16px 16px;
+}
+
+.themeGallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 340px), 1fr));
+  gap: 20px;
+}
+
+.themeCard {
+  display: flex;
+  flex-direction: column;
+  min-inline-size: 0;
+  border: 1px solid var(--border-color);
+  border-radius: calc(8px * var(--ui-roundness));
+  background: var(--card-bg-color);
+}
+
+.themePreview {
+  flex-shrink: 0;
+  aspect-ratio: 16 / 9;
+  display: grid;
+  place-items: center;
+  background: var(--bg-color);
+  border-radius: inherit;
+}
+
+.themePreview button,
+.themePreview img {
+  display: block;
+  inline-size: 100%;
+  block-size: 100%;
+  border-radius: inherit;
+}
+
+.themePreview button {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: zoom-in;
+}
+
+.screenshotHeader {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 16px;
+  margin-block-end: 16px;
+}
+
+.screenshotHeader h2 {
+  flex: 1;
+  min-inline-size: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.fullScreenshotStage {
+  display: grid;
+  place-items: center;
+  block-size: max(120px, calc(90dvh - 150px));
+}
+
+.fullThemeScreenshot {
+  display: block;
+  inline-size: 100%;
+  block-size: 100%;
+  min-block-size: 0;
+  object-fit: contain;
+}
+
+.screenshotNavigation {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+}
+
+.themeScreenshot-enter-active,
+.themeScreenshot-leave-active {
+  transition: opacity 120ms ease;
+}
+
+.themeScreenshot-enter-from,
+.themeScreenshot-leave-to {
+  opacity: 0;
+}
+
+.themePreview img {
+  aspect-ratio: 16 / 9;
+  object-fit: contain;
+}
+
+.screenshotChoices {
+  display: flex;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  padding: 8px;
+}
+
+.screenshotChoices button {
+  transition: background-color 120ms ease, color 120ms ease;
+  min-inline-size: 36px;
+  min-block-size: 36px;
+  border: 1px solid var(--border-color);
+  border-radius: calc(4px * var(--ui-roundness));
+  background: var(--card-bg-color);
+  color: var(--primary-text-color);
+  cursor: pointer;
+}
+
+.screenshotChoices button[aria-pressed='true'] {
+  background: var(--accent-color);
+  color: var(--text-with-accent-color);
+}
+
+.screenshotChoices button:hover {
+  background: var(--side-nav-hover-color);
+  color: var(--side-nav-hover-text-color);
+}
+
+.screenshotChoices button[aria-pressed='true']:hover {
+  background: color-mix(in oklab, var(--accent-color) 88%, white);
+  color: var(--text-with-accent-color);
+}
+
+.screenshotChoices button:focus-visible,
+.themePreview button:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+}
+
+.themeDetails {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  padding: 16px;
+  overflow-wrap: anywhere;
+}
+
+.themeDetails > a {
+  align-self: flex-start;
+}
+
+.themeDetails h2 {
+  margin-block: 0 8px;
+  font-size: 1.2em;
+}
+
+.themeDetails p {
+  white-space: pre-line;
+}
+
+.themeActions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin-block-start: auto;
+  padding-block-start: 16px;
+}
+
+.themeActions .btn {
+  min-inline-size: 0;
+  block-size: auto;
+  margin: 0;
+  padding-inline: 10px;
+  white-space: normal;
+}
+
+.loadMore {
+  margin-block-start: 20px;
+  margin-inline: auto;
+}
+
+.themeAutoLoadSentinel {
+  block-size: 1px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .themeScreenshot-enter-active,
+  .themeScreenshot-leave-active,
+  .screenshotChoices button {
+    transition: none;
+  }
+}
+</style>

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -99,6 +99,11 @@
     </FtFlexBox>
     <FtFlexBox class="customThemeActions">
       <FtButton
+        :label="t('Theme Discovery.Discover Themes')"
+        :icon="['fas', 'search']"
+        @click="showThemeDiscovery = true"
+      />
+      <FtButton
         :label="t('Settings.Theme Settings.Custom Theme.Create Custom Theme')"
         :icon="['fas', 'palette']"
         @click="openCustomThemeEditor(null)"
@@ -110,6 +115,10 @@
         @click="openCustomThemeEditor(selectedCustomThemeId)"
       />
     </FtFlexBox>
+    <ThemeDiscovery
+      :open="showThemeDiscovery"
+      @close="showThemeDiscovery = false"
+    />
     <CustomThemeEditor
       :open="showCustomThemeEditor"
       :theme-id="editingCustomThemeId"
@@ -385,6 +394,7 @@ import FtSliderGrid from './FtSliderGrid/FtSliderGrid.vue'
 import FtFlexBox from './ft-flex-box/ft-flex-box.vue'
 import FtButton from './FtButton/FtButton.vue'
 import FtPrompt from './FtPrompt/FtPrompt.vue'
+import ThemeDiscovery from './ThemeDiscovery.vue'
 import CustomThemeEditor from './CustomThemeEditor/CustomThemeEditor.vue'
 import QuickSettingsCustomizer from './QuickSettingsCustomizer/QuickSettingsCustomizer.vue'
 
@@ -546,6 +556,7 @@ function updateTabBarPosition(value) {
 const COLOR_VALUES = colors.map(color => color.name)
 const COLOR_SWATCHES = colors.map(color => color.value)
 const colorNames = useColorTranslations()
+const showThemeDiscovery = ref(false)
 const showCustomThemeEditor = ref(false)
 const editingCustomThemeId = ref(null)
 const systemFonts = ref([])

--- a/src/renderer/helpers/themeDiscovery.js
+++ b/src/renderer/helpers/themeDiscovery.js
@@ -1,0 +1,89 @@
+import { customThemeContentHash, normalizeCustomTheme } from '../../customTheme.js'
+
+export const THEME_DISCUSSIONS_URL = 'https://github.com/OpenTubeX/OpenTubeX/discussions/categories/themes'
+const DISCUSSION_URL = /^https:\/\/github\.com\/OpenTubeX\/OpenTubeX\/discussions\/([1-9]\d*)$/
+
+export function themeScreenshotUrl(source) {
+  try {
+    const url = new URL(source)
+    if (url.protocol !== 'https:' || url.username || url.password || url.port) return null
+    // Atom replaces attachments with expiring signed URLs. Use the original
+    // public attachment so screenshots still load after browsing for a while.
+    if (url.hostname === 'private-user-images.githubusercontent.com') {
+      const id = url.pathname.match(/\/\d+-([\da-f]{8}(?:-[\da-f]{4}){3}-[\da-f]{12})\.[a-z]+$/i)?.[1]
+      return id ? `https://github.com/user-attachments/assets/${id}` : null
+    }
+    if ((url.hostname === 'github.com' && url.pathname.startsWith('/user-attachments/assets/')) ||
+      ['user-images.githubusercontent.com', 'camo.githubusercontent.com'].includes(url.hostname)) {
+      return url.href
+    }
+  } catch { }
+  return null
+}
+
+export async function parseThemeFeed(source) {
+  const feed = new DOMParser().parseFromString(source, 'application/xml')
+  if (feed.querySelector('parsererror') || feed.documentElement.localName !== 'feed' ||
+    feed.documentElement.namespaceURI !== 'http://www.w3.org/2005/Atom') {
+    throw new Error('Invalid theme feed')
+  }
+  const entries = [...feed.querySelectorAll('entry')]
+  const themes = []
+  for (const entry of entries) {
+    const url = entry.querySelector('link[rel="alternate"]')?.getAttribute('href')
+    const number = url?.match(DISCUSSION_URL)?.[1]
+    if (!number) continue
+    // Template contents remain inert, including images, scripts and iframes.
+    // Never attach the supplied HTML to the document.
+    const template = document.createElement('template')
+    template.innerHTML = entry.querySelector('content')?.textContent ?? ''
+    const content = template.content
+    const blocks = content.querySelectorAll('.highlight-source-json, pre > code.language-json')
+    if (blocks.length !== 1) continue
+    try {
+      const block = blocks[0]
+      const json = block.getAttribute('data-snippet-clipboard-copy-content') ?? block.textContent
+      const submittedTheme = normalizeCustomTheme(JSON.parse(json))
+      // Authors often export the same ID for different themes. Scope installs
+      // to the discussion to preserve both posts and existing imported themes.
+      const theme = normalizeCustomTheme({
+        ...submittedTheme,
+        id: `discussion-${number}`,
+        discussionThemeHash: await customThemeContentHash(submittedTheme),
+      })
+      const screenshots = [...new Set([...content.querySelectorAll('img')]
+        .map(img => themeScreenshotUrl(img.getAttribute('src'))).filter(Boolean))]
+      const description = []
+      let sibling = content.querySelector('h2')?.nextElementSibling
+      while (sibling && !['H2', 'DETAILS'].includes(sibling.tagName)) {
+        if (!sibling.querySelector('img, pre, script, style, iframe')) description.push(sibling.textContent.trim())
+        sibling = sibling.nextElementSibling
+      }
+      themes.push({
+        theme,
+        url,
+        title: entry.querySelector('title')?.textContent.trim() || theme.name,
+        author: entry.querySelector('author > name')?.textContent.trim() || '',
+        description: description.filter(Boolean).join('\n').slice(0, 1000),
+        screenshots,
+      })
+    } catch {
+      // One invalid or incompatible post must not hide the remaining themes.
+    }
+  }
+  return { themes, hasMore: entries.length > 0 }
+}
+
+export async function loadThemeFeed(page, signal) {
+  const url = `${THEME_DISCUSSIONS_URL}.atom?page=${page}`
+  const options = { credentials: 'omit', referrerPolicy: 'no-referrer', signal }
+  let response
+  if (process.env.IS_CAPACITOR) {
+    const { capacitorHttpFetch } = await import('./api/capacitor-http')
+    response = await capacitorHttpFetch(url, options)
+  } else {
+    response = await fetch(url, options)
+  }
+  if (!response.ok) throw new Error(`Theme feed returned HTTP ${response.status}`)
+  return parseThemeFeed(await response.text())
+}

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -1680,3 +1680,16 @@ Channels:
 Search Bar:
   Open Search Container: فتح مربع البحث
   Search: بحث
+Theme Discovery:
+  Discover Themes: "استكشاف السمات"
+  Refresh: "تحديث"
+  View on GitHub: "عرض على GitHub"
+  Load Error: "تعذر تحميل السمات. حاول التحديث."
+  Loading: "جارٍ التحميل…"
+  No Themes: "لم يتم العثور على سمات قابلة للتثبيت."
+  No Preview: "لقطة الشاشة غير متاحة"
+  Load More: "تحميل المزيد"
+  Applied: "مطبّقة"
+  Apply Theme: "تطبيق السمة"
+  Install and Apply: "تثبيت وتطبيق"
+  Update and Apply: "تحديث وتطبيق"

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -1751,3 +1751,16 @@ Channels:
 Search Bar:
   Open Search Container: Адкрыць поле пошуку
   Search: Пошук
+Theme Discovery:
+  Discover Themes: "Знайсці тэмы"
+  Refresh: "Абнавіць"
+  View on GitHub: "Праглядзець на GitHub"
+  Load Error: "Не ўдалося загрузіць тэмы. Паспрабуйце абнавіць."
+  Loading: "Загрузка…"
+  No Themes: "Тэм для ўсталявання не знойдзена."
+  No Preview: "Здымак экрана недаступны"
+  Load More: "Загрузіць яшчэ"
+  Applied: "Ужыта"
+  Apply Theme: "Ужыць тэму"
+  Install and Apply: "Усталяваць і ўжыць"
+  Update and Apply: "Абнавіць і ўжыць"

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -1676,3 +1676,16 @@ Channels:
 Search Bar:
   Open Search Container: Отваряне на полето за търсене
   Search: Търсене
+Theme Discovery:
+  Discover Themes: "Откриване на теми"
+  Refresh: "Опресняване"
+  View on GitHub: "Преглед в GitHub"
+  Load Error: "Темите не можаха да се заредят. Опитайте да опресните."
+  Loading: "Зареждане…"
+  No Themes: "Няма намерени теми за инсталиране."
+  No Preview: "Екранната снимка не е налична"
+  Load More: "Зареждане на още"
+  Applied: "Приложена"
+  Apply Theme: "Прилагане на тема"
+  Install and Apply: "Инсталиране и прилагане"
+  Update and Apply: "Обновяване и прилагане"

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -1674,3 +1674,16 @@ Downloads:
     Subtitles Format: "Istitloù: {format}"
 Channels:
   Load More Channels: "Kargañ muioc'h a chadennoù"
+Theme Discovery:
+  Discover Themes: "Dizoleiñ neuzioù"
+  Refresh: "Freskaat"
+  View on GitHub: "Gwelet war GitHub"
+  Load Error: "N'eus ket bet gallet kargañ an neuzioù. Klaskit freskaat."
+  Loading: "O kargañ…"
+  No Themes: "N'eus bet kavet neuz ebet da staliañ."
+  No Preview: "Tapadenn skramm dihegerz"
+  Load More: "Kargañ muioc'h"
+  Applied: "Arloet"
+  Apply Theme: "Arloañ an neuz"
+  Install and Apply: "Staliañ hag arloañ"
+  Update and Apply: "Hizivaat hag arloañ"

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -2302,3 +2302,16 @@ Downloads:
     Audio Best: Àudio - Millor qualitat
     Audio Format: Àudio - {format}
     Subtitles Format: Subtítols - {format}
+Theme Discovery:
+  Discover Themes: "Descobreix temes"
+  Refresh: "Actualitza"
+  View on GitHub: "Mostra al GitHub"
+  Load Error: "No s'han pogut carregar els temes. Prova d'actualitzar."
+  Loading: "S'està carregant…"
+  No Themes: "No s'han trobat temes instal·lables."
+  No Preview: "Captura de pantalla no disponible"
+  Load More: "Carrega'n més"
+  Applied: "Aplicat"
+  Apply Theme: "Aplica el tema"
+  Install and Apply: "Instal·la i aplica"
+  Update and Apply: "Actualitza i aplica"

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -1665,3 +1665,16 @@ Downloads:
     Subtitles Format: Titulky – {format}
 Channels:
   Load More Channels: "Načíst další kanály"
+Theme Discovery:
+  Discover Themes: "Objevovat motivy"
+  Refresh: "Obnovit"
+  View on GitHub: "Zobrazit na GitHubu"
+  Load Error: "Motivy se nepodařilo načíst. Zkuste obnovit seznam."
+  Loading: "Načítání…"
+  No Themes: "Nebyly nalezeny žádné motivy k instalaci."
+  No Preview: "Snímek obrazovky není dostupný"
+  Load More: "Načíst další"
+  Applied: "Použito"
+  Apply Theme: "Použít motiv"
+  Install and Apply: "Nainstalovat a použít"
+  Update and Apply: "Aktualizovat a použít"

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -1685,3 +1685,16 @@ Channels:
 Search Bar:
   Open Search Container: Agor y blwch chwilio
   Search: Chwilio
+Theme Discovery:
+  Discover Themes: "Darganfod themâu"
+  Refresh: "Adnewyddu"
+  View on GitHub: "Gweld ar GitHub"
+  Load Error: "Methu llwytho themâu. Ceisiwch adnewyddu."
+  Loading: "Yn llwytho…"
+  No Themes: "Ni chanfuwyd themâu y gellir eu gosod."
+  No Preview: "Sgrinlun ddim ar gael"
+  Load More: "Llwytho rhagor"
+  Applied: "Wedi'i chymhwyso"
+  Apply Theme: "Cymhwyso thema"
+  Install and Apply: "Gosod a chymhwyso"
+  Update and Apply: "Diweddaru a chymhwyso"

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -1740,3 +1740,16 @@ Channels:
 Search Bar:
   Open Search Container: Åbn søgefelt
   Search: Søg
+Theme Discovery:
+  Discover Themes: "Find temaer"
+  Refresh: "Opdater"
+  View on GitHub: "Vis på GitHub"
+  Load Error: "Kunne ikke indlæse temaer. Prøv at opdatere."
+  Loading: "Indlæser…"
+  No Themes: "Ingen temaer til installation fundet."
+  No Preview: "Skærmbillede ikke tilgængeligt"
+  Load More: "Indlæs flere"
+  Applied: "Anvendt"
+  Apply Theme: "Anvend tema"
+  Install and Apply: "Installer og anvend"
+  Update and Apply: "Opdater og anvend"

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -1702,3 +1702,16 @@ Channels:
 Search Bar:
   Open Search Container: Άνοιγμα πεδίου αναζήτησης
   Search: Αναζήτηση
+Theme Discovery:
+  Discover Themes: "Ανακάλυψη θεμάτων"
+  Refresh: "Ανανέωση"
+  View on GitHub: "Προβολή στο GitHub"
+  Load Error: "Δεν ήταν δυνατή η φόρτωση θεμάτων. Δοκιμάστε ανανέωση."
+  Loading: "Φόρτωση…"
+  No Themes: "Δεν βρέθηκαν θέματα για εγκατάσταση."
+  No Preview: "Το στιγμιότυπο οθόνης δεν είναι διαθέσιμο"
+  Load More: "Φόρτωση περισσότερων"
+  Applied: "Εφαρμόστηκε"
+  Apply Theme: "Εφαρμογή θέματος"
+  Install and Apply: "Εγκατάσταση και εφαρμογή"
+  Update and Apply: "Ενημέρωση και εφαρμογή"

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -1640,3 +1640,16 @@ Downloads:
 Search Bar:
   Open Search Container: Open Search Container
   Search: Search
+Theme Discovery:
+  Discover Themes: "Discover themes"
+  Refresh: "Refresh"
+  View on GitHub: "View on GitHub"
+  Load Error: "Could not load themes. Try refreshing."
+  Loading: "Loading…"
+  No Themes: "No installable themes found."
+  No Preview: "Screenshot unavailable"
+  Load More: "Load more"
+  Applied: "Applied"
+  Apply Theme: "Apply theme"
+  Install and Apply: "Install and apply"
+  Update and Apply: "Update and apply"

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -2219,3 +2219,16 @@ Channels:
 Search Bar:
   Open Search Container: Abrir el campo de búsqueda
   Search: Buscar
+Theme Discovery:
+  Discover Themes: "Descubrir temas"
+  Refresh: "Actualizar"
+  View on GitHub: "Ver en GitHub"
+  Load Error: "No se pudieron cargar los temas. Prueba a actualizar."
+  Loading: "Cargando…"
+  No Themes: "No se encontraron temas instalables."
+  No Preview: "Captura de pantalla no disponible"
+  Load More: "Cargar más"
+  Applied: "Aplicado"
+  Apply Theme: "Aplicar tema"
+  Install and Apply: "Instalar y aplicar"
+  Update and Apply: "Actualizar y aplicar"

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -2092,3 +2092,16 @@ Channels:
 Search Bar:
   Open Search Container: Abrir el campo de búsqueda
   Search: Buscar
+Theme Discovery:
+  Discover Themes: "Descubrir temas"
+  Refresh: "Actualizar"
+  View on GitHub: "Ver en GitHub"
+  Load Error: "No se pudieron cargar los temas. Prueba a actualizar."
+  Loading: "Cargando…"
+  No Themes: "No se encontraron temas instalables."
+  No Preview: "Captura de pantalla no disponible"
+  Load More: "Cargar más"
+  Applied: "Aplicado"
+  Apply Theme: "Aplicar tema"
+  Install and Apply: "Instalar y aplicar"
+  Update and Apply: "Actualizar y aplicar"

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -1690,3 +1690,16 @@ Channels:
 Search Bar:
   Open Search Container: Abrir el campo de búsqueda
   Search: Buscar
+Theme Discovery:
+  Discover Themes: "Descubrir temas"
+  Refresh: "Actualizar"
+  View on GitHub: "Ver en GitHub"
+  Load Error: "No se pudieron cargar los temas. Prueba a actualizar."
+  Loading: "Cargando…"
+  No Themes: "No se encontraron temas instalables."
+  No Preview: "Captura de pantalla no disponible"
+  Load More: "Cargar más"
+  Applied: "Aplicado"
+  Apply Theme: "Aplicar tema"
+  Install and Apply: "Instalar y aplicar"
+  Update and Apply: "Actualizar y aplicar"

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -1674,3 +1674,16 @@ Channels:
 Search Bar:
   Open Search Container: Ava otsinguväli
   Search: Otsi
+Theme Discovery:
+  Discover Themes: "Avasta teemasid"
+  Refresh: "Värskenda"
+  View on GitHub: "Vaata GitHubis"
+  Load Error: "Teemade laadimine ebaõnnestus. Proovi värskendada."
+  Loading: "Laadimine…"
+  No Themes: "Paigaldatavaid teemasid ei leitud."
+  No Preview: "Kuvatõmmis pole saadaval"
+  Load More: "Laadi rohkem"
+  Applied: "Rakendatud"
+  Apply Theme: "Rakenda teema"
+  Install and Apply: "Paigalda ja rakenda"
+  Update and Apply: "Uuenda ja rakenda"

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -1685,3 +1685,16 @@ Channels:
 Search Bar:
   Open Search Container: Ireki bilaketa-eremua
   Search: Bilatu
+Theme Discovery:
+  Discover Themes: "Aurkitu gaiak"
+  Refresh: "Freskatu"
+  View on GitHub: "Ikusi GitHub-en"
+  Load Error: "Ezin izan dira gaiak kargatu. Saiatu freskatzen."
+  Loading: "Kargatzen…"
+  No Themes: "Ez da instalatzeko gairik aurkitu."
+  No Preview: "Pantaila-argazkia ez dago erabilgarri"
+  Load More: "Kargatu gehiago"
+  Applied: "Aplikatuta"
+  Apply Theme: "Aplikatu gaia"
+  Install and Apply: "Instalatu eta aplikatu"
+  Update and Apply: "Eguneratu eta aplikatu"

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -1742,3 +1742,16 @@ Channels:
 Search Bar:
   Open Search Container: باز کردن کادر جستجو
   Search: جستجو
+Theme Discovery:
+  Discover Themes: "کشف پوسته‌ها"
+  Refresh: "تازه‌سازی"
+  View on GitHub: "مشاهده در GitHub"
+  Load Error: "بارگیری پوسته‌ها ممکن نشد. دوباره تازه‌سازی کنید."
+  Loading: "در حال بارگیری…"
+  No Themes: "پوسته‌ای برای نصب یافت نشد."
+  No Preview: "تصویر صفحه در دسترس نیست"
+  Load More: "بارگیری بیشتر"
+  Applied: "اعمال‌شده"
+  Apply Theme: "اعمال پوسته"
+  Install and Apply: "نصب و اعمال"
+  Update and Apply: "به‌روزرسانی و اعمال"

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -1702,3 +1702,16 @@ Channels:
 Search Bar:
   Open Search Container: Avaa hakukenttä
   Search: Hae
+Theme Discovery:
+  Discover Themes: "Löydä teemoja"
+  Refresh: "Päivitä"
+  View on GitHub: "Näytä GitHubissa"
+  Load Error: "Teemoja ei voitu ladata. Kokeile päivittää."
+  Loading: "Ladataan…"
+  No Themes: "Asennettavia teemoja ei löytynyt."
+  No Preview: "Kuvakaappaus ei ole saatavilla"
+  Load More: "Lataa lisää"
+  Applied: "Käytössä"
+  Apply Theme: "Ota teema käyttöön"
+  Install and Apply: "Asenna ja ota käyttöön"
+  Update and Apply: "Päivitä ja ota käyttöön"

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -1656,3 +1656,16 @@ Downloads:
     Subtitles Format: Sous-titres - {format}
 Channels:
   Load More Channels: "Charger plus de chaînes"
+Theme Discovery:
+  Discover Themes: "Découvrir des thèmes"
+  Refresh: "Actualiser"
+  View on GitHub: "Voir sur GitHub"
+  Load Error: "Impossible de charger les thèmes. Essayez d'actualiser."
+  Loading: "Chargement…"
+  No Themes: "Aucun thème installable trouvé."
+  No Preview: "Capture d'écran indisponible"
+  Load More: "Charger plus"
+  Applied: "Appliqué"
+  Apply Theme: "Appliquer le thème"
+  Install and Apply: "Installer et appliquer"
+  Update and Apply: "Mettre à jour et appliquer"

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -1704,3 +1704,16 @@ Channels:
 Search Bar:
   Open Search Container: Abrir o campo de busca
   Search: Buscar
+Theme Discovery:
+  Discover Themes: "Descubrir temas"
+  Refresh: "Actualizar"
+  View on GitHub: "Ver en GitHub"
+  Load Error: "Non se puideron cargar os temas. Proba a actualizar."
+  Loading: "Cargando…"
+  No Themes: "Non se atoparon temas instalables."
+  No Preview: "Captura de pantalla non dispoñible"
+  Load More: "Cargar máis"
+  Applied: "Aplicado"
+  Apply Theme: "Aplicar tema"
+  Install and Apply: "Instalar e aplicar"
+  Update and Apply: "Actualizar e aplicar"

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -1704,3 +1704,16 @@ Channels:
 Search Bar:
   Open Search Container: פתיחת שדה החיפוש
   Search: חיפוש
+Theme Discovery:
+  Discover Themes: "גילוי ערכות נושא"
+  Refresh: "רענון"
+  View on GitHub: "הצגה ב-GitHub"
+  Load Error: "לא ניתן לטעון ערכות נושא. כדאי לנסות לרענן."
+  Loading: "בטעינה…"
+  No Themes: "לא נמצאו ערכות נושא להתקנה."
+  No Preview: "צילום המסך אינו זמין"
+  Load More: "טעינת עוד"
+  Applied: "הוחלה"
+  Apply Theme: "החלת ערכת נושא"
+  Install and Apply: "התקנה והחלה"
+  Update and Apply: "עדכון והחלה"

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -1680,3 +1680,16 @@ Channels:
 Search Bar:
   Open Search Container: Otvori polje za pretraživanje
   Search: Pretraži
+Theme Discovery:
+  Discover Themes: "Otkrij teme"
+  Refresh: "Osvježi"
+  View on GitHub: "Pogledaj na GitHubu"
+  Load Error: "Nije moguće učitati teme. Pokušaj osvježiti."
+  Loading: "Učitavanje…"
+  No Themes: "Nisu pronađene teme za instalaciju."
+  No Preview: "Snimka zaslona nije dostupna"
+  Load More: "Učitaj više"
+  Applied: "Primijenjeno"
+  Apply Theme: "Primijeni temu"
+  Install and Apply: "Instaliraj i primijeni"
+  Update and Apply: "Ažuriraj i primijeni"

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -1658,3 +1658,16 @@ Downloads:
     Subtitles Format: Feliratok - {format}
 Channels:
   Load More Channels: "További csatornák betöltése"
+Theme Discovery:
+  Discover Themes: "Témák felfedezése"
+  Refresh: "Frissítés"
+  View on GitHub: "Megtekintés a GitHubon"
+  Load Error: "Nem sikerült betölteni a témákat. Próbálja frissíteni a listát."
+  Loading: "Betöltés…"
+  No Themes: "Nem találhatók telepíthető témák."
+  No Preview: "A képernyőkép nem érhető el"
+  Load More: "Továbbiak betöltése"
+  Applied: "Alkalmazva"
+  Apply Theme: "Téma alkalmazása"
+  Install and Apply: "Telepítés és alkalmazás"
+  Update and Apply: "Frissítés és alkalmazás"

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -1694,3 +1694,16 @@ Channels:
 Search Bar:
   Open Search Container: Buka kolom pencarian
   Search: Cari
+Theme Discovery:
+  Discover Themes: "Jelajahi tema"
+  Refresh: "Muat ulang"
+  View on GitHub: "Lihat di GitHub"
+  Load Error: "Tidak dapat memuat tema. Coba muat ulang."
+  Loading: "Memuat…"
+  No Themes: "Tidak ditemukan tema yang dapat dipasang."
+  No Preview: "Tangkapan layar tidak tersedia"
+  Load More: "Muat lebih banyak"
+  Applied: "Diterapkan"
+  Apply Theme: "Terapkan tema"
+  Install and Apply: "Pasang dan terapkan"
+  Update and Apply: "Perbarui dan terapkan"

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -1701,3 +1701,16 @@ Channels:
 Search Bar:
   Open Search Container: Opna leitarreit
   Search: Leita
+Theme Discovery:
+  Discover Themes: "Finna þemu"
+  Refresh: "Endurhlaða"
+  View on GitHub: "Skoða á GitHub"
+  Load Error: "Ekki tókst að hlaða þemum. Prófaðu að endurhlaða."
+  Loading: "Hleð…"
+  No Themes: "Engin þemu fundust til uppsetningar."
+  No Preview: "Skjámynd ekki tiltæk"
+  Load More: "Hlaða fleiri"
+  Applied: "Virkt"
+  Apply Theme: "Virkja þema"
+  Install and Apply: "Setja upp og virkja"
+  Update and Apply: "Uppfæra og virkja"

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -1661,3 +1661,16 @@ Downloads:
     Subtitles Format: Sottotitoli - {format}
 Channels:
   Load More Channels: "Carica altri canali"
+Theme Discovery:
+  Discover Themes: "Scopri temi"
+  Refresh: "Ricarica"
+  View on GitHub: "Visualizza su GitHub"
+  Load Error: "Impossibile caricare i temi. Prova a ricaricare."
+  Loading: "Caricamento…"
+  No Themes: "Nessun tema installabile trovato."
+  No Preview: "Schermata non disponibile"
+  Load More: "Carica altro"
+  Applied: "Applicato"
+  Apply Theme: "Applica tema"
+  Install and Apply: "Installa e applica"
+  Update and Apply: "Aggiorna e applica"

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -1658,3 +1658,16 @@ Downloads:
     Subtitles Format: 字幕 - {format}
 Channels:
   Load More Channels: "チャンネルをさらに読み込む"
+Theme Discovery:
+  Discover Themes: "テーマを探す"
+  Refresh: "再読み込み"
+  View on GitHub: "GitHubで見る"
+  Load Error: "テーマを読み込めませんでした。再読み込みしてください。"
+  Loading: "読み込み中…"
+  No Themes: "インストールできるテーマが見つかりません。"
+  No Preview: "スクリーンショットを表示できません"
+  Load More: "さらに読み込む"
+  Applied: "適用済み"
+  Apply Theme: "テーマを適用"
+  Install and Apply: "インストールして適用"
+  Update and Apply: "更新して適用"

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -2109,3 +2109,16 @@ Channels:
 Search Bar:
   Open Search Container: 검색창 열기
   Search: 검색
+Theme Discovery:
+  Discover Themes: "테마 둘러보기"
+  Refresh: "새로고침"
+  View on GitHub: "GitHub에서 보기"
+  Load Error: "테마를 불러올 수 없습니다. 새로고침해 보세요."
+  Loading: "불러오는 중…"
+  No Themes: "설치 가능한 테마를 찾지 못했습니다."
+  No Preview: "스크린샷을 표시할 수 없습니다"
+  Load More: "더 불러오기"
+  Applied: "적용됨"
+  Apply Theme: "테마 적용"
+  Install and Apply: "설치 및 적용"
+  Update and Apply: "업데이트 및 적용"

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -2156,3 +2156,16 @@ Channels:
 Search Bar:
   Open Search Container: Atverti paieškos lauką
   Search: Ieškoti
+Theme Discovery:
+  Discover Themes: "Atrasti apipavidalinimus"
+  Refresh: "Įkelti iš naujo"
+  View on GitHub: "Peržiūrėti GitHub"
+  Load Error: "Nepavyko įkelti apipavidalinimų. Pabandykite įkelti iš naujo."
+  Loading: "Įkeliama…"
+  No Themes: "Nerasta įdiegiamų apipavidalinimų."
+  No Preview: "Ekrano kopija nepasiekiama"
+  Load More: "Įkelti daugiau"
+  Applied: "Pritaikyta"
+  Apply Theme: "Taikyti apipavidalinimą"
+  Install and Apply: "Įdiegti ir taikyti"
+  Update and Apply: "Atnaujinti ir taikyti"

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -1676,3 +1676,16 @@ Channels:
 Search Bar:
   Open Search Container: Åpne søkefeltet
   Search: Søk
+Theme Discovery:
+  Discover Themes: "Finn temaer"
+  Refresh: "Last inn på nytt"
+  View on GitHub: "Vis på GitHub"
+  Load Error: "Kunne ikke laste inn temaer. Prøv å laste inn på nytt."
+  Loading: "Laster…"
+  No Themes: "Fant ingen temaer som kan installeres."
+  No Preview: "Skjermbilde utilgjengelig"
+  Load More: "Last inn flere"
+  Applied: "Tatt i bruk"
+  Apply Theme: "Bruk tema"
+  Install and Apply: "Installer og bruk"
+  Update and Apply: "Oppdater og bruk"

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -1713,3 +1713,16 @@ Channels:
 Search Bar:
   Open Search Container: Zoekveld openen
   Search: Zoeken
+Theme Discovery:
+  Discover Themes: "Thema's ontdekken"
+  Refresh: "Vernieuwen"
+  View on GitHub: "Bekijken op GitHub"
+  Load Error: "Thema's konden niet worden geladen. Probeer te vernieuwen."
+  Loading: "Laden…"
+  No Themes: "Geen installeerbare thema's gevonden."
+  No Preview: "Schermafbeelding niet beschikbaar"
+  Load More: "Meer laden"
+  Applied: "Toegepast"
+  Apply Theme: "Thema toepassen"
+  Install and Apply: "Installeren en toepassen"
+  Update and Apply: "Bijwerken en toepassen"

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -2088,3 +2088,16 @@ Channels:
 Search Bar:
   Open Search Container: Opne søkjefeltet
   Search: Søk
+Theme Discovery:
+  Discover Themes: "Finn tema"
+  Refresh: "Last inn på nytt"
+  View on GitHub: "Vis på GitHub"
+  Load Error: "Klarte ikkje å laste inn tema. Prøv å laste inn på nytt."
+  Loading: "Lastar…"
+  No Themes: "Fann ingen tema som kan installerast."
+  No Preview: "Skjermbilete utilgjengeleg"
+  Load More: "Last inn fleire"
+  Applied: "Tekne i bruk"
+  Apply Theme: "Bruk tema"
+  Install and Apply: "Installer og bruk"
+  Update and Apply: "Oppdater og bruk"

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -873,3 +873,16 @@ Channels:
 Share:
   Share Link: "Udostępnij link"
   Share failed: "Nie udało się udostępnić linku"
+Theme Discovery:
+  Discover Themes: "Odkryj motywy"
+  Refresh: "Odśwież"
+  View on GitHub: "Zobacz na GitHubie"
+  Load Error: "Nie udało się wczytać motywów. Spróbuj odświeżyć."
+  Loading: "Wczytywanie…"
+  No Themes: "Nie znaleziono motywów do zainstalowania."
+  No Preview: "Zrzut ekranu niedostępny"
+  Load More: "Wczytaj więcej"
+  Applied: "Zastosowano"
+  Apply Theme: "Zastosuj motyw"
+  Install and Apply: "Zainstaluj i zastosuj"
+  Update and Apply: "Zaktualizuj i zastosuj"

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -1672,3 +1672,16 @@ Channels:
 Search Bar:
   Open Search Container: Abrir o campo de pesquisa
   Search: Pesquisar
+Theme Discovery:
+  Discover Themes: "Descobrir temas"
+  Refresh: "Recarregar"
+  View on GitHub: "Ver no GitHub"
+  Load Error: "Não foi possível carregar os temas. Tente recarregar."
+  Loading: "Carregando…"
+  No Themes: "Nenhum tema instalável encontrado."
+  No Preview: "Captura de tela indisponível"
+  Load More: "Carregar mais"
+  Applied: "Aplicado"
+  Apply Theme: "Aplicar tema"
+  Install and Apply: "Instalar e aplicar"
+  Update and Apply: "Atualizar e aplicar"

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -1691,3 +1691,16 @@ Channels:
 Search Bar:
   Open Search Container: Abrir o campo de pesquisa
   Search: Pesquisar
+Theme Discovery:
+  Discover Themes: "Descobrir temas"
+  Refresh: "Recarregar"
+  View on GitHub: "Ver no GitHub"
+  Load Error: "Não foi possível carregar os temas. Tente recarregar."
+  Loading: "A carregar…"
+  No Themes: "Não foram encontrados temas instaláveis."
+  No Preview: "Captura de ecrã indisponível"
+  Load More: "Carregar mais"
+  Applied: "Aplicado"
+  Apply Theme: "Aplicar tema"
+  Install and Apply: "Instalar e aplicar"
+  Update and Apply: "Atualizar e aplicar"

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -1709,3 +1709,16 @@ Channels:
 Search Bar:
   Open Search Container: Abrir o campo de pesquisa
   Search: Pesquisar
+Theme Discovery:
+  Discover Themes: "Descobrir temas"
+  Refresh: "Recarregar"
+  View on GitHub: "Ver no GitHub"
+  Load Error: "Não foi possível carregar os temas. Tente recarregar."
+  Loading: "A carregar…"
+  No Themes: "Não foram encontrados temas instaláveis."
+  No Preview: "Captura de ecrã indisponível"
+  Load More: "Carregar mais"
+  Applied: "Aplicado"
+  Apply Theme: "Aplicar tema"
+  Install and Apply: "Instalar e aplicar"
+  Update and Apply: "Atualizar e aplicar"

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -1704,3 +1704,16 @@ Channels:
 Search Bar:
   Open Search Container: Deschide câmpul de căutare
   Search: Caută
+Theme Discovery:
+  Discover Themes: "Descoperă teme"
+  Refresh: "Reîncarcă"
+  View on GitHub: "Vezi pe GitHub"
+  Load Error: "Temele nu au putut fi încărcate. Încearcă să reîncarci."
+  Loading: "Se încarcă…"
+  No Themes: "Nu s-au găsit teme instalabile."
+  No Preview: "Captura de ecran nu este disponibilă"
+  Load More: "Încarcă mai multe"
+  Applied: "Aplicată"
+  Apply Theme: "Aplică tema"
+  Install and Apply: "Instalează și aplică"
+  Update and Apply: "Actualizează și aplică"

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -1670,3 +1670,16 @@ Channels:
 Search Bar:
   Open Search Container: Открыть поле поиска
   Search: Поиск
+Theme Discovery:
+  Discover Themes: "Найти темы"
+  Refresh: "Обновить"
+  View on GitHub: "Посмотреть на GitHub"
+  Load Error: "Не удалось загрузить темы. Попробуйте обновить список."
+  Loading: "Загрузка…"
+  No Themes: "Темы для установки не найдены."
+  No Preview: "Снимок экрана недоступен"
+  Load More: "Загрузить ещё"
+  Applied: "Применено"
+  Apply Theme: "Применить тему"
+  Install and Apply: "Установить и применить"
+  Update and Apply: "Обновить и применить"

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -1658,3 +1658,16 @@ Downloads:
     Subtitles Format: Titulky – {format}
 Channels:
   Load More Channels: "Načítať ďalšie kanály"
+Theme Discovery:
+  Discover Themes: "Objavovať motívy"
+  Refresh: "Obnoviť"
+  View on GitHub: "Zobraziť na GitHube"
+  Load Error: "Motívy sa nepodarilo načítať. Skúste obnoviť zoznam."
+  Loading: "Načítava sa…"
+  No Themes: "Nenašli sa žiadne motívy na inštaláciu."
+  No Preview: "Snímka obrazovky nie je dostupná"
+  Load More: "Načítať ďalšie"
+  Applied: "Použité"
+  Apply Theme: "Použiť motív"
+  Install and Apply: "Nainštalovať a použiť"
+  Update and Apply: "Aktualizovať a použiť"

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -2252,3 +2252,16 @@ Downloads:
     Subtitles Format: Podnapisi - {format}
 Channels:
   Load More Channels: "Naloži več kanalov"
+Theme Discovery:
+  Discover Themes: "Odkrij teme"
+  Refresh: "Osveži"
+  View on GitHub: "Poglej na GitHubu"
+  Load Error: "Tem ni bilo mogoče naložiti. Poskusi osvežiti."
+  Loading: "Nalaganje…"
+  No Themes: "Ni najdenih tem za namestitev."
+  No Preview: "Posnetek zaslona ni na voljo"
+  Load More: "Naloži več"
+  Applied: "Uveljavljeno"
+  Apply Theme: "Uveljavi temo"
+  Install and Apply: "Namesti in uveljavi"
+  Update and Apply: "Posodobi in uveljavi"

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -1731,3 +1731,16 @@ Channels:
 Search Bar:
   Open Search Container: Отвори поље за претрагу
   Search: Претрага
+Theme Discovery:
+  Discover Themes: "Откриј теме"
+  Refresh: "Освежи"
+  View on GitHub: "Погледај на GitHub-у"
+  Load Error: "Није могуће учитати теме. Покушајте да освежите."
+  Loading: "Учитавање…"
+  No Themes: "Нису пронађене теме за инсталацију."
+  No Preview: "Снимак екрана није доступан"
+  Load More: "Учитај још"
+  Applied: "Примењено"
+  Apply Theme: "Примени тему"
+  Install and Apply: "Инсталирај и примени"
+  Update and Apply: "Ажурирај и примени"

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -1676,3 +1676,16 @@ Channels:
 Search Bar:
   Open Search Container: Öppna sökfältet
   Search: Sök
+Theme Discovery:
+  Discover Themes: "Upptäck teman"
+  Refresh: "Läs in igen"
+  View on GitHub: "Visa på GitHub"
+  Load Error: "Kunde inte läsa in teman. Försök att läsa in igen."
+  Loading: "Läser in…"
+  No Themes: "Inga installerbara teman hittades."
+  No Preview: "Skärmbild saknas"
+  Load More: "Läs in fler"
+  Applied: "Tillämpat"
+  Apply Theme: "Använd tema"
+  Install and Apply: "Installera och använd"
+  Update and Apply: "Uppdatera och använd"

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -1707,3 +1707,16 @@ Channels:
 Search Bar:
   Open Search Container: தேடல் பெட்டியைத் திற
   Search: தேடு
+Theme Discovery:
+  Discover Themes: "தீம்களைக் கண்டறி"
+  Refresh: "புதுப்பி"
+  View on GitHub: "GitHub இல் காண்க"
+  Load Error: "தீம்களை ஏற்ற முடியவில்லை. புதுப்பித்து முயற்சிக்கவும்."
+  Loading: "ஏற்றுகிறது…"
+  No Themes: "நிறுவக்கூடிய தீம்கள் எதுவும் இல்லை."
+  No Preview: "திரைப்பிடிப்பு கிடைக்கவில்லை"
+  Load More: "மேலும் ஏற்று"
+  Applied: "பயன்படுத்தப்பட்டது"
+  Apply Theme: "தீமைப் பயன்படுத்து"
+  Install and Apply: "நிறுவிப் பயன்படுத்து"
+  Update and Apply: "புதுப்பித்துப் பயன்படுத்து"

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -1658,3 +1658,16 @@ Downloads:
     Subtitles Format: Alt Yazılar - {format}
 Channels:
   Load More Channels: "Daha fazla kanal yükle"
+Theme Discovery:
+  Discover Themes: "Temaları keşfet"
+  Refresh: "Yenile"
+  View on GitHub: "GitHub'da görüntüle"
+  Load Error: "Temalar yüklenemedi. Yenilemeyi deneyin."
+  Loading: "Yükleniyor…"
+  No Themes: "Yüklenebilir tema bulunamadı."
+  No Preview: "Ekran görüntüsü kullanılamıyor"
+  Load More: "Daha fazla yükle"
+  Applied: "Uygulandı"
+  Apply Theme: "Temayı uygula"
+  Install and Apply: "Yükle ve uygula"
+  Update and Apply: "Güncelle ve uygula"

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -1695,3 +1695,16 @@ Channels:
 Search Bar:
   Open Search Container: Відкрити поле пошуку
   Search: Пошук
+Theme Discovery:
+  Discover Themes: "Знайти теми"
+  Refresh: "Оновити"
+  View on GitHub: "Переглянути на GitHub"
+  Load Error: "Не вдалося завантажити теми. Спробуйте оновити список."
+  Loading: "Завантаження…"
+  No Themes: "Тем для встановлення не знайдено."
+  No Preview: "Знімок екрана недоступний"
+  Load More: "Завантажити ще"
+  Applied: "Застосовано"
+  Apply Theme: "Застосувати тему"
+  Install and Apply: "Встановити й застосувати"
+  Update and Apply: "Оновити й застосувати"

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -1692,3 +1692,16 @@ Channels:
 Search Bar:
   Open Search Container: Mở ô tìm kiếm
   Search: Tìm kiếm
+Theme Discovery:
+  Discover Themes: "Khám phá giao diện"
+  Refresh: "Làm mới"
+  View on GitHub: "Xem trên GitHub"
+  Load Error: "Không thể tải giao diện. Hãy thử làm mới."
+  Loading: "Đang tải…"
+  No Themes: "Không tìm thấy giao diện có thể cài đặt."
+  No Preview: "Ảnh chụp màn hình không khả dụng"
+  Load More: "Tải thêm"
+  Applied: "Đã áp dụng"
+  Apply Theme: "Áp dụng giao diện"
+  Install and Apply: "Cài đặt và áp dụng"
+  Update and Apply: "Cập nhật và áp dụng"

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -1658,3 +1658,16 @@ Downloads:
     Subtitles Format: 字幕 - {format}
 Channels:
   Load More Channels: "加载更多频道"
+Theme Discovery:
+  Discover Themes: "发现主题"
+  Refresh: "刷新"
+  View on GitHub: "在 GitHub 上查看"
+  Load Error: "无法加载主题。请尝试刷新。"
+  Loading: "加载中…"
+  No Themes: "未找到可安装的主题。"
+  No Preview: "截图不可用"
+  Load More: "加载更多"
+  Applied: "已应用"
+  Apply Theme: "应用主题"
+  Install and Apply: "安装并应用"
+  Update and Apply: "更新并应用"

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -1674,3 +1674,16 @@ Channels:
 Search Bar:
   Open Search Container: 開啟搜尋欄
   Search: 搜尋
+Theme Discovery:
+  Discover Themes: "探索佈景主題"
+  Refresh: "重新整理"
+  View on GitHub: "在 GitHub 上檢視"
+  Load Error: "無法載入佈景主題。請嘗試重新整理。"
+  Loading: "載入中…"
+  No Themes: "找不到可安裝的佈景主題。"
+  No Preview: "螢幕截圖無法使用"
+  Load More: "載入更多"
+  Applied: "已套用"
+  Apply Theme: "套用佈景主題"
+  Install and Apply: "安裝並套用"
+  Update and Apply: "更新並套用"

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -2852,3 +2852,16 @@ Tutorial:
       zur Profilauswahl. Das Zahnrad in diesem Menü öffnet alle Einstellungen. Auch „Über“ und „Downloads“ wurden in
       dieses Menü verschoben.
 The playlist is at the beginning. Enable loop to continue playing: Die Wiedergabeliste ist am Anfang. Aktiviere die Wiederholung, um die Wiedergabe fortzusetzen
+Theme Discovery:
+  Discover Themes: "Themes entdecken"
+  Refresh: "Aktualisieren"
+  View on GitHub: "Auf GitHub ansehen"
+  Load Error: "Themes konnten nicht geladen werden. Versuche, die Ansicht zu aktualisieren."
+  Loading: "Wird geladen…"
+  No Themes: "Keine installierbaren Themes gefunden."
+  No Preview: "Screenshot nicht verfügbar"
+  Load More: "Mehr laden"
+  Applied: "Angewendet"
+  Apply Theme: "Theme anwenden"
+  Install and Apply: "Installieren und anwenden"
+  Update and Apply: "Aktualisieren und anwenden"

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -2874,3 +2874,16 @@ Downloads:
     Audio Best: Audio - Best Quality
     Audio Format: Audio - {format}
     Subtitles Format: Subtitles - {format}
+Theme Discovery:
+  Discover Themes: "Discover themes"
+  Refresh: "Refresh"
+  View on GitHub: "View on GitHub"
+  Load Error: "Could not load themes. Try refreshing."
+  Loading: "Loading…"
+  No Themes: "No installable themes found."
+  No Preview: "Screenshot unavailable"
+  Load More: "Load more"
+  Applied: "Applied"
+  Apply Theme: "Apply theme"
+  Install and Apply: "Install and apply"
+  Update and Apply: "Update and apply"

--- a/tests/unit/custom-theme.test.mjs
+++ b/tests/unit/custom-theme.test.mjs
@@ -3,6 +3,7 @@ import { test } from 'node:test'
 
 import {
   customThemeBackdropBlur,
+  customThemeContentHash,
   DEFAULT_CUSTOM_THEME,
   normalizeCustomTheme,
 } from '../../src/customTheme.js'
@@ -68,4 +69,45 @@ test('normalizes transparent colors and bounded backdrop blur strengths', () => 
   assert.equal(customThemeBackdropBlur(normalized.colors.cardBackground, 12), 'blur(12px)')
   assert.equal(customThemeBackdropBlur('#123456', 12), 'none')
   assert.equal(customThemeBackdropBlur('#12345680', 0), 'none')
+})
+
+test('preserves source fingerprints through save and sync, but drops them from copies', () => {
+  const theme = {
+    ...DEFAULT_CUSTOM_THEME,
+    id: 'discussion-1197',
+    discussionThemeHash: 'a'.repeat(64),
+  }
+  const normalized = normalizeCustomTheme(theme)
+  assert.equal(normalized.discussionThemeHash, 'a'.repeat(64))
+  assert.deepEqual(normalizeCustomTheme(JSON.parse(JSON.stringify(normalized))), normalized)
+  assert.equal(normalizeCustomTheme({ ...theme, id: 'my-copy' }).discussionThemeHash, undefined)
+  assert.equal(normalizeCustomTheme({ ...theme, discussionThemeHash: 'invalid' }).discussionThemeHash, undefined)
+})
+
+
+test('theme fingerprints ignore formatting, key order, local IDs and source fingerprints', async () => {
+  const theme = normalizeCustomTheme(DEFAULT_CUSTOM_THEME)
+  const expected = await customThemeContentHash(theme)
+  assert.match(expected, /^[\da-f]{64}$/)
+  const reordered = Object.fromEntries(Object.entries(theme).reverse())
+  reordered.colors = Object.fromEntries(Object.entries(theme.colors).reverse())
+  reordered.blurs = Object.fromEntries(Object.entries(theme.blurs).reverse())
+  assert.equal(await customThemeContentHash(JSON.parse(JSON.stringify(reordered, null, 4))), expected)
+  assert.equal(await customThemeContentHash({ ...theme, id: 'discussion-1197', discussionThemeHash: 'b'.repeat(64) }), expected)
+  assert.equal(await customThemeContentHash({ ...theme, colors: { ...theme.colors, background: '#ABCDEF' } }),
+    await customThemeContentHash({ ...theme, colors: { ...theme.colors, background: '#abcdef' } }))
+})
+
+test('theme fingerprints detect changes to colors, blur, name and theme settings', async () => {
+  const theme = normalizeCustomTheme(DEFAULT_CUSTOM_THEME)
+  const original = await customThemeContentHash(theme)
+  for (const patch of [
+    { colors: { ...theme.colors, background: '#112233' } },
+    { blurs: { ...theme.blurs, cardBackground: 10 } },
+    { name: 'New theme name' },
+    { isDark: !theme.isDark },
+    { basedOn: 'light' },
+    { mainColor: 'Purple' },
+    { secondaryColor: 'Green' },
+  ]) assert.notEqual(await customThemeContentHash({ ...theme, ...patch }), original)
 })

--- a/tests/unit/theme-discovery.test.mjs
+++ b/tests/unit/theme-discovery.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { themeScreenshotUrl } from '../../src/renderer/helpers/themeDiscovery.js'
+
+test('uses permanent public attachments instead of expiring screenshot signatures', () => {
+  const id = '5724b7e8-f82e-4107-835b-a16d12afd0b5'
+  const permanent = `https://github.com/user-attachments/assets/${id}`
+  assert.equal(themeScreenshotUrl(`https://private-user-images.githubusercontent.com/24937357/647695754-${id}.png?jwt=expired`), permanent)
+  assert.equal(themeScreenshotUrl(permanent), permanent)
+  assert.equal(themeScreenshotUrl('https://user-images.githubusercontent.com/1/example.png'), 'https://user-images.githubusercontent.com/1/example.png')
+  assert.equal(themeScreenshotUrl('https://camo.githubusercontent.com/hash/image'), 'https://camo.githubusercontent.com/hash/image')
+})
+
+test('does not load screenshot URLs from third-party servers or local resources', () => {
+  for (const url of [
+    'file:///etc/passwd', 'data:image/svg+xml,test', 'javascript:alert(1)',
+    'http://github.com/user-attachments/assets/id',
+    'https://github.com.evil.test/user-attachments/assets/id',
+    'https://tracker.test/image.png', 'https://127.0.0.1/image.png',
+    'https://user:pass@github.com/user-attachments/assets/id',
+    'https://github.com:444/user-attachments/assets/id',
+    'https://github.com/OpenTubeX/OpenTubeX',
+    'https://private-user-images.githubusercontent.com/not-an-attachment',
+    null,
+  ]) assert.equal(themeScreenshotUrl(url), null, String(url))
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Community themes currently require finding a discussion and importing its JSON manually. Add **Discover themes** under Settings → Appearance to browse screenshots, install and apply a theme in one click, and update it when its theme JSON changes.

The gallery includes an in-app image viewer, linked GitHub authors and discussions, and automatic or manual pagination using the existing setting. Updates compare normalized theme-content fingerprints, so discussion text, screenshots, JSON formatting, and local theme edits do not create false update prompts.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [x] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Discover community themes in Appearance settings, preview their screenshots, and install, apply, or update them in one click.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/2b0908ed-2bc8-4814-a285-0a4b104901a9">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/464b9e32-3e6d-4b4a-9fe2-f1c22c39515a">
  <img alt="Discover community themes with screenshots and one-click installation" src="https://github.com/user-attachments/assets/2b0908ed-2bc8-4814-a285-0a4b104901a9">
</picture>

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. In dev mode, open Settings → Appearance → Discover themes. Check that screenshots load, author handles open their GitHub profiles, and each card's actions align at the bottom.
2. Select screenshot numbers, then open a screenshot. Check animated switching, previous/next navigation, the top-right Close icon, and Escape returning focus to the gallery.
3. Install and apply a theme. Reopen the gallery after restarting the app; it should remain installed and applied.
4. To simulate an available update, use an installed discovered theme without local edits and run this in DevTools. Refresh the gallery, choose **Update and apply**, and verify that refreshing again shows **Applied**:

```js
const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
const theme = (await window.ftElectron.loadCustomTheme())
  .find(theme => theme.id.startsWith('discussion-'))
if (!theme) throw new Error('Install a discovered theme first')
theme.discussionThemeHash = '0'.repeat(64)
await store.dispatch('updateCustomThemes', await window.ftElectron.saveCustomTheme(theme))
console.log(`Refresh Discover themes and update ${theme.name}`)
```

5. With automatic loading enabled in General settings, scroll to the bottom and check for the loading spinner. Turn it off and verify the centered **Load more** button. Test at 85% and 110% UI scale, then refresh at the bottom to check that scrolling stays within the content.

The snippet changes only the saved update fingerprint. Applying an update replaces the installed theme with the discussion's current JSON, including any local edits.

## Additional context
<!-- Add any other context about the pull request here. -->
Uses the public GitHub discussions Atom feed; no GitHub token or new dependency is required.

Implemented and reviewed with GPT-6 in the Codex desktop app.



