### PR TITLE
fix(themes): remove seams in descriptions, feeds, and channel panels

### DIFF
--- a/e2e/helpers/colors.mjs
+++ b/e2e/helpers/colors.mjs
@@ -1,0 +1,28 @@
+export async function sampleColors(app, region, points) {
+  const { page } = app
+  await region.scrollIntoViewIfNeeded()
+  await page.evaluate(async () => {
+    document.getAnimations().forEach(animation => {
+      if (animation.effect.getComputedTiming().iterations !== Infinity) animation.finish()
+    })
+    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+  })
+  const origin = await region.evaluate(element => { const { x, y } = element.getBoundingClientRect(); return { x, y } })
+  const viewport = await page.evaluate(() => ({ width: innerWidth, height: innerHeight }))
+  // Capture Electron's actual zoomed framebuffer; Playwright's screenshot
+  // viewport emulation changes the pixel mapping at non-default UI scales.
+  const base64 = await app.electronApp.evaluate(async ({ BrowserWindow }) =>
+    (await BrowserWindow.getAllWindows()[0].webContents.capturePage()).toPNG().toString('base64'))
+  return page.evaluate(async ({ base64, points, origin, viewport }) => {
+    const bitmap = await createImageBitmap(new Blob([
+      Uint8Array.from(atob(base64), character => character.charCodeAt(0))
+    ], { type: 'image/png' }))
+    const canvas = new OffscreenCanvas(bitmap.width, bitmap.height)
+    const context = canvas.getContext('2d')
+    context.drawImage(bitmap, 0, 0)
+    const colors = points.map(([x, y]) =>
+      [...context.getImageData(Math.floor((x + origin.x) * bitmap.width / viewport.width), Math.floor((y + origin.y) * bitmap.height / viewport.height), 1, 1).data].slice(0, 3))
+    bitmap.close()
+    return colors
+  }, { base64, points, origin, viewport })
+}

--- a/e2e/tests/offline/theme-contrast.spec.mjs
+++ b/e2e/tests/offline/theme-contrast.spec.mjs
@@ -1,4 +1,5 @@
 import { test, expect, goToSettingsSection } from '../../helpers/app.mjs'
+import { sampleColors } from '../../helpers/colors.mjs'
 
 function contrastRatio(first, second) {
   const luminance = rgb => rgb.map(value => value / 255)
@@ -6,35 +7,6 @@ function contrastRatio(first, second) {
     .reduce((total, value, index) => total + value * [0.2126, 0.7152, 0.0722][index], 0)
   const values = [luminance(first), luminance(second)].sort((a, b) => b - a)
   return (values[0] + 0.05) / (values[1] + 0.05)
-}
-
-async function sampleColors(app, region, points) {
-  const { page } = app
-  await region.scrollIntoViewIfNeeded()
-  await page.evaluate(async () => {
-    document.getAnimations().forEach(animation => {
-      if (animation.effect.getComputedTiming().iterations !== Infinity) animation.finish()
-    })
-    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))
-  })
-  const origin = await region.evaluate(element => { const { x, y } = element.getBoundingClientRect(); return { x, y } })
-  const viewport = await page.evaluate(() => ({ width: innerWidth, height: innerHeight }))
-  // Capture Electron's actual zoomed framebuffer; Playwright's screenshot
-  // viewport emulation changes the pixel mapping at non-default UI scales.
-  const base64 = await app.electronApp.evaluate(async ({ BrowserWindow }) =>
-    (await BrowserWindow.getAllWindows()[0].webContents.capturePage()).toPNG().toString('base64'))
-  return page.evaluate(async ({ base64, points, origin, viewport }) => {
-    const bitmap = await createImageBitmap(new Blob([
-      Uint8Array.from(atob(base64), character => character.charCodeAt(0))
-    ], { type: 'image/png' }))
-    const canvas = new OffscreenCanvas(bitmap.width, bitmap.height)
-    const context = canvas.getContext('2d')
-    context.drawImage(bitmap, 0, 0)
-    const colors = points.map(([x, y]) =>
-      [...context.getImageData(Math.floor((x + origin.x) * bitmap.width / viewport.width), Math.floor((y + origin.y) * bitmap.height / viewport.height), 1, 1).data].slice(0, 3))
-    bitmap.close()
-    return colors
-  }, { base64, points, origin, viewport })
 }
 
 async function switchContrast(app, label, checked) {

--- a/e2e/tests/offline/theme-surfaces.spec.mjs
+++ b/e2e/tests/offline/theme-surfaces.spec.mjs
@@ -1,0 +1,167 @@
+import { test, expect, goTo } from '../../helpers/app.mjs'
+import { sampleColors } from '../../helpers/colors.mjs'
+import { openMockedVideo, waitForPlayback } from '../../helpers/player.mjs'
+import { mockPlayableWatchPage, watchViewHandle } from '../../helpers/watch.mjs'
+
+async function expectContinuousBackground(app, region, points) {
+  const colors = await sampleColors(app, region, points)
+  const difference = Math.max(...colors.slice(1).flatMap(color =>
+    color.map((value, index) => Math.abs(value - colors[0][index]))))
+  expect.soft(difference, `background pixels: ${JSON.stringify(colors)}`).toBeLessThanOrEqual(2)
+}
+
+async function expectDescriptionBackground(app, region, points) {
+  await app.page.mouse.move(0, 0)
+  // Compare identical viewport positions so the theme's natural color change
+  // across the fade isn't mistaken for a seam. Retry while scrolling or a
+  // transient player overlay still affects the captured framebuffer.
+  await expect.poll(async () => {
+    const actual = await sampleColors(app, region, points)
+    const style = await app.page.addStyleTag({
+      content: `
+        .videoDescription .descriptionStatus,
+        .videoDescription .descriptionStatus::before { background: transparent !important; }
+      `
+    })
+    try {
+      const reference = await sampleColors(app, region, points)
+      return Math.max(...actual.flatMap((color, point) =>
+        color.map((value, channel) => Math.abs(value - reference[point][channel]))))
+    } finally {
+      await style.evaluate(element => element.remove())
+    }
+  }, { message: 'Description overlay must match the card at the same pixels' }).toBeLessThanOrEqual(2)
+}
+
+async function attachThemeScreenshot(app, testInfo, name) {
+  await app.page.evaluate(() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve))))
+  const base64 = await app.electronApp.evaluate(async ({ BrowserWindow }) =>
+    (await BrowserWindow.getAllWindows()[0].webContents.capturePage()).toPNG().toString('base64'))
+  await testInfo.attach(name, { body: Buffer.from(base64, 'base64'), contentType: 'image/png' })
+}
+
+for (const theme of ['openTubeXLight', 'openTubeXDark']) {
+  for (const scale of [100, 125]) {
+    test.describe(`${theme} continuous backgrounds at ${scale}%`, () => {
+      test.use({
+        seed: {
+          settings: {
+            baseTheme: theme,
+            uiScale: scale,
+            currentLocale: 'en-US',
+            fetchSubscriptionsAutomatically: false,
+            showNewSubscriptionFeed: true,
+            scrollMiniPlayerEnabled: false,
+            videoPlaybackEngine: 'built-in',
+            ytDlpPlaybackEngineDefaultMigration: true
+          }
+        }
+      })
+
+      test('subscription category tabs blend into their card', async ({ app, page }, testInfo) => {
+        await goTo(page, 'subscriptions')
+        await page.locator('[data-subscription-feed-tab="all"]').click()
+        await page.getByRole('button', { name: 'Show tabbed view' }).click()
+        const header = page.locator('.subscriptionsHeader')
+        await expect(header.locator('.newFeedTabs')).toBeVisible()
+        const height = await header.evaluate(element => element.getBoundingClientRect().height)
+        // Sample the empty gutter on both sides of the header's bottom edge.
+        await expectContinuousBackground(app, header, [[5, height - 4], [5, height + 4]])
+        await attachThemeScreenshot(app, testInfo, `${theme} subscription header at ${scale}%`)
+      })
+
+      test('description controls and fades blend into their card', async ({ app, page }, testInfo) => {
+        await mockPlayableWatchPage(app, page)
+        await openMockedVideo(page)
+        const view = await watchViewHandle(page)
+        await view.evaluate(async component => {
+          component.isLoading = true
+          await component.$nextTick()
+          component.videoDescription = Array(30).fill('A short description line.').join('\n')
+          component.videoDescriptionHtml = ''
+          component.videoTags = []
+          component.isLoading = false
+          await component.$nextTick()
+        })
+        // Remounting updates the description's initial state and restarts the
+        // player. Let its startup scroll finish before sampling the card.
+        await waitForPlayback(page)
+        await page.locator('.ftVideoPlayer video').evaluate(video => video.pause())
+        const card = page.locator('.videoDescription')
+        await expect(card.locator('.description')).toContainText('A short description line.')
+        const expand = card.locator(':scope > .descriptionStatus')
+        for (const direction of ['ltr', 'rtl']) {
+          await card.evaluate((element, direction) => { element.dir = direction }, direction)
+          const width = await expand.evaluate(element => element.getBoundingClientRect().width)
+          // The fixture text leaves the fade and control padding clear.
+          const points = direction === 'ltr'
+            ? [[-36, 1], [-10, 1], [width / 2, 1], [width + 5, 1]]
+            : [[-5, 1], [width / 2, 1], [width + 10, 1], [width + 36, 1]]
+          await expectDescriptionBackground(app, expand, points)
+        }
+        await card.evaluate(element => { element.dir = 'ltr' })
+        await expand.click()
+        const footer = card.locator('.descriptionStatus')
+        await footer.scrollIntoViewIfNeeded()
+        const { width, height } = await footer.evaluate(element => {
+          const { width, height } = element.getBoundingClientRect()
+          return { width, height }
+        })
+        // Empty space next to Show less, through its fade and into card padding.
+        await expectDescriptionBackground(app, footer, [
+          [width - 60, -26], [width - 60, -12], [width - 60, height / 2], [width - 60, height + 5]
+        ])
+        await attachThemeScreenshot(app, testInfo, `${theme} description footer at ${scale}%`)
+      })
+
+      test('other feed headers and channel panels blend into their cards', async ({ app, page }, testInfo) => {
+        await page.evaluate(async () => {
+          const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+          await store.dispatch('updateBackendPreference', 'invidious')
+          await store.dispatch('updateDefaultInvidiousInstance', 'https://invidious.test')
+        })
+        await page.route('https://invidious.test/api/v1/popular/**', route => route.fulfill({ json: [] }))
+        await page.route('https://invidious.test/api/v1/trending/**', route => route.fulfill({ json: [] }))
+        for (const route of ['popular', 'trending']) {
+          const tab = await page.evaluate(route => window.ftElectron.tabs.create({
+            route: `/${route}`, makeActive: false
+          }), route)
+          await page.locator(`.tab[data-tab-id="${tab.id}"]`).click()
+          const header = page.locator(`.${route}Page .pageHeader`)
+          const height = await header.evaluate(element => element.getBoundingClientRect().height)
+          // Skip the intentional one-pixel separator.
+          await expectContinuousBackground(app, header, [[5, height - 4], [5, height + 4]])
+        }
+
+        const channelId = 'UCaaaaaaaaaaaaaaaaaaaaaa'
+        await page.route('https://invidious.test/api/v1/channels/**', route => route.fulfill({
+          json: {
+            author: 'Theme test channel',
+            authorId: channelId,
+            authorThumbnails: [],
+            authorBanners: [],
+            isFamilyFriendly: true,
+            subCount: 100,
+            description: 'A channel description.',
+            totalViews: 1000,
+            joined: 1000000000,
+            relatedChannels: [],
+            tabs: ['about']
+          }
+        }))
+        const tab = await page.evaluate(id => window.ftElectron.tabs.create({
+          route: `/channel/${id}/about`, makeActive: false
+        }), channelId)
+        await page.locator(`.tab[data-tab-id="${tab.id}"]`).click()
+        const info = page.locator('.channelDetails .infoContainer')
+        await expect(page.locator('#aboutPanel')).toBeVisible()
+        const infoWidth = await info.evaluate(element => element.getBoundingClientRect().width)
+        await expectContinuousBackground(app, info, [[infoWidth - 60, -4], [infoWidth - 60, 4]])
+        const about = page.locator('#aboutPanel')
+        const aboutWidth = await about.evaluate(element => element.getBoundingClientRect().width)
+        await expectContinuousBackground(app, about, [[aboutWidth - 5, 40], [aboutWidth + 5, 40]])
+        await attachThemeScreenshot(app, testInfo, `${theme} channel panels at ${scale}%`)
+      })
+    })
+  }
+}

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -3208,13 +3208,13 @@ test.describe('watch page', () => {
       const style = getComputedStyle(element)
       const fadeStyle = getComputedStyle(element, '::before')
       return {
-        fadeBackground: fadeStyle.backgroundImage,
+        fadeMask: fadeStyle.maskImage,
         fadeHeight: Number.parseFloat(fadeStyle.height),
         fontSize: Number.parseFloat(style.fontSize),
         marginBlockStart: Number.parseFloat(style.marginBlockStart)
       }
     })
-    expect(collapseControlStyles.fadeBackground).toContain('linear-gradient')
+    expect(collapseControlStyles.fadeMask).toContain('linear-gradient')
     expect(collapseControlStyles.fadeHeight).toBeGreaterThan(0)
     expect(collapseControlStyles.marginBlockStart).toBeGreaterThan(collapseControlStyles.fontSize)
     const maxScrollTop = await descriptionScroll.evaluate(element =>

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -737,7 +737,6 @@ test('repeats an A-B range and manages it from the player menu', async ({ app, p
   await expect(player.locator('.abRepeatRange')).toHaveCount(0)
   const abRepeatPopup = player.locator('.valueChangePopup')
   await expect(abRepeatPopup.locator('.valueChangeCustomIcon')).toBeVisible()
-  await expect(abRepeatPopup).toHaveCSS('white-space', 'nowrap')
   await expect.poll(() => abRepeatPopup.locator(':scope > span:last-child').evaluate((element) => {
     const range = document.createRange()
     range.selectNodeContents(element)

--- a/src/renderer/components/ChannelAbout/ChannelAbout.css
+++ b/src/renderer/components/ChannelAbout/ChannelAbout.css
@@ -1,5 +1,7 @@
 .about {
   background-color: var(--card-bg-color);
+  background-image: var(--card-bg-image);
+  background-attachment: fixed;
   backdrop-filter: var(--card-bg-blur, none);
   margin-block-start: 0;
   padding: 10px;

--- a/src/renderer/components/ChannelDetails/ChannelDetails.css
+++ b/src/renderer/components/ChannelDetails/ChannelDetails.css
@@ -17,6 +17,8 @@
 .infoContainer {
   position: relative;
   background-color: var(--card-bg-color);
+  background-image: var(--card-bg-image);
+  background-attachment: fixed;
   backdrop-filter: var(--card-bg-blur, none);
   border-radius: 0 0 calc(8px * var(--ui-roundness)) calc(8px * var(--ui-roundness));
   margin-block-start: 10px;

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
@@ -71,13 +71,20 @@
   cursor: pointer;
 }
 
+.descriptionStatus,
+.descriptionStatus::before {
+  /* Match the card at the same viewport position, including its theme gradient. */
+  background-color: var(--card-bg-color);
+  background-image: var(--card-bg-image);
+  background-attachment: fixed;
+}
+
 .videoDescription.short .descriptionStatus {
   position: absolute;
   z-index: 1;
   inset-block-end: calc(1lh + 12px);
   padding-block: 2px;
   inset-inline-end: 16px;
-  background-color: var(--card-bg-color);
   backdrop-filter: var(--card-bg-blur, none);
   text-decoration: none;
 }
@@ -91,7 +98,7 @@
   inset-block: 0;
   inset-inline-end: 100%;
   inline-size: 40px;
-  background: linear-gradient(90deg, transparent, var(--card-bg-color));
+  mask-image: linear-gradient(90deg, transparent, #000);
   content: '';
 }
 
@@ -101,7 +108,6 @@
   z-index: 1;
   inset-block-end: 0;
   margin-block-start: 1.5em;
-  background-color: var(--card-bg-color);
   backdrop-filter: var(--card-bg-blur, none);
 }
 
@@ -110,13 +116,13 @@
   inset-block-end: 100%;
   inset-inline: 0;
   block-size: 1.5em;
-  background: linear-gradient(transparent, var(--card-bg-color));
+  mask-image: linear-gradient(transparent, #000);
   pointer-events: none;
   content: '';
 }
 
 .videoDescription.short .descriptionStatus:dir(rtl)::before {
-  background: linear-gradient(270deg, transparent, var(--card-bg-color));
+  mask-image: linear-gradient(270deg, transparent, #000);
 }
 
 .videoDescription.short .description {

--- a/src/renderer/views/Popular/Popular.css
+++ b/src/renderer/views/Popular/Popular.css
@@ -24,6 +24,8 @@
   border-start-start-radius: calc(8px * var(--ui-roundness));
   border-start-end-radius: calc(8px * var(--ui-roundness));
   background-color: var(--card-bg-color);
+  background-image: var(--card-bg-image);
+  background-attachment: fixed;
   backdrop-filter: var(--card-bg-blur, none);
   box-shadow: 0 1px 0 var(--primary-shadow-color);
 }

--- a/src/renderer/views/Subscriptions/Subscriptions.css
+++ b/src/renderer/views/Subscriptions/Subscriptions.css
@@ -25,6 +25,8 @@
   border-start-start-radius: calc(8px * var(--ui-roundness));
   border-start-end-radius: calc(8px * var(--ui-roundness));
   background-color: var(--card-bg-color);
+  background-image: var(--card-bg-image);
+  background-attachment: fixed;
   backdrop-filter: var(--card-bg-blur, none);
   box-shadow: 0 1px 0 var(--primary-shadow-color);
 }

--- a/src/renderer/views/Trending/Trending.css
+++ b/src/renderer/views/Trending/Trending.css
@@ -24,6 +24,8 @@
   border-start-start-radius: calc(8px * var(--ui-roundness));
   border-start-end-radius: calc(8px * var(--ui-roundness));
   background-color: var(--card-bg-color);
+  background-image: var(--card-bg-image);
+  background-attachment: fixed;
   backdrop-filter: var(--card-bg-blur, none);
   box-shadow: 0 1px 0 var(--primary-shadow-color);
 }


### PR DESCRIPTION
The new OpenTubeX themes show hard background seams under feed headers and beside the description controls. This makes those areas follow the card gradient.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Reported directly by Nico. Follows the OpenTubeX themes added in #1144.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Description controls, their fades, and the Subscriptions, Trending, Most Popular, and channel panels now paint the same viewport-aligned gradient as their cards. Description fades use a mask so they preserve the theme background.

Also removes an obsolete A–B repeat test assertion after #1201 made player popups wrap when needed. The test still checks that the short repeat label renders on one line.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Select OpenTubeX Light or OpenTubeX Dark in Appearance settings.
2. Open Subscriptions, choose New, and switch to the tabbed view. The background should continue beneath the category tabs without a flat-colored strip.
3. Open a video with a long description. Check Show more, expand it, and scroll through the description. The fade and Show less should blend into the card while keeping clipped text hidden.
4. Check Trending, Most Popular, and a channel's details and About panel for matching backgrounds. Repeat at 125% UI scale and with the other OpenTubeX theme.

## Additional context
<!-- Add any other context about the pull request here. -->
The affected themes were added after the latest stable release, so this is marked Not noteworthy.

Description fade after the fix:

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/4ec77df9-f91e-4269-b6d9-e50caacdfab6">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/bf340738-b249-49bb-9644-ae8de5ec2c1b">
  <img alt="Description fade blends into the OpenTubeX theme background" src="https://github.com/user-attachments/assets/4ec77df9-f91e-4269-b6d9-e50caacdfab6">
</picture>

Prepared with GPT-6 in Codex.
