### PR TITLE
fix(subscriptions): allow marking New feed seen during other refreshes

### DIFF
--- a/e2e/tests/offline/subscriptions-refresh.spec.mjs
+++ b/e2e/tests/offline/subscriptions-refresh.spec.mjs
@@ -525,6 +525,60 @@ test.describe('subscription feed refresh controls', () => {
     await expect(page.locator('.newContentDot')).toHaveCount(0)
     await expect(markAllAsSeen).toHaveCount(0)
   })
+
+  test.describe('tabbed New feed', () => {
+    test.use({
+      seed: {
+        settings: {
+          ...commonSettings,
+          hideSubscriptionsShorts: false,
+          hideSubscriptionsLive: false,
+          showNewSubscriptionFeed: true,
+          showNewSubscriptionFeedIndicators: true
+        },
+        profiles: [profileWith(1)],
+        subscriptionCache: [{
+          ...cachedChannel(0),
+          videos: [{ ...cachedChannel(0).videos[0], isNewInSubscriptionFeed: true }],
+          shorts: [cachedShort],
+          shortsTimestamp: new Date(now - 2 * HOUR).toISOString(),
+          liveStreams: [{ ...cachedShort, videoId: 'cached-live', title: 'Cached live', liveNow: true }],
+          liveStreamsTimestamp: new Date(now - 2 * HOUR).toISOString()
+        }]
+      }
+    })
+
+    for (const feed of ['shorts', 'live']) {
+      test(`keeps Mark all as seen enabled for New ${feed} while Videos refreshes`, async ({ page }) => {
+        await page.route(/^https?:\/\//, route => route.abort())
+        // Leave the refresh pending until the test window closes.
+        const pendingRequest = page.waitForRequest('**/feeds/videos.xml**')
+        await page.route('**/feeds/videos.xml**', () => {})
+        await goTo(page, 'subscriptions')
+        await page.getByRole('button', { name: /Refresh Videos/ }).click()
+        await pendingRequest
+        await page.locator('[data-subscription-feed-tab="all"]').click()
+        const markAllAsSeen = page.getByRole('button', { name: 'Mark all as seen' })
+        await expect(markAllAsSeen).toBeDisabled()
+
+        await page.getByRole('button', { name: 'Show tabbed view' }).click()
+        await expect(markAllAsSeen).toBeDisabled()
+        await page.locator(`[data-new-feed-tab="${feed}"]`).click()
+        const entry = page.getByText(feed === 'shorts' ? 'Cached short' : 'Cached live', { exact: true })
+        await expect(entry).toHaveCount(1)
+        await expect(entry).toBeVisible()
+        await expect(markAllAsSeen).toBeEnabled({ timeout: 3_000 })
+        await markAllAsSeen.click()
+        await expect(entry).toHaveCount(0)
+        await expect(markAllAsSeen).toHaveCount(0)
+        await expect(page.getByTestId('subscription-refresh-toast')).toBeVisible()
+
+        await page.locator('[data-new-feed-tab="videos"]').click()
+        await expect(page.getByText('Cached video 0', { exact: true })).toBeVisible()
+        await expect(markAllAsSeen).toBeDisabled()
+      })
+    }
+  })
 })
 
 test.describe('seen state after a subscription feed refresh', () => {

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -568,7 +568,9 @@ const refreshingFeedTab = computed(() => {
 
 const currentTabRefreshing = computed(() => {
   if (currentTab.value === 'new') {
-    return refreshingFeedTab.value !== null
+    return newFeedView.value === 'tabbed'
+      ? refreshingFeedTab.value === currentNewFeedTab.value
+      : refreshingFeedTab.value !== null
   }
 
   const currentFeedTab = currentTab.value === 'community' ? 'posts' : currentTab.value


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
Reported directly by the user; no linked issue.
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
In the tabbed New subscriptions feed, a Videos refresh disabled “Mark all as seen” even when Shorts or Live was selected. Check the selected category’s refresh state in tabbed view. The combined view keeps its existing refresh guard.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed “Mark all as seen” being disabled in the tabbed New subscriptions feed while another feed refreshes.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Start refreshing Videos with unseen Shorts or Live entries available.
2. Open New, switch to tabbed view, and select Shorts or Live while Videos is still refreshing. “Mark all as seen” should be enabled and remove the selected category’s unseen entries when clicked.
3. Switch to Videos while its refresh is still running. “Mark all as seen” should remain disabled. The combined New view should also keep the button disabled during a refresh.

## Additional context
<!-- Add any other context about the pull request here. -->

Validation: both added regressions reproduced the disabled button before the fix. Afterward, all five affected Electron tests and 1,405 unit tests passed. Lint passed with one existing unrelated Vue i18n warning. Standards and spec reviews found no issues.

Implemented with GPT-6 through the Codex desktop app.
