### PR TITLE
fix: load YouTube Mix playlists and show unknown video counts

### DIFF
--- a/e2e/tests/offline/playlist-loading.spec.mjs
+++ b/e2e/tests/offline/playlist-loading.spec.mjs
@@ -56,6 +56,65 @@ async function openPlaylistTab(page, route) {
   await expect(page).toHaveURL(/#\/playlist\//)
 }
 
+test('loads an Invidious Mix response from the playlist endpoint', async ({ page, attachScreenshot }) => {
+  const playlistId = 'RDnGusAJYHcjo'
+  const errors = []
+  page.on('console', message => {
+    if (message.type() === 'error') errors.push(message.text())
+  })
+  // Invidious redirects RD playlists to /mixes, whose JSON only has these fields.
+  await page.route(new RegExp(`/api/v1/playlists/${playlistId}\\?`), route => route.fulfill({
+    json: {
+      title: 'Mix - Playlist video 1',
+      mixId: playlistId,
+      videos: [playlistVideo(0, 'nGusAJYHcjo'), playlistVideo(1)],
+    },
+  }))
+
+  await openPlaylistTab(page, `/playlist/${playlistId}`)
+
+  const playlistPage = page.locator('.playlistPage')
+  await expect(playlistPage.getByText('Playlist video 1', { exact: true })).toBeVisible()
+  await expect(playlistPage.getByText('Playlist video 2', { exact: true })).toBeVisible()
+  await expect(playlistPage.locator('.playlistInfo')).toContainText('2 videos')
+  await expect(playlistPage.locator('.playlistInfo')).not.toContainText('Invalid Date')
+  await expect(playlistPage.locator('.playlistInfo')).not.toContainText('Last Updated')
+  await expect(playlistPage.locator('.playlistInfo')).not.toContainText('views')
+  await expect(playlistPage.locator('.playlistChannel')).toHaveCount(0)
+  await expect(playlistPage.locator('.ft-auto-load-next-page-wrapper')).toHaveCount(0)
+  await expect(playlistPage.locator('.playlistThumbnail a')).toHaveAttribute('href', /\/watch\/nGusAJYHcjo/)
+  expect(errors).toEqual([])
+  await attachScreenshot('loaded-invidious-mix')
+
+  await playlistPage.getByText('Playlist video 1', { exact: true }).click()
+  const watchPlaylist = page.locator('.watchVideoPlaylist')
+  await expect(watchPlaylist.locator('.playlistItem')).toHaveCount(2)
+  await expect(watchPlaylist.locator('.playlistIndex label')).toHaveText('1 / 2')
+})
+
+test('displays an unknown Mix video count without a negative badge', async ({ page, attachScreenshot }) => {
+  await page.route('https://invidious.test/api/v1/search/**', route => route.fulfill({
+    json: [{
+      type: 'playlist',
+      title: 'Mix - Playlist video 1',
+      playlistId: 'RDnGusAJYHcjo',
+      playlistThumbnail: 'https://i.ytimg.com/vi/nGusAJYHcjo/hqdefault.jpg',
+      author: 'YouTube',
+      authorId: '',
+      videoCount: -1,
+      videos: [],
+    }],
+  }))
+
+  await page.locator(sel.searchInput).fill('mix')
+  await page.locator(sel.searchInput).press('Enter')
+
+  const mix = page.getByRole('link', { name: 'Mix - Playlist video 1' }).last()
+    .locator('xpath=ancestor::div[contains(@class, "ft-list-item")]')
+  await expect(mix.locator('.videoCountContainer')).toHaveText('∞')
+  await attachScreenshot('mix-search-count')
+})
+
 test('settles a missing user playlist into a persistent not-found state', async ({ page }) => {
   await openPlaylistTab(page, '/playlist/missing-playlist?playlistType=user')
 

--- a/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
+++ b/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
@@ -28,7 +28,8 @@
       >
         <div class="background" />
         <div class="inner">
-          <div>{{ playlistMetadata.videoCount }}</div>
+          <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- Infinity is a language-independent count indicator. -->
+          <div>{{ playlistMetadata.videoCount < 0 ? '∞' : playlistMetadata.videoCount }}</div>
           <div><FtIcon :icon="['fas','list']" /></div>
         </div>
       </div>

--- a/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
+++ b/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
@@ -69,14 +69,16 @@
         </h2>
         <p>
           {{ t('Global.Counts.Video Count', { count: parsedVideoCount }, videoCount) }}
-          <template v-if="!hideViews && !isUserPlaylist">
+          <template v-if="!hideViews && !isUserPlaylist && viewCount >= 0">
             - {{ t('Global.Counts.View Count', { count: parsedViewCount }, viewCount) }}
           </template>
-          -
-          <template v-if="infoSource !== 'local'">
-            {{ $t("Playlist.Last Updated On") }}
+          <template v-if="lastUpdated">
+            -
+            <template v-if="infoSource !== 'local'">
+              {{ $t("Playlist.Last Updated On") }}
+            </template>
+            {{ lastUpdated }}
           </template>
-          {{ lastUpdated }}
           <template v-if="durationFormatted !== ''">
             <br>
             {{ $t('User Playlists.TotalTimePlaylist', { duration: durationFormatted }) }}

--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -311,7 +311,7 @@ export async function searchInvidiousChannel(channelId, query, page) {
  *  descriptionHtml: string,
  *  videoCount: number,
  *  viewCount: number,
- *  updated: number,
+ *  updated: number | null,
  *  videos: {
  *    title: string,
  *    videoId: string,
@@ -334,6 +334,21 @@ export async function invidiousGetPlaylistInfo(playlistId, page) {
 
   playlist.pageVideoCount = playlist.videos.length
   playlist.videos = filterUnavailableInvidiousPlaylistVideos(playlist.videos)
+  // RD playlists redirect to /mixes, which returns only title, mixId and videos.
+  // Expose the returned batch as a playlist to both the playlist page and player.
+  if (playlist.mixId != null) {
+    Object.assign(playlist, {
+      playlistId: playlist.mixId,
+      author: '',
+      authorId: '',
+      authorThumbnails: [],
+      description: '',
+      descriptionHtml: '',
+      videoCount: playlist.videos.length,
+      viewCount: -1,
+      updated: null,
+    })
+  }
   normalizeManyInvidiousVideosAttributes(playlist.videos)
   setMultiplePublishedTimestamps(playlist.videos)
 

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -970,7 +970,7 @@ async function getPlaylistInvidious() {
       channelId: channelId.value
     })
 
-    lastUpdatedDate.value = new Date(result.updated * 1000)
+    lastUpdatedDate.value = result.updated == null ? null : new Date(result.updated * 1000)
     updateLastUpdatedDate()
 
     playlistItems.value = result.videos


### PR DESCRIPTION
YouTube Mix playlists fail to load even when Invidious returns HTTP 200. This fixes Mix response handling and replaces the negative video-count badge with an infinity indicator.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #1219

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Invidious redirects Mix playlist requests to `/mixes`, whose responses contain only `title`, `mixId`, and `videos`. Normalize that response for the playlist page and player so missing author thumbnails no longer cause the `.at` exception. Show the returned video batch and omit unavailable views, author details, and update dates.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
YouTube Mix playlists now load through Invidious, and unknown video counts show an infinity indicator instead of -1.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. In the running app, select Invidious as the backend and use a working instance. Disable backend fallback.
2. Paste `https://www.youtube.com/playlist?list=RDnGusAJYHcjo` into the search bar. The Mix should show its title, videos, and total duration without a playlist-loading error or a console `.at` exception. Unavailable view counts and update dates should be absent.
3. Open a video from the Mix. The player playlist should show its videos and the current position.
4. Search for a Mix and check that an unknown video count displays `∞` instead of `-1`. Open an ordinary playlist and confirm its count, views, and update date still display normally.

## Additional context
<!-- Add any other context about the pull request here. -->

The reported Mix was verified against a live Invidious instance: all 49 returned videos and the player playlist loaded. Separate channel HTTP 500 responses did not prevent Mix loading.

Changes prepared by GPT-6 using the Codex harness.
