### PR TITLE
fix: simplify video menus and enlarge mobile controls

### DIFF
--- a/e2e/tests/offline/navigation.spec.mjs
+++ b/e2e/tests/offline/navigation.spec.mjs
@@ -212,6 +212,16 @@ test.describe('side nav navigation', () => {
     await expect(page).toHaveURL(/#\/userplaylists/)
   })
 
+  test('mobile navigation history keeps its own menu sizing', async ({ page }) => {
+    await goTo(page, 'history')
+    await goTo(page, 'userplaylists')
+    await page.setViewportSize({ width: 375, height: 812 })
+    await page.locator(sel.backButton).click({ button: 'right' })
+    const popout = page.locator('.topNav .iconDropdown')
+    await expect(popout.getByRole('option').first()).toHaveCSS('font-size', '12px')
+    await expect(popout).toHaveCSS('min-width', '0px')
+  })
+
   test('navigation history popout shows page icons and a drop shadow', async ({ page }) => {
     await goTo(page, 'history')
     await goTo(page, 'userplaylists')

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -160,18 +160,21 @@ for (const [iconPack, uiScale] of [['material', 100], ['remix', 125]]) {
       await page.locator('.ft-list-video .optionsButton .iconButton').first().click()
       const menu = page.locator('.listVideoOptionsDropdown')
       const scrollbar = menu.locator('.os-scrollbar-vertical')
-      await menu.getByRole('option').last().scrollIntoViewIfNeeded()
-      await expect.poll(() => menu.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
-      await expect(scrollbar).not.toHaveClass(/os-scrollbar-unusable/)
+      for (let resize = 0; resize < 10; resize++) {
+        await page.setViewportSize({ width: 375, height: 400 })
+        await menu.getByRole('option').last().scrollIntoViewIfNeeded()
+        await expect.poll(() => menu.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+        await expect(scrollbar).not.toHaveClass(/os-scrollbar-unusable/)
 
-      await page.setViewportSize({ width: 1200, height: 1000 })
-      await expect(menu).toBeVisible()
-      await expect(menu.getByRole('option').first()).toHaveCSS('font-size', '14px')
-      await expect.poll(() => menu.evaluate(element => element.scrollTop)).toBe(0)
-      await expect.poll(() => menu.evaluate(element => element.scrollHeight - element.clientHeight)).toBeLessThanOrEqual(1)
-      await expect(scrollbar).toHaveClass(/os-scrollbar-unusable/)
-      await expect(menu.getByRole('option').first()).toBeInViewport()
-      await expect(menu.getByRole('option').last()).toBeInViewport()
+        await page.setViewportSize({ width: 1200, height: 1000 })
+        await expect(menu).toBeVisible()
+        await expect(menu.getByRole('option').first()).toHaveCSS('font-size', '14px')
+        await expect.poll(() => menu.evaluate(element => element.scrollTop)).toBe(0)
+        await expect.poll(() => menu.evaluate(element => element.scrollHeight - element.clientHeight)).toBeLessThanOrEqual(1)
+        await expect(scrollbar).toHaveClass(/os-scrollbar-unusable/)
+        await expect(menu.getByRole('option').first()).toBeInViewport()
+        await expect(menu.getByRole('option').last()).toBeInViewport()
+      }
     })
 
     test('opens a readable mobile menu with touch-sized options', async ({ page }) => {
@@ -1889,7 +1892,9 @@ test.describe('list video actions', () => {
 
   test('a tall options dropdown stays below the horizontal tab bar', async ({ page }) => {
     await goTo(page, 'history')
-    await page.setViewportSize({ width: 1200, height: 400 })
+    // The simplified menu needs a shorter viewport to exercise scrolling.
+    const viewportHeight = 300
+    await page.setViewportSize({ width: 1200, height: viewportHeight })
 
     const video = page.locator('.ft-list-video').first()
     await video.hover()
@@ -1912,7 +1917,7 @@ test.describe('list video actions', () => {
 
     expect(chromeBottom).toBeGreaterThan(0)
     expect(dropdownBounds.y).toBeGreaterThanOrEqual(chromeBottom)
-    expect(dropdownBounds.y + dropdownBounds.height).toBeLessThanOrEqual(400)
+    expect(dropdownBounds.y + dropdownBounds.height).toBeLessThanOrEqual(viewportHeight)
     expect(await dropdown.evaluate((element) => element.scrollHeight > element.clientHeight)).toBe(true)
 
     // Repositioning alone cannot keep up with a fast scroll, so the chrome also

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -77,6 +77,135 @@ function silentWav(duration, sampleRate = 8_000) {
 
 test.use({ seed: SEED })
 
+for (const [iconPack, uiScale] of [['material', 100], ['remix', 125]]) {
+  test.describe(`kebab menu with ${iconPack} at ${uiScale}% UI scale`, () => {
+    test.use({
+      seed: {
+        ...SEED,
+        settings: { ...SEED.settings, iconPack, uiScale },
+        history: [{ ...SEED.history[0], viewCount: 123456789 }]
+      }
+    })
+
+    test('keeps the mobile menu and page within the viewport', async ({ page }) => {
+      await goTo(page, 'history')
+      await page.setViewportSize({ width: 375, height: 812 })
+      const session = await page.context().newCDPSession(page)
+      try {
+        await session.send('Emulation.setTouchEmulationEnabled', { enabled: true })
+        for (const listType of ['list', 'grid']) {
+          await page.evaluate(value => {
+            document.querySelector('#app').__vue_app__.config.globalProperties.$store.commit('setListType', value)
+          }, listType)
+          const expectNoHorizontalOverflow = () => expect.poll(() => page.evaluate(() => (
+            Math.max(document.documentElement.scrollWidth, document.body.scrollWidth) - innerWidth
+          ))).toBeLessThanOrEqual(1)
+          await expectNoHorizontalOverflow()
+          const button = page.locator('.ft-list-video .optionsButton .iconButton').first()
+          expect(await button.evaluate(element => (
+            element.getBoundingClientRect().right - innerWidth
+          ))).toBeLessThanOrEqual(1)
+          await button.click()
+          await expect(page.locator('.listVideoOptionsDropdown')).toBeVisible()
+          await expectNoHorizontalOverflow()
+          expect(await page.evaluate(() => window.scrollX)).toBe(0)
+          await page.keyboard.press('Escape')
+          await expectNoHorizontalOverflow()
+        }
+      } finally {
+        await session.detach()
+      }
+    })
+
+    test('clears the obsolete scroll range when an open mobile menu becomes shorter', async ({ page }) => {
+      await goTo(page, 'history')
+      await page.setViewportSize({ width: 375, height: 400 })
+      await page.locator('.ft-list-video .optionsButton .iconButton').first().click()
+      const menu = page.locator('.listVideoOptionsDropdown')
+      const scrollbar = menu.locator('.os-scrollbar-vertical')
+      await menu.getByRole('option').last().scrollIntoViewIfNeeded()
+      await expect.poll(() => menu.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+      await expect(scrollbar).not.toHaveClass(/os-scrollbar-unusable/)
+
+      await page.setViewportSize({ width: 1200, height: 1000 })
+      await expect(menu).toBeVisible()
+      await expect(menu.getByRole('option').first()).toHaveCSS('font-size', '14px')
+      await expect.poll(() => menu.evaluate(element => element.scrollTop)).toBe(0)
+      await expect.poll(() => menu.evaluate(element => element.scrollHeight - element.clientHeight)).toBeLessThanOrEqual(1)
+      await expect(scrollbar).toHaveClass(/os-scrollbar-unusable/)
+      await expect(menu.getByRole('option').first()).toBeInViewport()
+      await expect(menu.getByRole('option').last()).toBeInViewport()
+    })
+
+    test('opens a readable mobile menu with touch-sized options', async ({ page }) => {
+      await goTo(page, 'history')
+      const session = await page.context().newCDPSession(page)
+      try {
+        await session.send('Emulation.setTouchEmulationEnabled', { enabled: true })
+        for (const viewport of [
+          { width: 375, height: 812 },
+          { width: 812, height: 375 },
+          { width: 1024, height: 768 }
+        ]) {
+          await page.setViewportSize(viewport)
+          await page.locator('.ft-list-video .optionsButton .iconButton').first().click()
+          const menu = page.locator('.listVideoOptionsDropdown')
+          const options = menu.getByRole('option')
+          await expect(options.first()).toHaveCSS('font-size', '16px')
+          expect(await options.evaluateAll(elements => elements.every(element => (
+            element.getBoundingClientRect().height >= 48
+          )))).toBe(true)
+          await expect.poll(() => menu.evaluate(element => {
+            const bounds = element.getBoundingClientRect()
+            return bounds.left >= -1 && bounds.right <= innerWidth + 1 &&
+              bounds.top >= -1 && bounds.bottom <= innerHeight + 1
+          })).toBe(true)
+          await options.last().scrollIntoViewIfNeeded()
+          await expect(options.last()).toBeInViewport()
+          await page.keyboard.press('Escape')
+        }
+        await page.locator('.ft-list-video .optionsButton .iconButton').first().click()
+        await page.getByRole('option', { name: 'Mark As Watched', exact: true }).click()
+        await expect(page.locator('.listVideoOptionsDropdown')).toBeHidden()
+      } finally {
+        await session.detach()
+      }
+    })
+
+    test('enlarges the mobile icon and tap target', async ({ page }) => {
+      await goTo(page, 'history')
+      const button = page.locator('.ft-list-video .optionsButton .iconButton').first()
+      const icon = button.locator('[data-icon="ellipsis-vertical"]')
+      await expect(icon).toHaveAttribute('data-icon-pack', iconPack)
+      await expect(button).toHaveCSS('width', '36px')
+      await expect(icon).toHaveCSS('font-size', '16px')
+
+      const session = await page.context().newCDPSession(page)
+      try {
+        await session.send('Emulation.setTouchEmulationEnabled', { enabled: true })
+        for (const viewport of [
+          { width: 375, height: 812 },
+          { width: 812, height: 375 },
+          { width: 1024, height: 768 }
+        ]) {
+          await page.setViewportSize(viewport)
+          await expect(button).toHaveCSS('width', '48px')
+          await expect(button).toHaveCSS('height', '48px')
+          await expect(icon).toHaveCSS('font-size', '20px')
+          // The added space around the glyph must open the menu too.
+          await button.click({ position: { x: 4, y: 24 } })
+          await expect(button).toHaveAttribute('aria-expanded', 'true')
+          await expect(page.getByRole('option', { name: 'Mark As Watched', exact: true })).toBeVisible()
+          await page.keyboard.press('Escape')
+          await expect(button).toHaveAttribute('aria-expanded', 'false')
+        }
+      } finally {
+        await session.detach()
+      }
+    })
+  })
+}
+
 test('persists the yt-dlp playback cache across app restarts', async ({ app, page }) => {
   const expiryTime = Date.now() + 60 * 60 * 1000
   const source = {

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -95,6 +95,7 @@ test.describe('video link copy actions', () => {
       await expect(menu.getByRole('option', { name: 'Open in YouTube', exact: true })).toBeVisible()
       await expect(menu.getByRole('option', { name: 'Open in Invidious', exact: true })).toBeVisible()
       await expect(menu.getByRole('option', { name: /^Copy / })).toHaveCount(0)
+      await expect(menu.getByRole('option', { name: 'Open YouTube Embedded Player', exact: true })).toHaveCount(0)
       await page.keyboard.press('Escape')
 
       await video.locator('.title').click({ button: 'right' })

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -77,6 +77,42 @@ function silentWav(duration, sampleRate = 8_000) {
 
 test.use({ seed: SEED })
 
+test.describe('video link copy actions', () => {
+  test.use({
+    seed: {
+      ...SEED,
+      settings: { ...SEED.settings, backendFallback: true, extraThumbnailAction: 'copyYoutube' }
+    }
+  })
+
+  for (const width of [1600, 375]) {
+    test(`keeps copying in the context menu and thumbnail action at ${width}px`, async ({ app, page }) => {
+      await goTo(page, 'history')
+      await page.setViewportSize({ width, height: 900 })
+      const video = page.locator('.ft-list-video').first()
+      await video.locator('.optionsButton .iconButton').click()
+      const menu = page.locator('.listVideoOptionsDropdown')
+      await expect(menu.getByRole('option', { name: 'Open in YouTube', exact: true })).toBeVisible()
+      await expect(menu.getByRole('option', { name: 'Open in Invidious', exact: true })).toBeVisible()
+      await expect(menu.getByRole('option', { name: /^Copy / })).toHaveCount(0)
+      await page.keyboard.press('Escape')
+
+      await video.locator('.title').click({ button: 'right' })
+      await expect(page.getByRole('menuitem', { name: 'Copy YouTube Link', exact: true })).toBeVisible()
+      await expect(page.getByRole('menuitem', { name: 'Copy Invidious Link', exact: true })).toBeVisible()
+      await page.getByRole('menuitem', { name: 'Copy YouTube Link', exact: true }).click()
+      await expect.poll(() => app.electronApp.evaluate(({ clipboard }) => clipboard.readText()))
+        .toBe('https://youtu.be/eeeeeeeeeee')
+
+      await app.electronApp.evaluate(({ clipboard }) => clipboard.clear())
+      await video.hover()
+      await video.locator('.extraThumbnailActionIcon .iconButton').click()
+      await expect.poll(() => app.electronApp.evaluate(({ clipboard }) => clipboard.readText()))
+        .toBe('https://youtu.be/eeeeeeeeeee')
+    })
+  }
+})
+
 for (const [iconPack, uiScale] of [['material', 100], ['remix', 125]]) {
   test.describe(`kebab menu with ${iconPack} at ${uiScale}% UI scale`, () => {
     test.use({
@@ -152,9 +188,11 @@ for (const [iconPack, uiScale] of [['material', 100], ['remix', 125]]) {
           const menu = page.locator('.listVideoOptionsDropdown')
           const options = menu.getByRole('option')
           await expect(options.first()).toHaveCSS('font-size', '16px')
-          expect(await options.evaluateAll(elements => elements.every(element => (
-            element.getBoundingClientRect().height >= 48
-          )))).toBe(true)
+          const minimumOptionHeight = await options.evaluateAll(elements => Math.min(
+            ...elements.map(element => element.getBoundingClientRect().height)
+          ))
+          // Electron zoom can introduce fractional-pixel rounding.
+          expect(minimumOptionHeight).toBeGreaterThanOrEqual(48 - 0.01)
           await expect.poll(() => menu.evaluate(element => {
             const bounds = element.getBoundingClientRect()
             return bounds.left >= -1 && bounds.right <= innerWidth + 1 &&

--- a/src/renderer/components/FtIconButton/FtIconButton.scss
+++ b/src/renderer/components/FtIconButton/FtIconButton.scss
@@ -149,6 +149,17 @@
   vertical-align: 0;
 }
 
+@media (pointer: coarse), (width <= 680px) {
+  .iconButton:has(> .icon[data-icon='ellipsis-vertical']) {
+    min-inline-size: 48px;
+    min-block-size: 48px;
+
+    > .icon {
+      font-size: 20px;
+    }
+  }
+}
+
 /* Overlay icons read as a cut-out of the main icon by matching the button background */
 .iconButton .overlayIcon {
   color: var(--card-bg-color);
@@ -293,5 +304,35 @@
   .listItem > .wrapLabel {
     overflow-wrap: anywhere;
     white-space: normal;
+  }
+}
+
+@media (pointer: coarse), (width <= 680px) {
+  .iconDropdown.kebabMenu {
+    &:has(> .list) {
+      min-inline-size: min(360px, calc(100vw - 16px));
+    }
+
+    .list {
+      font-size: 16px;
+      line-height: 1.5;
+    }
+
+    .listItem {
+      align-items: center;
+      box-sizing: border-box;
+      display: flex;
+      min-block-size: 48px;
+      padding: 12px;
+    }
+
+    .listItem > span {
+      overflow-wrap: anywhere;
+      white-space: normal;
+    }
+
+    .optionIconColumn {
+      font-size: 20px;
+    }
   }
 }

--- a/src/renderer/components/FtIconButton/FtIconButton.vue
+++ b/src/renderer/components/FtIconButton/FtIconButton.vue
@@ -106,6 +106,7 @@
           tabindex="-1"
           class="iconDropdown"
           :class="{
+            kebabMenu: isKebabMenu,
             left: dropdownPositionX === 'left',
             right: dropdownPositionX === 'right',
             center: dropdownPositionX === 'center',
@@ -275,6 +276,10 @@ const emit = defineEmits(['click', 'disabled-click'])
 const LONG_CLICK_BOUNDARY_MS = 500
 
 const id = useId()
+
+const isKebabMenu = computed(() => (
+  Array.isArray(props.icon) && ['ellipsis-v', 'ellipsis-vertical'].includes(props.icon[1])
+))
 
 const dropdownShown = ref(false)
 const useModal = ref(false)

--- a/src/renderer/components/FtIconButton/FtIconButton.vue
+++ b/src/renderer/components/FtIconButton/FtIconButton.vue
@@ -138,6 +138,7 @@
           <slot v-else>
             <ul
               v-if="dropdownOptions.length > 0"
+              ref="dropdownContentInner"
               class="list"
               role="listbox"
             >
@@ -424,8 +425,8 @@ function keepDropdownInViewport() {
     dropdown.value.style.overflowY = dropdownContent.value ? 'hidden' : 'auto'
   }
 
-  if (dropdownContent.value) {
-    clampOverlayScrollTop(dropdownContent.value, dropdownContentInner.value)
+  if (dropdownContentInner.value) {
+    clampOverlayScrollTop(dropdownContent.value ?? dropdown.value, dropdownContentInner.value)
   }
 
   if (props.dropdownPortal) {

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -981,11 +981,6 @@ const dropdownOptions = computed(() => {
         value: 'openYoutube',
         icon: ['fab', 'youtube']
       },
-      {
-        label: t('Video.Open YouTube Embedded Player'),
-        value: 'openYoutubeEmbed',
-        icon: ['fas', 'display']
-      },
       ...showInvidiousShareOptions.value
         ? [
             {
@@ -1145,10 +1140,6 @@ async function toggleLiveReminder() {
   }
 }
 
-function getYoutubeEmbedUrl() {
-  return `https://www.youtube-nocookie.com/embed/${id.value}`
-}
-
 function getYoutubeChannelUrl() {
   return `https://youtube.com/channel/${channelId.value}`
 }
@@ -1222,9 +1213,6 @@ function handleOptionsClick(option) {
       openExternalLink(videoUrl)
       break
     }
-    case 'openYoutubeEmbed':
-      openExternalLink(getYoutubeEmbedUrl())
-      break
     case 'openInvidious':
       openExternalLink(getInvidiousUrl())
       break

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -977,19 +977,9 @@ const dropdownOptions = computed(() => {
         type: 'divider'
       },
       {
-        label: t('Video.Copy YouTube Link'),
-        value: 'copyYoutube',
-        icon: ['fas', 'link']
-      },
-      {
         label: t('Video.Open in YouTube'),
         value: 'openYoutube',
         icon: ['fab', 'youtube']
-      },
-      {
-        label: t('Video.Copy YouTube Embedded Player Link'),
-        value: 'copyYoutubeEmbed',
-        icon: ['fas', 'display']
       },
       {
         label: t('Video.Open YouTube Embedded Player'),
@@ -1000,11 +990,6 @@ const dropdownOptions = computed(() => {
         ? [
             {
               type: 'divider'
-            },
-            {
-              label: t('Video.Copy Invidious Link'),
-              value: 'copyInvidious',
-              icon: ['fas', 'link']
             },
             {
               label: t('Video.Open in Invidious'),
@@ -1020,11 +1005,6 @@ const dropdownOptions = computed(() => {
           type: 'divider'
         },
         {
-          label: t('Video.Copy YouTube Channel Link'),
-          value: 'copyYoutubeChannel',
-          icon: ['fas', 'link']
-        },
-        {
           label: t('Video.Open Channel in YouTube'),
           value: 'openYoutubeChannel',
           icon: ['fab', 'youtube']
@@ -1033,11 +1013,6 @@ const dropdownOptions = computed(() => {
           ? [
               {
                 type: 'divider'
-              },
-              {
-                label: t('Video.Copy Invidious Channel Link'),
-                value: 'copyInvidiousChannel',
-                icon: ['fas', 'link']
               },
               {
                 label: t('Video.Open Channel in Invidious'),
@@ -1247,26 +1222,14 @@ function handleOptionsClick(option) {
       openExternalLink(videoUrl)
       break
     }
-    case 'copyYoutubeEmbed':
-      copyToClipboard(getYoutubeEmbedUrl(), { messageOnSuccess: t('Share.YouTube Embed URL copied to clipboard') })
-      break
     case 'openYoutubeEmbed':
       openExternalLink(getYoutubeEmbedUrl())
-      break
-    case 'copyInvidious':
-      copyToClipboard(getInvidiousUrl(), { messageOnSuccess: t('Share.Invidious URL copied to clipboard') })
       break
     case 'openInvidious':
       openExternalLink(getInvidiousUrl())
       break
-    case 'copyYoutubeChannel':
-      copyToClipboard(getYoutubeChannelUrl(), { messageOnSuccess: t('Share.YouTube Channel URL copied to clipboard') })
-      break
     case 'openYoutubeChannel':
       openExternalLink(getYoutubeChannelUrl())
-      break
-    case 'copyInvidiousChannel':
-      copyToClipboard(getInvidiousChannelUrl(), { messageOnSuccess: t('Share.Invidious Channel URL copied to clipboard') })
       break
     case 'openInvidiousChannel':
       openExternalLink(getInvidiousChannelUrl())

--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -424,6 +424,7 @@ $watched-transition-duration: 0.5s;
 
     &.result {
       .info {
+        grid-template-columns: minmax(0, 1fr) auto;
         min-inline-size: 0;
       }
 

--- a/src/renderer/views/History/History.css
+++ b/src/renderer/views/History/History.css
@@ -39,6 +39,7 @@
 
 .headingRow {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
@@ -58,7 +59,7 @@
   flex-wrap: wrap;
   justify-content: flex-end;
   gap: 8px;
-  margin-inline-end: 5px;
+  margin-inline: auto 5px;
 }
 
 .historySearch {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Video kebab menus duplicated copy-link actions available in the context menu and were too small to read and tap on phones. Remove video-link and channel-link copying, along with both embedded-player actions, from the kebab menu on desktop and mobile. Context-menu copying and the configurable thumbnail copy button remain available.

On mobile, kebab menus have larger text, icons, and rows, with a 20px trigger icon inside a 48px tap target. Video metadata can shrink and History header actions can wrap to prevent horizontal overflow. Resizing an open menu clamps its scroll position to the new content height. Thumbnail sizing stays the same.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Removed duplicate copy-link and embedded-player actions from video menus, made three-dot menus easier to use on phones, and kept video actions inside narrow layouts.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/4e185fdb-333c-4463-922a-1906ea679a61">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/6710429d-1c26-475e-964a-192ee79af3ae">
  <img alt="Simplified mobile video menu" src="https://github.com/user-attachments/assets/4e185fdb-333c-4463-922a-1906ea679a61">
</picture>
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. With this branch running in dev mode, use a phone-sized window and open a video's three-dot menu in Subscriptions or History. Menu labels and icons should be larger, and the space around the trigger should be tappable.
2. Check grid and list views at 100% and 125% UI scale. Video actions and the page should fit horizontally, including videos with long view counts.
3. Scroll a tall menu to its last option, then enlarge the window while it remains open. All options should remain reachable, with no empty scroll area or unnecessary scrollbar.
4. Open Back or Forward navigation history. Those menus should retain their existing sizing.

5. The video kebab menu should contain no copy-link or embedded-player actions. Right-click a video link and copy its YouTube link from the context menu; Invidious copying should also be available when that backend or fallback is enabled. If configured, the thumbnail copy button should still copy the video link.

## Additional context
<!-- Add any other context about the pull request here. -->

Implemented with GPT-6 in Codex.
