### PR TITLE
fix(themes): remove panel seams and dialog flashes, clarify seekbar progress

### DIFF
--- a/e2e/helpers/colors.mjs
+++ b/e2e/helpers/colors.mjs
@@ -1,12 +1,14 @@
-export async function sampleColors(app, region, points) {
+export async function sampleColors(app, region, points, { finishAnimations = true } = {}) {
   const { page } = app
   await region.scrollIntoViewIfNeeded()
-  await page.evaluate(async () => {
-    document.getAnimations().forEach(animation => {
-      if (animation.effect.getComputedTiming().iterations !== Infinity) animation.finish()
-    })
+  await page.evaluate(async finishAnimations => {
+    if (finishAnimations) {
+      document.getAnimations().forEach(animation => {
+        if (animation.effect.getComputedTiming().iterations !== Infinity) animation.finish()
+      })
+    }
     await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))
-  })
+  }, finishAnimations)
   const origin = await region.evaluate(element => { const { x, y } = element.getBoundingClientRect(); return { x, y } })
   const viewport = await page.evaluate(() => ({ width: innerWidth, height: innerHeight }))
   // Capture Electron's actual zoomed framebuffer; Playwright's screenshot

--- a/e2e/tests/offline/theme-contrast.spec.mjs
+++ b/e2e/tests/offline/theme-contrast.spec.mjs
@@ -1,5 +1,7 @@
 import { test, expect, goToSettingsSection } from '../../helpers/app.mjs'
 import { sampleColors } from '../../helpers/colors.mjs'
+import { openMockedVideo } from '../../helpers/player.mjs'
+import { mockPlayableWatchPage } from '../../helpers/watch.mjs'
 
 function contrastRatio(first, second) {
   const luminance = rgb => rgb.map(value => value / 255)
@@ -42,6 +44,60 @@ for (const theme of ['openTubeXLight', 'openTubeXDark']) {
   for (const scale of [100, 125]) {
     test.describe(`${theme} control contrast at ${scale}%`, () => {
       test.use({ seed: { settings: { baseTheme: theme, currentLocale: 'en-US', uiScale: scale } } })
+
+      test('seekbar progress stays neutral and SponsorBlock categories remain visible', async ({ app, page }) => {
+        await mockPlayableWatchPage(app, page)
+        const categories = ['sponsor', 'selfpromo', 'interaction', 'intro', 'outro', 'preview', 'hook', 'music_offtopic', 'filler', 'poi_highlight']
+        await page.route('**/api/skipSegments/**', route => route.fulfill({
+          json: [{
+            videoID: 'jNQXAC9IVRw',
+            segments: categories.map((category, index) => ({
+              UUID: `seekbar-${category}`,
+              category,
+              actionType: category === 'poi_highlight' ? 'poi' : 'skip',
+              segment: [index * 2 + 1, index * 2 + (category === 'poi_highlight' ? 1 : 2)],
+              videoDuration: 30,
+              votes: 1,
+              locked: 0,
+              description: ''
+            }))
+          }]
+        }))
+        await page.evaluate(() => {
+          document.querySelector('#app').__vue_app__.config.globalProperties.$store.commit('setUseSponsorBlock', true)
+        })
+        await openMockedVideo(page)
+        const player = page.locator('.ftVideoPlayer')
+        await player.locator('video').evaluate(video => {
+          video.pause()
+          video.currentTime = 24
+          video.dispatchEvent(new Event('timeupdate'))
+        })
+        await player.hover()
+        const bar = player.locator('.shaka-seek-bar-container')
+        await expect(bar.locator('.sponsorBlockMarker')).toHaveCount(categories.length)
+        await expect.poll(() => bar.locator('.shaka-seek-bar').inputValue()).toBe('24')
+        const points = await bar.evaluate(element => {
+          const rect = element.getBoundingClientRect()
+          return [
+            [rect.width * 0.75, rect.height / 2],
+            [rect.width * 0.95, rect.height / 2],
+            ...Array.from(element.querySelectorAll('.sponsorBlockMarker'), marker => {
+              const bounds = marker.getBoundingClientRect()
+              return [bounds.x - rect.x + bounds.width / 2, bounds.y - rect.y + bounds.height / 2]
+            })
+          ]
+        })
+        const [played, unplayed, ...markers] = await sampleColors(app, bar, points)
+        expect(Math.max(...played) - Math.min(...played), `neutral progress: ${played}`).toBeLessThanOrEqual(2)
+        expect(Math.min(...played), `soft white progress: ${played}`).toBeGreaterThanOrEqual(200)
+        expect(Math.max(...played), `retain marker colors: ${played}`).toBeLessThanOrEqual(235)
+        expect(Math.max(...played.map((value, index) => Math.abs(value - unplayed[index])))).toBeGreaterThanOrEqual(20)
+        for (const [index, marker] of markers.entries()) {
+          expect(Math.max(...marker.map((value, channel) => Math.abs(value - played[channel]))),
+            `${categories[index]} marker: ${marker}, progress: ${played}`).toBeGreaterThanOrEqual(20)
+        }
+      })
 
       test('toggle track and thumb remain distinct in both states', async ({ app, page, attachScreenshot }) => {
         await goToSettingsSection(page, 'general')

--- a/e2e/tests/offline/theme-surfaces.spec.mjs
+++ b/e2e/tests/offline/theme-surfaces.spec.mjs
@@ -1,4 +1,4 @@
-import { test, expect, goTo } from '../../helpers/app.mjs'
+import { test, expect, goTo, setPlayerFullscreen } from '../../helpers/app.mjs'
 import { sampleColors } from '../../helpers/colors.mjs'
 import { openMockedVideo, waitForPlayback } from '../../helpers/player.mjs'
 import { mockPlayableWatchPage, watchViewHandle } from '../../helpers/watch.mjs'
@@ -38,6 +38,28 @@ async function attachThemeScreenshot(app, testInfo, name) {
   const base64 = await app.electronApp.evaluate(async ({ BrowserWindow }) =>
     (await BrowserWindow.getAllWindows()[0].webContents.capturePage()).toPNG().toString('base64'))
   await testInfo.attach(name, { body: Buffer.from(base64, 'base64'), contentType: 'image/png' })
+}
+
+async function expectPanelOwnsBackground(app, card, points) {
+  // Compare identical pixels before and after removing the nested background
+  // so the panel gradient or video behind it cannot be mistaken for a seam.
+  const actual = await sampleColors(app, card, points)
+  const originalStyle = await card.getAttribute('style')
+  await card.evaluate(element => {
+    element.style.setProperty('background', 'transparent', 'important')
+    element.style.setProperty('backdrop-filter', 'none', 'important')
+  })
+  try {
+    const reference = await sampleColors(app, card, points)
+    const difference = Math.max(...actual.flatMap((color, point) =>
+      color.map((value, channel) => Math.abs(value - reference[point][channel]))))
+    expect.soft(difference, `Panel card pixels: ${JSON.stringify({ actual, reference })}`).toBeLessThanOrEqual(2)
+  } finally {
+    await card.evaluate((element, style) => {
+      if (style === null) element.removeAttribute('style')
+      else element.setAttribute('style', style)
+    }, originalStyle)
+  }
 }
 
 for (const theme of ['openTubeXLight', 'openTubeXDark']) {
@@ -112,6 +134,75 @@ for (const theme of ['openTubeXLight', 'openTubeXDark']) {
           [width - 60, -26], [width - 60, -12], [width - 60, height / 2], [width - 60, height + 5]
         ])
         await attachThemeScreenshot(app, testInfo, `${theme} description footer at ${scale}%`)
+      })
+
+      test('Shorts video information blends into its panel', async ({ app, page }, testInfo) => {
+        await mockPlayableWatchPage(app, page, { captionCueSettings: 'align:center' })
+        await openMockedVideo(page)
+        const view = await watchViewHandle(page)
+        await view.evaluate(async component => {
+          component.isLoading = true
+          await component.$nextTick()
+          component.isShort = true
+          component.videoDescription = 'A short description.'
+          component.videoDescriptionHtml = ''
+          component.videoTags = ['shorts', 'theme']
+          component.shortsMetadataOpen = true
+          component.isLoading = false
+          await component.$nextTick()
+        })
+        await waitForPlayback(page)
+        await page.locator('.ftVideoPlayer video').evaluate(video => video.pause())
+        const panel = page.locator('.shortsAuxPanel')
+        await expect(panel).toHaveClass(/shortsAuxPanelOpen/)
+        await page.mouse.move(0, 0)
+        for (const selector of ['.watchVideoInfo', '.videoDescription']) {
+          const card = panel.locator(selector)
+          await expect(card).toBeVisible()
+          const height = await card.evaluate(element => element.getBoundingClientRect().height)
+          // Compare the empty gutter immediately across each section boundary,
+          // skipping the header's intentional one-pixel separator.
+          await expectContinuousBackground(app, card, [[5, -4], [5, 4]])
+          await expectContinuousBackground(app, card, [[5, height - 4], [5, height + 4]])
+        }
+        await attachThemeScreenshot(app, testInfo, `${theme} Shorts information at ${scale}%`)
+
+        await setPlayerFullscreen(page, true)
+        const fullscreenPanel = page.locator('.fullscreenMetadataOverlay.open')
+        await expect(fullscreenPanel).toBeVisible()
+        for (const selector of ['.watchVideoInfo', '.videoDescription']) {
+          await expectPanelOwnsBackground(app, fullscreenPanel.locator(selector), [[5, 4], [5, 40]])
+        }
+        await attachThemeScreenshot(app, testInfo, `${theme} fullscreen information at ${scale}%`)
+
+        await view.evaluate(component => component.toggleTranscript())
+        const transcript = page.locator('.fullscreenTranscriptOverlay.open .watchVideoTranscript')
+        await expect(transcript).toBeVisible()
+        await expectPanelOwnsBackground(app, transcript, [[5, 80], [5, 160]])
+        await setPlayerFullscreen(page, false)
+        const shortsTranscript = panel.locator('.watchVideoTranscript')
+        await expect(shortsTranscript).toBeVisible()
+        await expectPanelOwnsBackground(app, shortsTranscript, [[5, 80], [5, 160]])
+      })
+
+      test('Shorts comments blend into their panel and fullscreen overlay', async ({ app, page }) => {
+        await mockPlayableWatchPage(app, page)
+        await openMockedVideo(page)
+        const view = await watchViewHandle(page)
+        await view.evaluate(async component => {
+          component.isShort = true
+          await component.$nextTick()
+          component.toggleShortsComments()
+        })
+        await page.locator('.ftVideoPlayer video').evaluate(video => video.pause())
+        const comments = page.locator('.shortsCommentsPanel .fullscreenCommentCard')
+        await expect(comments).toBeVisible()
+        await expectPanelOwnsBackground(app, comments, [[5, 80], [5, 160]])
+        await setPlayerFullscreen(page, true)
+        await page.locator('.fullscreenCommentsToggle').click({ force: true })
+        const fullscreenComments = page.locator('.fullscreenCommentsOverlay.open .fullscreenCommentCard')
+        await expect(fullscreenComments).toBeVisible()
+        await expectPanelOwnsBackground(app, fullscreenComments, [[5, 80], [5, 160]])
       })
 
       test('other feed headers and channel panels blend into their cards', async ({ app, page }, testInfo) => {

--- a/e2e/tests/offline/theme-surfaces.spec.mjs
+++ b/e2e/tests/offline/theme-surfaces.spec.mjs
@@ -3,6 +3,11 @@ import { sampleColors } from '../../helpers/colors.mjs'
 import { openMockedVideo, waitForPlayback } from '../../helpers/player.mjs'
 import { mockPlayableWatchPage, watchViewHandle } from '../../helpers/watch.mjs'
 
+function maxColorDifference(actual, reference) {
+  return Math.max(...actual.flatMap((color, point) =>
+    color.map((value, channel) => Math.abs(value - reference[point][channel]))))
+}
+
 async function expectContinuousBackground(app, region, points) {
   const colors = await sampleColors(app, region, points)
   const difference = Math.max(...colors.slice(1).flatMap(color =>
@@ -25,8 +30,7 @@ async function expectDescriptionBackground(app, region, points) {
     })
     try {
       const reference = await sampleColors(app, region, points)
-      return Math.max(...actual.flatMap((color, point) =>
-        color.map((value, channel) => Math.abs(value - reference[point][channel]))))
+      return maxColorDifference(actual, reference)
     } finally {
       await style.evaluate(element => element.remove())
     }
@@ -51,8 +55,7 @@ async function expectPanelOwnsBackground(app, card, points) {
   })
   try {
     const reference = await sampleColors(app, card, points)
-    const difference = Math.max(...actual.flatMap((color, point) =>
-      color.map((value, channel) => Math.abs(value - reference[point][channel]))))
+    const difference = maxColorDifference(actual, reference)
     expect.soft(difference, `Panel card pixels: ${JSON.stringify({ actual, reference })}`).toBeLessThanOrEqual(2)
   } finally {
     await card.evaluate((element, style) => {
@@ -90,6 +93,33 @@ for (const theme of ['openTubeXLight', 'openTubeXDark']) {
         // Sample the empty gutter on both sides of the header's bottom edge.
         await expectContinuousBackground(app, header, [[5, height - 4], [5, height + 4]])
         await attachThemeScreenshot(app, testInfo, `${theme} subscription header at ${scale}%`)
+      })
+
+      test('search filter background does not flash when its opening animation ends', async ({ app, page }) => {
+        await page.addStyleTag({ content: '.promptCard { animation-play-state: paused !important; }' })
+        await page.locator('.navFilterButton').click()
+        const dialog = page.getByRole('dialog', { name: 'Search Filters' })
+        await expect(dialog).toBeVisible()
+        await dialog.evaluate(element => {
+          const animation = element.getAnimations().find(animation => animation.animationName?.startsWith('prompt-card-enter'))
+          if (!animation) throw new Error('Missing prompt opening animation')
+          // Sample just before the transform is removed, with effectively
+          // identical geometry and opacity to the settled dialog.
+          animation.currentTime = animation.effect.getComputedTiming().duration - 0.001
+          element.closest('.prompt').getAnimations().forEach(animation => animation.finish())
+        })
+        await expect(dialog).not.toHaveCSS('transform', 'none')
+        const points = await dialog.evaluate(element => {
+          const { width, height } = element.getBoundingClientRect()
+          return [[4, 16], [width / 2, 4], [width - 4, height / 2], [4, height - 16]]
+        })
+        const opening = await sampleColors(app, dialog, points, { finishAnimations: false })
+        const settled = await sampleColors(app, dialog, points)
+        await expect(dialog).toHaveCSS('transform', 'none')
+        const difference = maxColorDifference(opening, settled)
+        expect(difference, `Opening and settled backgrounds: ${JSON.stringify({ opening, settled })}`).toBeLessThanOrEqual(2)
+        await page.getByRole('button', { name: 'Close', exact: true }).click()
+        await expect(dialog).toBeHidden()
       })
 
       test('description controls and fades blend into their card', async ({ app, page }, testInfo) => {

--- a/src/renderer/components/CommentSection/CommentSection.css
+++ b/src/renderer/components/CommentSection/CommentSection.css
@@ -21,7 +21,7 @@
   padding-inline: 0;
   overflow: hidden;
   color: #fff;
-  background-color: transparent;
+  background: transparent;
   backdrop-filter: none;
   box-shadow: none;
 }

--- a/src/renderer/components/FtPrompt/FtPrompt.css
+++ b/src/renderer/components/FtPrompt/FtPrompt.css
@@ -22,6 +22,9 @@
 
 .promptCard {
   animation: prompt-card-enter 150ms ease-out;
+
+  /* Keep the gradient anchored to the card when the entry transform ends. */
+  background-attachment: scroll;
   overflow-y: auto;
   max-block-size: 95%;
   box-shadow: 0 12px 40px rgb(0 0 0 / 38%);

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -2792,7 +2792,8 @@ html[data-reduced-motion='reduce'] .musicVisualizerCanvas {
   max-inline-size: 100%;
   margin: 0;
   color: #fff;
-  background-color: transparent;
+  background: transparent;
+  backdrop-filter: none;
   border-radius: 0;
   box-shadow: none;
 }
@@ -2923,7 +2924,8 @@ html[data-reduced-motion='reduce'] .musicVisualizerCanvas {
   margin: 0;
   overflow: hidden;
   color: #fff;
-  background-color: transparent;
+  background: transparent;
+  backdrop-filter: none;
   border-radius: 0;
   box-shadow: none;
 }

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -4509,7 +4509,7 @@ export default defineComponent({
             // the issue is clearly on the FreeTube side as shaka-player's demo page works fine and they show up all the time for the legacy formats.
             // As I have spent way too much time debugging it and still cannot make sense of it, we'll stick with FreeTube's own chapter markers for now.
             chapters: 'transparent',
-            played: 'var(--primary-color)'
+            played: 'var(--seekbar-played-color, var(--primary-color))'
           },
           showAudioCodec: false,
           // Paused media needs a visible way to resume on both desktop and touch devices.

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -2351,6 +2351,8 @@ body .os-scrollbar {
    their own primary and secondary colors. */
 .openTubeXLight,
 .openTubeXDark {
+  /* Leave enough tonal headroom for SponsorBlock's color-blended markers. */
+  --seekbar-played-color: #ddd;
   --toggle-track-color: #758b87;
   --toggle-checked-track-color: #4e9185;
   --toggle-thumb-color: #e6f4f1;

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -895,6 +895,8 @@
 
     .shortsAuxPanel {
       flex-direction: column;
+      // Paint one gradient across the header, contents and unused panel space.
+      background-image: var(--card-bg-image);
     }
 
     .shortsAuxPanelHeader {
@@ -935,6 +937,8 @@
       margin-inline: 0;
       border-radius: 0;
       box-shadow: none;
+      background: transparent;
+      backdrop-filter: none;
     }
 
     .shortsAuxPanelTarget :deep(.watchVideoTranscript) {


### PR DESCRIPTION
The OpenTubeX theme still showed seams between the sections of the Shorts information panel after #1207, and its teal seekbar was hard to distinguish from SponsorBlock markers. Search filters also flashed when their opening animation ended. This keeps panel and dialog gradients stable and uses soft white for playback progress.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Reported directly by Nico. Follow-up to #1207; no separate issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The Shorts information panel paints one shared theme gradient across its header, metadata, description, and unused space. Nested cards no longer repaint their own backgrounds or blur. Fullscreen information, transcript, and comment panels also clear their inherited card gradients. Shared prompts keep their gradients anchored to the card throughout the opening animation, preventing the search-filter flash. The OpenTubeX seekbar uses soft white while retaining the default SponsorBlock category colors. Pixel regressions cover panel boundaries, the prompt animation boundary, neutral progress, and all ten default marker categories in both OpenTubeX themes at 100% and 125% UI scale.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Select OpenTubeX Light or OpenTubeX Dark in Appearance settings and open a Short.
2. Open Video information. The background should continue through the metadata, description, tags, and unused space without hard seams.
3. Open comments, then check information, comments, and a captioned video's transcript in fullscreen. The fullscreen overlays should retain their dark backgrounds without theme-colored cards showing through.
4. Play a video with SponsorBlock segments. Progress should be soft white, distinct from the category-colored segments and the darker unplayed track.
5. Open Search Filters from the search bar. The gradient should stay stable as the dialog finishes opening. Close it, reopen it, and confirm the filters still work.
6. Repeat with the other OpenTubeX theme and at 125% UI scale.

## Additional context
<!-- Add any other context about the pull request here. -->
The affected OpenTubeX themes were added after the latest release, so this is marked Not noteworthy.

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/7fcbf1ef-1177-48b1-8740-f752d480bbaf">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/54e4a114-59d4-4608-809b-5218abb7b4b2">
  <img alt="Continuous background in the Shorts video information panel" src="https://github.com/user-attachments/assets/7fcbf1ef-1177-48b1-8740-f752d480bbaf">
</picture>

![Soft white seekbar with default SponsorBlock markers](https://github.com/user-attachments/assets/bf66d847-986d-43e5-a9af-64a7153a8b50)

Prepared with GPT-6 in Codex.


