### PR TITLE
feat: allow zero upcoming preloads and 32 concurrent preloads

### DIFF
--- a/e2e/tests/offline/playlists.spec.mjs
+++ b/e2e/tests/offline/playlists.spec.mjs
@@ -164,6 +164,8 @@ test.describe('seeded playlists', () => {
   })
 
   test('preloads every video in a user playlist with yt-dlp', async ({ app, page }) => {
+    await dispatchStoreAction(page, 'updateYtDlpPreloadEnabled', true)
+    await dispatchStoreAction(page, 'updateYtDlpPreloadCount', 0)
     await dispatchStoreAction(page, 'updateYtDlpPreloadConcurrency', 1)
     await app.electronApp.evaluate(({ ipcMain }, channel) => {
       globalThis.__ytDlpPreloadVideoIds = []

--- a/e2e/tests/offline/yt-dlp-preload-settings.spec.mjs
+++ b/e2e/tests/offline/yt-dlp-preload-settings.spec.mjs
@@ -37,19 +37,19 @@ test.describe('yt-dlp playback preloading', () => {
     await expect(segmentSlider).toBeEnabled()
     await expect(countSlider).toBeDisabled()
     await expect(countSlider).toHaveValue('2')
-    await expect(countSlider).toHaveAttribute('min', '1')
+    await expect(countSlider).toHaveAttribute('min', '0')
     await expect(countSlider).toHaveAttribute('max', '10')
     await expect(concurrencySlider).toHaveValue('2')
     await expect(concurrencySlider).toHaveAttribute('min', '1')
-    await expect(concurrencySlider).toHaveAttribute('max', '8')
+    await expect(concurrencySlider).toHaveAttribute('max', '32')
     await expect(concurrencySlider).toBeDisabled()
 
     await toggleLabel.click()
     await expect(toggle).toBeChecked()
     await expect(countSlider).toBeEnabled()
     await expect(concurrencySlider).toBeEnabled()
-    await countSlider.fill('4')
-    await concurrencySlider.fill('6')
+    await countSlider.fill('0')
+    await concurrencySlider.fill('32')
 
     await expect.poll(async () => {
       const settings = latestSettings(
@@ -60,12 +60,12 @@ test.describe('yt-dlp playback preloading', () => {
         count: settings.ytDlpPreloadCount,
         concurrency: settings.ytDlpPreloadConcurrency
       }
-    }).toEqual({ enabled: true, count: 4, concurrency: 6 })
+    }).toEqual({ enabled: true, count: 0, concurrency: 32 })
 
     const relaunched = await app.relaunch()
     const reloaded = await openYtDlpStreamingSettings(relaunched.page)
     await expect(reloaded.toggle).toBeChecked()
-    await expect(reloaded.countSlider).toHaveValue('4')
-    await expect(reloaded.concurrencySlider).toHaveValue('6')
+    await expect(reloaded.countSlider).toHaveValue('0')
+    await expect(reloaded.concurrencySlider).toHaveValue('32')
   })
 })

--- a/src/renderer/components/YtDlpStreamingSettings/YtDlpStreamingSettings.vue
+++ b/src/renderer/components/YtDlpStreamingSettings/YtDlpStreamingSettings.vue
@@ -25,7 +25,7 @@
         :label="t('Settings.Player Settings.Upcoming Videos to Preload')"
         :default-value="ytDlpPreloadCount"
         setting-key="ytDlpPreloadCount"
-        :min-value="1"
+        :min-value="0"
         :max-value="MAX_YT_DLP_PRELOAD_COUNT"
         :step="1"
         :disabled="!ytDlpPreloadEnabled"

--- a/src/renderer/helpers/player/ytDlpPlaybackPreload.js
+++ b/src/renderer/helpers/player/ytDlpPlaybackPreload.js
@@ -3,7 +3,7 @@ import { isYtDlpPlaybackSourceCacheable } from './ytDlpPlaybackCache.js'
 export const DEFAULT_YT_DLP_PRELOAD_COUNT = 2
 export const MAX_YT_DLP_PRELOAD_COUNT = 10
 export const DEFAULT_YT_DLP_PRELOAD_CONCURRENCY = 2
-export const MAX_YT_DLP_PRELOAD_CONCURRENCY = 8
+export const MAX_YT_DLP_PRELOAD_CONCURRENCY = 32
 
 const pendingPreloadTasks = []
 let activePreloadTasks = 0

--- a/tests/unit/yt-dlp-playback-preload.test.mjs
+++ b/tests/unit/yt-dlp-playback-preload.test.mjs
@@ -75,6 +75,8 @@ test('normalizes the number of upcoming yt-dlp videos to preload', () => {
 test('normalizes the number of concurrent yt-dlp preloads', () => {
   assert.equal(normalizeYtDlpPreloadConcurrency(3), 3)
   assert.equal(normalizeYtDlpPreloadConcurrency('4'), 4)
+  assert.equal(normalizeYtDlpPreloadConcurrency(32), 32)
+  assert.equal(normalizeYtDlpPreloadConcurrency(33), 32)
   assert.equal(normalizeYtDlpPreloadConcurrency(0), DEFAULT_YT_DLP_PRELOAD_CONCURRENCY)
   assert.equal(normalizeYtDlpPreloadConcurrency(-1), DEFAULT_YT_DLP_PRELOAD_CONCURRENCY)
   assert.equal(normalizeYtDlpPreloadConcurrency(1.5), DEFAULT_YT_DLP_PRELOAD_CONCURRENCY)
@@ -128,6 +130,21 @@ test('does not fall back to recommendations at the end of a playlist', () => {
     playlistVideos: [],
     recommendedVideos: [video('recommend01')],
   }), [])
+})
+
+test('selects no upcoming videos when the preload count is zero', () => {
+  for (const candidates of [
+    { queuedVideos: [video('queue000001')], playlistVideos: [video('list0000001')] },
+    { queuedVideos: [], playlistVideos: [video('list0000001')] },
+    { queuedVideos: [], playlistVideos: null },
+  ]) {
+    assert.deepEqual(selectYtDlpPreloadVideoIds({
+      currentVideoId: 'current00001',
+      limit: 0,
+      recommendedVideos: [video('recommend01')],
+      ...candidates,
+    }), [])
+  }
 })
 
 test('preloads unique videos with bounded concurrency and reports failures', async () => {
@@ -229,18 +246,18 @@ test('raises the shared preload concurrency limit when configured', async () => 
   })
 
   const firstRun = preloadYtDlpPlaybackSources(
-    ['first00001', 'first00002', 'first00003'],
-    { concurrency: 4, loadSource }
+    Array.from({ length: 20 }, (_, index) => `first${index}`),
+    { concurrency: 32, loadSource }
   )
   const secondRun = preloadYtDlpPlaybackSources(
-    ['second0001', 'second0002', 'second0003'],
-    { concurrency: 4, loadSource }
+    Array.from({ length: 20 }, (_, index) => `second${index}`),
+    { concurrency: 32, loadSource }
   )
 
   await new Promise(resolve => setImmediate(resolve))
-  assert.equal(active, 4)
+  const initiallyActive = active
 
-  for (let completed = 0; completed < 6; completed++) {
+  for (let completed = 0; completed < 40; completed++) {
     const release = releases.shift()
     assert.ok(release)
     release()
@@ -248,7 +265,8 @@ test('raises the shared preload concurrency limit when configured', async () => 
   }
 
   await Promise.all([firstRun, secondRun])
-  assert.equal(peakActive, 4)
+  assert.equal(initiallyActive, 32)
+  assert.equal(peakActive, 32)
 })
 
 test('reports sources that cannot be cached as preload failures', async () => {


### PR DESCRIPTION
Preload settings could not disable automatic upcoming-video preloads while retaining manual playlist preloading, and concurrent preloads were capped at 8. This allows an upcoming count of 0 and raises the concurrency limit to 32.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #1235

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Updates the existing slider bounds and shared runtime concurrency maximum. Tests cover saving and restoring 0/32, manual playlist preloading with an upcoming count of 0, and 32 concurrent tasks across overlapping preload runs.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Set upcoming video preloads to 0 to use only manual playlist preloading, and run up to 32 concurrent preloads.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Settings → Playback → yt-dlp Streaming and enable Preload Upcoming Videos.
2. Set Upcoming Videos to Preload to 0 and Concurrent Preloads to 32. Restart the app and confirm both values persist.
3. With yt-dlp selected as the playback engine, open a playlist and use Preload all videos. Confirm it still preloads playlist videos.
4. Play a video with recommendations and confirm no upcoming-video preloads start while the count is 0.

## Additional context
<!-- Add any other context about the pull request here. -->

Local validation passed: 1,347 unit tests and three focused Electron tests. Lint passed with one existing locale configuration warning. Separate Standards and Spec reviews reported no findings.

Implemented with GPT-6 in the Codex desktop app.
