### PR TITLE
feat(sidebar): move subscription visibility to navigation customization

### DIFF
--- a/src/renderer/components/DistractionSettings/DistractionSettings.vue
+++ b/src/renderer/components/DistractionSettings/DistractionSettings.vue
@@ -167,22 +167,6 @@
     <h4
       class="groupTitle"
     >
-      {{ t('Settings.Distraction Free Settings.Sections.Side Bar') }}
-    </h4>
-    <div class="switchColumnGrid">
-      <div class="switchColumn">
-        <FtToggleSwitch
-          :label="t('Settings.Distraction Free Settings.Hide Active Subscriptions')"
-          :compact="true"
-          :default-value="hideActiveSubscriptions"
-          setting-key="hideActiveSubscriptions"
-          @change="updateHideActiveSubscriptions"
-        />
-      </div>
-    </div>
-    <h4
-      class="groupTitle"
-    >
       {{ t('Settings.Distraction Free Settings.Sections.Subscriptions Page') }}
     </h4>
     <div class="switchColumnGrid">
@@ -527,16 +511,6 @@ const hideLiveChatReplay = computed(() => store.getters.getHideLiveChatReplay)
  */
 function updateHideLiveChatReplay(value) {
   store.dispatch('updateHideLiveChatReplay', value)
-}
-
-/** @type {import('vue').ComputedRef<boolean>} */
-const hideActiveSubscriptions = computed(() => store.getters.getHideActiveSubscriptions)
-
-/**
- * @param {boolean} value
- */
-function updateHideActiveSubscriptions(value) {
-  store.dispatch('updateHideActiveSubscriptions', value)
 }
 
 /** @type {import('vue').ComputedRef<boolean>} */

--- a/src/renderer/components/NavigationCustomizer/NavigationCustomizer.vue
+++ b/src/renderer/components/NavigationCustomizer/NavigationCustomizer.vue
@@ -163,12 +163,6 @@
       </li>
     </ul>
     <p
-      v-else
-      class="emptyState"
-    >
-      {{ t('Settings.No Settings Found') }}
-    </p>
-    <p
       class="reorderStatus"
       role="status"
       aria-live="polite"
@@ -176,6 +170,14 @@
     >
       {{ reorderStatus }}
     </p>
+    <div class="fixedNavigationOptions">
+      <FtToggleSwitch
+        :label="t('Settings.General Settings.Navigation.Show Active Subscriptions')"
+        :compact="true"
+        :default-value="!hideActiveSubscriptions"
+        @change="store.dispatch('updateHideActiveSubscriptions', !$event)"
+      />
+    </div>
   </FtSettingsSubpage>
 </template>
 
@@ -188,6 +190,7 @@ import { useRoute, useRouter } from 'vue-router'
 import FtButton from '../FtButton/FtButton.vue'
 import FtSettingsSubpage from '../FtSettingsSubpage/FtSettingsSubpage.vue'
 import FtSyncedSettingIndicator from '../FtSyncedSettingIndicator/FtSyncedSettingIndicator.vue'
+import FtToggleSwitch from '../FtToggleSwitch/FtToggleSwitch.vue'
 
 import store from '../../store/index'
 import { clampOverlayScrollTop } from '../../helpers/overlayScrollbars'
@@ -219,6 +222,7 @@ const catalog = computed(() => NAVIGATION_ITEM_DEFINITIONS
   })))
 const catalogById = computed(() => new Map(catalog.value.map(item => [item.id, item])))
 const navigationItems = computed(() => store.getters.getNavigationItems)
+const hideActiveSubscriptions = computed(() => store.getters.getHideActiveSubscriptions)
 const isDefaultNavigation = computed(() => (
   navigationItems.value.length === DEFAULT_NAVIGATION_ITEMS.length &&
   navigationItems.value.every((id, index) => id === DEFAULT_NAVIGATION_ITEMS[index])
@@ -460,16 +464,30 @@ function resetItems() {
   padding: 0;
 }
 
-.selectedItem {
+.selectedItem,
+.fixedNavigationOptions {
   align-items: center;
   background: var(--card-bg-color);
   border: 1px solid var(--divider-color);
   border-radius: calc(6px * var(--ui-roundness));
+  min-block-size: 56px;
+  user-select: none;
+}
+
+.selectedItem {
   display: grid;
   grid-template-columns: 44px 24px minmax(0, 1fr) auto;
-  min-block-size: 56px;
   position: relative;
-  user-select: none;
+}
+
+.fixedNavigationOptions {
+  box-sizing: border-box;
+  display: flex;
+  inline-size: 100%;
+  margin-block-start: 8px;
+  margin-inline: auto;
+  max-inline-size: 720px;
+  padding-inline: 12px;
 }
 
 .selectedItem.dragging {
@@ -555,9 +573,4 @@ function resetItems() {
   white-space: nowrap;
 }
 
-.emptyState {
-  color: var(--secondary-text-color);
-  margin-block: 24px;
-  text-align: center;
-}
 </style>

--- a/src/renderer/helpers/settings-search-config.js
+++ b/src/renderer/helpers/settings-search-config.js
@@ -109,6 +109,7 @@ export const SETTINGS_SEARCH_SOURCES = {
     type: 'distraction',
     key: 'Settings.Distraction Free Settings',
     exclude: new Set([
+      'Hide Active Subscriptions',
       'Hide Home',
       'Hide Popular Videos',
       'Hide Trending Videos',

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -248,6 +248,7 @@ Settings:
     Swipe to refresh: اسحب للتحديث
     Blur Thumbnails: تمويه الصور المصغرة
     Navigation:
+      Show Active Subscriptions: إظهار الاشتراكات النشطة
       Navigation: التنقل
       Customize Navigation: تخصيص التنقل
       Add Item: إضافة عنصر

--- a/static/locales/ai/az.yaml
+++ b/static/locales/ai/az.yaml
@@ -246,6 +246,7 @@ Settings:
     Swipe to refresh: Yeniləmək üçün sürüşdür
     Blur Thumbnails: Miniatürləri bulanıqlaşdır
     Navigation:
+      Show Active Subscriptions: Aktiv abunəlikləri göstər
       Navigation: Naviqasiya
       Customize Navigation: Naviqasiyanı fərdiləşdir
       Add Item: Element əlavə et

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -260,6 +260,7 @@ Settings:
     Swipe to refresh: Пацягніце, каб абнавіць
     Blur Thumbnails: Размываць мініяцюры
     Navigation:
+      Show Active Subscriptions: Паказваць актыўныя падпіскі
       Navigation: Навігацыя
       Customize Navigation: Наладзіць навігацыю
       Add Item: Дадаць элемент

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -246,6 +246,7 @@ Settings:
     Swipe to refresh: Плъзнете за опресняване
     Blur Thumbnails: Замъгляване на миниатюрите
     Navigation:
+      Show Active Subscriptions: Показване на активните абонаменти
       Navigation: Навигация
       Customize Navigation: Персонализиране на навигацията
       Add Item: Добавяне на елемент

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -244,6 +244,7 @@ Settings:
     Swipe to refresh: Riklañ evit freskaat
     Blur Thumbnails: Lakaat ar skeudennoùigoù da vezañ dispis
     Navigation:
+      Show Active Subscriptions: Diskouez ar c’houmanantoù oberiant
       Navigation: Merdeiñ
       Customize Navigation: Personelaat ar merdeiñ
       Add Item: Ouzhpennañ un elfenn

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -374,6 +374,7 @@ Settings:
     Swipe to refresh: Llisca per actualitzar
     Blur Thumbnails: Difumina les miniatures
     Navigation:
+      Show Active Subscriptions: Mostra les subscripcions actives
       Navigation: Navegació
       Customize Navigation: Personalitza la navegació
       Add Item: Afegeix un element

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -244,6 +244,7 @@ Settings:
     Swipe to refresh: Obnovit potažením
     Blur Thumbnails: Rozmazat miniatury
     Navigation:
+      Show Active Subscriptions: Zobrazit aktivní odběry
       Navigation: Navigace
       Customize Navigation: Přizpůsobit navigaci
       Add Item: Přidat položku

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -246,6 +246,7 @@ Settings:
     Swipe to refresh: Sychwch i adnewyddu
     Blur Thumbnails: Niwlio mân-luniau
     Navigation:
+      Show Active Subscriptions: Dangos tanysgrifiadau gweithredol
       Navigation: Llywio
       Customize Navigation: Addasu'r llywio
       Add Item: Ychwanegu eitem

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -255,6 +255,7 @@ Settings:
     Swipe to refresh: Stryg for at opdatere
     Blur Thumbnails: Slør miniaturebilleder
     Navigation:
+      Show Active Subscriptions: Vis aktive abonnementer
       Navigation: Navigation
       Customize Navigation: Tilpas navigation
       Add Item: Tilføj element

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -248,6 +248,7 @@ Settings:
     Swipe to refresh: Σύρετε για ανανέωση
     Blur Thumbnails: Θόλωση μικρογραφιών
     Navigation:
+      Show Active Subscriptions: Εμφάνιση ενεργών συνδρομών
       Navigation: Πλοήγηση
       Customize Navigation: Προσαρμογή πλοήγησης
       Add Item: Προσθήκη στοιχείου

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -243,6 +243,7 @@ Settings:
     Swipe to refresh: Swipe to refresh
     Blur Thumbnails: Blur thumbnails
     Navigation:
+      Show Active Subscriptions: Show Active Subscriptions
       Navigation: Navigation
       Customize Navigation: Customise navigation
       Add Item: Add item

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -264,6 +264,7 @@ Settings:
     Swipe to refresh: Deslizar para actualizar
     Blur Thumbnails: Desenfocar miniaturas
     Navigation:
+      Show Active Subscriptions: Mostrar suscripciones activas
       Navigation: Navegación
       Customize Navigation: Personalizar navegación
       Add Item: Agregar elemento

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -272,6 +272,7 @@ Settings:
     Swipe to refresh: Deslizar para actualizar
     Blur Thumbnails: Desenfocar miniaturas
     Navigation:
+      Show Active Subscriptions: Mostrar suscripciones activas
       Navigation: Navegación
       Customize Navigation: Personalizar navegación
       Add Item: Agregar elemento

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -246,6 +246,7 @@ Settings:
     Swipe to refresh: Deslizar para actualizar
     Blur Thumbnails: Desenfocar miniaturas
     Navigation:
+      Show Active Subscriptions: Mostrar suscripciones activas
       Navigation: Navegación
       Customize Navigation: Personalizar navegación
       Add Item: Añadir elemento

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -244,6 +244,7 @@ Settings:
     Swipe to refresh: Värskendamiseks viipa
     Blur Thumbnails: Hägusta pisipildid
     Navigation:
+      Show Active Subscriptions: Näita aktiivseid tellimusi
       Navigation: Navigeerimine
       Customize Navigation: Kohanda navigeerimist
       Add Item: Lisa üksus

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -246,6 +246,7 @@ Settings:
     Swipe to refresh: Irristatu freskatzeko
     Blur Thumbnails: Lausotu koadro txikiak
     Navigation:
+      Show Active Subscriptions: Erakutsi harpidetza aktiboak
       Navigation: Nabigazioa
       Customize Navigation: Pertsonalizatu nabigazioa
       Add Item: Gehitu elementua

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -261,6 +261,7 @@ Settings:
     Swipe to refresh: کشیدن برای تازه‌سازی
     Blur Thumbnails: تار کردن تصاویر بندانگشتی
     Navigation:
+      Show Active Subscriptions: نمایش اشتراک‌های فعال
       Navigation: پیمایش
       Customize Navigation: سفارشی‌سازی پیمایش
       Add Item: افزودن مورد

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -248,6 +248,7 @@ Settings:
     Swipe to refresh: Päivitä pyyhkäisemällä
     Blur Thumbnails: Sumenna pikkukuvat
     Navigation:
+      Show Active Subscriptions: Näytä aktiiviset tilaukset
       Navigation: Navigointi
       Customize Navigation: Mukauta navigointia
       Add Item: Lisää kohde

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -244,6 +244,7 @@ Settings:
     Swipe to refresh: Balayer pour actualiser
     Blur Thumbnails: Flouter les miniatures
     Navigation:
+      Show Active Subscriptions: Afficher les abonnements actifs
       Navigation: Navigation
       Customize Navigation: Personnaliser la navigation
       Add Item: Ajouter un élément

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -248,6 +248,7 @@ Settings:
     Swipe to refresh: Esvarar para actualizar
     Blur Thumbnails: Desenfocar miniaturas
     Navigation:
+      Show Active Subscriptions: Amosar as subscricións activas
       Navigation: Navegación
       Customize Navigation: Personalizar a navegación
       Add Item: Engadir elemento

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -248,6 +248,7 @@ Settings:
     Swipe to refresh: החלקה לרענון
     Blur Thumbnails: טשטוש תמונות ממוזערות
     Navigation:
+      Show Active Subscriptions: הצגת מינויים פעילים
       Navigation: ניווט
       Customize Navigation: התאמה אישית של הניווט
       Add Item: הוספת פריט

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -246,6 +246,7 @@ Settings:
     Swipe to refresh: Povucite za osvježavanje
     Blur Thumbnails: Zamuti minijature
     Navigation:
+      Show Active Subscriptions: Prikaži aktivne pretplate
       Navigation: Navigacija
       Customize Navigation: Prilagodi navigaciju
       Add Item: Dodaj stavku

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -244,6 +244,7 @@ Settings:
     Swipe to refresh: Frissítés húzással
     Blur Thumbnails: Bélyegképek elhomályosítása
     Navigation:
+      Show Active Subscriptions: Aktív feliratkozások megjelenítése
       Navigation: Navigáció
       Customize Navigation: Navigáció testreszabása
       Add Item: Elem hozzáadása

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -248,6 +248,7 @@ Settings:
     Swipe to refresh: Geser untuk menyegarkan
     Blur Thumbnails: Buramkan gambar mini
     Navigation:
+      Show Active Subscriptions: Tampilkan langganan aktif
       Navigation: Navigasi
       Customize Navigation: Sesuaikan navigasi
       Add Item: Tambah item

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -248,6 +248,7 @@ Settings:
     Swipe to refresh: Strjúktu til að endurhlaða
     Blur Thumbnails: Þoka smámyndir
     Navigation:
+      Show Active Subscriptions: Sýna virkar áskriftir
       Navigation: Leiðsögn
       Customize Navigation: Sérsníða leiðsögn
       Add Item: Bæta við atriði

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -244,6 +244,7 @@ Settings:
     Swipe to refresh: Scorri per aggiornare
     Blur Thumbnails: Sfoca le miniature
     Navigation:
+      Show Active Subscriptions: Mostra iscrizioni attive
       Navigation: Navigazione
       Customize Navigation: Personalizza la navigazione
       Add Item: Aggiungi elemento

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -244,6 +244,7 @@ Settings:
     Swipe to refresh: スワイプして更新
     Blur Thumbnails: サムネイルをぼかす
     Navigation:
+      Show Active Subscriptions: 登録チャンネルを表示
       Navigation: ナビゲーション
       Customize Navigation: ナビゲーションをカスタマイズ
       Add Item: 項目を追加

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -332,6 +332,7 @@ Settings:
     Swipe to refresh: 스와이프하여 새로고침
     Blur Thumbnails: 썸네일 흐리게 표시
     Navigation:
+      Show Active Subscriptions: 활성 구독 표시
       Navigation: 탐색
       Customize Navigation: 탐색 맞춤 설정
       Add Item: 항목 추가

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -357,6 +357,7 @@ Settings:
     Swipe to refresh: Perbraukite, kad atnaujintumėte
     Blur Thumbnails: Sulieti miniatiūras
     Navigation:
+      Show Active Subscriptions: Rodyti aktyvias prenumeratas
       Navigation: Naršymas
       Customize Navigation: Tinkinti naršymą
       Add Item: Pridėti elementą

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -244,6 +244,7 @@ Settings:
     Swipe to refresh: Sveip for å oppdatere
     Blur Thumbnails: Gjør miniatyrbilder uskarpe
     Navigation:
+      Show Active Subscriptions: Vis aktive abonnementer
       Navigation: Navigasjon
       Customize Navigation: Tilpass navigasjon
       Add Item: Legg til element

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -248,6 +248,7 @@ Settings:
     Swipe to refresh: Vegen om te vernieuwen
     Blur Thumbnails: Miniaturen vervagen
     Navigation:
+      Show Active Subscriptions: Actieve abonnementen tonen
       Navigation: Navigatie
       Customize Navigation: Navigatie aanpassen
       Add Item: Item toevoegen

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -299,6 +299,7 @@ Settings:
     Swipe to refresh: Sveip for å oppdatere
     Blur Thumbnails: Gjer miniatyrbilete uskarpe
     Navigation:
+      Show Active Subscriptions: Vis aktive abonnement
       Navigation: Navigasjon
       Customize Navigation: Tilpass navigasjon
       Add Item: Legg til element

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -100,6 +100,7 @@ Settings:
     Swipe to refresh: Przeciągnij, aby odświeżyć
     Blur Thumbnails: Rozmyj miniatury
     Navigation:
+      Show Active Subscriptions: Pokaż aktywne subskrypcje
       Navigation: Nawigacja
       Customize Navigation: Dostosuj nawigację
       Add Item: Dodaj element

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -244,6 +244,7 @@ Settings:
     Swipe to refresh: Deslizar para atualizar
     Blur Thumbnails: Desfocar miniaturas
     Navigation:
+      Show Active Subscriptions: Mostrar inscrições ativas
       Navigation: Navegação
       Customize Navigation: Personalizar navegação
       Add Item: Adicionar item

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -248,6 +248,7 @@ Settings:
     Swipe to refresh: Deslizar para atualizar
     Blur Thumbnails: Desfocar miniaturas
     Navigation:
+      Show Active Subscriptions: Mostrar subscrições ativas
       Navigation: Navegação
       Customize Navigation: Personalizar navegação
       Add Item: Adicionar item

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -248,6 +248,7 @@ Settings:
     Swipe to refresh: Deslizar para atualizar
     Blur Thumbnails: Desfocar miniaturas
     Navigation:
+      Show Active Subscriptions: Mostrar subscrições ativas
       Navigation: Navegação
       Customize Navigation: Personalizar navegação
       Add Item: Adicionar item

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -246,6 +246,7 @@ Settings:
     Swipe to refresh: Glisează pentru a reîmprospăta
     Blur Thumbnails: Estompează miniaturile
     Navigation:
+      Show Active Subscriptions: Afișează abonamentele active
       Navigation: Navigare
       Customize Navigation: Personalizează navigarea
       Add Item: Adaugă element

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -223,6 +223,7 @@ Settings:
     Swipe to refresh: Обновлять смахиванием
     Blur Thumbnails: Размывать миниатюры
     Navigation:
+      Show Active Subscriptions: Показывать активные подписки
       Navigation: Навигация
       Customize Navigation: Настроить навигацию
       Add Item: Добавить элемент

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -244,6 +244,7 @@ Settings:
     Swipe to refresh: Obnoviť potiahnutím
     Blur Thumbnails: Rozmazať miniatúry
     Navigation:
+      Show Active Subscriptions: Zobraziť aktívne odbery
       Navigation: Navigácia
       Customize Navigation: Prispôsobiť navigáciu
       Add Item: Pridať položku

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -366,6 +366,7 @@ Settings:
     Swipe to refresh: Povlecite za osvežitev
     Blur Thumbnails: Zamegli sličice
     Navigation:
+      Show Active Subscriptions: Prikaži aktivne naročnine
       Navigation: Krmarjenje
       Customize Navigation: Prilagodi krmarjenje
       Add Item: Dodaj element

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -254,6 +254,7 @@ Settings:
     Swipe to refresh: Превуците за освежавање
     Blur Thumbnails: Замагли сличице
     Navigation:
+      Show Active Subscriptions: Прикажи активне претплате
       Navigation: Навигација
       Customize Navigation: Прилагоди навигацију
       Add Item: Додај ставку

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -246,6 +246,7 @@ Settings:
     Swipe to refresh: Svep för att uppdatera
     Blur Thumbnails: Gör miniatyrbilder suddiga
     Navigation:
+      Show Active Subscriptions: Visa aktiva prenumerationer
       Navigation: Navigering
       Customize Navigation: Anpassa navigeringen
       Add Item: Lägg till objekt

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -249,6 +249,7 @@ Settings:
     Swipe to refresh: புதுப்பிக்க ஸ்வைப் செய்யவும்
     Blur Thumbnails: சிறுபடங்களை மங்கலாக்கு
     Navigation:
+      Show Active Subscriptions: செயலில் உள்ள சந்தாக்களைக் காட்டு
       Navigation: வழிசெலுத்தல்
       Customize Navigation: வழிசெலுத்தலைத் தனிப்பயனாக்கு
       Add Item: உருப்படியைச் சேர்

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -244,6 +244,7 @@ Settings:
     Swipe to refresh: Yenilemek için kaydır
     Blur Thumbnails: Küçük resimleri bulanıklaştır
     Navigation:
+      Show Active Subscriptions: Etkin abonelikleri göster
       Navigation: Gezinme
       Customize Navigation: Gezinmeyi özelleştir
       Add Item: Öğe ekle

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -248,6 +248,7 @@ Settings:
     Swipe to refresh: Проведіть, щоб оновити
     Blur Thumbnails: Розмивати мініатюри
     Navigation:
+      Show Active Subscriptions: Показувати активні підписки
       Navigation: Навігація
       Customize Navigation: Налаштувати навігацію
       Add Item: Додати елемент

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -248,6 +248,7 @@ Settings:
     Swipe to refresh: Vuốt để làm mới
     Blur Thumbnails: Làm mờ hình thu nhỏ
     Navigation:
+      Show Active Subscriptions: Hiển thị các kênh đăng ký đang hoạt động
       Navigation: Điều hướng
       Customize Navigation: Tùy chỉnh điều hướng
       Add Item: Thêm mục

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -244,6 +244,7 @@ Settings:
     Swipe to refresh: 下拉刷新
     Blur Thumbnails: 模糊缩略图
     Navigation:
+      Show Active Subscriptions: 显示活跃订阅
       Navigation: 导航
       Customize Navigation: 自定义导航
       Add Item: 添加项目

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -244,6 +244,7 @@ Settings:
     Swipe to refresh: 下拉重新整理
     Blur Thumbnails: 模糊縮圖
     Navigation:
+      Show Active Subscriptions: 顯示活躍訂閱
       Navigation: 導覽
       Customize Navigation: 自訂導覽
       Add Item: 新增項目

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -332,6 +332,7 @@ Settings:
     Blur Thumbnails: Vorschaubilder weichzeichnen
     General Settings: Allgemein
     Navigation:
+      Show Active Subscriptions: Aktive Abos anzeigen
       Navigation: Navigation
       Customize Navigation: Navigation anpassen
       Add Item: Eintrag hinzufügen

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -510,6 +510,7 @@ Settings:
     Blur Thumbnails: Blur thumbnails
     General Settings: General
     Navigation:
+      Show Active Subscriptions: Show Active Subscriptions
       Navigation: Navigation
       Customize Navigation: Customize navigation
       Add Item: Add item


### PR DESCRIPTION
Sidebar subscription visibility was tucked away in Distraction Free settings instead of the navigation customizer.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Requested in the Codex task; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Move it to Appearance → Customize navigation as a fixed last row with a left-hand “Show Active Subscriptions” switch and no reorder or action controls. The switch inverts the existing saved preference, preserving current visibility. Update settings search and translations.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Moved the sidebar subscription visibility setting from Distraction Free settings to Appearance → Customize navigation.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/4fd7a07c-de8f-493f-b2fb-11105c629e1e">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/62135ef6-6d18-4acc-9535-66d216c08f37">
  <img alt="Show Active Subscriptions as a fixed final row in Customize navigation" src="https://github.com/user-attachments/assets/4fd7a07c-de8f-493f-b2fb-11105c629e1e">
</picture>
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Settings → Appearance → Customize navigation. The “Show Active Subscriptions” row should stay below all navigation items, with a switch on the left and no controls on the right.
2. With a subscribed channel, turn the switch off and on. Sidebar channels should disappear and return; reopening the app should preserve the choice.
3. Reorder the navigation items. The subscription switch should remain last. Confirm it is absent from Distraction Free settings and searchable under Appearance.
4. Check the row in light and dark themes and at 125% UI scale.

## Additional context
<!-- Add any other context about the pull request here. -->

Implemented with GPT-6 in the Codex desktop app.


