### PR TITLE
fix(android): prevent screenshot picker crashes and settings overflow

### DIFF
--- a/android/app/src/androidTest/java/org/opentubex/app/AndroidFileExportTest.java
+++ b/android/app/src/androidTest/java/org/opentubex/app/AndroidFileExportTest.java
@@ -18,6 +18,7 @@ import org.json.JSONObject;
 import org.junit.Test;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -25,7 +26,53 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class AndroidFileExportTest {
     @Test
+    public void savesLargeScreenshotThroughDocumentPicker() throws Exception {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        String[] exportsBefore = stagedExports();
+        String filename = "screenshot-" + UUID.randomUUID() + ".png";
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            awaitValue(scenario, "typeof window.Capacitor === 'object' && document.readyState === 'complete'", "true");
+            // A video frame can easily exceed Android's activity-state transaction limit.
+            evaluate(scenario, "window.exportResult=null;window.screenshotData=btoa('frame'.repeat(300000));" +
+                "window.Capacitor.nativePromise('AndroidStorage','saveFile'," +
+                "{fileName:'" + filename + "',mimeType:'image/png',data:window.screenshotData})" +
+                ".then(function(result){window.exportResult=result;},function(error){window.exportResult={error:error.message};});");
+            awaitPicker();
+            // Leave time for the stopped activity's state to reach Android before saving.
+            Thread.sleep(2000);
+            clickPickerSave();
+            awaitValue(scenario, "window.exportResult !== null", "true");
+            JSONObject result = new JSONObject(new JSONArray("[" + evaluate(scenario, "JSON.stringify(window.exportResult)") + "]").getString(0));
+            assertTrue(result.toString(), result.optBoolean("saved"));
+            assertArrayEquals(exportsBefore, stagedExports());
+            Uri uri = Uri.parse(result.getString("uri"));
+            try {
+                try (InputStream input = context.getContentResolver().openInputStream(uri)) {
+                    assertArrayEquals("frame".repeat(300000).getBytes(StandardCharsets.UTF_8), YtDlpFiles.read(input, 2_000_000));
+                }
+            } finally {
+                DocumentsContract.deleteDocument(context.getContentResolver(), uri);
+            }
+        }
+    }
+
+    private static void clickPickerSave() throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        do {
+            android.view.accessibility.AccessibilityNodeInfo root = InstrumentationRegistry.getInstrumentation().getUiAutomation().getRootInActiveWindow();
+            if (root != null) {
+                for (android.view.accessibility.AccessibilityNodeInfo node : root.findAccessibilityNodeInfosByText("Save")) {
+                    if (node.isClickable() && node.isEnabled() && node.performAction(android.view.accessibility.AccessibilityNodeInfo.ACTION_CLICK)) return;
+                }
+            }
+            Thread.sleep(100);
+        } while (System.nanoTime() < deadline);
+        fail("Android's save button is available");
+    }
+
+    @Test
     public void overlappingPickersRejectWithoutLosingTheOriginalCallback() throws Exception {
+        String[] exportsBefore = stagedExports();
         try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
             awaitValue(scenario, "typeof window.Capacitor === 'object' && document.readyState === 'complete'", "true");
             for (String first : new String[]{"chooseDirectory", "saveFile"}) {
@@ -49,6 +96,7 @@ public class AndroidFileExportTest {
                     awaitValue(scenario, "window.firstPickerResult !== null", "true");
                     assertEquals(first.equals("saveFile") ? "{\"saved\":false}" : "{}",
                         evaluate(scenario, "window.firstPickerResult"));
+                    assertArrayEquals(exportsBefore, stagedExports());
                 }
             }
         }
@@ -119,6 +167,14 @@ public class AndroidFileExportTest {
 
     private static String encode(String value) {
         return Base64.encodeToString(value.getBytes(StandardCharsets.UTF_8), Base64.NO_WRAP);
+    }
+
+    private static String[] stagedExports() {
+        String[] names = InstrumentationRegistry.getInstrumentation().getTargetContext().getCacheDir()
+            .list((directory, name) -> name.startsWith("export-") && name.endsWith(".tmp"));
+        assertNotNull(names);
+        Arrays.sort(names);
+        return names;
     }
 
     private static JSONObject save(ActivityScenario<MainActivity> scenario, JSONObject options) throws Exception {

--- a/android/app/src/androidTest/java/org/opentubex/app/AndroidFileExportTest.java
+++ b/android/app/src/androidTest/java/org/opentubex/app/AndroidFileExportTest.java
@@ -44,6 +44,10 @@ public class AndroidFileExportTest {
             awaitValue(scenario, "window.exportResult !== null", "true");
             JSONObject result = new JSONObject(new JSONArray("[" + evaluate(scenario, "JSON.stringify(window.exportResult)") + "]").getString(0));
             assertTrue(result.toString(), result.optBoolean("saved"));
+            long cleanupDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+            while (!Arrays.equals(exportsBefore, stagedExports()) && System.nanoTime() < cleanupDeadline) {
+                Thread.sleep(20);
+            }
             assertArrayEquals(exportsBefore, stagedExports());
             Uri uri = Uri.parse(result.getString("uri"));
             try {

--- a/android/app/src/androidTest/java/org/opentubex/app/AndroidFileExportTest.java
+++ b/android/app/src/androidTest/java/org/opentubex/app/AndroidFileExportTest.java
@@ -65,7 +65,7 @@ public class AndroidFileExportTest {
         do {
             android.view.accessibility.AccessibilityNodeInfo root = InstrumentationRegistry.getInstrumentation().getUiAutomation().getRootInActiveWindow();
             if (root != null) {
-                for (android.view.accessibility.AccessibilityNodeInfo node : root.findAccessibilityNodeInfosByText("Save")) {
+                for (android.view.accessibility.AccessibilityNodeInfo node : root.findAccessibilityNodeInfosByViewId("android:id/button1")) {
                     if (node.isClickable() && node.isEnabled() && node.performAction(android.view.accessibility.AccessibilityNodeInfo.ACTION_CLICK)) return;
                 }
             }

--- a/android/app/src/main/java/org/opentubex/app/AndroidStoragePlugin.java
+++ b/android/app/src/main/java/org/opentubex/app/AndroidStoragePlugin.java
@@ -15,6 +15,8 @@ import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.annotation.ActivityCallback;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.concurrent.CountDownLatch;
@@ -65,24 +67,42 @@ public class AndroidStoragePlugin extends Plugin {
             writeExport(call, null);
             return;
         }
-        openPicker(call, new Intent(Intent.ACTION_CREATE_DOCUMENT)
-            .addCategory(Intent.CATEGORY_OPENABLE)
-            .setType(call.getString("mimeType", "application/octet-stream"))
-            .putExtra(Intent.EXTRA_TITLE, name), "fileChosen");
+        File staged = null;
+        try {
+            staged = File.createTempFile("export-", ".tmp", getContext().getCacheDir());
+            try (OutputStream output = new FileOutputStream(staged)) {
+                output.write(Base64.decode(call.getString("data"), Base64.DEFAULT));
+            }
+            // Capacitor persists the entire call when the picker stops our activity.
+            // Keep the bytes on disk so screenshots cannot exceed Binder's state limit.
+            call.getData().remove("data");
+            call.getData().put("stagedExport", staged.getName());
+            if (!openPicker(call, new Intent(Intent.ACTION_CREATE_DOCUMENT)
+                .addCategory(Intent.CATEGORY_OPENABLE)
+                .setType(call.getString("mimeType", "application/octet-stream"))
+                .putExtra(Intent.EXTRA_TITLE, name), "fileChosen")) {
+                staged.delete();
+            }
+        } catch (Exception error) {
+            if (staged != null) staged.delete();
+            call.reject("Unable to prepare export file", error);
+        }
     }
 
-    private void openPicker(PluginCall call, Intent intent, String callbackName) {
+    private boolean openPicker(PluginCall call, Intent intent, String callbackName) {
         // Capacitor keeps only one activity-result call per plugin, including across picker types.
         if (pickerOpen) {
             call.reject("A file or folder dialog is already open");
-            return;
+            return false;
         }
         pickerOpen = true;
         try {
             startActivityForResult(call, intent, callbackName);
+            return true;
         } catch (Exception error) {
             pickerOpen = false;
             call.reject("Unable to open file picker", error);
+            return false;
         }
     }
 
@@ -91,6 +111,7 @@ public class AndroidStoragePlugin extends Plugin {
         pickerOpen = false;
         if (call == null) return;
         if (result.getResultCode() != Activity.RESULT_OK || result.getData() == null || result.getData().getData() == null) {
+            stagedExport(call).delete();
             call.resolve(new JSObject().put("saved", false));
             return;
         }
@@ -100,8 +121,8 @@ public class AndroidStoragePlugin extends Plugin {
 
     private void writeExport(PluginCall call, Uri destination) {
         DocumentFile created = null;
+        File staged = destination == null ? null : stagedExport(call);
         try {
-            byte[] data = Base64.decode(call.getString("data"), Base64.DEFAULT);
             if (destination == null) {
                 DocumentFile directory = DocumentFile.fromTreeUri(getContext(), Uri.parse(call.getString("directory")));
                 if (directory == null || !directory.isDirectory() || !directory.canWrite()) {
@@ -113,7 +134,15 @@ public class AndroidStoragePlugin extends Plugin {
             }
             try (OutputStream output = getContext().getContentResolver().openOutputStream(destination, "wt")) {
                 if (output == null) throw new IOException("Unable to open export file");
-                output.write(data);
+                if (staged == null) {
+                    output.write(Base64.decode(call.getString("data"), Base64.DEFAULT));
+                } else {
+                    try (FileInputStream input = new FileInputStream(staged)) {
+                        byte[] buffer = new byte[8192];
+                        int length;
+                        while ((length = input.read(buffer)) != -1) output.write(buffer, 0, length);
+                    }
+                }
             }
             call.resolve(new JSObject().put("saved", true).put("uri", destination.toString()));
         } catch (Exception error) {
@@ -121,7 +150,13 @@ public class AndroidStoragePlugin extends Plugin {
                 try { created.delete(); } catch (Exception ignored) { /* Preserve the write error. */ }
             }
             call.reject("Unable to save file: " + error.getMessage(), error);
+        } finally {
+            if (staged != null) staged.delete();
         }
+    }
+
+    private File stagedExport(PluginCall call) {
+        return new File(getContext().getCacheDir(), call.getString("stagedExport"));
     }
 
     @PluginMethod

--- a/e2e/tests/offline/screenshot-settings.spec.mjs
+++ b/e2e/tests/offline/screenshot-settings.spec.mjs
@@ -1,0 +1,97 @@
+import { test, expect, goToSettingsSection, setWindowSize, updateInputWithoutScrolling } from '../../helpers/app.mjs'
+
+async function expectValidScrollRange(content) {
+  await expect.poll(() => content.evaluate(element => {
+    const section = element.querySelector(':scope > .section, :scope > .settingsSearchResults')
+    const end = section.getBoundingClientRect().bottom - element.getBoundingClientRect().top + element.scrollTop +
+      Number.parseFloat(getComputedStyle(element).paddingBottom)
+    return element.scrollTop - Math.max(0, end - element.clientHeight)
+  })).toBeLessThanOrEqual(1)
+  await content.evaluate(element => { element.scrollTop = element.scrollHeight })
+  await expect.poll(() => content.evaluate(element => {
+    const section = element.querySelector(':scope > .section, :scope > .settingsSearchResults')
+    const end = section.getBoundingClientRect().bottom - element.getBoundingClientRect().top + element.scrollTop +
+      Number.parseFloat(getComputedStyle(element).paddingBottom)
+    const maxScroll = Math.max(0, end - element.clientHeight)
+    const scrollbar = element.querySelector('.os-scrollbar-vertical')
+    if (maxScroll <= 1) return element.scrollTop <= 1 && scrollbar.classList.contains('os-scrollbar-unusable')
+    const track = scrollbar.querySelector('.os-scrollbar-track').getBoundingClientRect()
+    const handle = scrollbar.querySelector('.os-scrollbar-handle')
+    const thumb = handle.getBoundingClientRect()
+    const expectedHeight = Math.max(Number.parseFloat(getComputedStyle(handle).minHeight) || 0,
+      track.height * element.clientHeight / end)
+    return Math.abs(element.scrollTop - maxScroll) <= 1 &&
+      !scrollbar.classList.contains('os-scrollbar-unusable') &&
+      Math.abs(track.bottom - thumb.bottom) <= 1 && Math.abs(thumb.height - expectedHeight) <= 1
+  })).toBe(true)
+}
+
+for (const uiScale of [100, 125]) {
+  test.describe(`screenshot settings at ${uiScale}% UI scale`, () => {
+    test.use({ seed: { settings: { uiScale, enableScreenshot: true, screenshotMode: 'prompt_folder' } } })
+
+    test('clamps the bottom offset and updates the scrollbar when screenshot settings shorten', async ({ app, page }) => {
+      await setWindowSize(app, page, { width: 375, height: 850 })
+      await goToSettingsSection(page, 'playback')
+      const content = page.locator('.settingsContent')
+      const update = values => page.evaluate(async values => {
+        const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+        for (const [action, value] of Object.entries(values)) await store.dispatch(action, value)
+      }, values)
+      const scrollToBottom = async () => {
+        await content.evaluate(element => { element.scrollTop = element.scrollHeight })
+        await expect.poll(() => content.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+      }
+      for (const values of [
+        { updateScreenshotMode: 'prompt_folder' },
+        { updateScreenshotMode: 'clipboard' },
+        { updateEnableScreenshot: false },
+      ]) {
+        await update({ updateEnableScreenshot: true, updateScreenshotMode: 'default_folder' })
+        await expect(content.locator('.screenshotFolderPath')).toBeVisible()
+        await scrollToBottom()
+        const previousHeight = await content.locator(':scope > .section').evaluate(element => element.getBoundingClientRect().height)
+        await update(values)
+        await expect.poll(() => content.locator(':scope > .section').evaluate(element => element.getBoundingClientRect().height)).toBeLessThan(previousHeight)
+        await expectValidScrollRange(content)
+      }
+      await update({ updateEnableScreenshot: true, updateScreenshotMode: 'default_folder' })
+      await expect(content.locator('.screenshotFolderPath')).toBeVisible()
+      await scrollToBottom()
+      await setWindowSize(app, page, { width: 850, height: 900 })
+      await expectValidScrollRange(content)
+      await scrollToBottom()
+      await updateInputWithoutScrolling(page.getByPlaceholder('Search settings'), 'Screenshot')
+      await expect(content.locator('.settingsSearchResults')).toBeVisible()
+      await expectValidScrollRange(content)
+    })
+
+    test('keeps screenshot controls inside the settings viewport on narrow screens', async ({ app, page }, testInfo) => {
+      await setWindowSize(app, page, { width: 375, height: 850 })
+      await goToSettingsSection(page, 'playback')
+      const content = page.locator('.settingsContent')
+      const mode = content.locator('.select').filter({ hasText: 'Screenshot Mode' }).locator('select')
+      for (const value of ['prompt_folder', 'default_folder', 'clipboard', 'prompt_folder']) {
+        await mode.selectOption(value)
+        await expect.poll(() => content.evaluate(element => {
+          const viewport = element.querySelector('[data-overlayscrollbars-viewport]') ?? element
+          return viewport.scrollWidth - viewport.clientWidth
+        })).toBeLessThanOrEqual(1)
+        await expect(content.locator('.os-scrollbar-horizontal')).toHaveClass(/os-scrollbar-unusable/)
+      }
+      await content.locator('.screenshotFilenamePatternInput').scrollIntoViewIfNeeded()
+      await page.evaluate(() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve))))
+      // Capture the full Electron framebuffer, including at non-default zoom.
+      const screenshot = await app.electronApp.evaluate(async ({ BrowserWindow }) =>
+        (await BrowserWindow.getAllWindows()[0].webContents.capturePage()).toPNG().toString('base64'))
+      await testInfo.attach('screenshot settings on phone', {
+        body: Buffer.from(screenshot, 'base64'), contentType: 'image/png',
+      })
+      await setWindowSize(app, page, { width: 850, height: 375 })
+      await expect.poll(() => content.evaluate(element => {
+        const viewport = element.querySelector('[data-overlayscrollbars-viewport]') ?? element
+        return viewport.scrollWidth - viewport.clientWidth
+      })).toBeLessThanOrEqual(1)
+    })
+  })
+}

--- a/src/renderer/components/ChannelSettings/ChannelSettings.css
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.css
@@ -6,7 +6,7 @@
 
 .preferenceToggles {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(300px, 100%), 1fr));
   gap: 1em 2em;
   margin-block-end: 1em;
 }

--- a/src/renderer/components/PlayerSettings/PlayerSettings.css
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.css
@@ -48,6 +48,12 @@
   flex-grow: 0;
 }
 
+.screenshotFilenamePatternTitle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
 .screenshotFolderPath,
 .screenshotFilenamePatternInput,
 .screenshotFilenamePatternExample {
@@ -92,6 +98,12 @@
 .settingButtonWithSync {
   display: inline-flex;
   align-items: center;
+  max-inline-size: 100%;
+}
+
+.settingButtonWithSync :deep(.btn) {
+  min-inline-size: 0;
+  white-space: normal;
 }
 
 .quickPlaybackSpeedToolbarActions,

--- a/src/renderer/components/PlayerSettings/PlayerSettings.vue
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.vue
@@ -465,7 +465,7 @@
         v-if="screenshotMode !== 'clipboard'"
         class="screenshotFolderContainer"
       >
-        <p class="screenshotFilenamePatternTitle">
+        <p class="screenshotFilenamePatternTitle labelRow">
           {{ t('Settings.Player Settings.Screenshot.File Name Label') }}
           <FtTooltip
             class="selectTooltip"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #1203.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Selecting **Ask for Save Folder** could crash Android and leave an empty screenshot file. The screenshot settings also caused horizontal scrolling on narrow screens.

Stage screenshot bytes in the app cache before opening Android's document picker, keeping large base64 payloads out of Capacitor's saved activity state. Stream the staged file into the chosen document and clean it up after saving, cancellation, or errors. Keep the filename help icon in its label row and let the playback customization button and channel-preference grid fit narrow screens.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. On Android, enable screenshots in Playback settings and select **Ask for Save Folder**. Capture a high-resolution video frame, save through the picker, and open the resulting image. The app should remain open and the image should contain the captured frame.
2. Cancel the picker, then try another screenshot. Also check **Save to Folder** still writes to the selected folder.
3. At phone width, switch between screenshot modes at 100% and 125% UI scale. Controls should remain within the settings page without horizontal scrolling. Scroll to the bottom, hide screenshot controls or widen the window, and check that no empty area remains below the settings and the scrollbar updates.

## Additional context
<!-- Add any other context about the pull request here. -->

The Android regression reproduced `TransactionTooLargeException` with an 8 MB saved-state parcel before the fix. The document-picker save path was introduced after the latest stable release, so this is marked Not noteworthy.

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/4b09ff41-a383-4241-90cc-902b201e9f79">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/f32c45cd-8f46-469f-9a50-e7f21588618d">
  <img alt="Screenshot settings fit a phone-width screen with the filename help icon beside its label" src="https://github.com/user-attachments/assets/4b09ff41-a383-4241-90cc-902b201e9f79">
</picture>

Implemented with GPT-6 in the Codex app.

