### PR TITLE
fix: keep post menus readable and open them to the right

### DIFF
--- a/e2e/tests/offline/subscriptions-hide-channel-type.spec.mjs
+++ b/e2e/tests/offline/subscriptions-hide-channel-type.spec.mjs
@@ -189,27 +189,46 @@ test('keeps both types hidden when another hide is queued during a save', async 
 for (const locale of ['en-US', 'de-DE']) {
   test.describe(`${locale} menu labels`, () => {
     test.use({ seed: { ...seed, settings: { ...seed.settings, currentLocale: locale } } })
-    test('shows the full hide action label on desktop and narrow windows', async ({ app, page }) => {
-      await goTo(page, 'subscriptions')
-      for (const width of [1600, 375]) {
-        await app.electronApp.evaluate(({ BrowserWindow }, width) => {
-          BrowserWindow.getAllWindows()[0].setContentSize(width, 900)
-        }, width)
-        await card(page, 'videos').getByRole('button', {
-          name: locale === 'en-US' ? 'More Options' : 'Weitere Optionen', exact: true
-        }).click()
-        const label = page.getByRole('option', {
-          name: locale === 'en-US'
-            ? 'Never show Videos from this channel in feeds again'
-            : 'Nie wieder Videos von diesem Kanal in Feeds anzeigen',
-          exact: true
-        }).locator(':scope > span')
-        await expect(label).toBeVisible()
-        await expect.poll(() => label.evaluate(element => (
-          element.scrollWidth <= element.clientWidth && element.scrollHeight <= element.clientHeight
-        ))).toBe(true)
-        await page.keyboard.press('Escape')
-      }
-    })
+    for (const uiScale of [100, 125]) {
+      test(`shows readable hide action labels at ${uiScale}% UI scale`, async ({ app, page }) => {
+        await page.evaluate(scale => window.ftElectron.setZoomFactor(scale / 100), uiScale)
+        await goTo(page, 'subscriptions')
+        for (const width of [1600, 375]) {
+          await app.electronApp.evaluate(({ BrowserWindow }, width) => {
+            BrowserWindow.getAllWindows()[0].setContentSize(width, 900)
+          }, width)
+          for (const category of ['videos', 'posts']) {
+            await page.locator(`[data-subscription-feed-tab="${category}"]`).click()
+            await card(page, category).getByRole('button', {
+              name: locale === 'en-US' ? 'More Options' : 'Weitere Optionen', exact: true
+            }).click()
+            const type = locale === 'de-DE' && category === 'posts' ? 'Beiträge' : labels[category]
+            const label = page.getByRole('option', {
+              name: locale === 'en-US'
+                ? `Never show ${type} from this channel in feeds again`
+                : `Nie wieder ${type} von diesem Kanal in Feeds anzeigen`,
+              exact: true
+            }).locator(':scope > span')
+            await expect(label).toBeVisible()
+            await expect.poll(() => label.evaluate(element => (
+              element.scrollWidth <= element.clientWidth && element.scrollHeight <= element.clientHeight
+            ))).toBe(true)
+            // Wrapping must preserve whole words, not squeeze the label into a
+            // character-wide column that still passes the overflow check above.
+            const splitWords = await label.evaluate(element => {
+              const text = element.firstChild
+              return [...text.textContent.matchAll(/\S+/g)].filter(match => {
+                const range = document.createRange()
+                range.setStart(text, match.index)
+                range.setEnd(text, match.index + match[0].length)
+                return range.getClientRects().length > 1
+              }).map(match => match[0])
+            })
+            expect(splitWords).toEqual([])
+            await page.keyboard.press('Escape')
+          }
+        }
+      })
+    }
   })
 }

--- a/e2e/tests/offline/subscriptions-hide-channel-type.spec.mjs
+++ b/e2e/tests/offline/subscriptions-hide-channel-type.spec.mjs
@@ -199,9 +199,10 @@ for (const locale of ['en-US', 'de-DE']) {
           }, width)
           for (const category of ['videos', 'posts']) {
             await page.locator(`[data-subscription-feed-tab="${category}"]`).click()
-            await card(page, category).getByRole('button', {
+            const menuButton = card(page, category).getByRole('button', {
               name: locale === 'en-US' ? 'More Options' : 'Weitere Optionen', exact: true
-            }).click()
+            })
+            await menuButton.click()
             const type = locale === 'de-DE' && category === 'posts' ? 'Beiträge' : labels[category]
             const label = page.getByRole('option', {
               name: locale === 'en-US'
@@ -225,6 +226,12 @@ for (const locale of ['en-US', 'de-DE']) {
               }).map(match => match[0])
             })
             expect(splitWords).toEqual([])
+            if (category === 'posts' && width === 1600) {
+              const buttonBounds = await menuButton.boundingBox()
+              const menuBounds = await page.locator('.iconDropdown').boundingBox()
+              expect(menuBounds.x).toBeGreaterThanOrEqual(buttonBounds.x - 1)
+              expect(menuBounds.x).toBeLessThanOrEqual(buttonBounds.x + buttonBounds.width + 1)
+            }
             await page.keyboard.press('Escape')
           }
         }

--- a/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
+++ b/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
@@ -167,7 +167,7 @@
         theme="base-no-default"
         :size="18"
         :use-shadow="false"
-        dropdown-position-x="left"
+        dropdown-position-x="right"
         :dropdown-options="[hideSubscriptionFeedTypeOption]"
         @click="hideSubscriptionFeedType"
       />

--- a/src/renderer/components/FtIconButton/FtIconButton.scss
+++ b/src/renderer/components/FtIconButton/FtIconButton.scss
@@ -179,6 +179,12 @@
   z-index: 6;
   overflow: hidden;
 
+  // Wrappable labels must not shrink the menu to its icon-sized anchor.
+  &:has(.wrapLabel) {
+    inline-size: max-content;
+    max-inline-size: min(320px, calc(100vw - 16px));
+  }
+
   &.hasFixedHeader {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

Reported in a screenshot during this task. No linked issue.
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description

The community post menu could collapse into a narrow column, wrapping its hide-channel action letter by letter. Menus with wrapping labels now size to their content, capped at 320 CSS pixels and the available window width. Post menus expand to the right of the three-dot button.
<!-- Please write a clear and concise description of what the pull request does. -->

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing

1. Open Subscriptions, select Posts, and open a subscribed channel’s post menu. The menu should expand to the right of its button. The full hide action should remain readable and wrap between words.
2. Repeat with a video menu, English and German, and UI Scale set to 100% and 125%.
3. Narrow the window and confirm the action remains readable and fits within the window.
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

## Additional context

The hide-channel menu action has not appeared in the latest stable release, so this fix is marked Not noteworthy.

Implemented and reviewed with GPT-6 in the Codex desktop app.

Visual verification uses deterministic local fixtures.

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/f050ac6e-c9f1-4ee7-ac26-d2b2224fcd0f">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/6bbfa789-d3af-4aa1-9ca5-aea8cf447e32">
  <img alt="Readable community post menu expanding to the right" src="https://github.com/user-attachments/assets/f050ac6e-c9f1-4ee7-ac26-d2b2224fcd0f">
</picture>
<!-- Add any other context about the pull request here. -->

