### PR TITLE
fix(posts): restore spacing below community images

### DIFF
--- a/e2e/tests/offline/community-post-images.spec.mjs
+++ b/e2e/tests/offline/community-post-images.spec.mjs
@@ -226,6 +226,31 @@ test.describe('community post images', () => {
     }
   })
 
+  test('separates post images from the like and comment row at different UI scales', async ({ page, attachScreenshot }) => {
+    await stubPostImages(page)
+    await goTo(page, 'subscriptions')
+    await page.locator('[data-subscription-feed-tab="posts"]').click()
+
+    for (const scale of [1, 0.95, 1.25]) {
+      await page.evaluate((factor) => window.ftElectron.setZoomFactor(factor), scale)
+
+      for (const title of ['Single image community post', 'Multi image community post']) {
+        const post = page.locator('.ft-list-post').filter({ hasText: title })
+        const image = post.locator('img.communityImage').first()
+        await expect.poll(() => image.evaluate((element) => element.naturalWidth)).toBeGreaterThan(0)
+        await post.locator('.bottomSection').scrollIntoViewIfNeeded()
+
+        await expect.poll(() => post.evaluate((element) => {
+          const imageBottom = element.querySelector('img.communityImage').getBoundingClientRect().bottom
+          const actionsTop = element.querySelector('.bottomSection').getBoundingClientRect().top
+          return actionsTop - imageBottom
+        }), { message: `${title} needs space above its actions at ${scale * 100}% UI scale` }).toBeGreaterThanOrEqual(8)
+      }
+
+      await attachScreenshot(`post image spacing at ${scale * 100}% UI scale`)
+    }
+  })
+
   test('restores carousel navigation after returning to the Posts tab', async ({ page }) => {
     await stubPostImages(page)
 

--- a/src/renderer/components/FtCommunityPost/FtCommunityPost.scss
+++ b/src/renderer/components/FtCommunityPost/FtCommunityPost.scss
@@ -77,7 +77,7 @@
   display: flex;
   align-items: center;
   font-size: 15px;
-  margin-block-start: 4px;
+  margin-block-start: 12px;
   max-inline-size: 100%;
   text-align: start;
 


### PR DESCRIPTION
Community-post images sat too close to the like and comment row after the image-sizing fix removed their implicit inline spacing. Set an explicit 12px margin above the row, preserving image sizing and carousel layout.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
No linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Adds explicit spacing and a regression test for single images and carousels at 95%, 100%, and 125% UI scale.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Restored spacing between community-post images and the like and comment row.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/c0922a71-ef7c-49be-87a9-23524d16178d">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/32ab3e51-3faf-415e-b18a-09c2270740ae">
  <img alt="Restored spacing below a community-post image" src="https://github.com/user-attachments/assets/c0922a71-ef7c-49be-87a9-23524d16178d">
</picture>

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a channel or subscription feed with single-image and multi-image community posts.
2. Check that the like and comment row has a clear gap below the images and carousel navigation still works.
3. Repeat at 95%, 100%, and 125% UI scale. Images should retain their aspect ratio and rounded corners.

## Additional context
<!-- Add any other context about the pull request here. -->

The regression originated in f8fbb1903, which made community images block-level.

Implemented and reviewed with GPT-6 in Codex.


