### PR TITLE
fix(player): size Shorts mini player consistently and hide extra controls

### DIFF
--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -1576,6 +1576,94 @@ test.describe('scroll mini player', () => {
       }
     })
 
+    async function usePortraitShort(page) {
+      const watch = await page.evaluateHandle(findWatchComponent)
+      await watch.evaluate(async component => {
+        component.proxy.useCustomShortsPlayerForCurrentVideo = true
+        component.proxy.updateShortsPlayerState(30, [{ width: 360, height: 640 }])
+        await component.proxy.$nextTick()
+      })
+      await watch.dispose()
+      // Keep local playback, but report the dimensions of a portrait stream.
+      await page.locator('.ftVideoPlayer video').evaluate(video => {
+        Object.defineProperties(video, {
+          videoWidth: { configurable: true, value: 360 },
+          videoHeight: { configurable: true, value: 640 }
+        })
+        video.dispatchEvent(new Event('resize'))
+      })
+      await expect(page.locator('.ftVideoPlayer')).toHaveClass(/shortsPlayer/)
+    }
+
+    test('hides Shorts controls in the cross-tab mini player and restores them on return', async ({ app, page }) => {
+      await openDemoVideo({ app, page })
+      await usePortraitShort(page)
+      const player = page.locator('.ftVideoPlayer')
+      await page.locator('.tabBar .newTabButton').click()
+      await expect(player).toHaveClass(/scrollMiniPlayer/)
+      await player.locator('.scrollMiniPlayPause').click()
+      await expect.poll(() => player.locator('video').evaluate(video => video.paused)).toBe(true)
+      await expect(player.locator('.shortsTopControls')).toBeHidden()
+      await expect(player).toHaveCSS('overflow', 'clip')
+      await expect(player.locator('.scrollMiniPlayPause')).toBeVisible()
+      await expect(player).toBeInViewport({ ratio: 1 })
+      // Playwright screenshots crop Electron's output at non-100% UI scale.
+      const screenshot = await app.electronApp.evaluate(async ({ BrowserWindow }) => {
+        const image = await BrowserWindow.getAllWindows()[0].capturePage()
+        return image.toPNG().toString('base64')
+      })
+      await test.info().attach('Shorts cross-tab mini player', {
+        body: Buffer.from(screenshot, 'base64'), contentType: 'image/png'
+      })
+
+      await page.locator('.tabBar .tab').first().click()
+      await expect(player).not.toHaveClass(/scrollMiniPlayer/)
+      await expect(player.locator('.shortsTopControls')).toBeVisible()
+    })
+
+    test('shares the longest mini-player edge between Shorts and normal videos', async ({ app, page }) => {
+      await openDemoVideo({ app, page })
+      const player = page.locator('.ftVideoPlayer')
+      const size = () => player.evaluate(element => ({
+        width: Number.parseFloat(element.style.width),
+        height: Number.parseFloat(element.style.height)
+      }))
+      await page.locator('.tabBar .newTabButton').click()
+      await expect(player).toHaveClass(/scrollMiniPlayer/)
+      const landscape = await size()
+      await page.locator('.tabBar .tab').first().click()
+      await usePortraitShort(page)
+      await player.locator('video').evaluate(video => video.play())
+      await page.locator('.tabBar .tab').nth(1).click()
+      await expect(player).toHaveClass(/scrollMiniPlayer/)
+      await expect.poll(async () => (await size()).height).toBe(landscape.width)
+
+      const handle = player.locator('.scrollMiniResizeHandle')
+      await handle.dispatchEvent('pointerdown', { button: 0, clientX: 0, clientY: 0, pointerId: 1 })
+      await page.evaluate(() => {
+        const rect = document.querySelector('.scrollMiniPlayer').getBoundingClientRect()
+        for (const type of ['pointermove', 'pointerup']) {
+          window.dispatchEvent(new PointerEvent(type, {
+            clientX: rect.right - 270, clientY: rect.top, pointerId: 1
+          }))
+        }
+      })
+      await expect.poll(async () => (await size()).height).toBe(480)
+      await page.locator('.tabBar .tab').first().click()
+      const watch = await page.evaluateHandle(findWatchComponent)
+      await watch.evaluate(component => { component.proxy.isShort = false })
+      await watch.dispose()
+      await player.locator('video').evaluate(video => {
+        delete video.videoWidth
+        delete video.videoHeight
+        video.dispatchEvent(new Event('resize'))
+        return video.play()
+      })
+      await page.locator('.tabBar .tab').nth(1).click()
+      await expect(player).toHaveClass(/scrollMiniPlayer/)
+      await expect.poll(size).toEqual({ width: 480, height: 270 })
+    })
+
     test('remembers separate mini player positions for scrolling and tab switches', async ({ app, page }) => {
       await openDemoVideo({ app, page })
       let player = page.locator('.ftVideoPlayer')

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -244,7 +244,7 @@ html[data-reduced-motion='reduce'] .musicVisualizerCanvas {
   transition-delay: 0s, 0s;
 }
 
-.ftVideoPlayer.shortsPlayer {
+.ftVideoPlayer.shortsPlayer:not(.scrollMiniPlayer) {
   /*
     Keep the container from becoming a focus-scroll area and let the seek
     thumb extend below the video. The video itself owns the rounded crop.
@@ -4131,6 +4131,7 @@ html[data-reduced-motion='reduce'] .musicVisualizerCanvas {
   border-radius: calc(10px * var(--ui-roundness));
 }
 
+.ftVideoPlayer.scrollMiniPlayer.shortsPlayer > .shortsTopControls,
 .ftVideoPlayer.scrollMiniPlayer :deep(.shaka-bottom-controls),
 .ftVideoPlayer.scrollMiniPlayer :deep(.shaka-controls-button-panel),
 .ftVideoPlayer.scrollMiniPlayer :deep(.shaka-spinner-container),

--- a/src/renderer/helpers/scrollMiniPlayer.js
+++ b/src/renderer/helpers/scrollMiniPlayer.js
@@ -1,7 +1,7 @@
-export const DEFAULT_WIDTH = 360
+export const DEFAULT_SIZE = 360
 export const DEFAULT_HEIGHT = 202
-export const MIN_WIDTH = 240
-export const MAX_WIDTH = 560
+export const MIN_SIZE = 240
+export const MAX_SIZE = 560
 export const MARGIN = 16
 export const EDGE_SNAP = 72
 export const BOUNCE_MS = 450
@@ -173,7 +173,10 @@ function getLegacyVerticalAnchor(rect, insets) {
  */
 export function reanchorScrollMiniPlayerRect(rect, aspectRatio = DEFAULT_ASPECT_RATIO) {
   const insets = getViewportInsets()
-  const sized = clampScrollMiniPlayerRect(rect, aspectRatio)
+  // Share the longest edge across orientations, so a saved landscape width
+  // becomes the portrait height instead of producing a much larger player.
+  const width = Math.max(rect.width, rect.height) * Math.min(1, normalizeAspectRatio(aspectRatio))
+  const sized = clampScrollMiniPlayerRect({ ...rect, width }, aspectRatio)
   const anchor = pickScrollMiniVerticalAnchor(rect) ?? getLegacyVerticalAnchor(sized, insets)
 
   const top = anchor.verticalDock === 'top'
@@ -181,7 +184,7 @@ export function reanchorScrollMiniPlayerRect(rect, aspectRatio = DEFAULT_ASPECT_
     : window.innerHeight - insets.bottom - sized.height - anchor.verticalOffset
 
   return {
-    ...clampScrollMiniPlayerRect(snapScrollMiniPlayerToEdge({ ...sized, top }, insets), aspectRatio),
+    ...clampScrollMiniPlayerRect(snapScrollMiniPlayerToEdge({ ...sized, top, dock: rect.dock }, insets), aspectRatio),
     ...anchor,
   }
 }
@@ -284,7 +287,7 @@ export function getViewportInsets() {
  */
 export function getDefaultScrollMiniPlayerRect(aspectRatio = DEFAULT_ASPECT_RATIO) {
   const insets = getViewportInsets()
-  const width = DEFAULT_WIDTH
+  const width = DEFAULT_SIZE * Math.min(1, normalizeAspectRatio(aspectRatio))
   const height = getHeightForAspectRatio(width, aspectRatio)
 
   return {
@@ -303,11 +306,12 @@ export function getDefaultScrollMiniPlayerRect(aspectRatio = DEFAULT_ASPECT_RATI
  */
 export function clampScrollMiniPlayerRect(rect, aspectRatio = DEFAULT_ASPECT_RATIO) {
   const insets = getViewportInsets()
-  const maxWidth = Math.min(MAX_WIDTH, getViewportWidth() - insets.left - insets.right)
-  const maxHeight = window.innerHeight - insets.top - insets.bottom
   const normalizedAspectRatio = normalizeAspectRatio(aspectRatio)
+  const widthFactor = Math.min(1, normalizedAspectRatio)
+  const maxWidth = Math.min(MAX_SIZE * widthFactor, getViewportWidth() - insets.left - insets.right)
+  const maxHeight = window.innerHeight - insets.top - insets.bottom
 
-  let width = Math.min(Math.max(rect.width, MIN_WIDTH), maxWidth)
+  let width = Math.min(Math.max(rect.width, MIN_SIZE * widthFactor), maxWidth)
   let height = getHeightForAspectRatio(width, normalizedAspectRatio)
   if (height > maxHeight) {
     height = maxHeight
@@ -340,8 +344,8 @@ export function getDockFromRect(rect, insets) {
  */
 export function scrollMiniPlayerRectToStyle(rect) {
   // Overlays (e.g. the SponsorBlock skip notice) are sized for a full-size
-  // player, so scale them down with the mini player to keep them inside it.
-  const scale = Math.max(0.6, Math.min(1, rect.width / DEFAULT_WIDTH))
+  // player, so scale them to the available width, including on portrait videos.
+  const scale = Math.max(0.6, Math.min(1, rect.width / DEFAULT_SIZE))
 
   return {
     position: 'fixed',
@@ -555,9 +559,10 @@ export function getResizeHandleCorner(rect, insets) {
  */
 export function resizeScrollMiniPlayerFromCorner(rect, corner, pointerX, pointerY, insets, aspectRatio = DEFAULT_ASPECT_RATIO) {
   const dock = getDockFromRect(rect, insets)
-  const maxWidth = Math.min(MAX_WIDTH, getViewportWidth() - insets.left - insets.right)
-  const maxHeight = window.innerHeight - insets.top - insets.bottom
   const normalizedAspectRatio = normalizeAspectRatio(aspectRatio)
+  const widthFactor = Math.min(1, normalizedAspectRatio)
+  const maxWidth = Math.min(MAX_SIZE * widthFactor, getViewportWidth() - insets.left - insets.right)
+  const maxHeight = window.innerHeight - insets.top - insets.bottom
 
   let width
   if (corner.endsWith('right')) {
@@ -566,7 +571,7 @@ export function resizeScrollMiniPlayerFromCorner(rect, corner, pointerX, pointer
     width = rect.left + rect.width - pointerX
   }
 
-  width = Math.min(Math.max(width, MIN_WIDTH), maxWidth)
+  width = Math.min(Math.max(width, MIN_SIZE * widthFactor), maxWidth)
   let height = getHeightForAspectRatio(width, normalizedAspectRatio)
 
   if (height > maxHeight) {

--- a/tests/unit/scroll-mini-player-insets.test.mjs
+++ b/tests/unit/scroll-mini-player-insets.test.mjs
@@ -4,6 +4,8 @@ import test from 'node:test'
 import {
   getViewportInsets,
   getViewportWidth,
+  getDefaultScrollMiniPlayerRect,
+  resizeScrollMiniPlayerFromCorner,
   snapScrollMiniPlayerToEdge,
   clampScrollMiniPlayerRect,
   parseScrollMiniPlayerSavedRect,
@@ -186,6 +188,56 @@ const SAVED_RECT = {
   verticalDock: 'bottom',
   verticalOffset: 96
 }
+
+test('portrait and landscape defaults use the same longest edge', () => {
+  stubViewport({ clientWidth: 1585 })
+  const landscape = clampScrollMiniPlayerRect(getDefaultScrollMiniPlayerRect())
+  const portrait = clampScrollMiniPlayerRect(getDefaultScrollMiniPlayerRect(9 / 16), 9 / 16)
+  assert.equal(portrait.height, landscape.width)
+  assert.ok(Math.abs(portrait.width - landscape.height) <= 1)
+})
+
+test('the shared size survives switching between portrait and landscape', () => {
+  stubViewport({ clientWidth: 1585 })
+  const portrait = reanchorScrollMiniPlayerRect(SAVED_RECT, 9 / 16)
+  assert.equal(portrait.width, SAVED_RECT.height)
+  assert.equal(portrait.height, SAVED_RECT.width)
+  const restored = reanchorScrollMiniPlayerRect(portrait)
+  assert.equal(restored.width, SAVED_RECT.width)
+  assert.equal(restored.height, SAVED_RECT.height)
+})
+
+test('switching a large docked mini player to portrait preserves its dock edge', () => {
+  stubViewport({ clientWidth: 800, clientHeight: 900 })
+  for (const dock of ['left', 'right']) {
+    const saved = {
+      left: dock === 'left' ? 16 : 224,
+      top: 16,
+      width: 560,
+      height: 315,
+      dock,
+      verticalDock: 'top',
+      verticalOffset: 0,
+    }
+    const portrait = reanchorScrollMiniPlayerRect(saved, 9 / 16)
+    assert.equal(portrait.dock, dock)
+    assert.equal(portrait.left, dock === 'left' ? 16 : 469)
+    assert.equal(reanchorScrollMiniPlayerRect(portrait).left, saved.left)
+  }
+})
+
+test('portrait resize limits apply to the longest edge', () => {
+  stubViewport({ clientWidth: 1585, clientHeight: 1200 })
+  const portrait = { left: 16, top: 16, width: 202.5, height: 360, dock: 'left' }
+  for (const [pointerX, expectedHeight] of [[16, 240], [1000, 560]]) {
+    const resized = resizeScrollMiniPlayerFromCorner(
+      portrait, 'bottom-right', pointerX, 0, getViewportInsets(), 9 / 16
+    )
+    assert.equal(resized.height, expectedHeight)
+    const landscape = reanchorScrollMiniPlayerRect(resized)
+    assert.equal(landscape.width, expectedHeight)
+  }
+})
 
 test('scroll and tab-switch positions do not overwrite each other', () => {
   const tabRect = { ...SAVED_RECT, top: 200 }


### PR DESCRIPTION
Shorts showed duplicate controls above the cross-tab mini player and became much larger than normal videos at the same saved size.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Reported directly by the user; no linked GitHub issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Hide the Shorts toolbar while the mini player is active and keep its contents clipped to the video frame. Use the longer edge for the shared default, saved size, and resize limits: a 360 × 203 landscape player becomes approximately 203 × 360 in portrait. Preserve the saved dock edge when changing orientation.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Shorts mini players now hide duplicate controls and use a size comparable to normal videos when switching tabs.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Enable the mini player on tab switches, play a Short, and switch to another tab. Confirm only mini-player controls appear and stay inside its frame.
2. Pause the mini player and return to its video tab. Confirm the normal Shorts toolbar returns.
3. Compare a Short with a normal video. At the same saved size, their longer edges should match. Resize either and verify that the other uses the corresponding size.
4. Dock a large landscape player on the right, then switch to a Short. Confirm it stays on the right. Repeat at 125% UI scale and after resizing the window.

## Additional context
<!-- Add any other context about the pull request here. -->

Local validation: unit suite, lint, and focused offline Electron tests. The review covered standards and the original request; the orientation/docking regression found during review now has a failing-before-fix unit test.

Implemented with GPT-6 in Codex.
