### PR TITLE
fix(mobile): support tab order, close focus, startup and history settings

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -1214,15 +1214,16 @@ onMounted(async () => {
       removeTabsStateListener = removeListener
       window.ftElectron.tabs.rendererReady()
     })
-  } else if (isCapacitor) {
-    tabsReady = capacitorTabService.initialize(route)
-    removeCapacitorTabPreviews = initializeCapacitorTabPreviews(store)
   }
 
   const settingsReady = store.dispatch('grabUserSettings').then(tutorialState => {
     removeAndroidYtDlpSettingsListener = initializeAndroidYtDlp()
     return tutorialState
   })
+  if (isCapacitor) {
+    tabsReady = settingsReady.then(() => capacitorTabService.initialize(route))
+    removeCapacitorTabPreviews = initializeCapacitorTabPreviews(store)
+  }
   const customThemesReady = loadCustomThemes().catch((error) => {
     console.error('Failed to load custom theme:', error)
     return []

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -128,7 +128,7 @@
         @change="updateLandingPage"
       />
       <FtSelect
-        v-if="mode === 'general' && USING_ELECTRON"
+        v-if="mode === 'general' && (USING_ELECTRON || IS_CAPACITOR)"
         :placeholder="t('Settings.General Settings.New Tab Position.New Tab Position')"
         :value="newTabPosition"
         setting-key="newTabPosition"
@@ -138,7 +138,7 @@
         @change="updateNewTabPosition"
       />
       <FtSelect
-        v-if="mode === 'general' && USING_ELECTRON"
+        v-if="mode === 'general' && (USING_ELECTRON || IS_CAPACITOR)"
         :placeholder="t('Settings.General Settings.Tab Close Focus.Tab Close Focus')"
         :value="tabCloseFocus"
         setting-key="tabCloseFocus"
@@ -148,7 +148,7 @@
         @change="updateTabCloseFocus"
       />
       <FtSelect
-        v-if="mode === 'general' && USING_ELECTRON"
+        v-if="mode === 'general' && (USING_ELECTRON || IS_CAPACITOR)"
         :placeholder="t('Settings.General Settings.Startup Behavior.Startup Behavior')"
         :value="startupBehavior"
         setting-key="startupBehavior"

--- a/src/renderer/components/PrivacySettings.vue
+++ b/src/renderer/components/PrivacySettings.vue
@@ -44,7 +44,7 @@
           @change="updateEnableSearchSuggestions"
         />
         <FtToggleSwitch
-          v-if="USING_ELECTRON"
+          v-if="USING_ELECTRON || IS_CAPACITOR"
           :label="$t('Settings.General Settings.Remember Tab Navigation History')"
           :default-value="rememberTabNavigationHistory"
           setting-key="rememberTabNavigationHistory"
@@ -122,6 +122,7 @@ import store from '../store/index'
 
 const { locale, t } = useI18n()
 const USING_ELECTRON = process.env.IS_ELECTRON
+const IS_CAPACITOR = process.env.IS_CAPACITOR
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const rememberHistory = computed(() => store.getters.getRememberHistory)

--- a/src/renderer/helpers/settingsSearch.js
+++ b/src/renderer/helpers/settingsSearch.js
@@ -120,7 +120,7 @@ function isSettingsSearchMessageVisible(sectionType, path, options) {
     if (group === 'Minimize to system tray') {
       return usingElectron && !isMac && !isLinuxWayland
     }
-    if (['New Tab Position', 'Tab Close Focus', 'Startup Behavior'].includes(group)) {
+    if (['New Tab Position', 'Tab Close Focus', 'Startup Behavior', 'Remember Tab Navigation History'].includes(group)) {
       return usingElectron || isCapacitor
     }
     if ([

--- a/src/renderer/helpers/settingsSearch.js
+++ b/src/renderer/helpers/settingsSearch.js
@@ -120,11 +120,11 @@ function isSettingsSearchMessageVisible(sectionType, path, options) {
     if (group === 'Minimize to system tray') {
       return usingElectron && !isMac && !isLinuxWayland
     }
+    if (['New Tab Position', 'Tab Close Focus', 'Startup Behavior'].includes(group)) {
+      return usingElectron || isCapacitor
+    }
     if ([
       'Open Deep Links In New Window',
-      'New Tab Position',
-      'Tab Close Focus',
-      'Startup Behavior',
       'Confirm Before',
       'Confirmation Options',
       'Stream Extraction Method'

--- a/src/renderer/tabs/CapacitorTabService.js
+++ b/src/renderer/tabs/CapacitorTabService.js
@@ -52,15 +52,25 @@ export class CapacitorTabService {
   async initialize(currentRoute) {
     if (this.initialized) return
 
-    const persisted = readPersistedSession()
+    const startupBehavior = this.store.getters.getStartupBehavior ?? 'loadLastActiveTab'
+    const persisted = startupBehavior === 'emptySession' ? null : readPersistedSession()
+    const initialRoute = currentRoute.path === '/'
+      ? this.router.resolve(`/${this.store.getters.getLandingPage}`)
+      : currentRoute
     this.sessionUpdatedAt = Number.isFinite(persisted?.updatedAt)
       ? persisted.updatedAt
       : Date.now()
     let session = restoreCapacitorTabSession(
       persisted,
-      currentRoute
+      initialRoute
     )
-    session = loadCapacitorTab(session, session.activeTabId)
+    for (const tab of session.tabs) {
+      if (tab.id === session.activeTabId || startupBehavior === 'loadAllTabs') {
+        session = loadCapacitorTab(session, tab.id)
+      } else if (startupBehavior !== 'restoreTabLoadState') {
+        session = unloadCapacitorTab(session, tab.id)
+      }
+    }
     this.commitSession(session, session.activeTabId)
     this.store.commit('setPresentedTab', session.activeTabId)
     tabMediaCoordinator.setPresented(session.activeTabId)
@@ -93,7 +103,7 @@ export class CapacitorTabService {
   async createTab(location = `/${this.store.getters.getLandingPage}`, title = '', makeActive = true) {
     const tab = createCapacitorTab(this.router.resolve(location), title)
     const previous = this.currentSession()
-    const session = addCapacitorTab(previous, tab, makeActive)
+    const session = addCapacitorTab(previous, tab, makeActive, this.store.getters.getNewTabPosition ?? 'afterCurrentInOrder')
     if (!makeActive) {
       this.commitSession(session)
       return tab.id
@@ -117,7 +127,7 @@ export class CapacitorTabService {
     const tab = createCapacitorTab(source.route)
     tab.title = source.contentTitle || source.title || source.route.fullPath
     const previous = this.currentSession()
-    const session = addCapacitorTab(previous, tab)
+    const session = addCapacitorTab(previous, tab, true, this.store.getters.getNewTabPosition ?? 'afterCurrentInOrder')
     return await this.commitAndPresent(previous, session) ? tab.id : null
   }
 
@@ -131,7 +141,7 @@ export class CapacitorTabService {
     if (wasActive) this.navigation.saveScroll(tabId)
 
     if (wasActive && previous.tabs.length > 1) {
-      const nextTabId = findReplacementTabId(previous.tabs, tabId)
+      const nextTabId = findReplacementTabId(previous.tabs, tabId, this.store.getters.getTabCloseFocus)
       if (!nextTabId || !await this.activateTab(nextTabId)) return false
       previous = this.currentSession()
     }
@@ -272,7 +282,7 @@ export class CapacitorTabService {
     if (session.activeTabId === tabId) {
       if (session.tabs.length <= 1) return false
 
-      const nextTabId = findReplacementTabId(session.tabs, tabId)
+      const nextTabId = findReplacementTabId(session.tabs, tabId, this.store.getters.getTabCloseFocus)
       if (!nextTabId || !await this.activateTab(nextTabId)) return false
       session = this.currentSession()
     }
@@ -330,6 +340,7 @@ export class CapacitorTabService {
         id: tab.id,
         title: tab.contentTitle || tab.title || tab.route.fullPath,
         isPinned: tab.isPinned === true,
+        placementOpenerTabId: tab.placementOpenerTabId,
         route: tab.route,
         history: tab.history,
         historyIndex: tab.historyIndex,
@@ -344,6 +355,7 @@ export class CapacitorTabService {
         id: tab.id,
         title: tab.title || tab.route.fullPath,
         isPinned: tab.isPinned === true,
+        placementOpenerTabId: tab.placementOpenerTabId,
         route: tab.route,
         history: tab.history,
         historyIndex: tab.historyIndex
@@ -376,15 +388,17 @@ export class CapacitorTabService {
   }
 }
 
-function findReplacementTabId(tabs, tabId) {
+function findReplacementTabId(tabs, tabId, focus) {
   const tabIndex = tabs.findIndex(tab => tab.id === tabId)
   if (tabIndex === -1) return null
 
-  const candidates = [
-    ...tabs.slice(tabIndex + 1),
-    ...tabs.slice(0, tabIndex).reverse()
-  ]
-  return candidates.find(tab => tab.loadState === 'loaded')?.id ?? candidates[0]?.id ?? null
+  const previous = tabs[tabIndex - 1]
+  const next = tabs[tabIndex + 1]
+  const [preferred, fallback] = focus === 'nextTab' ? [next, previous] : [previous, next]
+  // Match desktop: prefer a loaded opposite neighbor, but never skip over
+  // the nearest tab on the configured side to find a more distant loaded tab.
+  if (preferred?.loadState !== 'loaded' && fallback?.loadState === 'loaded') return fallback.id
+  return preferred?.id ?? fallback?.id ?? null
 }
 
 function toPersistedSession(session) {
@@ -392,6 +406,7 @@ function toPersistedSession(session) {
     id: tab.id,
     title: tab.title,
     isPinned: tab.isPinned,
+    placementOpenerTabId: tab.placementOpenerTabId,
     route: tab.route,
     history: tab.history,
     historyIndex: tab.historyIndex,

--- a/src/renderer/tabs/CapacitorTabService.js
+++ b/src/renderer/tabs/CapacitorTabService.js
@@ -20,6 +20,7 @@ const STORAGE_KEY = 'opentubex-capacitor-tabs'
 const PERSISTED_MUTATIONS = new Set([
   'setHistoryEntryScroll',
   'setPresentedTab',
+  'setRememberTabNavigationHistory',
   'setTabContentTitle',
   'setTabNavigation',
   'setTabsState'
@@ -62,7 +63,9 @@ export class CapacitorTabService {
       : Date.now()
     let session = restoreCapacitorTabSession(
       persisted,
-      initialRoute
+      initialRoute,
+      undefined,
+      this.store.getters.getRememberTabNavigationHistory === true
     )
     for (const tab of session.tabs) {
       if (tab.id === session.activeTabId || startupBehavior === 'loadAllTabs') {
@@ -375,7 +378,10 @@ export class CapacitorTabService {
   persist() {
     try {
       this.sessionUpdatedAt = Date.now()
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(toPersistedSession(this.currentSession())))
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(toPersistedSession(
+        this.currentSession(),
+        this.store.getters.getRememberTabNavigationHistory === true
+      )))
     } catch (error) {
       console.error('Failed to persist Capacitor tabs:', error)
     }
@@ -401,15 +407,14 @@ function findReplacementTabId(tabs, tabId, focus) {
   return preferred?.id ?? fallback?.id ?? null
 }
 
-function toPersistedSession(session) {
+function toPersistedSession(session, rememberHistory) {
   const serializeTab = (tab, includeLoadState) => ({
     id: tab.id,
     title: tab.title,
     isPinned: tab.isPinned,
     placementOpenerTabId: tab.placementOpenerTabId,
     route: tab.route,
-    history: tab.history,
-    historyIndex: tab.historyIndex,
+    ...(rememberHistory && { history: tab.history, historyIndex: tab.historyIndex }),
     ...(includeLoadState && { isUnloaded: tab.loadState === 'unloaded' })
   })
 

--- a/src/renderer/tabs/capacitorTabState.js
+++ b/src/renderer/tabs/capacitorTabState.js
@@ -24,7 +24,7 @@ export function createCapacitorTab(route, title = '', id = window.crypto.randomU
   }
 }
 
-export function restoreCapacitorTabSession(value, currentRoute, createId = () => window.crypto.randomUUID()) {
+export function restoreCapacitorTabSession(value, currentRoute, createId = () => window.crypto.randomUUID(), rememberHistory = true) {
   const seenIds = new Set()
   const tabs = Array.isArray(value?.tabs)
     ? value.tabs
@@ -33,7 +33,7 @@ export function restoreCapacitorTabSession(value, currentRoute, createId = () =>
           seenIds.add(tab.id)
           return true
         })
-        .map(normalizeRestoredTab)
+        .map(tab => normalizeRestoredTab(tab, rememberHistory))
     : []
 
   const closedTabIds = new Set()
@@ -45,7 +45,7 @@ export function restoreCapacitorTabSession(value, currentRoute, createId = () =>
           return true
         })
         .slice(-MAX_CLOSED_CAPACITOR_TABS)
-        .map(normalizePersistedTab)
+        .map(tab => normalizePersistedTab(tab, rememberHistory))
     : []
 
   if (tabs.length === 0) {
@@ -290,12 +290,12 @@ function isValidPersistedTab(tab) {
     typeof tab.route === 'object'
 }
 
-function normalizePersistedTab(tab) {
+function normalizePersistedTab(tab, rememberHistory = true) {
   const route = normalizeRoute(tab.route)
   const title = typeof tab.title === 'string' && tab.title.length > 0
     ? tab.title
     : route.fullPath
-  const history = Array.isArray(tab.history) && tab.history.length > 0
+  const history = rememberHistory && Array.isArray(tab.history) && tab.history.length > 0
     ? tab.history.map(entry => ({
         route: cloneRoute(entry?.route),
         title: typeof entry?.title === 'string' ? entry.title : entry?.route?.fullPath || '/',
@@ -333,8 +333,8 @@ function normalizePersistedTab(tab) {
   }
 }
 
-function normalizeRestoredTab(tab) {
-  const normalized = normalizePersistedTab(tab)
+function normalizeRestoredTab(tab, rememberHistory) {
+  const normalized = normalizePersistedTab(tab, rememberHistory)
   if (normalized.loadState === 'unloaded') return normalized
 
   return {

--- a/src/renderer/tabs/capacitorTabState.js
+++ b/src/renderer/tabs/capacitorTabState.js
@@ -67,8 +67,19 @@ export function restoreCapacitorTabSession(value, currentRoute, createId = () =>
   }
 }
 
-export function addCapacitorTab(session, tab, makeActive = true) {
-  const tabs = [...session.tabs, normalizePersistedTab(tab)]
+export function addCapacitorTab(session, tab, makeActive = true, position = 'end') {
+  const tabs = [...session.tabs]
+  const openerIndex = tabs.findIndex(candidate => candidate.id === session.activeTabId)
+  const pinnedCount = tabs.filter(candidate => candidate.isPinned).length
+  let insertIndex = tabs.length
+  if (position !== 'end' && openerIndex !== -1) {
+    insertIndex = Math.max(openerIndex + 1, tab.isPinned ? 0 : pinnedCount)
+    if (position === 'afterCurrentInOrder') {
+      while (tabs[insertIndex]?.placementOpenerTabId === session.activeTabId) insertIndex += 1
+    }
+  }
+  insertIndex = tab.isPinned ? Math.min(insertIndex, pinnedCount) : Math.max(insertIndex, pinnedCount)
+  tabs.splice(insertIndex, 0, normalizePersistedTab({ ...tab, placementOpenerTabId: session.activeTabId }))
   return {
     ...session,
     tabs,
@@ -208,9 +219,11 @@ export function setCapacitorTabPinned(session, tabId, pinned) {
     return session
   }
 
-  const updated = session.tabs.map(tab => (
-    tab.id === tabId ? { ...tab, isPinned: pinned } : tab
-  ))
+  const updated = session.tabs.map(tab => ({
+    ...tab,
+    isPinned: tab.id === tabId ? pinned : tab.isPinned,
+    placementOpenerTabId: null
+  }))
   return {
     ...session,
     tabs: [
@@ -235,7 +248,7 @@ export function moveCapacitorTab(session, tabId, targetIndex) {
   const tabs = [...session.tabs]
   tabs.splice(sourceIndex, 1)
   tabs.splice(clampedIndex, 0, source)
-  return { ...session, tabs }
+  return { ...session, tabs: tabs.map(tab => ({ ...tab, placementOpenerTabId: null })) }
 }
 
 export function toRuntimeTabState(session, presentedTabId = session.activeTabId) {
@@ -304,6 +317,7 @@ function normalizePersistedTab(tab) {
     id: tab.id,
     title,
     isPinned: tab.isPinned === true,
+    placementOpenerTabId: typeof tab.placementOpenerTabId === 'string' ? tab.placementOpenerTabId : null,
     route,
     history,
     historyIndex,

--- a/tests/unit/capacitor-tab-service.test.mjs
+++ b/tests/unit/capacitor-tab-service.test.mjs
@@ -250,3 +250,154 @@ test('uses tab actions on Android WebViews without Array.toReversed', async () =
     Array.prototype.toReversed = toReversed
   }
 })
+
+function createThreeTabSession() {
+  let session = createLoadedSession()
+  for (const id of ['tab-b', 'tab-c']) {
+    session = addCapacitorTab(session, createCapacitorTab(WATCH_ROUTE, id, id), false)
+    session = completeCapacitorTabMount(session, id, 1)
+  }
+  return activateCapacitorTab(session, 'tab-b')
+}
+
+for (const position of ['end', 'afterCurrent', 'afterCurrentInOrder']) {
+  test(`mobile creates background tabs with position ${position}`, async () => {
+    const store = createStore(createThreeTabSession())
+    store.getters.getNewTabPosition = position
+    const service = new CapacitorTabService(createRouter(), store, createNavigation(store, true))
+    const first = await service.createTab(WATCH_ROUTE, '', false)
+    const second = await service.createTab(WATCH_ROUTE, '', false)
+    const expected = position === 'end'
+      ? ['tab-a', 'tab-b', 'tab-c', first, second]
+      : ['tab-a', 'tab-b', ...(position === 'afterCurrent' ? [second, first] : [first, second]), 'tab-c']
+    assert.deepEqual(store.getters.getTabs.map(tab => tab.id), expected)
+    assert.equal(store.getters.getActiveTabId, 'tab-b')
+  })
+}
+
+for (const action of ['closeTab', 'unloadTab']) {
+  for (const focus of ['previousTab', 'nextTab']) {
+    test(`mobile ${action} respects ${focus}`, async () => {
+      const store = createStore(createThreeTabSession())
+      store.getters.getTabCloseFocus = focus
+      const service = new CapacitorTabService(createRouter(), store, createNavigation(store, true))
+      assert.equal(await service[action]('tab-b'), true)
+      assert.equal(store.getters.getActiveTabId, focus === 'previousTab' ? 'tab-a' : 'tab-c')
+    })
+  }
+}
+
+for (const behavior of ['loadAllTabs', 'restoreTabLoadState', 'loadLastActiveTab', 'emptySession']) {
+  test(`mobile startup applies ${behavior}`, async () => {
+    const session = unloadCapacitorTab(createThreeTabSession(), 'tab-c')
+    const persisted = {
+      ...session,
+      tabs: session.tabs.map(({ loadState, ...tab }) => ({ ...tab, isUnloaded: loadState === 'unloaded' })),
+    }
+    const previousStorage = globalThis.localStorage
+    let saved
+    globalThis.localStorage = {
+      getItem: () => JSON.stringify(saved ?? persisted),
+      setItem: (_key, value) => { saved = JSON.parse(value) },
+    }
+    const store = createStore(createLoadedSession())
+    store.getters.getStartupBehavior = behavior
+    store.getters.getLandingPage = 'subscriptions'
+    store.subscribe = () => () => {}
+    const router = createRouter()
+    router.afterEach = () => () => {}
+    const navigation = createNavigation(store, true)
+    navigation.projectRoute = async route => { router.currentRoute.value = route }
+    navigation.restoreScroll = () => {}
+    const service = new CapacitorTabService(router, store, navigation)
+    try {
+      await service.initialize({ path: '/', fullPath: '/' })
+      if (behavior === 'emptySession') {
+        assert.equal(store.getters.getTabs.length, 1)
+        assert.equal(store.getters.getActiveTab.route.fullPath, '/subscriptions')
+        assert.equal(store.getters.getClosedTabs.length, 0)
+      } else {
+        assert.equal(store.getters.getActiveTabId, 'tab-b')
+        assert.deepEqual(store.getters.getTabs.map(tab => tab.loadState), {
+          loadAllTabs: ['mounting', 'mounting', 'mounting'],
+          restoreTabLoadState: ['mounting', 'mounting', 'unloaded'],
+          loadLastActiveTab: ['unloaded', 'mounting', 'unloaded'],
+        }[behavior])
+        assert.deepEqual(saved.tabs.map(tab => tab.isUnloaded), store.getters.getTabs.map(tab => tab.isUnloaded))
+        store.getters.getNewTabPosition = 'afterCurrentInOrder'
+        const first = await service.createTab(WATCH_ROUTE, '', false)
+        const second = await service.createTab(WATCH_ROUTE, '', false)
+        service.persist()
+        service.dispose()
+        await service.initialize(HOME_ROUTE)
+        const third = await service.createTab(WATCH_ROUTE, '', false)
+        assert.deepEqual(store.getters.getTabs.map(tab => tab.id), ['tab-a', 'tab-b', first, second, third, 'tab-c'])
+      }
+    } finally {
+      service.dispose()
+      globalThis.localStorage = previousStorage
+    }
+  })
+}
+
+for (const position of ['afterCurrent', 'afterCurrentInOrder']) {
+  test(`mobile ${position} keeps new tabs after the pinned group`, async () => {
+    const store = createStore(createThreeTabSession())
+    store.getters.getNewTabPosition = position
+    const service = new CapacitorTabService(createRouter(), store, createNavigation(store, true))
+    service.setPinned('tab-a', true)
+    service.setPinned('tab-b', true)
+    await service.activateTab('tab-a')
+    const first = await service.createTab(WATCH_ROUTE, '', false)
+    const second = await service.createTab(WATCH_ROUTE, '', false)
+    assert.deepEqual(store.getters.getTabs.map(tab => tab.id), [
+      'tab-a', 'tab-b', ...(position === 'afterCurrent' ? [second, first] : [first, second]), 'tab-c',
+    ])
+  })
+}
+
+test('mobile starts a new opened-order group after manually moving tabs', async () => {
+  const store = createStore(createThreeTabSession())
+  store.getters.getNewTabPosition = 'afterCurrentInOrder'
+  const service = new CapacitorTabService(createRouter(), store, createNavigation(store, true))
+  const first = await service.createTab(WATCH_ROUTE, '', false)
+  const second = await service.createTab(WATCH_ROUTE, '', false)
+  service.moveTab(first, 4)
+  const third = await service.createTab(WATCH_ROUTE, '', false)
+  assert.deepEqual(store.getters.getTabs.map(tab => tab.id), ['tab-a', 'tab-b', third, second, 'tab-c', first])
+})
+
+test('mobile duplicates tabs using the configured new-tab position', async () => {
+  const store = createStore(createThreeTabSession())
+  store.getters.getNewTabPosition = 'afterCurrent'
+  const service = new CapacitorTabService(createRouter(), store, createNavigation(store, true))
+  const duplicate = await service.duplicateTab('tab-b')
+  assert.deepEqual(store.getters.getTabs.map(tab => tab.id), ['tab-a', 'tab-b', duplicate, 'tab-c'])
+  assert.equal(store.getters.getActiveTabId, duplicate)
+})
+
+for (const focus of ['previousTab', 'nextTab']) {
+  test(`mobile ${focus} falls back to an already loaded tab on the other side`, async () => {
+    const preferred = focus === 'previousTab' ? 'tab-a' : 'tab-c'
+    const fallback = focus === 'previousTab' ? 'tab-c' : 'tab-a'
+    const store = createStore(unloadCapacitorTab(createThreeTabSession(), preferred))
+    store.getters.getTabCloseFocus = focus
+    const service = new CapacitorTabService(createRouter(), store, createNavigation(store, true))
+    assert.equal(await service.closeTab('tab-b'), true)
+    assert.equal(store.getters.getActiveTabId, fallback)
+  })
+}
+
+for (const action of ['closeTab', 'unloadTab']) {
+  for (const focus of ['previousTab', 'nextTab']) {
+    test(`mobile ${action} with ${focus} selects the nearest unloaded neighbor`, async () => {
+      const activeTabId = focus === 'previousTab' ? 'tab-c' : 'tab-a'
+      const session = activateCapacitorTab(unloadCapacitorTab(createThreeTabSession(), 'tab-b'), activeTabId)
+      const store = createStore(session)
+      store.getters.getTabCloseFocus = focus
+      const service = new CapacitorTabService(createRouter(), store, createNavigation(store, true))
+      assert.equal(await service[action](activeTabId), true)
+      assert.equal(store.getters.getActiveTabId, 'tab-b')
+    })
+  }
+}

--- a/tests/unit/capacitor-tab-service.test.mjs
+++ b/tests/unit/capacitor-tab-service.test.mjs
@@ -25,6 +25,7 @@ const WATCH_ROUTE = { path: '/watch/video', fullPath: '/watch/video', query: {} 
 
 function createStore (session, presentedTabId = session.activeTabId) {
   let runtime = toRuntimeTabState(session, presentedTabId)
+  const subscribers = new Set()
   const getters = {
     getLandingPage: 'home',
     getTabById: tabId => runtime.tabs.find(tab => tab.id === tabId),
@@ -47,10 +48,16 @@ function createStore (session, presentedTabId = session.activeTabId) {
     get runtime () { return runtime },
     getters,
     state,
+    subscribe(callback) {
+      subscribers.add(callback)
+      return () => subscribers.delete(callback)
+    },
     commit (type, payload) {
       if (type === 'setTabsState') runtime = payload
       else if (type === 'setPresentedTab') runtime.presentedTabId = payload
+      else if (type === 'setRememberTabNavigationHistory') getters.getRememberTabNavigationHistory = payload
       else throw new Error(`Unexpected mutation: ${type}`)
+      for (const subscriber of subscribers) subscriber({ type, payload })
     }
   }
 }
@@ -400,4 +407,54 @@ for (const action of ['closeTab', 'unloadTab']) {
       assert.equal(store.getters.getActiveTabId, 'tab-b')
     })
   }
+}
+
+for (const rememberHistory of [true, false, undefined]) {
+  test(`mobile navigation history persistence honors ${rememberHistory ?? 'the default'}`, async () => {
+    const history = [HOME_ROUTE, WATCH_ROUTE, { path: '/history', fullPath: '/history' }]
+      .map((route, index) => ({ route, title: route.fullPath, scroll: { left: 0, top: index * 100 } }))
+    const tab = { ...createCapacitorTab(WATCH_ROUTE, 'Video', 'tab-a'), history, historyIndex: 1 }
+    let saved = { tabs: [tab], closedTabs: [{ ...tab, id: 'closed-tab' }], activeTabId: tab.id }
+    const previousStorage = globalThis.localStorage
+    globalThis.localStorage = {
+      getItem: () => JSON.stringify(saved),
+      setItem: (_key, value) => { saved = JSON.parse(value) },
+    }
+    const store = createStore(createLoadedSession())
+    store.getters.getRememberTabNavigationHistory = rememberHistory
+    const router = createRouter()
+    router.afterEach = () => () => {}
+    const navigation = createNavigation(store, true)
+    navigation.projectRoute = async route => { router.currentRoute.value = route }
+    navigation.restoreScroll = () => {}
+    const service = new CapacitorTabService(router, store, navigation)
+    try {
+      await service.initialize(HOME_ROUTE)
+      for (const restored of [store.getters.getActiveTab, store.getters.getClosedTabs[0]]) {
+        assert.equal(restored.history.length, rememberHistory === true ? 3 : 1)
+        assert.equal(restored.historyIndex, rememberHistory === true ? 1 : 0)
+        assert.equal(restored.route.fullPath, WATCH_ROUTE.fullPath)
+      }
+      for (const persisted of [...saved.tabs, ...saved.closedTabs]) {
+        assert.equal(Object.hasOwn(persisted, 'history'), rememberHistory === true)
+        assert.equal(Object.hasOwn(persisted, 'historyIndex'), rememberHistory === true)
+      }
+      if (rememberHistory === true) {
+        assert.equal(store.getters.getActiveTab.history[1].scroll.top, 100)
+        store.commit('setRememberTabNavigationHistory', false)
+        for (const persisted of [...saved.tabs, ...saved.closedTabs]) {
+          assert.equal(Object.hasOwn(persisted, 'history'), false)
+          assert.equal(Object.hasOwn(persisted, 'historyIndex'), false)
+        }
+        // Turning persistence off must leave in-session back/forward navigation intact.
+        assert.equal(store.getters.getActiveTab.history.length, 3)
+        store.commit('setRememberTabNavigationHistory', true)
+        assert.equal(saved.tabs[0].history.length, 3)
+        assert.equal(saved.closedTabs[0].history.length, 3)
+      }
+    } finally {
+      service.dispose()
+      globalThis.localStorage = previousStorage
+    }
+  })
 }

--- a/tests/unit/general-tab-settings.test.mjs
+++ b/tests/unit/general-tab-settings.test.mjs
@@ -63,3 +63,26 @@ test('mobile startup waits for saved settings before restoring tabs', async () =
   await tabsReady
   assert.equal(restored, true)
 })
+
+const privacySource = await readFile(new URL('../../src/renderer/components/PrivacySettings.vue', import.meta.url), 'utf8')
+const historyToggle = [...privacySource.matchAll(/<FtToggleSwitch\s[\s\S]*?\/>/g)]
+  .map(([template]) => template)
+  .find(template => template.includes('setting-key="rememberTabNavigationHistory"'))
+assert.ok(historyToggle)
+for (const [platform, USING_ELECTRON, IS_CAPACITOR] of [
+  ['desktop', true, false], ['mobile', false, true], ['web', false, false],
+]) {
+  test(`${platform} exposes navigation history persistence only with logical tabs`, async () => {
+    const app = createSSRApp({
+      render: compile(historyToggle),
+      setup: () => ({ USING_ELECTRON, IS_CAPACITOR, rememberTabNavigationHistory: false, updateRememberTabNavigationHistory: () => {} }),
+    })
+    app.config.globalProperties.$t = key => key
+    app.component('FtToggleSwitch', {
+      inheritAttrs: false,
+      setup: (_props, { attrs }) => () => h('button', { 'data-setting': attrs['setting-key'] }),
+    })
+    const html = await renderToString(app)
+    assert.equal(html.includes('data-setting="rememberTabNavigationHistory"'), USING_ELECTRON || IS_CAPACITOR)
+  })
+}

--- a/tests/unit/general-tab-settings.test.mjs
+++ b/tests/unit/general-tab-settings.test.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import vm from 'node:vm'
+import { compile, createSSRApp, h } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+
+const source = await readFile(new URL('../../src/renderer/components/GeneralSettings/GeneralSettings.vue', import.meta.url), 'utf8')
+const keys = ['landingPage', 'newTabPosition', 'tabCloseFocus', 'startupBehavior']
+const selects = [...source.matchAll(/<FtSelect\s[\s\S]*?\/>/g)]
+  .map(([template]) => template)
+  .filter(template => keys.some(key => template.includes(`setting-key="${key}"`)))
+assert.equal(selects.length, keys.length)
+const render = compile(`<div>${selects.join('\n')}</div>`)
+
+for (const [platform, USING_ELECTRON, IS_CAPACITOR] of [
+  ['desktop', true, false], ['mobile', false, true], ['web', false, false],
+]) {
+  test(`${platform} renders the general tab settings supported by its tab system`, async () => {
+    const bindings = {
+      mode: 'general', USING_ELECTRON, IS_CAPACITOR, t: key => key,
+      defaultPageNames: [], defaultPageValues: [],
+      NEW_TAB_POSITION_VALUES: [], TAB_CLOSE_FOCUS_VALUES: [], STARTUP_BEHAVIOR_VALUES: [],
+    }
+    for (const key of keys) {
+      bindings[key] = ''
+      bindings[`${key}Names`] = []
+      bindings[`update${key[0].toUpperCase()}${key.slice(1)}`] = () => {}
+    }
+    const app = createSSRApp({ render, setup: () => bindings })
+    app.component('FtSelect', {
+      inheritAttrs: false,
+      setup: (_props, { attrs }) => () => h('select', { 'data-setting': attrs['setting-key'] }),
+    })
+    const html = await renderToString(app)
+    for (const key of keys) {
+      assert.equal(html.includes(`data-setting="${key}"`), key === 'landingPage' || USING_ELECTRON || IS_CAPACITOR, key)
+    }
+  })
+}
+
+test('mobile startup waits for saved settings before restoring tabs', async () => {
+  const app = await readFile(new URL('../../src/renderer/App.vue', import.meta.url), 'utf8')
+  const start = app.indexOf('  let tabsReady = Promise.resolve()')
+  const initialization = app.slice(start, app.indexOf('  const customThemesReady =', start))
+  let finishSettings
+  const settingsReady = new Promise(resolve => { finishSettings = resolve })
+  let restored = false
+  const { tabsReady } = vm.runInNewContext(`${initialization}; ({ tabsReady })`, {
+    isElectron: false,
+    isCapacitor: true,
+    route: {},
+    ytDlp: { addYtDlpBinaryUpdatedListener: () => {} },
+    invalidateAllYtDlpPlaybackSources: () => {},
+    store: { dispatch: () => settingsReady },
+    initializeAndroidYtDlp: () => {},
+    initializeCapacitorTabPreviews: () => {},
+    capacitorTabService: { initialize: async () => { restored = true } },
+  })
+  await Promise.resolve()
+  assert.equal(restored, false)
+  finishSettings({})
+  await tabsReady
+  assert.equal(restored, true)
+})

--- a/tests/unit/settings-search-config.test.mjs
+++ b/tests/unit/settings-search-config.test.mjs
@@ -325,3 +325,18 @@ for (const [platform, usingElectron, isCapacitor] of [
     }
   })
 }
+
+for (const [platform, usingElectron, isCapacitor] of [
+  ['desktop', true, false], ['mobile', false, true], ['web', false, false],
+]) {
+  test(`${platform} privacy search matches navigation history setting visibility`, () => {
+    const entries = createSettingsSearchIndex({
+      sections: [{ type: 'privacy', title: 'Privacy', description: '' }],
+      tm: path => getAtPath(locale, path),
+      store: { getters: {} },
+      usingElectron,
+      isCapacitor,
+    }).get('privacy')
+    assert.equal(entries.some(({ label }) => label === 'Remember Tab Navigation History'), usingElectron || isCapacitor)
+  })
+}

--- a/tests/unit/settings-search-config.test.mjs
+++ b/tests/unit/settings-search-config.test.mjs
@@ -303,3 +303,25 @@ test('ignored comment translation languages follow local API availability', () =
   assert.ok(!webValues.some(({ label }) => label === 'Enable comment translations'))
   assert.ok(!webValues.some(({ label }) => label === 'Comment translations'))
 })
+
+for (const [platform, usingElectron, isCapacitor] of [
+  ['desktop', true, false], ['mobile', false, true], ['web', false, false],
+]) {
+  test(`${platform} general settings search matches tab support`, () => {
+    const entries = createSettingsSearchIndex({
+      sections: [{ type: 'general', title: 'General', description: '' }],
+      tm: path => getAtPath(locale, path),
+      store: { getters: {} },
+      usingElectron,
+      isCapacitor,
+    }).get('general')
+    for (const path of [
+      'New Tab Position.New Tab Position',
+      'Tab Close Focus.Tab Close Focus',
+      'Startup Behavior.Startup Behavior',
+    ]) {
+      const label = getAtPath(locale, `Settings.General Settings.${path}`)
+      assert.equal(entries.some(entry => entry.label === label), usingElectron || isCapacitor, label)
+    }
+  })
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

Fixes the missing mobile tab settings reported directly by Nico. No dedicated issue.
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description

Mobile had tab support but hid its tab settings and ignored their saved values. Expose New Tab Position, After Closing a Tab, and On Startup in General settings, plus Remember Tab Navigation History in Privacy settings and search.

Apply tab placement, close focus, and startup choices on mobile, including opened-order placement across restarts. Save and restore back/forward history only when enabled; disabling it clears persisted open/closed-tab history immediately while keeping navigation available for the current session. Startup now waits for saved settings before restoring tabs.
<!-- Please write a clear and concise description of what the pull request does. -->

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Mobile now supports settings for tab position, selection after closing, startup restoration, and remembering back/forward navigation history.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing

1. On Android, open Settings → General. Verify that New Tab Position, After Closing a Tab, and On Startup are available and appear in settings search.
2. Open several tabs in the background using each new-tab position. Check the order, including when the active tab is pinned. Reorder a tab and verify that subsequent tabs start a new opened-order group.
3. Select previous/next tab after closing and close a middle tab. Repeat with an unloaded adjacent tab; it should load the nearest neighbor unless the opposite neighbor is already loaded.
4. Restart with each startup option. Verify that all tabs, previously loaded tabs, only the last active tab, or a fresh landing-page tab load as selected.
5. Enable Remember Tab Navigation History in Privacy, navigate back and forward within a tab, then restart. Verify that both directions and the current position are restored. Disable the setting and restart; tabs should retain only their current page. Toggling it off should preserve back/forward navigation until that restart.
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

## Additional context

The local review found and fixed a close-focus mismatch with desktop for unloaded neighboring tabs.

Implemented with GPT-6 in the Codex desktop app.
<!-- Add any other context about the pull request here. -->
