### PR TITLE
fix: show speedometer icon when changing playback speed

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -4696,7 +4696,7 @@ export default defineComponent({
 
         player.cancelTrickPlay()
 
-        showValueChange(`${getDefaultPlaybackRateForVideo()}x`)
+        showValueChange(`${getDefaultPlaybackRateForVideo()}x`, 'gauge')
       }
     }
 
@@ -9218,7 +9218,7 @@ export default defineComponent({
           player.trickPlay(newPlaybackRate, false)
         }
 
-        showValueChange(`${newPlaybackRateString}x`)
+        showValueChange(`${newPlaybackRateString}x`, 'gauge')
       }
     }
 

--- a/tests/unit/playback-rate-osd.test.mjs
+++ b/tests/unit/playback-rate-osd.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+import { resolveMappedIcon } from '../../src/renderer/icons/iconMappingResolver.js'
+
+const source = readFileSync(new URL('../../src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js', import.meta.url), 'utf8')
+const readIconJson = name => JSON.parse(readFileSync(new URL(`../../src/renderer/icons/${name}.json`, import.meta.url), 'utf8'))
+const aliases = readIconJson('faAliasToCanon')
+const mapping = readIconJson('faIconMap')
+
+function fixture() {
+  const state = {
+    valueChangeMessage: { value: '' },
+    valueChangeIcons: { value: [] },
+    showValueChangePopup: { value: false },
+    invertValueChangeContentOrder: { value: false },
+    valueChangeTimeout: null,
+    maxVideoPlaybackRate: { value: 4 },
+    playbackRateUserSet: false,
+    player: { cancelTrickPlay() {}, trickPlay() {} },
+    getDefaultPlaybackRateForVideo: () => 1,
+    showOverlayControls() {},
+    setTimeout() {},
+    clearTimeout() {},
+  }
+  const names = ['applyPlaybackRate', 'handleControlsContainerClick', 'showValueChange']
+  const functions = names.map(name => {
+    const match = source.match(new RegExp(`    function ${name}\\([^]*?\\n    }`))
+    assert.ok(match, `missing ${name}`)
+    return match[0]
+  }).join('\n')
+  const api = vm.runInNewContext(`${functions}\n({ ${names.join(', ')} })`, state)
+  return { state, api }
+}
+
+function assertSpeedOsd(state, message) {
+  assert.equal(state.showValueChangePopup.value, true)
+  assert.equal(state.valueChangeMessage.value, message)
+  assert.equal(state.valueChangeIcons.value.length, 1, 'playback speed OSD must show an icon')
+  for (const pack of ['material', 'remix']) {
+    const icon = resolveMappedIcon(['fas', state.valueChangeIcons.value[0]], pack, aliases, mapping)
+    assert.ok(icon, `speed icon must resolve in ${pack}`)
+    assert.ok(readIconJson(`iconifyBundles/${pack}`)[icon], `speed icon must be bundled in ${pack}`)
+  }
+}
+
+test('playback speed changes show an icon alongside the multiplier', () => {
+  const { state, api } = fixture()
+  for (const rate of [1.5, 0.75, 1]) {
+    api.applyPlaybackRate(rate)
+    assertSpeedOsd(state, `${rate.toFixed(2)}x`)
+  }
+})
+
+test('Ctrl/Meta-click speed reset shows an icon alongside the default multiplier', () => {
+  for (const modifier of ['ctrlKey', 'metaKey']) {
+    const { state, api } = fixture()
+    api.handleControlsContainerClick({ [modifier]: true, stopPropagation() {} })
+    assertSpeedOsd(state, '1x')
+  }
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Reported directly in a Codex task; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Changing playback speed showed only the multiplier because the OSD calls omitted an icon. Pass the existing speedometer icon for speed changes and Ctrl/Meta-click resets, using the existing Material and Remix mappings.

Regression tests cover both paths and verify that the icon resolves and is bundled in both packs.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Playback speed changes and resets now show a speedometer icon beside the multiplier.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Play a video and use P/O to increase or decrease playback speed. The OSD should show a speedometer beside the multiplier.
2. Ctrl-click or Meta-click the player controls to reset the speed. The reset OSD should also show the speedometer.
3. Repeat with Material and Remix selected in appearance settings.

## Additional context
<!-- Add any other context about the pull request here. -->

History confirms ordinary playback-speed OSD calls omitted the icon from their introduction. The hold-to-speed-up indicator already uses a separate forward icon.

Validation: both regression tests failed before the fix and pass afterward; all 1,414 unit tests pass. The filtered Electron playback-speed keyboard test also passes on a private X server. JavaScript and style lint pass with one unrelated existing Vue i18n warning.

Implemented with GPT-6 in the Codex desktop app.
