### PR TITLE
fix(android): restore video and page screenshots in tab previews

### DIFF
--- a/android/app/src/androidTest/java/org/opentubex/app/WebViewScreenshotTest.java
+++ b/android/app/src/androidTest/java/org/opentubex/app/WebViewScreenshotTest.java
@@ -6,8 +6,12 @@ import static org.junit.Assert.assertTrue;
 
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.Color;
+import android.view.TextureView;
+import android.view.ViewGroup;
 import android.webkit.WebView;
 
+import androidx.media3.datasource.DefaultDataSource;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
@@ -24,6 +28,75 @@ import java.util.concurrent.atomic.AtomicReference;
 
 @RunWith(AndroidJUnit4.class)
 public class WebViewScreenshotTest {
+    @Test
+    public void windowCaptureIncludesNativeVideoAndWebControls() throws Exception {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            AtomicReference<WebView> view = new AtomicReference<>();
+            AtomicReference<NativePlaybackScreen> screen = new AtomicReference<>();
+            AtomicReference<NativePlaybackEngine> engine = new AtomicReference<>();
+            scenario.onActivity(activity -> view.set(activity.getBridge().getWebView()));
+            WebView webView = view.get();
+            awaitCondition(webView, "!!document.querySelector('.app')");
+            scenario.onActivity(activity -> webView.loadData("""
+                <html><head><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+                <body style="margin:0;background:transparent">
+                  <video style="width:100vw;height:100vh;opacity:0"></video>
+                  <div id="control" style="position:fixed;left:40vw;top:40vh;width:20vw;height:20vh;background:cyan"></div>
+                </body></html>
+                """, "text/html", "UTF-8"));
+            awaitCondition(webView, "!!document.querySelector('#control')");
+            try {
+                scenario.onActivity(activity -> {
+                    engine.set(new NativePlaybackEngine(activity, new DefaultDataSource.Factory(activity), state -> {}));
+                    screen.set(new NativePlaybackScreen(activity, engine.get(), webView, "en-US", action -> {}));
+                    activity.addContentView(screen.get(), new ViewGroup.LayoutParams(-1, -1));
+                    screen.get().setFullscreen(false);
+                    screen.get().setInlineVisible(true);
+                    screen.get().setControlsVisible(false);
+                });
+                CountDownLatch painted = new CountDownLatch(1);
+                scenario.onActivity(activity -> webView.postVisualStateCallback(2, new WebView.VisualStateCallback() {
+                    @Override public void onComplete(long requestId) {
+                        webView.postOnAnimation(() -> {
+                            TextureView texture = (TextureView) ((ViewGroup) screen.get().getChildAt(0)).getChildAt(0);
+                            assertTrue("The native video texture is ready", texture.isAvailable());
+                            // Paint a deterministic frame into the same texture used by Media3.
+                            android.graphics.Canvas canvas = texture.lockCanvas();
+                            assertNotNull(canvas);
+                            canvas.drawColor(Color.MAGENTA);
+                            texture.unlockCanvasAndPost(canvas);
+                            webView.postOnAnimation(() -> webView.postOnAnimation(painted::countDown));
+                        });
+                    }
+                }));
+                assertTrue("The native frame and web controls have rendered", painted.await(10, TimeUnit.SECONDS));
+                AtomicReference<Bitmap> captured = new AtomicReference<>();
+                AtomicReference<Exception> error = new AtomicReference<>();
+                CountDownLatch completed = new CountDownLatch(1);
+                scenario.onActivity(activity -> WebViewScreenshot.capture(activity, webView,
+                    bitmap -> { captured.set(bitmap); completed.countDown(); },
+                    failure -> { error.set(failure); completed.countDown(); }));
+                assertTrue("Window capture completes", completed.await(10, TimeUnit.SECONDS));
+                assertEquals(null, error.get());
+                Bitmap bitmap = captured.get();
+                assertNotNull(bitmap);
+                try {
+                    assertEquals("The window already contains the native video frame", Color.MAGENTA,
+                        bitmap.getPixel(bitmap.getWidth() / 4, bitmap.getHeight() / 2));
+                    assertEquals("Web controls remain above the native video", Color.CYAN,
+                        bitmap.getPixel(bitmap.getWidth() / 2, bitmap.getHeight() / 2));
+                } finally {
+                    bitmap.recycle();
+                }
+            } finally {
+                scenario.onActivity(activity -> {
+                    if (screen.get() != null) screen.get().close();
+                    if (engine.get() != null) engine.get().release();
+                });
+            }
+        }
+    }
+
     @Test
     public void populatedFeedControlsKeepTheirRenderedProportions() throws Exception {
         try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {

--- a/src/renderer/tabs/capacitorTabPreviews.js
+++ b/src/renderer/tabs/capacitorTabPreviews.js
@@ -48,7 +48,10 @@ export function initializeCapacitorTabPreviews(store) {
     cache.prune(store.getters.getTabs)
     schedule()
   }, { immediate: true, flush: 'sync' })
-  document.addEventListener('scroll', schedule, true)
+  // Native playback can become ready after the route's initial screenshot.
+  // Refresh that cached image before a slow organizer capture needs it.
+  const contentEvents = ['scroll', 'loadeddata', 'playing', 'seeked']
+  for (const event of contentEvents) document.addEventListener(event, schedule, true)
   document.addEventListener('visibilitychange', schedule)
   window.addEventListener('resize', schedule)
   return () => {
@@ -56,7 +59,7 @@ export function initializeCapacitorTabPreviews(store) {
     clearTimeout(timer)
     cache.clear()
     captureCurrent = async () => {}
-    document.removeEventListener('scroll', schedule, true)
+    for (const event of contentEvents) document.removeEventListener(event, schedule, true)
     document.removeEventListener('visibilitychange', schedule)
     window.removeEventListener('resize', schedule)
   }
@@ -83,34 +86,17 @@ async function capturePage() {
   // Crop the top of the visible content to the card's aspect ratio.
   const cropHeight = Math.min(height - top, width * 9 / 16)
   canvas.height = Math.round(canvas.width * cropHeight / width)
-  const scaleX = canvas.width / width
-  const scaleY = canvas.height / cropHeight
-  const videos = [...document.querySelectorAll('.tabContent:not([inert]) video')]
-    .map(video => ({ video, rect: video.getBoundingClientRect() }))
-    .filter(({ rect }) => rect.width > 0 && rect.height > 0 && rect.bottom > top && rect.top < top + cropHeight)
   const { uri } = await Screenshot.take()
   try {
     const screenshot = new Image()
     screenshot.src = Capacitor.convertFileSrc(uri)
     await screenshot.decode()
     if (hasVisibleOverlay()) return null
+    // PixelCopy captures the native video texture and the WebView together.
+    // Android's DOM video only carries playback state, not drawable frames.
     context.drawImage(screenshot, 0, top * screenshot.height / height,
       screenshot.width, cropHeight * screenshot.height / height,
       0, 0, canvas.width, canvas.height)
-    // Hardware video surfaces can be separate from the window buffer. Composite
-    // readable frames; otherwise retain the card fallback.
-    for (const { video, rect } of videos) {
-      if (video.readyState < 2 || !video.videoWidth) return null
-      const fit = Math.min(rect.width / video.videoWidth, rect.height / video.videoHeight)
-      const frameWidth = video.videoWidth * fit
-      const frameHeight = video.videoHeight * fit
-      context.fillStyle = '#000'
-      context.fillRect(rect.left * scaleX, (rect.top - top) * scaleY, rect.width * scaleX, rect.height * scaleY)
-      context.drawImage(video,
-        (rect.left + (rect.width - frameWidth) / 2) * scaleX,
-        (rect.top - top + (rect.height - frameHeight) / 2) * scaleY,
-        frameWidth * scaleX, frameHeight * scaleY)
-    }
     return canvas.toDataURL('image/jpeg', 0.7)
   } finally {
     try {

--- a/tests/unit/capacitor-tab-previews.test.mjs
+++ b/tests/unit/capacitor-tab-previews.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import { Capacitor } from '@capacitor/core'
+import { attachAndroidMediaElement } from '../../src/renderer/helpers/player/androidMediaElement.js'
 
 // Register the plugins against a native bridge so their real proxies call our mocks.
 globalThis.androidBridge = {}
@@ -16,8 +17,9 @@ const {
 } = await import('../../src/renderer/tabs/capacitorTabPreviews.js')
 delete globalThis.androidBridge
 
-function setup(t, { cleanupError, decodeError } = {}) {
+function setup(t, { cleanupError, decodeError, videos = [] } = {}) {
   const preview = 'data:image/jpeg;base64,cHJldmlldw=='
+  let captureImage = preview
   const uri = '/cache/temporary-screenshot.jpg'
   const tab = { id: 'tab', route: { fullPath: '/home' }, loadState: 'loaded' }
   const store = { getters: {
@@ -29,16 +31,20 @@ function setup(t, { cleanupError, decodeError } = {}) {
   } }
   const document = new EventTarget()
   let overlayReads = 0
+  const drawImage = t.mock.fn(source => {
+    if (videos.includes(source)) throw new DOMException('The video has no decoded frame', 'InvalidStateError')
+  })
   Object.assign(document, {
     visibilityState: 'visible',
     querySelector: () => null,
     querySelectorAll: selector => {
       if (selector.includes('[role=')) overlayReads += 1
+      if (selector.includes('video')) return videos
       return []
     },
     createElement: () => ({
-      getContext: () => ({ drawImage() {} }),
-      toDataURL: () => preview,
+      getContext: () => ({ drawImage, fillRect() {} }),
+      toDataURL: () => captureImage,
     }),
   })
   const globals = {
@@ -84,7 +90,57 @@ function setup(t, { cleanupError, decodeError } = {}) {
     for (const restore of restoreGlobals) restore()
   })
   overlayReads = 0
-  return { document, store, tab, preview, uri, take, remove, warn, overlayReads: () => overlayReads }
+  return { document, store, tab, preview, uri, take, remove, warn, drawImage,
+    setCaptureImage: image => { captureImage = image }, overlayReads: () => overlayReads }
+}
+
+for (const event of ['loadeddata', 'playing', 'seeked']) {
+  test(`${event} replaces a cached loading screenshot before the organizer opens`, async t => {
+    const state = setup(t)
+    t.mock.timers.tick(600)
+    await new Promise(setImmediate)
+    assert.equal(getCapacitorTabPreview(state.tab), state.preview)
+
+    const frame = 'data:image/jpeg;base64,bmF0aXZlLWZyYW1l'
+    state.setCaptureImage(frame)
+    state.document.dispatchEvent(new Event(event))
+    t.mock.timers.tick(600)
+    await new Promise(setImmediate)
+
+    assert.equal(getCapacitorTabPreview(state.tab), frame)
+    assert.equal(state.take.mock.callCount(), 2)
+  })
+}
+
+for (const playback of [
+  { name: 'playing', ready: true, playing: true, paused: false, width: 1920, height: 1080 },
+  { name: 'paused', ready: true, playing: false, paused: true, width: 1920, height: 1080 },
+  { name: 'loading', ready: false },
+  { name: 'audio-only', ready: true, width: 0, height: 0 },
+]) {
+  test(`watch previews retain the native window screenshot during ${playback.name} playback`, async t => {
+    // Android's DOM video carries native playback state and layout, but never
+    // contains a decoded frame that CanvasRenderingContext2D can draw.
+    const video = Object.assign(new EventTarget(), {
+      style: {},
+      pause() {},
+      getBoundingClientRect: () => ({ left: 0, top: 56, bottom: 267, width: 375, height: 211 }),
+    })
+    const media = attachAndroidMediaElement(video, {
+      command: async () => {}, load: async () => {}, onError: assert.fail,
+    })
+    t.after(() => media.detach())
+    media.update(playback)
+    const state = setup(t, { videos: [video] })
+    state.tab.route.fullPath = '/watch/test-video'
+
+    await captureBeforeTabOrganizer()
+
+    assert.equal(getCapacitorTabPreview(state.tab), state.preview)
+    assert.equal(state.drawImage.mock.callCount(), 1)
+    assert.equal(state.remove.mock.callCount(), 1)
+    assert.equal(state.warn.mock.callCount(), 0)
+  })
 }
 
 test('a cleanup failure preserves the successfully captured page preview', async t => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #1234

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Android watch-page previews were discarded or replaced with blank images because capture tried to redraw a DOM video element that contains no decoded frames. Use the native window screenshot, which already includes the video texture and web controls. Refresh cached previews when playback becomes ready or seeks so the organizer can use a recent image if its immediate capture is slow.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. On Android, open a video and let it play, then open the tab organizer. The card should show the captured video frame.
2. Repeat with playback paused and after seeking. The preview should retain the visible video and controls.
3. Open another video, History, and Playlists in separate tabs. Visit each page, then reopen the organizer. Each card should show its own page.
4. Switch back to either video and seek. Its preview should update while the other cards retain their own screenshots.

## Additional context
<!-- Add any other context about the pull request here. -->

Validated with the unit suite and lint after rebasing. Android API 35 instrumentation verifies native texture and WebView composition. Real native playback and four-tab switching were also checked on the emulator; updating either video preserved the other three preview images byte-for-byte.

Standards and spec reviews found no actionable issues. Tab previews are absent from the latest stable release, so this is marked Not noteworthy.

![Two native video previews alongside History and Playlists](https://github.com/user-attachments/assets/c40a6af0-b97c-4faf-b8c0-c60d585633ca)

Implemented with GPT-6 in Codex.
