### PR TITLE
feat(subscriptions): hide channel content types from feed menus

### DIFF
--- a/e2e/tests/offline/subscriptions-hide-channel-type.spec.mjs
+++ b/e2e/tests/offline/subscriptions-hide-channel-type.spec.mjs
@@ -1,0 +1,215 @@
+import { test, expect, goTo, goToSettingsSection } from '../../helpers/app.mjs'
+
+const CHANNEL_A = 'UCaaaaaaaaaaaaaaaaaaaaaa'
+const CHANNEL_B = 'UCbbbbbbbbbbbbbbbbbbbbbb'
+const types = ['videos', 'shorts', 'live', 'posts']
+const labels = { videos: 'Videos', shorts: 'Shorts', live: 'Live', posts: 'Posts' }
+const now = Date.now()
+const subscriptions = [CHANNEL_A, CHANNEL_B].map((id, index) => ({
+  id, name: `Channel ${index === 0 ? 'A' : 'B'}`, thumbnail: '', dailyVideoLimit: null
+}))
+
+function entry(channelId, category, index = 0) {
+  const common = {
+    author: channelId === CHANNEL_A ? 'Channel A' : 'Channel B',
+    authorId: channelId,
+    isNewInSubscriptionFeed: true
+  }
+  if (category === 'posts') {
+    return {
+      ...common,
+      type: 'community',
+      postId: `${channelId}-post-${index}`,
+      postText: `${channelId} posts ${index}`,
+      publishedTime: now - index * 3600000,
+      authorThumbnails: [{ url: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"/>', width: 55, height: 55 }],
+      voteCount: 1,
+      commentCount: 0,
+      postContent: { type: 'text', content: '' }
+    }
+  }
+  return {
+    ...common,
+    type: 'video',
+    videoId: `${channelId}-${category}-${index}`,
+    title: `${channelId} ${category} ${index}`,
+    published: now - index * 3600000,
+    lengthSeconds: 120,
+    viewCount: 100,
+    // Live archives and running premieres must use their feed's category.
+    liveNow: category === 'videos',
+    isPremiere: category === 'videos',
+    isUpcoming: false
+  }
+}
+
+const seed = {
+  settings: {
+    currentLocale: 'en-US',
+    fetchSubscriptionsAutomatically: false,
+    hideSubscriptionsVideos: false,
+    hideSubscriptionsShorts: false,
+    hideSubscriptionsLive: false,
+    hideSubscriptionsCommunity: false,
+    showNewSubscriptionFeed: true,
+    useRssFeeds: false,
+    uiScale: 125,
+    thumbnailSize: 180
+  },
+  profiles: [
+    { _id: 'allChannels', name: 'All Channels', subscriptions },
+    { _id: 'second', name: 'Second', subscriptions }
+  ].map(profile => ({ ...profile, bgColor: '#000000', textColor: '#FFFFFF' })),
+  subscriptionCache: [CHANNEL_A, CHANNEL_B].map(channelId => ({
+    _id: channelId,
+    ...Object.fromEntries(types.flatMap(category => {
+      const key = { videos: 'videos', shorts: 'shorts', live: 'liveStreams', posts: 'communityPosts' }[category]
+      return [
+        [key, Array.from({ length: channelId === CHANNEL_A ? 18 : 1 }, (_, index) => entry(channelId, category, index))],
+        [`${key}Timestamp`, new Date(now).toISOString()]
+      ]
+    }))
+  }))
+}
+
+test.use({ seed })
+
+function card(page, category, channelId = CHANNEL_A, index = 0) {
+  return page.locator(category === 'posts' ? '.ft-list-post' : '.ft-list-video')
+    .filter({ hasText: `${channelId} ${category} ${index}` }).first()
+}
+
+for (const category of types) {
+  test(`hides a channel's ${category} immediately and persists the setting`, async ({ app, page }) => {
+    await goTo(page, 'subscriptions')
+    await page.locator(`[data-subscription-feed-tab="${category}"]`).click()
+    const lastCard = card(page, category, CHANNEL_A, 17)
+    await expect(card(page, category)).toBeVisible()
+    await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight))
+    await lastCard.scrollIntoViewIfNeeded()
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
+    await lastCard.getByRole('button', { name: 'More Options', exact: true }).click()
+    const action = page.getByRole('option', { name: `Never show ${labels[category]} from this channel in feeds again`, exact: true })
+    await expect(action).toBeVisible()
+    await action.focus()
+    await page.keyboard.press('Enter')
+    await expect(card(page, category)).toHaveCount(0)
+    await expect(card(page, category, CHANNEL_B)).toBeVisible()
+    await expect.poll(() => page.evaluate(() => {
+      const grid = document.querySelector('.autoGrid')
+      const lastItem = grid.lastElementChild
+      return Math.abs(grid.getBoundingClientRect().bottom - lastItem.getBoundingClientRect().bottom)
+    })).toBeLessThanOrEqual(1)
+    await expect.poll(() => page.evaluate(() => {
+      const maximum = Math.max(0, document.documentElement.scrollHeight - window.innerHeight)
+      const scrollbar = document.querySelector('body > .os-scrollbar-vertical')
+      return Math.abs(window.scrollY - maximum) <= 1 &&
+        scrollbar.classList.contains('os-scrollbar-unusable') === (maximum <= 1)
+    })).toBe(true)
+
+    await page.locator('[data-subscription-feed-tab="all"]').click()
+    await expect(card(page, category)).toHaveCount(0)
+    for (const other of types.filter(type => type !== category)) {
+      await page.locator(`[data-subscription-feed-tab="${other}"]`).click()
+      await expect(card(page, other)).toBeVisible()
+    }
+    const expectedTypes = types.filter(type => type !== category)
+    await expect.poll(() => page.evaluate(channelId => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.getters.getProfileList.map(profile => profile.subscriptions.find(channel => channel.id === channelId).feedTypes)
+    }, CHANNEL_A)).toEqual([expectedTypes, expectedTypes])
+
+    ;({ page } = await app.relaunch())
+    const settings = await goToSettingsSection(page, 'subscription')
+    await settings.getByRole('button', { name: 'Subscription settings', exact: true }).click()
+    const group = page.getByRole('group', { name: 'Channel A', exact: true })
+    await expect(group.getByRole('checkbox', { name: labels[category], exact: true })).toHaveAttribute('aria-checked', 'false')
+    await group.getByRole('checkbox', { name: labels[category], exact: true }).click()
+    await page.locator('.settingsWindow').getByRole('button', { name: 'Close', exact: true }).click()
+    await goTo(page, 'subscriptions')
+    await page.locator(`[data-subscription-feed-tab="${category}"]`).click()
+    await expect(card(page, category)).toBeVisible()
+  })
+}
+
+test('hides from a combined New feed section and reports failed writes', async ({ page }) => {
+  await goTo(page, 'subscriptions')
+  await page.locator('[data-subscription-feed-tab="all"]').click()
+  await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    const original = store._actions.updateChannelSettings
+    store._actions.updateChannelSettings = [() => {
+      store._actions.updateChannelSettings = original
+      return Promise.resolve(false)
+    }]
+  })
+  await page.locator('.mediaSection').first().scrollIntoViewIfNeeded()
+  const short = card(page, 'shorts')
+  await short.getByRole('button', { name: 'More Options', exact: true }).click()
+  await page.getByRole('option', { name: 'Never show Shorts from this channel in feeds again', exact: true }).click()
+  await expect(page.locator('.toast', { hasText: 'Failed to save channel settings' })).toBeVisible()
+  await expect(short).toBeVisible()
+  await short.getByRole('button', { name: 'More Options', exact: true }).click()
+  await page.getByRole('option', { name: 'Never show Shorts from this channel in feeds again', exact: true }).click()
+  await expect(short).toHaveCount(0)
+  await expect(card(page, 'videos')).toHaveCount(1)
+  await page.locator('[data-subscription-feed-tab="shorts"]').click()
+  await expect(card(page, 'shorts')).toHaveCount(0)
+})
+
+test('keeps both types hidden when another hide is queued during a save', async ({ page }) => {
+  await goTo(page, 'subscriptions')
+  await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    const update = store._actions.updateChannelSettings[0]
+    let first = true
+    store._actions.updateChannelSettings = [async payload => {
+      if (first) {
+        first = false
+        await new Promise(resolve => { window.releaseFirstFeedHide = resolve })
+      }
+      return update(payload)
+    }]
+  })
+  for (const category of ['videos', 'shorts']) {
+    await page.locator(`[data-subscription-feed-tab="${category}"]`).click()
+    await card(page, category).getByRole('button', { name: 'More Options', exact: true }).click()
+    await page.getByRole('option', { name: `Never show ${labels[category]} from this channel in feeds again`, exact: true }).click()
+  }
+  await page.evaluate(() => window.releaseFirstFeedHide())
+  await expect.poll(() => page.evaluate(channelId => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    return store.getters.getSubscribedChannelsById.get(channelId).feedTypes
+  }, CHANNEL_A)).toEqual(['live', 'posts'])
+  await expect(card(page, 'shorts')).toHaveCount(0)
+  await page.locator('[data-subscription-feed-tab="videos"]').click()
+  await expect(card(page, 'videos')).toHaveCount(0)
+})
+
+for (const locale of ['en-US', 'de-DE']) {
+  test.describe(`${locale} menu labels`, () => {
+    test.use({ seed: { ...seed, settings: { ...seed.settings, currentLocale: locale } } })
+    test('shows the full hide action label on desktop and narrow windows', async ({ app, page }) => {
+      await goTo(page, 'subscriptions')
+      for (const width of [1600, 375]) {
+        await app.electronApp.evaluate(({ BrowserWindow }, width) => {
+          BrowserWindow.getAllWindows()[0].setContentSize(width, 900)
+        }, width)
+        await card(page, 'videos').getByRole('button', {
+          name: locale === 'en-US' ? 'More Options' : 'Weitere Optionen', exact: true
+        }).click()
+        const label = page.getByRole('option', {
+          name: locale === 'en-US'
+            ? 'Never show Videos from this channel in feeds again'
+            : 'Nie wieder Videos von diesem Kanal in Feeds anzeigen',
+          exact: true
+        }).locator(':scope > span')
+        await expect(label).toBeVisible()
+        await expect.poll(() => label.evaluate(element => (
+          element.scrollWidth <= element.clientWidth && element.scrollHeight <= element.clientHeight
+        ))).toBe(true)
+        await page.keyboard.press('Escape')
+      }
+    })
+  })
+}

--- a/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
+++ b/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
@@ -160,6 +160,17 @@
         class="shareButton"
         :size="18"
       />
+      <FtIconButton
+        v-if="hideSubscriptionFeedTypeOption"
+        :icon="['fas', 'ellipsis-v']"
+        :title="$t('Video.More Options')"
+        theme="base-no-default"
+        :size="18"
+        :use-shadow="false"
+        dropdown-position-x="left"
+        :dropdown-options="[hideSubscriptionFeedTypeOption]"
+        @click="hideSubscriptionFeedType"
+      />
     </div>
   </div>
 </template>
@@ -174,6 +185,8 @@ import FtListPlaylist from '../FtListPlaylist/FtListPlaylist.vue'
 import FtCommunityPoll from '../FtCommunityPoll/FtCommunityPoll.vue'
 import FtNewContentDot from '../FtNewContentDot/FtNewContentDot.vue'
 import FtShareButton from '../FtShareButton/FtShareButton.vue'
+import FtIconButton from '../FtIconButton/FtIconButton.vue'
+import { useHideSubscriptionFeedType } from '../../composables/useHideSubscriptionFeedType'
 import { vSaferHtml } from '../../directives/vSaferHtml.js'
 
 import store from '../../store/index'
@@ -207,6 +220,7 @@ const props = defineProps({
 })
 
 const relativeTimeNow = useRelativeTimeClock()
+const { hideSubscriptionFeedType, hideSubscriptionFeedTypeOption } = useHideSubscriptionFeedType(() => props.data.authorId, true)
 
 /** @type {import('vue').ComputedRef<'grid' | 'list'>} */
 const listType = computed(() => {

--- a/src/renderer/components/FtElementList/FtElementList.vue
+++ b/src/renderer/components/FtElementList/FtElementList.vue
@@ -43,7 +43,8 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, provide } from 'vue'
+import { subscriptionFeedTypeKey } from '../../composables/useHideSubscriptionFeedType'
 
 import FtAutoGrid from '../FtAutoGrid/FtAutoGrid.vue'
 import FtListLazyWrapper from '../FtListLazyWrapper/FtListLazyWrapper.vue'
@@ -51,6 +52,10 @@ import FtListLazyWrapper from '../FtListLazyWrapper/FtListLazyWrapper.vue'
 import store from '../../store/index'
 
 const props = defineProps({
+  subscriptionFeedType: {
+    type: String,
+    default: null
+  },
   appear: {
     type: Boolean,
     default: false
@@ -150,6 +155,8 @@ const props = defineProps({
     default: false,
   },
 })
+
+provide(subscriptionFeedTypeKey, computed(() => props.subscriptionFeedType))
 
 const emit = defineEmits([
   'move-dragged-video',

--- a/src/renderer/components/FtIconButton/FtIconButton.scss
+++ b/src/renderer/components/FtIconButton/FtIconButton.scss
@@ -283,4 +283,9 @@
     justify-content: center;
     min-inline-size: 1em;
   }
+
+  .listItem > .wrapLabel {
+    overflow-wrap: anywhere;
+    white-space: normal;
+  }
 }

--- a/src/renderer/components/FtIconButton/FtIconButton.vue
+++ b/src/renderer/components/FtIconButton/FtIconButton.vue
@@ -89,7 +89,7 @@
                     :icon="option.active ? ['fas', 'check'] : option.icon"
                   />
                 </div>
-                <span>{{ option.label }}</span>
+                <span :class="{ wrapLabel: option.wrapLabel }">{{ option.label }}</span>
               </template>
             </li>
           </ul>
@@ -167,7 +167,10 @@
                     :icon="option.active ? ['fas', 'check'] : option.icon"
                   />
                 </div>
-                <span v-if="option.type !== 'divider'">{{ option.label }}</span>
+                <span
+                  v-if="option.type !== 'divider'"
+                  :class="{ wrapLabel: option.wrapLabel }"
+                >{{ option.label }}</span>
               </li>
             </ul>
           </slot>
@@ -253,6 +256,7 @@ const props = defineProps({
     // - (OPTIONAL) icon: semantic icon tuple (if type === 'labelValue')
     // - (OPTIONAL) active: Number (if type === 'labelValue')
     // - (OPTIONAL) disabled: Boolean (if type === 'labelValue')
+    // - (OPTIONAL) wrapLabel: Boolean (if type === 'labelValue')
     type: Array,
     default: () => []
   },

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -437,6 +437,7 @@ import {
 } from '../../helpers/viewTransitions.js'
 import { setCollaboratorsLoading } from './collaboratorsLoading.js'
 import { useRelativeTimeClock } from '../../composables/useRelativeTimeClock.js'
+import { useHideSubscriptionFeedType } from '../../composables/useHideSubscriptionFeedType'
 import { useResultChannelAvatar } from '../../composables/useResultChannelAvatar.js'
 import { formatDate, formatDateTime } from '../../helpers/dateFormat.js'
 import thumbnailPlaceholder from '../../assets/img/thumbnail_placeholder.svg'
@@ -900,6 +901,8 @@ const hideSharingActions = computed(() => store.getters.getHideSharingActions)
 /** @type {import('vue').ComputedRef<boolean>} */
 const showInvidiousShareOptions = computed(() => backendPreference.value === 'invidious' || store.getters.getBackendFallback)
 
+const { hideSubscriptionFeedType, hideSubscriptionFeedTypeOption } = useHideSubscriptionFeedType(() => channelId.value)
+
 const dropdownOptions = computed(() => {
   const options = [
     {
@@ -946,6 +949,9 @@ const dropdownOptions = computed(() => {
         }]
       : [])
   ]
+  if (hideSubscriptionFeedTypeOption.value) {
+    options.push(hideSubscriptionFeedTypeOption.value)
+  }
   if (inUserPlaylist.value) {
     if (props.canMoveVideoUp || props.canMoveVideoDown) {
       options.push({ type: 'divider' })
@@ -1191,6 +1197,9 @@ function getInvidiousChannelUrl() {
  */
 function handleOptionsClick(option) {
   switch (option) {
+    case 'hideSubscriptionFeedType':
+      hideSubscriptionFeedType()
+      break
     case 'playNext':
       addToWatchQueue(true)
       break

--- a/src/renderer/components/SubscriptionsNew.vue
+++ b/src/renderer/components/SubscriptionsNew.vue
@@ -3,6 +3,7 @@
     class="newFeed"
     :is-loading="isLoading"
     :video-list="displayedEntries"
+    :subscription-feed-type="activeCategory ?? 'videos'"
     :error-channels="errorChannels"
     :attempted-fetch="attemptedFetch"
     :only-show-new="true"
@@ -26,6 +27,7 @@
         <h3>{{ $t('Global.Shorts') }}</h3>
         <FtElementList
           :data="newShorts"
+          subscription-feed-type="shorts"
           stable-item-keys
           :youtube-style-shorts="useCustomShortsPlayer"
           :use-channels-hidden-preference="false"
@@ -40,6 +42,7 @@
         <h3>{{ $t('Global.Live') }}</h3>
         <FtElementList
           :data="newLive"
+          subscription-feed-type="live"
           stable-item-keys
           :use-channels-hidden-preference="false"
         />
@@ -53,6 +56,7 @@
         <h3>{{ $t('Global.Posts') }}</h3>
         <FtElementList
           :data="newPosts"
+          subscription-feed-type="posts"
           display="list"
           stable-item-keys
           :use-channels-hidden-preference="false"

--- a/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
+++ b/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
@@ -55,6 +55,7 @@
     />
     <FtElementList
       :data="activeVideoList"
+      :subscription-feed-type="subscriptionFeedType ?? refreshTab"
       :use-channels-hidden-preference="false"
       :display="isCommunity ? 'list' : ''"
       :stable-item-keys="stableItemKeys"
@@ -120,6 +121,10 @@ const root = useTemplateRef('root')
 useKeepAliveEffectScope()
 
 const props = defineProps({
+  subscriptionFeedType: {
+    type: String,
+    default: null
+  },
   isLoading: {
     type: Boolean,
     default: false

--- a/src/renderer/composables/useHideSubscriptionFeedType.js
+++ b/src/renderer/composables/useHideSubscriptionFeedType.js
@@ -1,0 +1,70 @@
+import { computed, inject, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import store from '../store'
+import { getSubscriptionFeedTypeOptions, getUpdatedSubscriptionFeedTypes, normalizeSubscriptionChannelSettings } from '../helpers/subscription-channels'
+import { showToast } from '../helpers/utils'
+
+export const subscriptionFeedTypeKey = Symbol('subscriptionFeedType')
+
+// Cards share this queue so each hide starts with the preceding save's settings.
+let pendingFeedTypeUpdates = Promise.resolve()
+
+/**
+ * @param {() => string} getChannelId
+ * @param {boolean} isPost
+ */
+export function useHideSubscriptionFeedType(getChannelId, isPost = false) {
+  const { t } = useI18n()
+  const feedType = inject(subscriptionFeedTypeKey, ref(null))
+  const saving = ref(false)
+  const channel = computed(() => store.getters.getSubscribedChannelsById.get(getChannelId()))
+  const option = computed(() => {
+    const type = getSubscriptionFeedTypeOptions(t).find(type => type.id === feedType.value)
+    // Embedded videos in posts must not change the embedded author's post settings.
+    if (!type || isPost !== (type.id === 'posts') || !channel.value ||
+      !normalizeSubscriptionChannelSettings(channel.value).feedTypes.includes(type.id)) return null
+
+    return {
+      label: t('Subscriptions.Never show {type} from this channel in feeds again', { type: type.label }),
+      value: 'hideSubscriptionFeedType',
+      icon: ['fas', 'eye-slash'],
+      wrapLabel: true,
+      disabled: saving.value
+    }
+  })
+
+  function hide() {
+    if (!option.value || saving.value) return
+    const channelId = getChannelId()
+    const typeToHide = feedType.value
+    saving.value = true
+    pendingFeedTypeUpdates = pendingFeedTypeUpdates.then(async () => {
+      try {
+        const currentChannel = store.getters.getSubscribedChannelsById.get(channelId)
+        const saved = await store.dispatch('updateChannelSettings', {
+          channelId,
+          settings: {
+            feedTypes: getUpdatedSubscriptionFeedTypes(
+              normalizeSubscriptionChannelSettings(currentChannel).feedTypes,
+              typeToHide,
+              false
+            )
+          }
+        })
+        if (!saved) throw new Error('Failed to save subscription feed type')
+      } catch (error) {
+        console.error(error)
+        showToast({
+          message: t('Channel.Failed to save subscription settings'),
+          icon: ['fas', 'circle-exclamation']
+        })
+      } finally {
+        saving.value = false
+      }
+    })
+    return pendingFeedTypeUpdates
+  }
+
+  return { hideSubscriptionFeedType: hide, hideSubscriptionFeedTypeOption: option }
+}

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: جميع الأقسام مخفية
   All sections hidden description: خصّص الصفحة الرئيسية لإظهار قسم من جديد.
 Subscriptions:
+  Never show {type} from this channel in feeds again: عدم عرض {type} من هذه القناة في الخلاصات مجددًا
   Refreshing Subscription Videos: تحديث مقاطع الفيديو الخاصة بالاشتراك
   Refreshing Subscription Shorts: 'تحديث الفيديوهات القصيرة للاشتراكات'
   Refreshing Subscription Live Streams: تحديث البث المباشر للاشتراك

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -148,6 +148,7 @@ Home Page:
   All sections hidden: Усе раздзелы схаваны
   All sections hidden description: Наладзьце галоўную, каб зноў паказаць раздзел.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Больш не паказваць {type} з гэтага канала ў стужках
   Refreshing Subscription Videos: Абнаўляюцца відэа з падпісак
   Refreshing Subscription Shorts: Абнаўляюцца кароткія відэа з падпісак
   Refreshing Subscription Live Streams: Абнаўляюцца жывыя трансляцыі з падпісак

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Всички раздели са скрити
   All sections hidden description: Персонализирайте началната страница, за да покажете отново раздел.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Никога повече да не се показват {type} от този канал в емисиите
   Refreshing Subscription Videos: Обновяват се видеоклиповете от абонаментите
   Refreshing Subscription Shorts: Обновяват се кратките видеоклипове от абонаментите
   Refreshing Subscription Live Streams: Обновяват се предаванията на живо от абонаментите

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Kuzhet eo an holl rannoù
   All sections hidden description: Personelait ar bajenn degemer evit diskouez ur rann en-dro.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Na ziskouez biken {type} eus ar chadenn-mañ er gwazhioù en-dro
   Refreshing Subscription Videos: "Oc'h adkargañ videoioù ar c'houmanantoù"
   Refreshing Subscription Shorts: "Oc'h adkargañ videoioù berr (Shorts) ar c'houmanantoù"
   Refreshing Subscription Live Streams: "Oc'h adkargañ skignadoù war-eeun ar c'houmanantoù"

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -172,6 +172,7 @@ Home Page:
   All sections hidden: Totes les seccions estan ocultes
   All sections hidden description: Personalitzeu l'inici per tornar a mostrar una secció.
 Subscriptions:
+  Never show {type} from this channel in feeds again: No tornis a mostrar {type} d’aquest canal als canals de contingut
   Disabled Automatic Fetching: Heu desactivat l'obtenció automàtica de subscripcions. Actualitzeu-les per veure-les aquí.
   Empty Channels: Els canals als quals us heu subscrit no tenen cap vídeo ara mateix.
   Empty Posts: Els canals als quals us heu subscrit no tenen cap publicació ara mateix.

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Všechny sekce jsou skryté
   All sections hidden description: Přizpůsobte domovskou stránku a některou sekci znovu zobrazte.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Už nikdy nezobrazovat {type} z tohoto kanálu ve feedech
   Refreshing Subscription Videos: Obnovování videí z odběrů
   Refreshing Subscription Shorts: Obnovování krátkých videí z odběrů
   Refreshing Subscription Live Streams: Obnovování živých přenosů z odběrů

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Mae pob adran wedi'i chuddio
   All sections hidden description: Addaswch yr hafan i ddangos adran eto.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Peidio byth â dangos {type} o’r sianel hon mewn ffrydiau eto
   Refreshing Subscription Videos: Wrthi'n adnewyddu fideos tanysgrifiadau
   Refreshing Subscription Shorts: Wrthi'n adnewyddu Byrion tanysgrifiadau
   Refreshing Subscription Live Streams: Wrthi'n adnewyddu ffrydiau byw tanysgrifiadau

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -144,6 +144,7 @@ Home Page:
   All sections hidden: Alle sektioner er skjult
   All sections hidden description: Tilpas startsiden for at vise en sektion igen.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Vis aldrig {type} fra denne kanal i feeds igen
   Refreshing Subscription Videos: Opdaterer videoer fra abonnementer
   Refreshing Subscription Shorts: Opdaterer Shorts fra abonnementer
   Refreshing Subscription Live Streams: Opdaterer livestreams fra abonnementer

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Όλες οι ενότητες είναι κρυφές
   All sections hidden description: Προσαρμόστε την αρχική για να εμφανίσετε ξανά μια ενότητα.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Να μην εμφανίζεται ξανά περιεχόμενο τύπου {type} από αυτό το κανάλι στις ροές
   Refreshing Subscription Videos: Ανανέωση βίντεο συνδρομών
   Refreshing Subscription Shorts: Ανανέωση σύντομων βίντεο συνδρομών
   Refreshing Subscription Live Streams: Ανανέωση ζωντανών μεταδόσεων συνδρομών

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -141,6 +141,7 @@ Home Page:
   All sections hidden: All sections are hidden
   All sections hidden description: Customise Home to show a section again.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Never show {type} from this channel in feeds again
   Refreshing Subscription Videos: Refreshing subscription videos
   Refreshing Subscription Shorts: Refreshing subscription shorts
   Refreshing Subscription Live Streams: Refreshing subscription live streams

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -150,6 +150,7 @@ Home Page:
   All sections hidden: Todas las secciones están ocultas
   All sections hidden description: Personalizá Inicio para volver a mostrar una sección.
 Subscriptions:
+  Never show {type} from this channel in feeds again: No volver a mostrar {type} de este canal en los feeds
   Refreshing Subscription Videos: Actualizando videos de las suscripciones
   Refreshing Subscription Shorts: Actualizando Shorts de las suscripciones
   Refreshing Subscription Live Streams: Actualizando emisiones en directo de las suscripciones

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -148,6 +148,7 @@ Home Page:
   All sections hidden: Todas las secciones están ocultas
   All sections hidden description: Personaliza Inicio para volver a mostrar una sección.
 Subscriptions:
+  Never show {type} from this channel in feeds again: No volver a mostrar {type} de este canal en los feeds
   Refreshing Subscription Videos: Actualizando videos de las suscripciones
   Refreshing Subscription Shorts: Actualizando Shorts de las suscripciones
   Refreshing Subscription Live Streams: Actualizando emisiones en directo de las suscripciones

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Todas las secciones están ocultas
   All sections hidden description: Personaliza Inicio para volver a mostrar una sección.
 Subscriptions:
+  Never show {type} from this channel in feeds again: No volver a mostrar {type} de este canal en los feeds
   Refreshing Subscription Videos: Actualizando vídeos de las suscripciones
   Refreshing Subscription Shorts: Actualizando Shorts de las suscripciones
   Refreshing Subscription Live Streams: Actualizando emisiones en directo de las suscripciones

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Kõik jaotised on peidetud
   All sections hidden description: Kohanda avalehte, et mõni jaotis uuesti kuvada.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Ära enam näita selle kanali sisu tüübiga {type} voogudes
   Refreshing Subscription Videos: Tellimuste videote värskendamine
   Refreshing Subscription Shorts: Tellimuste Shorts-videote värskendamine
   Refreshing Subscription Live Streams: Tellimuste otseülekannete värskendamine

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Atal guztiak ezkutatuta daude
   All sections hidden description: Pertsonalizatu hasiera atal bat berriro erakusteko.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Ez erakutsi berriro kanal honetako {type} jarioetan
   Refreshing Subscription Videos: Harpidetzetako bideoak freskatzen
   Refreshing Subscription Shorts: Harpidetzetako bideo laburrak freskatzen
   Refreshing Subscription Live Streams: Harpidetzetako zuzeneko emankizunak freskatzen

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -152,6 +152,7 @@ Home Page:
   All sections hidden: همهٔ بخش‌ها پنهان هستند
   All sections hidden description: صفحهٔ اصلی را سفارشی کنید تا بخشی دوباره نمایش داده شود.
 Subscriptions:
+  Never show {type} from this channel in feeds again: دیگر هرگز {type} این کانال را در خوراک‌ها نشان نده
   Refreshing Subscription Videos: در حال تازه‌سازی ویدیوهای اشتراک‌ها
   Refreshing Subscription Shorts: در حال تازه‌سازی ویدیوهای کوتاه اشتراک‌ها
   Refreshing Subscription Live Streams: در حال تازه‌سازی پخش‌های زنده اشتراک‌ها

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Kaikki osiot on piilotettu
   All sections hidden description: Mukauta etusivua, jotta voit näyttää osion uudelleen.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Älä enää näytä tämän kanavan sisältöä tyypillä {type} syötteissä
   Refreshing Subscription Videos: Päivitetään tilausten videoita
   Refreshing Subscription Shorts: Päivitetään tilausten Shorts-videoita
   Refreshing Subscription Live Streams: Päivitetään tilausten suoria lähetyksiä

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Toutes les sections sont masquées
   All sections hidden description: Personnalisez l’accueil pour afficher à nouveau une section.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Ne plus jamais afficher les contenus de type {type} de cette chaîne dans les flux
   Refreshing Subscription Videos: Actualisation des vidéos des abonnements
   Refreshing Subscription Shorts: Actualisation des Shorts des abonnements
   Refreshing Subscription Live Streams: Actualisation des diffusions en direct des abonnements

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Todas as seccións están ocultas
   All sections hidden description: Personaliza o inicio para volver amosar unha sección.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Non volver mostrar {type} desta canle nos fluxos
   Refreshing Subscription Videos: Actualizando os vídeos das subscricións
   Refreshing Subscription Shorts: Actualizando os vídeos curtos das subscricións
   Refreshing Subscription Live Streams: Actualizando as emisións en directo das subscricións

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: כל המקטעים מוסתרים
   All sections hidden description: התאימו אישית את דף הבית כדי להציג שוב מקטע.
 Subscriptions:
+  Never show {type} from this channel in feeds again: לא להציג שוב תוכן מסוג {type} מהערוץ הזה בפידים
   Refreshing Subscription Videos: סרטוני המינויים מתרעננים
   Refreshing Subscription Shorts: הסרטונים הקצרים מהמינויים מתרעננים
   Refreshing Subscription Live Streams: השידורים החיים מהמינויים מתרעננים

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Svi su odjeljci skriveni
   All sections hidden description: Prilagodite početnu stranicu kako biste ponovno prikazali odjeljak.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Nikad više ne prikazuj {type} s ovog kanala u sažecima sadržaja
   Refreshing Subscription Videos: Osvježavanje videozapisa iz pretplata
   Refreshing Subscription Shorts: Osvježavanje sadržaja Shorts iz pretplata
   Refreshing Subscription Live Streams: Osvježavanje prijenosa uživo iz pretplata

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Minden szakasz el van rejtve
   All sections hidden description: Szabja testre a kezdőlapot egy szakasz újbóli megjelenítéséhez.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Soha többé ne jelenjen meg {type} típusú tartalom ettől a csatornától a hírcsatornákban
   Refreshing Subscription Videos: Feliratkozások videóinak frissítése
   Refreshing Subscription Shorts: Feliratkozások rövid videóinak frissítése
   Refreshing Subscription Live Streams: Feliratkozások élő közvetítéseinek frissítése

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Semua bagian disembunyikan
   All sections hidden description: Sesuaikan Beranda untuk menampilkan kembali bagian.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Jangan pernah tampilkan {type} dari channel ini di feed lagi
   Refreshing Subscription Videos: Memperbarui video langganan
   Refreshing Subscription Shorts: Memperbarui Shorts langganan
   Refreshing Subscription Live Streams: Memperbarui siaran langsung langganan

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Allir hlutar eru faldir
   All sections hidden description: Sérsníddu heimasíðuna til að sýna hluta aftur.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Aldrei sýna aftur efni af gerðinni {type} frá þessari rás í straumum
   Refreshing Subscription Videos: Endurnýja myndbönd úr áskriftum
   Refreshing Subscription Shorts: Endurnýja Shorts-myndbönd úr áskriftum
   Refreshing Subscription Live Streams: Endurnýja beinar útsendingar úr áskriftum

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Tutte le sezioni sono nascoste
   All sections hidden description: Personalizza Home per mostrare di nuovo una sezione.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Non mostrare più contenuti di tipo {type} di questo canale nei feed
   Refreshing Subscription Videos: Aggiornamento dei video delle iscrizioni
   Refreshing Subscription Shorts: Aggiornamento degli Shorts delle iscrizioni
   Refreshing Subscription Live Streams: Aggiornamento delle dirette delle iscrizioni

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: すべてのセクションが非表示です
   All sections hidden description: ホームをカスタマイズして、セクションを再表示してください。
 Subscriptions:
+  Never show {type} from this channel in feeds again: このチャンネルの「{type}」をフィードに今後表示しない
   Refreshing Subscription Videos: 登録チャンネルの動画を更新中
   Refreshing Subscription Shorts: 登録チャンネルのショート動画を更新中
   Refreshing Subscription Live Streams: 登録チャンネルのライブ配信を更新中

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -149,6 +149,7 @@ Home Page:
   All sections hidden: 모든 섹션이 숨겨져 있습니다
   All sections hidden description: 홈을 맞춤 설정하여 섹션을 다시 표시하세요.
 Subscriptions:
+  Never show {type} from this channel in feeds again: 이 채널의 {type} 콘텐츠를 피드에 다시 표시하지 않기
   Refreshing Subscription Videos: 구독 동영상 새로 고치는 중
   Refreshing Subscription Shorts: 구독 Shorts 새로 고치는 중
   Refreshing Subscription Live Streams: 구독 실시간 스트림 새로 고치는 중

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -164,6 +164,7 @@ Home Page:
   All sections hidden: Visi skyriai paslėpti
   All sections hidden description: Tinkinkite pradžios puslapį, kad vėl būtų rodomas skyrius.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Daugiau niekada nerodyti šio kanalo {type} turinio srautuose
   Load More Posts: Įkelti daugiau įrašų
   Subscriptions Tabs: Prenumeratų kortelės
   All Subscription Tabs Hidden: Visos prenumeratų kortelės paslėptos. Kad čia matytumėte turinį, skiltyje „{settingsSection}“ → „{subsection}“ įjunkite norimas korteles.

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Alle deler er skjult
   All sections hidden description: Tilpass startsiden for å vise en del igjen.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Vis aldri {type} fra denne kanalen i strømmer igjen
   Refreshing Subscription Videos: Oppdaterer abonnementsvideoer
   Refreshing Subscription Shorts: Oppdaterer Shorts fra abonnementer
   Refreshing Subscription Live Streams: Oppdaterer direktesendinger fra abonnementer

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Alle secties zijn verborgen
   All sections hidden description: Pas de startpagina aan om weer een sectie te tonen.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Nooit meer {type} van dit kanaal in feeds tonen
   Refreshing Subscription Videos: Abonnementsvideo's vernieuwen
   Refreshing Subscription Shorts: Shorts van abonnementen vernieuwen
   Refreshing Subscription Live Streams: Livestreams van abonnementen vernieuwen

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -148,6 +148,7 @@ Home Page:
   All sections hidden: Alle delar er gøymde
   All sections hidden description: Tilpass heimesida for å vise ein del igjen.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Vis aldri {type} frå denne kanalen i straumar igjen
   Subscriptions Tabs: Abonnementsfaner
   All Subscription Tabs Hidden: Alle abonnementsfanene er gøymde. Vis nokre faner i delen "{subsection}" under "{settingsSection}" for å sjå innhald her.
   Refreshing Subscription Videos: Oppdaterer abonnementsvideoar

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -55,6 +55,7 @@ Home Page:
   All sections hidden: Wszystkie sekcje są ukryte
   All sections hidden description: Dostosuj stronę główną, aby ponownie wyświetlić sekcję.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Nigdy więcej nie pokazuj treści typu {type} z tego kanału w strumieniach
   New Content Tabs: Karty nowych treści
   Show Tabbed View: Pokaż widok kart
   Show Combined View: Pokaż widok łączny

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Todas as seções estão ocultas
   All sections hidden description: Personalize a página inicial para mostrar uma seção novamente.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Nunca mais mostrar {type} deste canal nos feeds
   Refreshing Subscription Videos: Atualizando os vídeos das inscrições
   Refreshing Subscription Shorts: Atualizando os Shorts das inscrições
   Refreshing Subscription Live Streams: Atualizando as transmissões ao vivo das inscrições

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Todas as secções estão ocultas
   All sections hidden description: Personalize a página inicial para voltar a mostrar uma secção.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Nunca mais mostrar {type} deste canal nos feeds
   Refreshing Subscription Videos: A atualizar os vídeos das subscrições
   Refreshing Subscription Shorts: A atualizar os Shorts das subscrições
   Refreshing Subscription Live Streams: A atualizar as transmissões em direto das subscrições

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Todas as secções estão ocultas
   All sections hidden description: Personalize a página inicial para voltar a mostrar uma secção.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Nunca mais mostrar {type} deste canal nos feeds
   Refreshing Subscription Videos: A atualizar os vídeos das subscrições
   Refreshing Subscription Shorts: A atualizar os Shorts das subscrições
   Refreshing Subscription Live Streams: A atualizar as transmissões em direto das subscrições

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Toate secțiunile sunt ascunse
   All sections hidden description: Personalizează pagina principală pentru a afișa din nou o secțiune.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Nu mai afișa niciodată conținut de tip {type} de pe acest canal în fluxuri
   Refreshing Subscription Videos: Se reîmprospătează videoclipurile din abonamente
   Refreshing Subscription Shorts: Se reîmprospătează videoclipurile Shorts din abonamente
   Refreshing Subscription Live Streams: Se reîmprospătează transmisiunile în direct din abonamente

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -117,6 +117,7 @@ Home Page:
   All sections hidden: Все разделы скрыты
   All sections hidden description: Настройте главную, чтобы снова показать раздел.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Больше никогда не показывать {type} с этого канала в лентах
   Refreshing Subscription Videos: Обновление видео из подписок
   Refreshing Subscription Shorts: Обновление Shorts из подписок
   Refreshing Subscription Live Streams: Обновление трансляций из подписок

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Všetky sekcie sú skryté
   All sections hidden description: Prispôsobte domovskú stránku a znova zobrazte sekciu.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Už nikdy nezobrazovať {type} z tohto kanála v kanáloch odberov
   Refreshing Subscription Videos: Obnovujú sa videá z odberov
   Refreshing Subscription Shorts: Obnovujú sa krátke videá z odberov
   Refreshing Subscription Live Streams: Obnovujú sa živé prenosy z odberov

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -171,6 +171,7 @@ Home Page:
   All sections hidden: Vsi razdelki so skriti
   All sections hidden description: Prilagodite domačo stran, da znova prikažete razdelek.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Nikoli več ne prikazuj vsebine vrste {type} s tega kanala v virih
   Empty Posts: Kanali, na katere ste naročeni, trenutno nimajo objav.
   Load More Posts: Naloži več objav
   Subscriptions Tabs: Zavihki naročnin

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -144,6 +144,7 @@ Home Page:
   All sections hidden: Сви одељци су сакривени
   All sections hidden description: Прилагодите почетну страницу да бисте поново приказали одељак.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Никада више не приказуј {type} са овог канала у фидовима
   Refreshing Subscription Videos: Освежавају се видео-снимци из претплата
   Refreshing Subscription Shorts: Освежавају се кратки видео-снимци из претплата
   Refreshing Subscription Live Streams: Освежавају се преноси уживо из претплата

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Alla avsnitt är dolda
   All sections hidden description: Anpassa startsidan för att visa ett avsnitt igen.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Visa aldrig {type} från den här kanalen i flöden igen
   Refreshing Subscription Videos: Uppdaterar prenumerationsvideor
   Refreshing Subscription Shorts: Uppdaterar Shorts från prenumerationer
   Refreshing Subscription Live Streams: Uppdaterar liveströmmar från prenumerationer

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -145,6 +145,7 @@ Home Page:
   All sections hidden: அனைத்துப் பிரிவுகளும் மறைக்கப்பட்டுள்ளன
   All sections hidden description: ஒரு பிரிவை மீண்டும் காட்ட முகப்பைத் தனிப்பயனாக்கவும்.
 Subscriptions:
+  Never show {type} from this channel in feeds again: இந்தச் சேனலின் {type} உள்ளடக்கத்தை ஊட்டங்களில் இனி ஒருபோதும் காட்டாதே
   Refreshing Subscription Videos: சந்தாக்களின் காணொளிகள் புதுப்பிக்கப்படுகின்றன
   Refreshing Subscription Shorts: சந்தாக்களின் Shorts புதுப்பிக்கப்படுகின்றன
   Refreshing Subscription Live Streams: சந்தாக்களின் நேரலைகள் புதுப்பிக்கப்படுகின்றன

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Tüm bölümler gizli
   All sections hidden description: Bir bölümü yeniden göstermek için Ana Sayfayı özelleştirin.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Bu kanalın {type} içeriklerini akışlarda bir daha gösterme
   Refreshing Subscription Videos: Abonelik videoları yenileniyor
   Refreshing Subscription Shorts: Abonelik kısa videoları yenileniyor
   Refreshing Subscription Live Streams: Abonelik canlı yayınları yenileniyor

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Усі розділи приховано
   All sections hidden description: Налаштуйте головну, щоб знову показати розділ.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Більше ніколи не показувати {type} із цього каналу в стрічках
   Refreshing Subscription Videos: Оновлення відео з підписок
   Refreshing Subscription Shorts: Оновлення коротких відео з підписок
   Refreshing Subscription Live Streams: Оновлення прямих трансляцій з підписок

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Tất cả các mục đều bị ẩn
   All sections hidden description: Tùy chỉnh Trang chủ để hiển thị lại một mục.
 Subscriptions:
+  Never show {type} from this channel in feeds again: Không bao giờ hiển thị {type} từ kênh này trong bảng tin nữa
   Refreshing Subscription Videos: Đang làm mới video từ kênh đăng ký
   Refreshing Subscription Shorts: Đang làm mới video ngắn từ kênh đăng ký
   Refreshing Subscription Live Streams: Đang làm mới luồng trực tiếp từ kênh đăng ký

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: 所有版块均已隐藏
   All sections hidden description: 自定义首页以重新显示版块。
 Subscriptions:
+  Never show {type} from this channel in feeds again: 不再在动态中显示此频道的{type}
   Refreshing Subscription Videos: 正在刷新订阅视频
   Refreshing Subscription Shorts: 正在刷新订阅短视频
   Refreshing Subscription Live Streams: 正在刷新订阅直播

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: 所有區塊均已隱藏
   All sections hidden description: 自訂首頁以重新顯示區塊。
 Subscriptions:
+  Never show {type} from this channel in feeds again: 不再於動態中顯示此頻道的{type}
   Refreshing Subscription Videos: 正在重新整理訂閱影片
   Refreshing Subscription Shorts: 正在重新整理訂閱的 Shorts 短片
   Refreshing Subscription Live Streams: 正在重新整理訂閱直播

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -141,6 +141,7 @@ Home Page:
   All sections hidden description: Passe die Startseite an, um wieder einen Bereich anzuzeigen.
 
 Subscriptions:
+  Never show {type} from this channel in feeds again: Nie wieder {type} von diesem Kanal in Feeds anzeigen
     # On Subscriptions Page
   Subscriptions: Abos
   'Your Subscription list is currently empty. Start adding subscriptions to see them here.': Deine Aboliste ist derzeit leer. Wenn du deine Abos importieren möchtest, wähle in den Einstellungen unter dem Bereich „Daten“ „Abos importieren“. Alternativ kannst du nach einem Kanal suchen und diesen abonnieren.

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -259,6 +259,7 @@ Home Page:
   All sections hidden description: Customize Home to show a section again.
 
 Subscriptions:
+  Never show {type} from this channel in feeds again: Never show {type} from this channel in feeds again
     # On Subscriptions Page
   Subscriptions: Subscriptions
   # channels that were likely deleted


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

Filtering a channel’s content currently requires opening its subscription settings. This adds a shortcut directly to the feed item’s three-dot menu.

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #1216

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The action hides the selected channel’s Videos, Shorts, Live, or Posts through the existing persistent settings, including in the New feed. Other content types and channels stay visible, and the setting can be reversed in Subscription settings. Saves are serialized to preserve overlapping hides, and the menu label wraps at narrow widths.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Hide a channel’s videos, Shorts, live streams, or posts directly from the subscription feed’s three-dot menu.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/ffc0ba9a-2c4e-4820-9328-71a1ac784dc4">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/ba320683-6042-4d8f-a034-353685c0c924">
  <img alt="Subscription feed menu with the channel content-type hide action" src="https://github.com/user-attachments/assets/ffc0ba9a-2c4e-4820-9328-71a1ac784dc4">
</picture>
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a subscription feed with cached content, open an item’s three-dot menu, and select “Never show … from this channel in feeds again.” All entries of that type from the channel should disappear, while other channels and content types remain.
2. Repeat in the New feed and with Videos, Shorts, Live, and Posts. A running premiere in Videos should hide Videos; an archived stream in Live should hide Live.
3. Restart the app. The channel’s selected content type should remain hidden. Re-enable it in Subscription settings and check that the entries return.
4. Try a narrow window and a non-default UI scale. The full action label should remain readable, and removing entries at the bottom should leave no obsolete scroll offset or empty space.

## Additional context
<!-- Add any other context about the pull request here. -->

Implemented and reviewed with GPT-6 in Codex.

