### PR TITLE
fix(releases): prevent nightly failures when PRs merge during publishing

### DIFF
--- a/_scripts/releaseNotes.mjs
+++ b/_scripts/releaseNotes.mjs
@@ -447,14 +447,15 @@ function gitIsAncestor(ancestor, descendant) {
 export function selectPullRequests(pullRequests, previousTag, target) {
   if (!gitIsAncestor(previousTag, target)) { throw new Error(`${previousTag} is not an ancestor of ${target}.`) }
 
-  return pullRequests
-    .filter(({ mergeCommit }) => {
-      const commit = mergeCommit?.oid
+  // API results can include merges made after checkout. Match against the fixed
+  // release range without asking Git to resolve those newer commit objects.
+  const commits = new Set(execFileSync('git', ['rev-list', `${previousTag}..${target}`], {
+    encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024,
+  }).split('\n').filter(Boolean))
 
-      return commit &&
-        gitIsAncestor(commit, target) &&
-        !gitIsAncestor(commit, previousTag)
-    })
+  return pullRequests
+    .filter(({ mergeCommit }) => commits.has(mergeCommit?.oid))
     .sort((left, right) => left.mergedAt.localeCompare(right.mergedAt))
 }
 

--- a/tests/unit/release-notes-selection.test.mjs
+++ b/tests/unit/release-notes-selection.test.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import { selectPullRequests } from '../../_scripts/releaseNotes.mjs'
+
+function withCheckout(callback) {
+  const directory = mkdtempSync(path.join(tmpdir(), 'release-notes-selection-'))
+  const originalDirectory = process.cwd()
+  const source = path.join(directory, 'source')
+  const checkout = path.join(directory, 'checkout')
+  const git = (...args) => execFileSync('git', args, {
+    cwd: source,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Release notes test',
+      GIT_AUTHOR_EMAIL: 'test@example.com',
+      GIT_COMMITTER_NAME: 'Release notes test',
+      GIT_COMMITTER_EMAIL: 'test@example.com',
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim()
+
+  try {
+    execFileSync('git', ['init', '--quiet', source])
+    const tree = git('mktree')
+    const commit = (message, parent) => git('commit-tree', tree, '-m', message, ...(parent ? ['-p', parent] : []))
+    const previous = commit('Previous release')
+    const first = commit('First change', previous)
+    const target = commit('Release target', first)
+    const unrelated = commit('Another branch', previous)
+    git('update-ref', 'refs/heads/development', target)
+    git('update-ref', 'refs/heads/other', unrelated)
+    git('tag', 'previous', previous)
+    git('symbolic-ref', 'HEAD', 'refs/heads/development')
+    execFileSync('git', ['clone', '--quiet', '--no-local', source, checkout])
+
+    // GitHub can report a merge that happened after the runner's checkout.
+    const later = commit('Merged after checkout', target)
+    git('update-ref', 'refs/heads/development', later)
+    process.chdir(checkout)
+    callback({ previous, first, target, unrelated, later })
+  } finally {
+    process.chdir(originalDirectory)
+    rmSync(directory, { recursive: true, force: true })
+  }
+}
+
+test('release notes exclude merges after checkout and keep only the release range in order', () => {
+  withCheckout(({ previous, first, target, unrelated, later }) => {
+    const pullRequest = (oid, number) => ({
+      mergeCommit: { oid },
+      mergedAt: `2026-09-08T07:30:0${number}Z`,
+      number,
+    })
+    const firstPullRequest = pullRequest(first, 1)
+    const targetPullRequest = pullRequest(target, 2)
+
+    assert.deepEqual(selectPullRequests([
+      pullRequest(later, 3),
+      targetPullRequest,
+      pullRequest(previous, 0),
+      pullRequest(unrelated, 4),
+      { mergeCommit: null },
+      firstPullRequest,
+    ], 'previous', target), [firstPullRequest, targetPullRequest])
+    assert.deepEqual(selectPullRequests([firstPullRequest], 'previous', previous), [])
+  })
+})
+
+test('release notes still reject invalid release boundaries', () => {
+  withCheckout(({ target, unrelated, later }) => {
+    assert.throws(() => selectPullRequests([], unrelated, target), /is not an ancestor/)
+    assert.throws(() => selectPullRequests([], 'missing-tag', target), /Could not compare Git commits/)
+    assert.throws(() => selectPullRequests([], 'previous', later), /Could not compare Git commits/)
+  })
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

[Failed nightly publishing job](https://github.com/OpenTubeX/OpenTubeX/actions/runs/34198496016/job/101975151710).

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Nightly publishing failed when a PR merged after checkout: the changelog query returned its commit, but Git could not resolve it locally. Select PRs from the fixed previous-release-to-build-target commit range so later merges are excluded without aborting publishing. Preserve chronological ordering and errors for invalid release boundaries.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

This changes release tooling only; there is no in-app verification flow.

## Additional context
<!-- Add any other context about the pull request here. -->


The regression test recreates the race using a clone followed by a new commit in its source repository. It failed before the fix and passes afterward. All 1,277 unit tests pass; lint passes with one unrelated i18n warning. Standards and spec reviews found no issues.

Today’s nightly was recovered by rerunning the failed publishing job.

Implemented with GPT-6 through Codex.
