### PR TITLE
fix(player): prevent extra SABR waits and keep countdown posters

### DIFF
--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -594,6 +594,35 @@ test('a stale yt-dlp rejection probe preserves a newer cache entry', async ({ ap
 })
 
 for (const zoom of [1, 1.25]) {
+  test(`startup countdown keeps artwork visible at ${zoom * 100}% scale`, async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await page.route('https://i.ytimg.com/**', route => route.fulfill({
+      contentType: 'image/svg+xml',
+      body: '<svg xmlns="http://www.w3.org/2000/svg" width="480" height="360"><rect width="480" height="360" fill="#326b8a"/></svg>'
+    }))
+    await page.evaluate(zoom => window.ftElectron.setZoomFactor(zoom), zoom)
+    await openMockedVideo(page)
+    const watchView = await watchViewHandle(page)
+    await watchView.evaluate(async view => {
+      view.isLoading = true
+      await view.$nextTick()
+      view.adEndTimeUnixMs = Date.now() + 8000
+      view.isLoading = false
+    })
+    const player = page.locator('.ftVideoPlayer')
+    await expect(player.locator('.countdownOverlay')).toBeVisible()
+    const poster = player.locator('.countdownPoster img')
+    await expect(poster).toBeVisible()
+    await expect.poll(() => poster.evaluate(image => image.naturalWidth)).toBe(480)
+    expect(await poster.getAttribute('alt')).toBe('')
+    const bounds = await player.boundingBox()
+    expect(await poster.boundingBox()).toEqual(bounds)
+    expect(await poster.evaluate(image => getComputedStyle(image).objectFit)).toBe('contain')
+    await expect(player.locator('.countdownOverlay')).toBeHidden({ timeout: 15_000 })
+    await expect(poster).toHaveCount(0)
+    await expect.poll(() => player.locator('video').evaluate(video => video.readyState)).toBeGreaterThanOrEqual(3)
+  })
+
   for (const posterAvailable of [true, false]) {
     test(`yt-dlp 403 recovery keeps the player height at ${zoom * 100}% scale with poster ${posterAvailable ? 'available' : 'unavailable'}`, async ({ app, page }, testInfo) => {
       await mockPlayableWatchPage(app, page)

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -1870,6 +1870,20 @@ html[data-reduced-motion='reduce'] .musicVisualizerCanvas {
   font-size: 0.8em;
 }
 
+.countdownPoster {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background: #000;
+  pointer-events: none;
+}
+
+.countdownPoster img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
 .countdownOverlay {
   position: absolute;
   inset: 0;
@@ -3117,6 +3131,7 @@ html[data-reduced-motion='reduce'] .musicVisualizerCanvas {
 }
 
 :deep(.shaka-spinner-container),
+.countdownPoster,
 .countdownOverlay {
   transition: inset-inline-end 250ms ease;
 }
@@ -4307,6 +4322,7 @@ html[data-reduced-motion='reduce'] .musicVisualizerCanvas {
 .ftVideoPlayer.presentationModeChanging .player,
 .ftVideoPlayer.presentationModeChanging :deep(.shaka-controls-container),
 .ftVideoPlayer.presentationModeChanging :deep(.shaka-spinner-container),
+.ftVideoPlayer.presentationModeChanging .countdownPoster,
 .ftVideoPlayer.presentationModeChanging .countdownOverlay,
 .ftVideoPlayer.presentationModeChanging :deep(.videoAnnotations),
 .ftVideoPlayer.presentationModeChanging :deep(.shaka-text-container),
@@ -4332,6 +4348,7 @@ html[data-reduced-motion='reduce'] .musicVisualizerCanvas {
 
 .ftVideoPlayer:is(:fullscreen, [data-native-player-screen]):is(.fullscreenDockLayoutOpen, .fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) :is(
   :deep(.shaka-spinner-container),
+  .countdownPoster,
   .countdownOverlay,
   :deep(.videoAnnotations),
   :deep(.shaka-text-container),
@@ -4339,6 +4356,7 @@ html[data-reduced-motion='reduce'] .musicVisualizerCanvas {
 ),
   .ftVideoPlayer.fullWindow:is(.fullscreenDockLayoutOpen, .fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) :is(
   :deep(.shaka-spinner-container),
+  .countdownPoster,
   .countdownOverlay,
   :deep(.videoAnnotations),
   :deep(.shaka-text-container),

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -151,6 +151,17 @@
         @enterpictureinpicture="handleEnterPictureInPicture"
         @leavepictureinpicture="handleLeavePictureInPicture"
       />
+      <!-- Native playback hides the video element, including its poster. -->
+      <div
+        v-if="showCountdownOverlay && !audioPlayerMode && thumbnail"
+        class="countdownPoster"
+        aria-hidden="true"
+      >
+        <img
+          :src="thumbnail"
+          alt=""
+        >
+      </div>
       <div
         v-if="audioPlayerMode"
         class="musicAudioSurface"

--- a/src/renderer/helpers/player/SabrSchemePlugin.js
+++ b/src/renderer/helpers/player/SabrSchemePlugin.js
@@ -65,7 +65,7 @@ const ShakaError = shaka.util.Error
  * @property {string} sabrUrl
  * @property {Set<number>} activeSabrContextTypes
  * @property {Map<number, SabrContextUpdate>} sabrContexts
- * @property {?NextRequestPolicy} nextRequestPolicy
+ * @property {number} backoffUntilMs
  * @property {Uint8Array | undefined} playbackCookieBytes
  * @property {boolean} playerReloadRequested
  * @property {number} requestNumber
@@ -300,13 +300,25 @@ async function doRequest(
 
   try {
     let shouldReloadDueToBackoffLoop = false
-    if ((currentState.sabrStreamState.nextRequestPolicy?.backoffTimeMs || 0) > 0) {
-      const currentBackoffTimeMs = currentState.sabrStreamState.nextRequestPolicy.backoffTimeMs
+    while (currentState.sabrStreamState.backoffUntilMs > Date.now()) {
+      const currentBackoffTimeMs = currentState.sabrStreamState.backoffUntilMs - Date.now()
       currentState.eventEmitter.emit('backoff-requested', { backoffMs: currentBackoffTimeMs })
       // Wait but can be aborted
       await new Promise((resolve, reject) => {
-        setTimeout(resolve, currentBackoffTimeMs)
-        currentState.abortController.signal.addEventListener('abort', reject)
+        const signal = currentState.abortController.signal
+        if (signal.aborted) {
+          reject(signal.reason)
+          return
+        }
+        const timer = setTimeout(() => {
+          signal.removeEventListener('abort', onAbort)
+          resolve()
+        }, currentBackoffTimeMs)
+        const onAbort = () => {
+          clearTimeout(timer)
+          reject(signal.reason)
+        }
+        signal.addEventListener('abort', onAbort, { once: true })
       })
       // Must reset AFTER waiting to avoid requested aborted
       // Since long backoff time mostly happens on the start of video playback we only reset timeout once
@@ -324,6 +336,7 @@ async function doRequest(
         (timeoutMs > 0 && timeoutMs <= currentState.cumulativeBackOffTimeMs)
       ) {
         shouldReloadDueToBackoffLoop = true
+        break
       }
     }
     if (shouldReloadDueToBackoffLoop || currentState.cumulativeRetryDueToNextRequestPolicy >= 100) {
@@ -360,6 +373,11 @@ async function doRequest(
       }
 
       const remainingData = new UmpReader(chunkedDataBuffer).read((part) => {
+        // MEDIA_END completes this request and aborts its response. A WebView
+        // can deliver later parts in the same chunk; ignore them just as we
+        // ignore later chunks, so they cannot change another loader's backoff.
+        if (currentState.abortStatus.finished) return
+
         switch (part.type) {
           case UMPPartId.STREAM_PROTECTION_STATUS: {
             const streamProtectionStatus = decodePart(part, StreamProtectionStatus)
@@ -423,7 +441,10 @@ async function doRequest(
             shouldRetry = true
             shouldRetryDueToNextRequestPolicy = true
 
-            currentState.sabrStreamState.nextRequestPolicy = nextRequestPolicy
+            // Audio and video loaders can reach this policy at different times.
+            // Count from receipt so each loader waits only the remaining time,
+            // and later segments do not repeat a delay that already elapsed.
+            currentState.sabrStreamState.backoffUntilMs = Date.now() + (nextRequestPolicy?.backoffTimeMs || 0)
 
             const rawPolicy = part.data.chunks.length === 1
               ? part.data.chunks[0]
@@ -754,7 +775,7 @@ export function createSabrTransport(sabrData, getRequestContext) {
     sabrUrl: sabrData.url,
     activeSabrContextTypes: new Set(),
     sabrContexts: new Map(),
-    nextRequestPolicy: undefined,
+    backoffUntilMs: 0,
     playbackCookieBytes: undefined,
     playerReloadRequested: false,
     requestNumber: 0,

--- a/tests/unit/sabr-transport.test.mjs
+++ b/tests/unit/sabr-transport.test.mjs
@@ -28,18 +28,18 @@ const context = { audioFormatId, videoFormatId, bufferedRanges: [], drcEnabled: 
 const sabrData = { url: 'https://example.test/sabr', scheme: 'sabr1', poToken: '', ustreamerConfig: '', clientInfo: {} }
 const request = uri => ({ uris: [uri], retryParameters: { timeout: 1000 } })
 
-function response(data, isInit = false) {
+function response(data, isInit = false, formatId = audioFormatId) {
   const buffer = new CompositeBuffer([])
   const writer = new UmpWriter(buffer)
   writer.write(protos.UMPPartId.MEDIA_HEADER, protos.MediaHeader.encode({
-    headerId: 1, formatId: audioFormatId, isInitSeg: isInit, sequenceNumber: 1,
+    headerId: 1, formatId, isInitSeg: isInit, sequenceNumber: 1,
   }).finish())
   writer.write(protos.UMPPartId.MEDIA, Uint8Array.of(1, ...data))
   writer.write(protos.UMPPartId.MEDIA_END, Uint8Array.of(1))
   return new Response(utils.concatenateChunks(buffer.chunks), { status: 200 })
 }
 
-function load(fetch) {
+function load(fetch, globals = {}) {
   const schemes = new Map()
   const api = vm.runInNewContext(`${source}\n({ createSabrTransport, setupSabrScheme })`, {
     ...utils, ...protos, ...protocol, CompositeBuffer, UmpReader,
@@ -48,9 +48,157 @@ function load(fetch) {
         unregisterScheme: key => schemes.delete(key) },
     } },
     fetch, process: { env: {} }, URL, AbortController, setTimeout, clearTimeout, console,
+    ...globals,
   })
   return { ...api, schemes }
 }
+
+function policyResponse(backoffTimeMs) {
+  const buffer = new CompositeBuffer([])
+  new UmpWriter(buffer).write(protos.UMPPartId.NEXT_REQUEST_POLICY,
+    protos.NextRequestPolicy.encode({ backoffTimeMs }).finish())
+  return new Response(utils.concatenateChunks(buffer.chunks))
+}
+
+async function flushRequests() {
+  for (let i = 0; i < 30; i++) await Promise.resolve()
+}
+
+for (const coalesced of [false, true]) {
+  test(`a completed segment does not apply a trailing backoff with ${coalesced ? 'coalesced' : 'separate'} network chunks`, async t => {
+    t.mock.timers.enable({ apis: ['setTimeout', 'Date'], now: 0 })
+    const media = new Uint8Array(await response([1], true).arrayBuffer())
+    const policy = new Uint8Array(await policyResponse(30000).arrayBuffer())
+    const chunks = coalesced ? [utils.concatenateChunks([media, policy])] : [media, policy]
+    const calls = []
+    const waits = []
+    const { createSabrTransport } = load(async () => {
+      calls.push(Date.now())
+      if (calls.length > 1) return response([2], true, videoFormatId)
+      return new Response(new ReadableStream({
+        start(controller) {
+          for (const chunk of chunks) controller.enqueue(chunk)
+          controller.close()
+        }
+      }))
+    }, { Date })
+    const transport = createSabrTransport(sabrData, () => context)
+    t.after(() => transport.cleanup())
+    transport.onBackoffRequested(({ backoffMs }) => waits.push(backoffMs))
+    const makeRequest = uri => transport.request(uri, {
+      uris: [uri], retryParameters: { timeout: 60000 }
+    }, 1).promise
+    await makeRequest('sabr1:audio?formatId=140-123-&init')
+    const video = makeRequest('sabr1:video?formatId=137-456-&resolution=1080&init')
+    await flushRequests()
+    t.mock.timers.tick(30000)
+    await video
+    assert.deepEqual(waits, [], 'bytes after the requested MEDIA_END must not delay another loader')
+    assert.deepEqual(calls, [0, 0])
+  })
+}
+
+test('staggered native audio and video initialization share the server backoff deadline', async t => {
+  t.mock.timers.enable({ apis: ['setTimeout', 'Date'], now: 0 })
+  const calls = []
+  const waits = []
+  const { createSabrTransport } = load(async (_uri, options) => {
+    const body = protos.VideoPlaybackAbrRequest.decode(options.body)
+    calls.push(Date.now())
+    if (calls.length === 1) return policyResponse(15000)
+    return response([1], true, body.clientAbrState.enabledTrackTypesBitfield === 1 ? audioFormatId : videoFormatId)
+  }, { Date })
+  const transport = createSabrTransport(sabrData, () => context)
+  t.after(() => transport.cleanup())
+  transport.onBackoffRequested(({ backoffMs }) => waits.push(backoffMs))
+  const audio = 'sabr1:audio?formatId=140-123-&init'
+  const video = 'sabr1:video?formatId=137-456-&resolution=1080&init'
+  const makeRequest = uri => ({ uris: [uri], retryParameters: { timeout: 30000 } })
+  const audioPending = transport.request(audio, makeRequest(audio), 1).promise
+  await flushRequests()
+  t.mock.timers.tick(5000)
+  const videoPending = transport.request(video, makeRequest(video), 1).promise
+  await flushRequests()
+  t.mock.timers.tick(10000)
+  await flushRequests()
+  // Observe both completions before assertions so a failing run can clean up.
+  t.mock.timers.tick(5000)
+  await Promise.all([audioPending, videoPending])
+  assert.deepEqual(waits, [15000, 10000], 'the second loader must not restart the full startup countdown')
+  assert.deepEqual(calls, [0, 15000, 15000])
+})
+
+test('later native segments do not repeat an expired server backoff', async t => {
+  t.mock.timers.enable({ apis: ['setTimeout', 'Date'], now: 0 })
+  let calls = 0
+  const waits = []
+  const { createSabrTransport } = load(async () => {
+    if (++calls === 1) return policyResponse(15000)
+    return response([1])
+  }, { Date })
+  const transport = createSabrTransport(sabrData, () => context)
+  t.after(() => transport.cleanup())
+  transport.onBackoffRequested(({ backoffMs }) => waits.push(backoffMs))
+  const uri = 'sabr1:audio?formatId=140-123-&sq=1'
+  const request = { uris: [uri], retryParameters: { timeout: 30000 } }
+  const first = transport.request(uri, request, 1).promise
+  await flushRequests()
+  t.mock.timers.tick(15000)
+  await first
+  const later = transport.request(uri, request, 1).promise
+  await flushRequests()
+  t.mock.timers.tick(15000)
+  await later
+  assert.deepEqual(waits, [15000])
+  assert.equal(calls, 3)
+})
+
+test('closing a native source cancels its backoff without sending a delayed request', async t => {
+  t.mock.timers.enable({ apis: ['setTimeout', 'Date'], now: 0 })
+  let calls = 0
+  const { createSabrTransport } = load(async () => {
+    calls++
+    return policyResponse(15000)
+  }, { Date })
+  const transport = createSabrTransport(sabrData, () => context)
+  const uri = 'sabr1:audio?formatId=140-123-&init'
+  const pending = transport.request(uri, { uris: [uri], retryParameters: { timeout: 30000 } }, 1).promise
+  await flushRequests()
+  transport.cleanup()
+  await assert.rejects(pending, error => error.code === ShakaError.Code.OPERATION_ABORTED)
+  t.mock.timers.tick(30000)
+  await flushRequests()
+  assert.equal(calls, 1)
+})
+
+test('a newer server policy extends the deadline for loaders already waiting', async t => {
+  t.mock.timers.enable({ apis: ['setTimeout', 'Date'], now: 0 })
+  let releaseVideo
+  const calls = []
+  const { createSabrTransport } = load(async (_uri, options) => {
+    calls.push(Date.now())
+    if (calls.length === 1) return policyResponse(15000)
+    if (calls.length === 2) return new Promise(resolve => { releaseVideo = resolve })
+    const body = protos.VideoPlaybackAbrRequest.decode(options.body)
+    return response([1], true, body.clientAbrState.enabledTrackTypesBitfield === 1 ? audioFormatId : videoFormatId)
+  }, { Date })
+  const transport = createSabrTransport(sabrData, () => context)
+  t.after(() => transport.cleanup())
+  const pending = [
+    'sabr1:audio?formatId=140-123-&init',
+    'sabr1:video?formatId=137-456-&resolution=1080&init',
+  ].map(uri => transport.request(uri, { uris: [uri], retryParameters: { timeout: 30000 } }, 1).promise)
+  await flushRequests()
+  t.mock.timers.tick(5000)
+  releaseVideo(policyResponse(20000))
+  await flushRequests()
+  t.mock.timers.tick(10000)
+  await flushRequests()
+  assert.equal(calls.length, 2, 'the audio loader must respect the newer deadline')
+  t.mock.timers.tick(10000)
+  await Promise.all(pending)
+  assert.deepEqual(calls, [0, 0, 25000, 25000])
+})
 
 test('native SABR transport encodes decoder state and returns only the requested media bytes', async () => {
   const requests = []


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Reported during Pixel playback testing; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Android startup could show unnecessarily long SABR countdowns. Audio and video loaders restarted the full server delay, and response parts following the requested media's completion could apply another backoff when delivered in the same network chunk.

Share the backoff expiry across loaders and stop handling response parts after the requested media completes. Keep the thumbnail behind active countdowns, including native Android playback, while leaving controls accessible.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Avoid extra SABR startup waits and keep video thumbnails visible during countdowns.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run this branch on Android and open a SABR video. If a startup backoff occurs, its remaining time should continue decreasing as audio and video initialize.
2. While a countdown is active, confirm that the thumbnail remains visible behind it and the controls remain usable. After the countdown ends, the thumbnail overlay should disappear and playback should work normally.
3. Seek and change quality after startup. An expired delay should not return on subsequent segment requests. Check countdown layout on desktop at 100% and 125% UI scale as well.

## Additional context
<!-- Add any other context about the pull request here. -->


Forced Pixel checks reproduced both failures before the fixes:

- A 15-second delay with audio/video initialization staggered by five seconds went from 21.0 seconds to 15.8 seconds to readiness.
- A 20-second policy following a completed initialization in the same network chunk went from 21.4 seconds to 1.5 seconds, with no countdown after the fix. Playback advanced normally.

Twelve additional normal Pixel startups produced no backoff. The original naturally occurring incident remains uncaptured; this change does not impose a six-second limit on genuine server-requested delays.

Validation: 1,302 unit tests, 30 playback-recovery E2E tests, and lint passed. E2E includes countdown poster coverage at 100% and 125% UI scale.

Pixel evidence from the forced countdown test, showing the retained poster:

![Pixel poster behind an active SABR countdown](https://github.com/user-attachments/assets/f962a094-e236-4e10-88c1-72636a9856cb)

Implemented and reviewed with GPT-6 in the Codex desktop app.
