### PR TITLE
feat(player): show poster and recommendations when videos end

### DIFF
--- a/e2e/tests/offline/player-end-screen.spec.mjs
+++ b/e2e/tests/offline/player-end-screen.spec.mjs
@@ -1,0 +1,243 @@
+import { fileURLToPath } from 'node:url'
+import { test, expect, setWindowSize, setPlayerFullscreen } from '../../helpers/app.mjs'
+import { findWatchComponent, openMockedVideo, waitForPlayback } from '../../helpers/player.mjs'
+import { mockPlayableWatchPage } from '../../helpers/watch.mjs'
+
+test.use({
+  seed: {
+    settings: {
+      videoPlaybackEngine: 'built-in',
+      ytDlpPlaybackEngineDefaultMigration: true,
+      playNextVideo: false,
+      hideRecommendedVideos: true,
+      hideEndScreenAnnotations: false,
+    }
+  }
+})
+
+async function endVideo(video) {
+  await video.evaluate(element => {
+    element.currentTime = element.duration - 0.1
+    return element.play()
+  })
+  await expect.poll(() => video.evaluate(element => element.ended)).toBe(true)
+}
+
+async function openVideo({ app, page }) {
+  await mockPlayableWatchPage(app, page)
+  await page.route('https://i.ytimg.com/**', route => route.fulfill({
+    path: fileURLToPath(new URL('../../fixtures/media/video-thumbnail.svg', import.meta.url)),
+    contentType: 'image/svg+xml'
+  }))
+  const video = await openMockedVideo(page)
+  const watch = await page.evaluateHandle(findWatchComponent)
+  await watch.evaluate(component => {
+    component.proxy.videoAnnotations = [{
+      id: 'end-video',
+      type: 'VIDEO',
+      title: 'Annotated video',
+      startTime: 0,
+      endTime: 1000,
+      left: 0.6,
+      top: 0.2,
+      width: 0.3,
+      aspectRatio: 16 / 9,
+      route: '/watch/aqz-KE-bpKQ',
+      thumbnail: component.proxy.thumbnail,
+    }]
+  })
+  return { video, watch }
+}
+
+test('restores the poster and hides annotations at the end, then clears it on seek and replay', async ({ app, page }) => {
+  const { video } = await openVideo({ app, page })
+  await expect(page.locator('.videoAnnotations')).toBeVisible()
+  await endVideo(video)
+  const poster = page.locator('.endedPoster')
+  await expect(poster).toBeVisible()
+  await expect(poster.locator('img')).toHaveCSS('opacity', '0.35')
+  await expect.poll(() => poster.locator('img').evaluate(image => image.naturalWidth)).toBeGreaterThan(0)
+  await expect(page.locator('.videoAnnotations')).toHaveCount(0)
+  await expect(page.locator('.endedRecommendations')).toHaveCount(0)
+  await video.evaluate(element => { element.currentTime = 1 })
+  await expect(poster).toHaveCount(0)
+  await expect(page.locator('.videoAnnotations')).toBeVisible()
+  await endVideo(video)
+  await expect(poster).toBeVisible()
+  await page.locator('.shaka-controls-button-panel .shaka-play-button').click()
+  await expect(poster).toHaveCount(0)
+  await expect.poll(() => video.evaluate(element => element.paused)).toBe(false)
+})
+
+test('shows recommended thumbnails over a darkened poster with working keyboard navigation', async ({ app, page, attachScreenshot }) => {
+  const { video, watch } = await openVideo({ app, page })
+  await watch.evaluate(async component => {
+    await component.proxy.$store.dispatch('updateHideRecommendedVideos', false)
+    component.proxy.recommendedVideos = Array.from({ length: 8 }, (_, index) => ({
+      videoId: `video00000${index}`,
+      title: `Recommended video ${index + 1}`,
+      author: 'Example channel',
+      authorId: 'example-channel',
+      type: 'video',
+      lengthSeconds: 120,
+    }))
+  })
+  const titleStyle = element => {
+    const style = getComputedStyle(element)
+    return Object.fromEntries([
+      'paddingTop', 'paddingBottom', 'paddingLeft', 'paddingRight',
+      'backgroundImage', 'fontSize', 'fontWeight', 'lineHeight', 'textShadow'
+    ].map(property => [property, /^[\d.]+px$/.test(style[property])
+      ? Math.round(parseFloat(style[property]) * 10) / 10
+      : style[property]]))
+  }
+  const annotationTitleStyle = await page.locator('.annotationTitle').evaluate(titleStyle)
+  await endVideo(video)
+  const cards = page.locator('.endedRecommendation')
+  await expect(cards).toHaveCount(6)
+  await expect.poll(() => cards.first().locator('.endedRecommendationTitle').evaluate(titleStyle)).toEqual(annotationTitleStyle)
+  await expect(cards.first().locator('.endedRecommendationTitleText')).toBeVisible()
+  await expect(cards.first().locator('.endedRecommendationTitleText')).toHaveText('Recommended video 1')
+  await expect(page.locator('.endedPoster img')).toHaveCSS('opacity', '0.35')
+  await expect(cards.first()).toHaveAttribute('href', '#/watch/video000000')
+  await expect(cards.first().locator('img')).toHaveAttribute('src', /\/vi\/video000000\/mqdefault.jpg$/)
+  await expect.poll(() => cards.first().locator('img').evaluate(image => image.naturalWidth)).toBeGreaterThan(0)
+  await cards.first().click({ trial: true })
+  await attachScreenshot('video ended with recommendations')
+  await setPlayerFullscreen(page, true)
+  await expect(cards.first()).toBeVisible()
+  await cards.first().click({ trial: true })
+  await setPlayerFullscreen(page, false)
+  await page.evaluate(() => window.ftElectron.setZoomFactor(0.95))
+  await setWindowSize(app, page, { width: 480, height: 800 })
+  const grid = page.locator('.endedRecommendations')
+  await expect.poll(() => grid.evaluate(element => element.scrollHeight <= element.clientHeight + 1)).toBe(true)
+  await expect(cards.first()).toBeVisible()
+  await expect(cards.nth(4)).toBeHidden()
+  await expect(cards.first().locator('.endedRecommendationTitleText')).toBeVisible()
+  await attachScreenshot('video ended in a narrow player')
+  await watch.evaluate(component => component.proxy.$store.dispatch('updateBlurThumbnails', true))
+  await expect(cards.first().locator('img')).toHaveCSS('filter', 'blur(20px)')
+  await expect(cards.first().locator('.endedRecommendationTitle')).toHaveCSS('filter', 'none')
+  await watch.evaluate(component => component.proxy.$store.dispatch('updateBlurThumbnails', false))
+  await expect(cards.first().locator('img')).toHaveCSS('filter', 'none')
+  await watch.evaluate(async component => {
+    await component.proxy.$store.dispatch('updateThumbnailPreference', 'hidden')
+  })
+  await expect(cards.first().locator('img')).toHaveAttribute('src', /thumbnail_placeholder/)
+  await watch.evaluate(async component => {
+    await component.proxy.$store.dispatch('updateHideRecommendedVideos', true)
+  })
+  await expect(grid).toHaveCount(0)
+  await expect(page.locator('.endedPoster img')).toHaveCSS('opacity', '0.35')
+  await watch.evaluate(async component => {
+    await component.proxy.$store.dispatch('updateHideRecommendedVideos', false)
+  })
+  await cards.first().focus()
+  await cards.first().press('Enter')
+  await expect(page).toHaveURL(/#\/watch\/video000000$/)
+  await expect(page.locator('.endedPoster')).toHaveCount(0)
+  await waitForPlayback(page)
+})
+
+test('keeps the autoplay countdown instead of the finished poster when autoplay is enabled', async ({ app, page }) => {
+  const { video, watch } = await openVideo({ app, page })
+  await watch.evaluate(async component => {
+    await component.proxy.$store.dispatch('updateHideRecommendedVideos', false)
+    component.proxy.autoplayNextRecommendedVideo = true
+    component.proxy.recommendedVideos = [{ videoId: 'video000000', title: 'Next video', type: 'video' }]
+  })
+  await endVideo(video)
+  await expect(page.locator('.autoplayCountdownOverlay')).toBeVisible()
+  await expect(page.locator('.endedPoster')).toHaveCount(0)
+  await expect(page.locator('.endedRecommendations')).toHaveCount(0)
+})
+
+test('filters hidden and current videos and keeps the poster darkened when none remain', async ({ app, page }) => {
+  const { video, watch } = await openVideo({ app, page })
+  await watch.evaluate(async component => {
+    await component.proxy.$store.dispatch('updateHideRecommendedVideos', false)
+    await component.proxy.$store.dispatch('updateForbiddenTitles', JSON.stringify(['blocked']))
+    await component.proxy.$store.dispatch('updateChannelsHidden', JSON.stringify([{ name: 'hidden-channel' }]))
+    component.proxy.recommendedVideos = [
+      { videoId: component.proxy.videoId, title: 'Current video' },
+      { videoId: 'video000001', title: 'Blocked title' },
+      { videoId: 'video000002', title: 'Hidden channel video', authorId: 'hidden-channel' },
+      { videoId: 'video000003', title: 'Visible video' },
+    ]
+  })
+  await endVideo(video)
+  await expect(page.locator('.endedRecommendation')).toHaveCount(1)
+  await expect(page.locator('.endedRecommendation')).toHaveAttribute('aria-label', 'Visible video')
+  await watch.evaluate(component => { component.proxy.recommendedVideos = [] })
+  await expect(page.locator('.endedRecommendations')).toHaveCount(0)
+  await expect(page.locator('.endedPoster')).toBeVisible()
+  await expect(page.locator('.endedPoster img')).toHaveCSS('opacity', '0.35')
+})
+
+test('uses original recommendation titles only for the entire-app preference and handles late replies', async ({ app, page }) => {
+  const { video, watch } = await openVideo({ app, page })
+  const requests = []
+  let releaseTitle
+  const titleReady = new Promise(resolve => { releaseTitle = resolve })
+  await page.route('https://www.youtube.com/oembed**', async route => {
+    requests.push(route.request().url())
+    await titleReady
+    if (route.request().url().includes('video000010')) {
+      await route.fulfill({ status: 404, json: {} })
+      return
+    }
+    const title = route.request().url().includes('video000009') ? 'Another original title' : 'Original recommendation title'
+    await route.fulfill({ json: { title } })
+  })
+  await watch.evaluate(async component => {
+    await component.proxy.$store.dispatch('updateHideRecommendedVideos', false)
+    component.proxy.recommendedVideos = [{ videoId: 'video000008', title: 'Translated recommendation title', type: 'video' }]
+  })
+  await endVideo(video)
+  const card = page.locator('.endedRecommendation')
+  await expect(card).toHaveAttribute('title', 'Translated recommendation title')
+  await watch.evaluate(component => component.proxy.$store.dispatch('updateAvoidTranslation', 'watch_only'))
+  await expect(card).toHaveAttribute('title', 'Translated recommendation title')
+  expect(requests).toHaveLength(0)
+  await watch.evaluate(component => component.proxy.$store.dispatch('updateAvoidTranslation', 'entire_app'))
+  await expect.poll(() => requests.length).toBe(1)
+  await watch.evaluate(component => component.proxy.$store.dispatch('updateAvoidTranslation', 'disabled'))
+  const originalResponse = page.waitForResponse('https://www.youtube.com/oembed**')
+  releaseTitle()
+  await (await originalResponse).finished()
+  await expect(card).toHaveAttribute('title', 'Translated recommendation title')
+  await watch.evaluate(component => component.proxy.$store.dispatch('updateAvoidTranslation', 'entire_app'))
+  await expect(card).toHaveAttribute('title', 'Original recommendation title')
+  await expect(card).toHaveAttribute('aria-label', 'Original recommendation title')
+  await expect(card.locator('.endedRecommendationTitleText')).toHaveText('Original recommendation title')
+  expect(requests).toHaveLength(1)
+  await watch.evaluate(component => {
+    component.proxy.recommendedVideos = [{ videoId: 'video000009', title: 'Another translated title', type: 'video' }]
+  })
+  await expect.poll(() => requests.length).toBe(2)
+  await expect(card).toHaveAttribute('title', 'Another original title')
+  await watch.evaluate(component => {
+    component.proxy.recommendedVideos = [{ videoId: 'video000010', title: 'Fallback title', type: 'video' }]
+  })
+  await expect.poll(() => requests.length).toBe(3)
+  await expect(card).toHaveAttribute('title', 'Fallback title')
+})
+
+test('hides the VR canvas behind the finished poster and restores it after seeking', async ({ app, page }) => {
+  const { video, watch } = await openVideo({ app, page })
+  await watch.evaluate(component => { component.proxy.vrProjection = 'EQUIRECTANGULAR' })
+  const canvas = page.locator('.vrCanvas')
+  await expect(canvas).toBeVisible()
+  await canvas.evaluate(element => {
+    const context = element.getContext('2d')
+    context.fillStyle = 'red'
+    context.fillRect(0, 0, element.width, element.height)
+  })
+  await endVideo(video)
+  await expect(page.locator('.endedPoster')).toBeVisible()
+  await expect(canvas).toBeHidden()
+  await video.evaluate(element => { element.currentTime = 1 })
+  await expect(page.locator('.endedPoster')).toHaveCount(0)
+  await expect(canvas).toBeVisible()
+})

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -652,6 +652,100 @@ html[data-reduced-motion='reduce'] .musicVisualizerCanvas {
   transition: inset-inline-end 250ms ease;
 }
 
+.endedScreen {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  container-type: size;
+  pointer-events: none;
+}
+
+.endedPoster {
+  position: absolute;
+  z-index: 0;
+  pointer-events: none;
+  inset: 0;
+  background: #000;
+}
+
+.endedPoster img {
+  opacity: 0.35;
+  inline-size: 100%;
+  block-size: 100%;
+  object-fit: contain;
+}
+
+.endedRecommendations {
+  position: absolute;
+  inset: 12% 8% 22%;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-rows: repeat(2, minmax(0, 1fr));
+  gap: clamp(6px, 1.5cqw, 16px);
+  align-content: center;
+}
+
+.endedRecommendation {
+  position: relative;
+  min-inline-size: 0;
+  min-block-size: 0;
+  overflow: hidden;
+  border-radius: calc(6px * var(--ui-roundness));
+  background: #000;
+  color: #fff;
+  text-decoration: none;
+  pointer-events: auto;
+}
+
+.endedRecommendation img {
+  display: block;
+  inline-size: 100%;
+  block-size: 100%;
+  object-fit: cover;
+}
+
+.endedRecommendation .blur {
+  filter: blur(20px);
+}
+
+.endedRecommendationTitle {
+  --ended-title-padding: clamp(3px, 0.75cqw, 10px);
+
+  position: absolute;
+  inset-block-start: 0;
+  inset-inline: 0;
+  overflow: hidden;
+  padding: var(--ended-title-padding);
+  background: linear-gradient(to bottom, rgb(0 0 0 / 88%), transparent);
+  font-size: clamp(8px, 1.55cqw, 20px);
+  font-weight: 600;
+  line-height: 1.2;
+  text-shadow: 0 1px 2px #000;
+}
+
+.endedRecommendationTitleText {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.endedRecommendation:hover,
+.endedRecommendation:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+@container (width < 500px) {
+  .endedRecommendations {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .endedRecommendation:nth-child(n + 5) {
+    display: none;
+  }
+}
+
 .autoplayCountdownOverlay {
   position: absolute;
   z-index: 13;
@@ -856,6 +950,10 @@ html[data-reduced-motion='reduce'] .musicVisualizerCanvas {
   width: 100%;
   height: 100%;
   pointer-events: none;
+}
+
+.endedPoster ~ .vrCanvas {
+  visibility: hidden;
 }
 
 /*
@@ -4322,6 +4420,7 @@ html[data-reduced-motion='reduce'] .musicVisualizerCanvas {
 .ftVideoPlayer.presentationModeChanging .player,
 .ftVideoPlayer.presentationModeChanging :deep(.shaka-controls-container),
 .ftVideoPlayer.presentationModeChanging :deep(.shaka-spinner-container),
+.ftVideoPlayer.presentationModeChanging .endedScreen,
 .ftVideoPlayer.presentationModeChanging .countdownPoster,
 .ftVideoPlayer.presentationModeChanging .countdownOverlay,
 .ftVideoPlayer.presentationModeChanging :deep(.videoAnnotations),
@@ -4348,6 +4447,8 @@ html[data-reduced-motion='reduce'] .musicVisualizerCanvas {
 
 .ftVideoPlayer:is(:fullscreen, [data-native-player-screen]):is(.fullscreenDockLayoutOpen, .fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) :is(
   :deep(.shaka-spinner-container),
+  .endedPoster,
+  .endedScreen,
   .countdownPoster,
   .countdownOverlay,
   :deep(.videoAnnotations),
@@ -4356,6 +4457,8 @@ html[data-reduced-motion='reduce'] .musicVisualizerCanvas {
 ),
   .ftVideoPlayer.fullWindow:is(.fullscreenDockLayoutOpen, .fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) :is(
   :deep(.shaka-spinner-container),
+  .endedPoster,
+  .endedScreen,
   .countdownPoster,
   .countdownOverlay,
   :deep(.videoAnnotations),

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -60,6 +60,8 @@ import {
 import {
   addKeyboardShortcutToActionTitle,
   formatDurationAsTimestamp,
+  getCachedOembedTitle,
+  getOembedTitle,
   showToast,
   writeFileWithPicker,
   throttle,
@@ -316,6 +318,10 @@ export default defineComponent({
       default: ''
     },
     annotations: {
+      type: Array,
+      default: () => []
+    },
+    endScreenRecommendations: {
       type: Array,
       default: () => []
     },
@@ -584,10 +590,42 @@ export default defineComponent({
     // Shorts request autoplay, so do not render their paused-only controls
     // while the media element is still preparing its first `play` event.
     const shortsPaused = ref(false)
-    const shortsEnded = ref(false)
+    const playbackEnded = ref(false)
     const shortsMuted = ref(false)
     const shortsCaptionsAvailable = ref(false)
     const shortsCaptionsEnabled = ref(false)
+    const showEndedScreen = computed(() => playbackEnded.value &&
+      !props.autoplayEnabled && !props.autoplayCountdown && !props.shortsPlayer && !audioPlayerMode.value)
+    const blurThumbnails = computed(() => store.getters.getBlurThumbnails)
+    const originalEndedTitles = ref({})
+    const preferOriginalRecommendationTitles = computed(() => store.getters.getAvoidTranslation === 'entire_app')
+    watch(
+      [showEndedScreen, () => props.endScreenRecommendations, preferOriginalRecommendationTitles],
+      ([visible, recommendations, preferOriginal], _previous, onCleanup) => {
+        originalEndedTitles.value = {}
+        if (!visible || !preferOriginal) return
+
+        let active = true
+        onCleanup(() => { active = false })
+        for (const { videoId } of recommendations) {
+          const cachedTitle = getCachedOembedTitle(videoId)
+          if (cachedTitle !== null) {
+            originalEndedTitles.value[videoId] = cachedTitle
+          } else {
+            getOembedTitle(videoId).then(title => {
+              if (active && title) originalEndedTitles.value[videoId] = title
+            })
+          }
+        }
+      }
+    )
+    const endedRecommendations = computed(() => props.endScreenRecommendations.map(video => ({
+      ...video,
+      title: preferOriginalRecommendationTitles.value
+        ? originalEndedTitles.value[video.videoId] ?? video.title
+        : video.title,
+      thumbnail: getRecommendationThumbnail(video.videoId)
+    })))
     const showPoster = ref(true)
     const showPaidPromotion = ref(false)
     let paidPromotionTimer = null
@@ -610,8 +648,9 @@ export default defineComponent({
     }
 
     const autoplayNextVideo = computed(() => props.autoplayCountdown?.video ?? null)
-    const autoplayThumbnail = computed(() => {
-      const videoId = autoplayNextVideo.value?.videoId
+    const autoplayThumbnail = computed(() => getRecommendationThumbnail(autoplayNextVideo.value?.videoId))
+
+    function getRecommendationThumbnail(videoId) {
       if (!videoId) {
         return thumbnailPlaceholder
       }
@@ -638,7 +677,7 @@ export default defineComponent({
       }
 
       return `${baseUrl}/vi/${videoId}/${thumbnailName}`
-    })
+    }
     const autoplayDuration = computed(() => {
       const lengthSeconds = Number(autoplayNextVideo.value?.lengthSeconds)
       return Number.isFinite(lengthSeconds) && lengthSeconds > 0
@@ -5427,11 +5466,11 @@ export default defineComponent({
       mediaSessionStopped = false
       voiceOverTranslation.reset()
       showPoster.value = true
+      playbackEnded.value = false
       sponsorBlockMuteController.reset()
       clearSponsorBlockMuteSegments()
       if (props.shortsPlayer) {
         shortsPaused.value = false
-        shortsEnded.value = false
         shortsCaptionsAvailable.value = false
         shortsCaptionsEnabled.value = false
       }
@@ -5988,7 +6027,7 @@ export default defineComponent({
       playerPaused.value = false
       clearPausedInterfaceReveal()
       shortsPaused.value = false
-      shortsEnded.value = false
+      playbackEnded.value = false
       const isCurrentPictureInPictureVideo = document.pictureInPictureElement === video.value
       if (
         !isActiveTab.value &&
@@ -6083,7 +6122,7 @@ export default defineComponent({
 
       setShowUiOnPaused(true)
       shortsPaused.value = true
-      shortsEnded.value = true
+      playbackEnded.value = true
       syncPlayPauseControlIcons()
 
       if (isCapacitorMobilePlayer()) {
@@ -6115,7 +6154,7 @@ export default defineComponent({
 
     function handleSeeking() {
       hasPlaybackPosition.value = true
-      shortsEnded.value = false
+      playbackEnded.value = false
       cancelSponsorBlockSkipSchedule()
       clearAbRepeatBoundarySchedule()
       syncPlayPauseControlIcons()
@@ -11284,7 +11323,7 @@ export default defineComponent({
       useNativePlayback: process.env.IS_CAPACITOR,
       videoLayoutReady,
       shortsPaused,
-      shortsEnded,
+      playbackEnded,
       replayIcon: shaka.ui.Enums.MaterialDesignSVGIcons.REPLAY,
       shortsMuted,
       shortsCaptionsAvailable,
@@ -11292,6 +11331,9 @@ export default defineComponent({
       closedCaptionsOutlinedIcon: CLOSED_CAPTIONS_OUTLINED,
       closedCaptionsFilledIcon: shaka.ui.Enums.MaterialDesignSVGIcons.CLOSED_CAPTIONS,
       showPoster,
+      showEndedScreen,
+      endedRecommendations,
+      blurThumbnails,
       showPaidPromotion,
       toggleShortsPlayback,
       toggleShortsMuted,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -151,6 +151,50 @@
         @enterpictureinpicture="handleEnterPictureInPicture"
         @leavepictureinpicture="handleLeavePictureInPicture"
       />
+      <template v-if="showEndedScreen">
+        <div
+          class="endedPoster"
+          aria-hidden="true"
+        >
+          <img
+            :src="thumbnail"
+            alt=""
+          >
+        </div>
+        <div
+          v-if="endedRecommendations.length > 0"
+          class="endedScreen"
+        >
+          <nav
+            class="endedRecommendations shaka-no-propagation"
+            :aria-label="$t('Up Next')"
+            @click.stop
+            @dblclick.stop
+            @pointerdown.stop
+          >
+            <router-link
+              v-for="recommendation in endedRecommendations"
+              :key="recommendation.videoId"
+              class="endedRecommendation"
+              :to="{ path: `/watch/${recommendation.videoId}` }"
+              :title="recommendation.title"
+              :aria-label="recommendation.title"
+            >
+              <img
+                :class="{ blur: blurThumbnails }"
+                :src="recommendation.thumbnail"
+                alt=""
+              >
+              <span
+                class="endedRecommendationTitle"
+                dir="auto"
+              >
+                <span class="endedRecommendationTitleText">{{ recommendation.title }}</span>
+              </span>
+            </router-link>
+          </nav>
+        </div>
+      </template>
       <!-- Native playback hides the video element, including its poster. -->
       <div
         v-if="showCountdownOverlay && !audioPlayerMode && thumbnail"
@@ -240,7 +284,7 @@
             @click.stop="toggleShortsPlayback"
           >
             <svg
-              v-if="shortsEnded"
+              v-if="playbackEnded"
               class="shortsReplayIcon"
               viewBox="0 -960 960 960"
               aria-hidden="true"
@@ -523,7 +567,7 @@
         class="vrCanvas"
       />
       <FtVideoAnnotations
-        v-if="!hideAnnotations"
+        v-if="!hideAnnotations && !showEndedScreen"
         :active="isActiveTab"
         :annotations="annotations"
         :current-time="annotationCurrentTime"

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1054,6 +1054,13 @@ export default defineComponent({
 
       return this.$store.getters.getPlaylist(this.playlistId)
     },
+    endScreenRecommendations: function () {
+      if (this.hideRecommendedVideos) return []
+      return this.recommendedVideos.filter(video =>
+        video.videoId && video.videoId !== this.videoId &&
+        !this.isHiddenVideo(this.forbiddenTitles, this.channelsHidden, video)
+      ).slice(0, 6)
+    },
     nextRecommendedVideo: function () {
       return this.recommendedVideos.find((video) =>
         !this.isHiddenVideo(this.forbiddenTitles, this.channelsHidden, video)

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -100,6 +100,7 @@
           :storyboard-src="videoStoryboardSrc"
           :annotations="videoAnnotations"
           :hide-annotations="hideEndScreenAnnotations"
+          :end-screen-recommendations="endScreenRecommendations"
           :format="activeFormat"
           :thumbnail="thumbnail"
           :video-id="videoId"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Requested directly in this task; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

With autoplay off, finished videos leave the last frame and end-screen annotations visible. Restore a darkened poster instead, with up to six recommended videos when recommendations are enabled.

Recommendation titles use the existing annotation styling and honor the Entire App untranslated-text preference. Thumbnail hiding, blurring, and frame preferences apply; replaying or seeking clears the end screen. The grid adapts to smaller players and fullscreen docks, and the poster also replaces the VR canvas.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
When autoplay is off, finished videos show a darkened poster with recommended videos and hide end-screen annotations.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
![A finished video with six recommended videos over a darkened poster](https://github.com/user-attachments/assets/e0ec038d-d35b-4e81-b03c-e688c5deada0)
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Disable autoplay and let a video finish. Its darkened poster should replace the last frame, with end-screen annotations hidden.
2. Enable recommendations to see the thumbnail grid. Titles should look like annotation titles; choosing a video by mouse or keyboard should start it. Check the Blur and Hidden thumbnail preferences and the Entire App untranslated-text preference.
3. Replay or seek backward. The poster and grid should disappear. Repeat with a 360° video to confirm its canvas returns when seeking.
4. Check the grid in a narrow window, fullscreen, and at a non-default UI scale. Replay controls should remain usable.

## Additional context
<!-- Add any other context about the pull request here. -->

