### PR TITLE
fix: make phone thumbnail grids resize from two columns to full width

### DIFF
--- a/e2e/tests/offline/phone-shorts-thumbnail-size.spec.mjs
+++ b/e2e/tests/offline/phone-shorts-thumbnail-size.spec.mjs
@@ -1,0 +1,105 @@
+import { test, expect, goTo } from '../../helpers/app.mjs'
+
+const now = Date.now()
+const CHANNEL_ID = 'UCaaaaaaaaaaaaaaaaaaaaaa'
+const shorts = Array.from({ length: 8 }, (_, index) => ({
+  videoId: `short${String(index).padStart(6, '0')}`,
+  title: `Phone short ${index}`,
+  author: 'Channel A',
+  authorId: CHANNEL_ID,
+  published: now - index * 3600000,
+  viewCount: 1000,
+  lengthSeconds: 30,
+  liveNow: false,
+  isUpcoming: false,
+  type: 'video'
+}))
+
+for (const listType of ['grid', 'list']) {
+  test.describe(`phone Shorts with ${listType} display preference`, () => {
+    test.use({
+      seed: {
+        settings: {
+          fetchSubscriptionsAutomatically: false,
+          hideSubscriptionsShorts: false,
+          useCustomShortsPlayer: true,
+          thumbnailSize: 100,
+          listType
+        },
+        profiles: [{
+          _id: 'allChannels',
+          name: 'All Channels',
+          bgColor: '#000000',
+          textColor: '#FFFFFF',
+          subscriptions: [{ id: CHANNEL_ID, name: 'Channel A', thumbnail: '' }]
+        }],
+        subscriptionCache: [{
+          _id: CHANNEL_ID,
+          videos: [],
+          videosTimestamp: new Date(now).toISOString(),
+          shorts,
+          shortsTimestamp: new Date(now).toISOString()
+        }]
+      }
+    })
+
+    test('scales portrait cards distinctly and stops at full width', async ({ app, page }) => {
+      await app.electronApp.evaluate(({ BrowserWindow }) => {
+        const window = BrowserWindow.getAllWindows()[0]
+        window.setMinimumSize(0, 0)
+        window.setContentSize(412, 900)
+      })
+      await goTo(page, 'subscriptions')
+      await page.locator('[data-subscription-feed-tab="shorts"]').click()
+      const grid = page.locator('.autoGrid.youtubeStyleShorts')
+      await expect(grid.locator('.ft-list-video.youtubeShort').first()).toBeVisible()
+      const columns = () => grid.evaluate(element => getComputedStyle(element).gridTemplateColumns.split(' ').length)
+      const cardWidth = () => grid.locator(':scope > *').first().evaluate(element => element.getBoundingClientRect().width)
+      const gridWidth = await grid.evaluate(element => element.getBoundingClientRect().width)
+
+      await page.locator('.profileTrigger').click()
+      const slider = page.locator('.thumbnailSizeSlider .input')
+      await expect(slider).toHaveAttribute('max', '110')
+      await expect.poll(columns).toBe(2)
+      const defaultWidth = await cardWidth()
+      for (let size = 60; size <= 110; size += 10) {
+        await slider.evaluate((element, value) => {
+          element.value = String(value)
+          element.dispatchEvent(new Event('input', { bubbles: true }))
+          element.dispatchEvent(new Event('change', { bubbles: true }))
+        }, size)
+        await expect.poll(cardWidth).toBeCloseTo(size === 110 ? gridWidth : defaultWidth * size / 100, 0)
+        expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true)
+      }
+      await expect.poll(columns).toBe(1)
+
+      if (listType === 'list') {
+        await page.locator('.profileTrigger').click()
+        await page.locator('[data-subscription-feed-tab="videos"]').click()
+        await page.locator('.profileTrigger').click()
+        await expect(slider).toHaveAttribute('max', '180')
+      }
+    })
+
+    if (listType === 'grid') {
+      test('updates a constrained grid when the viewport crosses the phone breakpoint', async ({ app, page }) => {
+        await goTo(page, 'subscriptions')
+        await page.locator('[data-subscription-feed-tab="shorts"]').click()
+        const grid = page.locator('.autoGrid.youtubeStyleShorts')
+        await expect(grid.locator('.ft-list-video.youtubeShort').first()).toBeVisible()
+        await grid.evaluate(element => { element.style.inlineSize = '300px' })
+        const columns = () => grid.evaluate(element => getComputedStyle(element).gridTemplateColumns.split(' ').length)
+        await expect.poll(() => grid.evaluate(element => element.getBoundingClientRect().width)).toBe(300)
+        await expect.poll(columns).toBe(1)
+
+        await app.electronApp.evaluate(({ BrowserWindow }) => {
+          const window = BrowserWindow.getAllWindows()[0]
+          window.setMinimumSize(0, 0)
+          window.setContentSize(650, 900)
+        })
+        await expect.poll(() => grid.evaluate(element => element.getBoundingClientRect().width)).toBe(300)
+        await expect.poll(columns).toBe(2)
+      })
+    }
+  })
+}

--- a/e2e/tests/offline/thumbnail-size-slider.spec.mjs
+++ b/e2e/tests/offline/thumbnail-size-slider.spec.mjs
@@ -1,4 +1,4 @@
-import { test, expect, goTo } from '../../helpers/app.mjs'
+import { test, expect, goTo, goToSettingsSection } from '../../helpers/app.mjs'
 
 const now = Date.now()
 const CHANNEL_ID = 'UCaaaaaaaaaaaaaaaaaaaaaa'
@@ -62,6 +62,139 @@ async function dragSlider(page, values) {
 }
 
 test.describe('thumbnail size slider', () => {
+  for (const [width, uiScale] of [[375, 100], [412, 100], [375, 125], [412, 125]]) {
+    test(`fits thumbnails to a ${width}px window at ${uiScale}% UI scale`, async ({ app, page }) => {
+      await app.electronApp.evaluate(({ BrowserWindow }, { width, uiScale }) => {
+        const window = BrowserWindow.getAllWindows()[0]
+        window.setMinimumSize(0, 0)
+        window.webContents.setZoomFactor(uiScale / 100)
+        window.setContentSize(Math.round(width * uiScale / 100), 900)
+      }, { width, uiScale })
+      await goTo(page, 'subscriptions')
+      await expect(page.getByText('Feed video 00')).toBeVisible()
+      const grid = page.locator('.autoGrid')
+      const columns = () => grid.evaluate(element => getComputedStyle(element).gridTemplateColumns.split(' ').length)
+      await expect.poll(columns).toBe(2)
+      const cardWidth = () => grid.locator(':scope > *').first().evaluate(element => element.getBoundingClientRect().width)
+      const defaultWidth = await cardWidth()
+
+      await page.locator('.profileTrigger').click()
+      await expect(page.locator('.thumbnailSizeSlider')).toBeVisible()
+      await expect(page.locator('.thumbnailSizeSlider .input')).toHaveAttribute('max', '110')
+      let previousWidth = 0
+      for (let size = 60; size <= 100; size += 10) {
+        await dragSlider(page, [size])
+        await expect.poll(cardWidth).toBeCloseTo(defaultWidth * size / 100, 0)
+        const currentWidth = await cardWidth()
+        expect(currentWidth).toBeGreaterThan(previousWidth)
+        previousWidth = currentWidth
+        expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true)
+      }
+      await dragSlider(page, [110])
+      await expect.poll(columns).toBe(1)
+      const gridWidth = await grid.evaluate(element => element.getBoundingClientRect().width)
+      await expect.poll(cardWidth).toBeCloseTo(gridWidth, 0)
+
+      await dragSlider(page, [100])
+      await expect.poll(columns).toBe(2)
+      const cards = await grid.locator(':scope > *').evaluateAll(elements => elements.slice(0, 2).map(element => {
+        const { x, y, width } = element.getBoundingClientRect()
+        return { x, y, width }
+      }))
+      expect(cards[0].y).toBeCloseTo(cards[1].y, 0)
+      expect(cards[1].x).toBeGreaterThan(cards[0].x + cards[0].width)
+
+      if (width === 412 && uiScale === 100) {
+        const slider = page.locator('.thumbnailSizeSlider .input')
+        const resize = width => app.electronApp.evaluate(({ BrowserWindow }, width) => {
+          BrowserWindow.getAllWindows()[0].setContentSize(width, 900)
+        }, width)
+        await resize(1000)
+        await expect(slider).toHaveAttribute('max', '180')
+        await dragSlider(page, [180])
+        await resize(412)
+        await expect(slider).toHaveAttribute('max', '110')
+        await expect(slider).toHaveValue('110')
+        await expect.poll(cardWidth).toBeCloseTo(gridWidth, 0)
+        await resize(1000)
+        await expect(slider).toHaveValue('180')
+        await resize(412)
+        await page.locator('.profileTrigger').click()
+
+        await goToSettingsSection(page, 'theme')
+        await expect(page.getByRole('slider', { name: 'Thumbnail Size' })).toHaveAttribute('max', '110')
+        await expect(page.getByRole('slider', { name: 'Thumbnail Size' })).toHaveValue('110')
+      }
+    })
+  }
+
+  for (const uiScale of [100, 125]) {
+    for (const trigger of [100, 60, 'wider viewport']) {
+      test(`clamps the bottom after changing to ${trigger} at ${uiScale}% UI scale`, async ({ app, page }) => {
+        const resize = width => app.electronApp.evaluate(({ BrowserWindow }, { width, uiScale }) => {
+          const window = BrowserWindow.getAllWindows()[0]
+          window.setMinimumSize(0, 0)
+          window.webContents.setZoomFactor(uiScale / 100)
+          window.setContentSize(Math.round(width * uiScale / 100), 900)
+        }, { width, uiScale })
+        const setSize = size => page.evaluate(value => {
+          const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+          store.commit('setThumbnailSize', value)
+        }, size)
+        const scrollState = () => page.evaluate(() => {
+          const root = document.documentElement
+          const scrollbar = document.querySelector('body > .os-scrollbar-vertical')
+          const track = scrollbar.querySelector('.os-scrollbar-track').getBoundingClientRect()
+          const handleElement = scrollbar.querySelector('.os-scrollbar-handle')
+          const handle = handleElement.getBoundingClientRect()
+          const minHandleHeight = Number.parseFloat(getComputedStyle(handleElement).minHeight) || 0
+          const card = document.querySelector('.subscriptionsPage .card')
+          const route = document.querySelector('.app > .routerView')
+          const contentBottom = card.getBoundingClientRect().bottom
+          const bottomMargin = Number.parseFloat(getComputedStyle(card).marginBottom) +
+            Math.max(0, Number.parseFloat(getComputedStyle(route).marginBottom))
+          return {
+            height: root.scrollHeight,
+            offset: window.scrollY,
+            bottomDistance: root.scrollHeight - root.clientHeight - window.scrollY,
+            contentBottomError: Math.abs(root.clientHeight - contentBottom - bottomMargin),
+            thumbBottomDistance: track.bottom - handle.bottom,
+            thumbHeightError: Math.abs(handle.height - Math.max(minHandleHeight, track.height * root.clientHeight / root.scrollHeight)),
+            scrollbarVisible: scrollbar.classList.contains('os-scrollbar-visible')
+          }
+        })
+
+        await resize(412)
+        await goTo(page, 'subscriptions')
+        await expect(page.getByText('Feed video 00')).toBeVisible()
+        await page.evaluate(() => document.fonts.ready)
+        await setSize(110)
+        await expect.poll(() => page.locator('.autoGrid').evaluate(element => getComputedStyle(element).gridTemplateColumns.split(' ').length)).toBe(1)
+        await expect.poll(async () => {
+          await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight))
+          return Math.abs((await scrollState()).bottomDistance)
+        }).toBeLessThanOrEqual(1)
+        const before = await scrollState()
+        expect(before.offset).toBeGreaterThan(0)
+
+        if (trigger === 'wider viewport') {
+          await resize(1000)
+        } else {
+          await setSize(trigger)
+        }
+
+        await expect.poll(async () => (await scrollState()).height).toBeLessThan(before.height)
+        await expect.poll(async () => Math.abs((await scrollState()).bottomDistance)).toBeLessThanOrEqual(1)
+        // Include the desktop route's bottom margin as well as the card's;
+        // the phone route has a negative margin and adds no bottom space.
+        await expect.poll(async () => (await scrollState()).contentBottomError).toBeLessThanOrEqual(1)
+        await expect.poll(async () => Math.abs((await scrollState()).thumbBottomDistance)).toBeLessThanOrEqual(1)
+        await expect.poll(async () => (await scrollState()).thumbHeightError).toBeLessThanOrEqual(1)
+        expect((await scrollState()).scrollbarVisible).toBe(true)
+      })
+    }
+  }
+
   test('resizes the feed without re-measuring every card', async ({ page, attachScreenshot }) => {
     await goTo(page, 'subscriptions')
     await expect(page.getByText('Feed video 00')).toBeVisible()

--- a/src/renderer/components/FtAutoGrid/FtAutoGrid.css
+++ b/src/renderer/components/FtAutoGrid/FtAutoGrid.css
@@ -21,6 +21,13 @@
   justify-content: start;
 }
 
+@media (width <= 680px) {
+  .grid.youtubeStyleShorts.thumbnailSizeReady {
+    grid-template-columns: repeat(auto-fill, min(var(--thumbnail-grid-size), 100%));
+    justify-content: space-evenly;
+  }
+}
+
 .list {
   display: grid;
   gap: 4px;

--- a/src/renderer/components/FtAutoGrid/FtAutoGrid.vue
+++ b/src/renderer/components/FtAutoGrid/FtAutoGrid.vue
@@ -20,11 +20,12 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue'
+import { computed, onActivated, onBeforeUnmount, onDeactivated, onMounted, ref, useTemplateRef, watch } from 'vue'
 
 import store from '../../store/index'
 
-import { getThumbnailGridStyles } from '../../constants/thumbnailSize'
+import { getThumbnailGridStyles, PHONE_THUMBNAIL_VIEWPORT_WIDTH } from '../../constants/thumbnailSize'
+import { setThumbnailGridVisible } from '../../composables/useThumbnailSizeSlider'
 import { getAnimationSpeedMultiplier } from '../../helpers/animationSpeed'
 import { measureStableGridWidth } from './gridWidth'
 
@@ -65,6 +66,22 @@ const feedTransitionDuration = computed(() => {
 // costs a layout pass over the whole feed. Dragging the thumbnail size slider
 // emits an event per step, which turned that into hundreds of forced layouts.
 let gridWidth = 0
+let active = true
+
+function updateGridSliderLimit() {
+  const element = gridElement.value?.$el
+  if (element) setThumbnailGridVisible(element, active && props.grid && gridWidth > 0)
+}
+
+watch(() => props.grid, updateGridSliderLimit)
+onActivated(() => {
+  active = true
+  updateGridSliderLimit()
+})
+onDeactivated(() => {
+  active = false
+  updateGridSliderLimit()
+})
 
 // Only whether the width is known needs to reach the template, and that flips
 // just once, right after mount.
@@ -104,7 +121,7 @@ function applyThumbnailSizeStyles() {
     return
   }
 
-  const styles = getThumbnailGridStyles(store.getters.getThumbnailSize, gridWidth)
+  const styles = getThumbnailGridStyles(store.getters.getThumbnailSize, gridWidth, window.innerWidth)
 
   for (const [property, value] of Object.entries(styles)) {
     element.style.setProperty(property, value)
@@ -131,10 +148,13 @@ function captureLeavingItemLayout(element) {
 }
 
 let resizeObserver = null
+let phoneWidthQuery = null
 let observedScrollbarWidth = 0
 let observedViewportWidth = null
 
 onMounted(() => {
+  phoneWidthQuery = window.matchMedia(`(width <= ${PHONE_THUMBNAIL_VIEWPORT_WIDTH}px)`)
+  phoneWidthQuery.addEventListener('change', applyThumbnailSizeStyles)
   reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
   prefersReducedMotion.value = reducedMotionQuery.matches
   reducedMotionQuery.addEventListener('change', handleReducedMotionChange)
@@ -161,6 +181,7 @@ onMounted(() => {
       }, 100)
 
       gridWidth = measurement.gridWidth
+      updateGridSliderLimit()
       applyThumbnailSizeStyles()
       thumbnailSizeReady.value = gridWidth > 0
     }
@@ -170,7 +191,10 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+  active = false
+  updateGridSliderLimit()
   resizeObserver?.disconnect()
+  phoneWidthQuery?.removeEventListener('change', applyThumbnailSizeStyles)
   reducedMotionQuery?.removeEventListener('change', handleReducedMotionChange)
   clearTimeout(suppressResetTimeout)
 })

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
@@ -233,7 +233,7 @@
                       :default-value="thumbnailSize"
                       setting-key="thumbnailSize"
                       :min-value="MIN_THUMBNAIL_SIZE"
-                      :max-value="MAX_THUMBNAIL_SIZE"
+                      :max-value="maxThumbnailSize"
                       :step="THUMBNAIL_SIZE_STEP"
                       value-extension="%"
                       @input="previewThumbnailSize"
@@ -407,8 +407,8 @@ import { localeTranslationPercentages } from '../../i18n/index'
 import { colors } from '../../helpers/colors'
 import { OPEN_COMMAND_PALETTE_EVENT } from '../../helpers/commandPalette'
 import { useColorTranslations } from '../../composables/colors'
+import { useThumbnailSizeSlider } from '../../composables/useThumbnailSizeSlider'
 import {
-  MAX_THUMBNAIL_SIZE,
   MIN_THUMBNAIL_SIZE,
   THUMBNAIL_SIZE_STEP
 } from '../../constants/thumbnailSize'
@@ -533,7 +533,7 @@ const mainColorAvailable = computed(() => (
   !usesFixedThemePalette.value
 ))
 const uiScale = computed(() => store.getters.getUiScale)
-const thumbnailSize = computed(() => store.getters.getThumbnailSize)
+const { thumbnailSize, maxThumbnailSize } = useThumbnailSizeSlider()
 const playNextVideo = computed(() => store.getters.getPlayNextVideo)
 const enableSubtitlesByDefault = computed(() => store.getters.getEnableSubtitlesByDefault)
 const listType = computed(() => store.getters.getListType)

--- a/src/renderer/components/FtSlider/FtSlider.vue
+++ b/src/renderer/components/FtSlider/FtSlider.vue
@@ -92,11 +92,12 @@ const FIGURE_SPACE = '\u2007'
 const id = useId()
 const currentValue = ref(props.defaultValue)
 
+// Apply new bounds before the value, or a range input clamps it to the old max.
 watch(() => props.defaultValue, (value) => {
   if (currentValue.value !== value) {
     currentValue.value = value
   }
-})
+}, { flush: 'post' })
 
 /**
  * @param {number} value

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -309,7 +309,7 @@
         :default-value="thumbnailSize"
         setting-key="thumbnailSize"
         :min-value="MIN_THUMBNAIL_SIZE"
-        :max-value="MAX_THUMBNAIL_SIZE"
+        :max-value="maxThumbnailSize"
         :step="THUMBNAIL_SIZE_STEP"
         value-extension="%"
         @input="previewThumbnailSize"
@@ -394,8 +394,8 @@ import { customThemeIdFromValue, customThemeValue } from '../../customTheme'
 
 import { colors } from '../helpers/colors'
 import { useColorTranslations } from '../composables/colors'
+import { useThumbnailSizeSlider } from '../composables/useThumbnailSizeSlider'
 import {
-  MAX_THUMBNAIL_SIZE,
   MIN_THUMBNAIL_SIZE,
   THUMBNAIL_SIZE_STEP
 } from '../constants/thumbnailSize'
@@ -895,8 +895,7 @@ function updateUiScale(value) {
   store.dispatch('updateUiScale', value)
 }
 
-/** @type {import('vue').ComputedRef<number>} */
-const thumbnailSize = computed(() => store.getters.getThumbnailSize)
+const { thumbnailSize, maxThumbnailSize } = useThumbnailSizeSlider()
 const uiRoundness = computed(() => store.getters.getUiRoundness)
 const scrollbarThumbWidth = computed(
   () => normalizeScrollbarThumbWidth(store.getters.getScrollbarThumbWidth)

--- a/src/renderer/composables/useThumbnailSizeSlider.js
+++ b/src/renderer/composables/useThumbnailSizeSlider.js
@@ -1,0 +1,34 @@
+import { computed, onBeforeUnmount, ref, shallowReactive } from 'vue'
+
+import store from '../store/index'
+import {
+  MAX_THUMBNAIL_SIZE,
+  PHONE_THUMBNAIL_MAX_SIZE,
+  PHONE_THUMBNAIL_VIEWPORT_WIDTH
+} from '../constants/thumbnailSize'
+
+const visibleGrids = shallowReactive(new Set())
+
+// Some views, including YouTube-style Shorts, force a grid even when the
+// global preference is list. Track rendered grids using their resize observer.
+export function setThumbnailGridVisible(element, visible) {
+  if (visible) visibleGrids.add(element)
+  else visibleGrids.delete(element)
+}
+
+export function useThumbnailSizeSlider() {
+  const query = window.matchMedia(`(width <= ${PHONE_THUMBNAIL_VIEWPORT_WIDTH}px)`)
+  const phoneWidth = ref(query.matches)
+  const updatePhoneWidth = () => { phoneWidth.value = query.matches }
+  query.addEventListener('change', updatePhoneWidth)
+  onBeforeUnmount(() => query.removeEventListener('change', updatePhoneWidth))
+
+  const maxThumbnailSize = computed(() => phoneWidth.value && (store.getters.getListType === 'grid' || visibleGrids.size > 0)
+    ? PHONE_THUMBNAIL_MAX_SIZE
+    : MAX_THUMBNAIL_SIZE)
+  // A size chosen in a wider window already renders full-width on a phone.
+  // Display that endpoint without overwriting the saved desktop preference.
+  const thumbnailSize = computed(() => Math.min(store.getters.getThumbnailSize, maxThumbnailSize.value))
+
+  return { thumbnailSize, maxThumbnailSize }
+}

--- a/src/renderer/constants/thumbnailSize.js
+++ b/src/renderer/constants/thumbnailSize.js
@@ -2,18 +2,22 @@ export const DEFAULT_THUMBNAIL_SIZE = 100
 export const MIN_THUMBNAIL_SIZE = 60
 export const MAX_THUMBNAIL_SIZE = 180
 export const THUMBNAIL_SIZE_STEP = 10
+export const PHONE_THUMBNAIL_MAX_SIZE = 110
+export const PHONE_THUMBNAIL_VIEWPORT_WIDTH = 680
 
 const DEFAULT_GRID_ITEM_SIZE = 262
 const DEFAULT_SHORTS_GRID_ITEM_MIN_SIZE = 190
 const GRID_GAP = 8
 
-function getDefaultGridItemSize(gridWidth) {
+function getDefaultGridItemSize(gridWidth, viewportWidth) {
   if (gridWidth <= 0) {
     return DEFAULT_GRID_ITEM_SIZE
   }
 
+  // Start with two columns on phones, then scale the resulting card width
+  // directly so every thumbnail slider step visibly changes its size.
   const columnCount = Math.max(
-    1,
+    viewportWidth <= PHONE_THUMBNAIL_VIEWPORT_WIDTH ? 2 : 1,
     Math.floor((gridWidth + GRID_GAP) / (DEFAULT_GRID_ITEM_SIZE + GRID_GAP))
   )
 
@@ -25,14 +29,17 @@ function getDefaultGridItemSize(gridWidth) {
  * set on each grid element.
  * @param {number} thumbnailSize
  * @param {number} [gridWidth]
+ * @param {number} [viewportWidth]
  */
-export function getThumbnailGridStyles(thumbnailSize, gridWidth = 0) {
+export function getThumbnailGridStyles(thumbnailSize, gridWidth = 0, viewportWidth = gridWidth) {
   const scale = thumbnailSize / DEFAULT_THUMBNAIL_SIZE
-  const defaultGridItemSize = getDefaultGridItemSize(gridWidth)
+  const defaultGridItemSize = getDefaultGridItemSize(gridWidth, viewportWidth)
+  const fullWidth = gridWidth > 0 && viewportWidth <= PHONE_THUMBNAIL_VIEWPORT_WIDTH &&
+    thumbnailSize > DEFAULT_THUMBNAIL_SIZE
 
   return {
-    '--thumbnail-grid-size': `${defaultGridItemSize * scale}px`,
-    '--shorts-thumbnail-grid-min-size': `${DEFAULT_SHORTS_GRID_ITEM_MIN_SIZE * scale}px`
+    '--thumbnail-grid-size': `${fullWidth ? gridWidth : defaultGridItemSize * scale}px`,
+    '--shorts-thumbnail-grid-min-size': `${fullWidth ? gridWidth : DEFAULT_SHORTS_GRID_ITEM_MIN_SIZE * scale}px`
   }
 }
 

--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -489,6 +489,7 @@ $watched-transition-duration: 0.5s;
     block-size: 100%;
 
     .info {
+      grid-template-columns: minmax(0, 1fr) auto;
       min-inline-size: 0;
     }
 

--- a/tests/unit/thumbnail-size.test.mjs
+++ b/tests/unit/thumbnail-size.test.mjs
@@ -6,6 +6,48 @@ import {
   getThumbnailListStyles
 } from '../../src/renderer/constants/thumbnailSize.js'
 
+test('phone grids fit two columns at the default thumbnail size', () => {
+  for (const width of [240, 313, 343, 380, 428.8]) {
+    const size = Number.parseFloat(getThumbnailGridStyles(100, width)['--thumbnail-grid-size'])
+    assert.equal(size * 2 + 8, width)
+  }
+})
+
+test('every phone thumbnail slider step changes the card width proportionally', () => {
+  for (const width of [313, 343, 380, 428.8]) {
+    const defaultSize = (width - 8) / 2
+    let previousSize = 0
+    for (let size = 60; size <= 100; size += 10) {
+      const cardSize = Number.parseFloat(getThumbnailGridStyles(size, width)['--thumbnail-grid-size'])
+      assert.equal(cardSize, defaultSize * (size / 100))
+      assert.ok(cardSize > previousSize)
+      assert.ok(cardSize < width)
+      previousSize = cardSize
+    }
+  }
+})
+
+test('phone grids fill the row above 100% and stop growing at full width', () => {
+  for (const width of [313, 343, 428.8, 640]) {
+    for (const size of [110, 140, 180]) {
+      assert.equal(getThumbnailGridStyles(size, width)['--thumbnail-grid-size'], `${width}px`)
+    }
+  }
+})
+
+test('desktop grids retain proportional thumbnail sizing', () => {
+  for (const width of [532, 800, 1200]) {
+    const defaultSize = Number.parseFloat(getThumbnailGridStyles(100, width)['--thumbnail-grid-size'])
+    for (const size of [60, 180]) {
+      assert.equal(Number.parseFloat(getThumbnailGridStyles(size, width, 1200)['--thumbnail-grid-size']), defaultSize * (size / 100))
+    }
+  }
+})
+
+test('narrow grids in desktop viewports retain their full-width default', () => {
+  assert.equal(getThumbnailGridStyles(100, 450, 900)['--thumbnail-grid-size'], '450px')
+})
+
 test('scales YouTube-style Shorts cards with the thumbnail size setting', () => {
   assert.equal(
     getThumbnailGridStyles(60)['--shorts-thumbnail-grid-min-size'],


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Reported during Pixel testing; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Reducing thumbnail size on phones could leave feeds in one column, with several slider values producing the same layout. Phone video and Shorts grids now show two columns at 100%, shrink progressively below it, and stop at a full-width 110%.

Larger synced desktop values remain saved. The phone displays them as 110% without changing the shared setting until the slider is edited. Desktop and regular list layouts retain their existing range.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Phone video and Shorts grids now show two columns at the default thumbnail size, with smaller cards and a full-width maximum.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/7a18997a-80fa-4255-aec1-2174f783fc05">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/96977014-3022-4376-8e75-89db9c709d52">
  <img alt="Phone thumbnail grid at 100% size" src="https://github.com/user-attachments/assets/7a18997a-80fa-4255-aec1-2174f783fc05">
</picture>

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. On a phone or narrow window, open Quick Settings or Theme Settings. Set thumbnail size to 100% for two columns, then try each smaller step and confirm the cards shrink. At 110%, one card fills the available width and the slider stops.
2. Open Shorts and repeat with both grid and list display preferences. Return to regular videos in list mode and confirm the slider allows 180%.
3. Sync a desktop thumbnail size above 110%. Confirm the phone displays a full-width grid at 110% while the saved desktop value remains unchanged. Widen a desktop window and confirm the larger value returns in the slider.
4. Scroll to the bottom of a feed, then decrease thumbnail size or widen the window. Confirm there is no obsolete empty space and the scrollbar matches the shorter content. Repeat at 125% UI scale.

## Additional context
<!-- Add any other context about the pull request here. -->

Implemented and reviewed with GPT-6 in Codex.
