### PR TITLE
fix(android): restore fullscreen button and combine rotation with entry

### DIFF
--- a/e2e/tests/offline/android-native-screen.spec.mjs
+++ b/e2e/tests/offline/android-native-screen.spec.mjs
@@ -1205,6 +1205,33 @@ test('double taps on invisible seek feedback text and icons still seek', async (
   }
 })
 
+test('native fullscreen stays available when the WebView has no browser fullscreen support', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  await page.evaluate(() => Object.defineProperty(document, 'fullscreenEnabled', { configurable: true, value: false }))
+  const video = await openMockedVideo(page)
+  const button = page.locator('.shaka-fullscreen-button')
+  await expect(button).toBeHidden()
+  await openNativeScreen(page, false)
+  try {
+    // The app binds native controls before applying its UI configuration.
+    await video.evaluate(element => element.ui.configure({ tapSeekDistance: 5 }))
+    for (const event of ['loadedmetadata', 'loadeddata']) {
+      await video.evaluate((element, event) => {
+        element.dispatchEvent(new Event(event))
+        element.ui.getControls().showUI()
+      }, event)
+      await expect(button).toBeVisible()
+      await button.click()
+      await expect(page.locator('.ftVideoPlayer')).toHaveAttribute('data-native-player-screen')
+      await button.click()
+      await expect(page.locator('.ftVideoPlayer')).not.toHaveAttribute('data-native-player-screen')
+    }
+  } finally {
+    await page.evaluate(() => window.nativeScreenTest.destroy())
+  }
+  expect(await video.evaluate(element => element.ui.getControls().isFullScreenSupported())).toBe(false)
+})
+
 test('native rotation returns to inline portrait and keeps the fullscreen button usable', async ({ app, page }) => {
   await mockPlayableWatchPage(app, page)
   const video = await openMockedVideo(page)

--- a/src/renderer/helpers/player/androidNativeScreen.js
+++ b/src/renderer/helpers/player/androidNativeScreen.js
@@ -283,11 +283,11 @@ export function createAndroidNativeScreen({ element, container, getController, g
     setOpen(true)
     const sequence = presentationSequence
     try {
-      await attach()
-      // Android rotation captures the current window. Wait until the native
-      // screen has drawn the fullscreen WebView, so that snapshot contains no
-      // inline page controls and needs only the final orientation resize.
-      if (open && presentationSequence === sequence) document.dispatchEvent(new Event('fullscreenchange'))
+      const attaching = attach()
+      // Queue rotation with native fullscreen, before waiting for its first
+      // frame. Waiting here presents portrait fullscreen before rotating it.
+      document.dispatchEvent(new Event('fullscreenchange'))
+      await attaching
     } catch (error) {
       if (presentationSequence === sequence) setOpen(false)
       throw error
@@ -325,6 +325,8 @@ export function createAndroidNativeScreen({ element, container, getController, g
       restoreControls?.()
       controls = nextControls
       restoreControls = overrideShakaMethods(controls, {
+        // Android owns fullscreen even when the WebView's browser API is unavailable.
+        isFullScreenSupported: () => true,
         toggleFullScreen: () => open ? hide() : show(),
         isFullScreenEnabled: () => open,
       })

--- a/tests/unit/android-native-screen.test.mjs
+++ b/tests/unit/android-native-screen.test.mjs
@@ -74,6 +74,21 @@ async function fixture({ fullscreen = true, chrome = [], deferTransitions = fals
   } }
 }
 
+test('native fullscreen support overrides WebView detection and restores it on teardown', async () => {
+  const f = await fixture({ fullscreen: false })
+  const unsupported = () => false
+  const prototype = { isFullScreenSupported: unsupported, compiledSupport: unsupported }
+  const controls = Object.create(prototype)
+  const otherControls = Object.create(prototype)
+  f.screen.bindControls(controls)
+  assert.equal(controls.isFullScreenSupported(), true)
+  assert.equal(controls.compiledSupport(), true)
+  assert.equal(otherControls.isFullScreenSupported(), false)
+  f.screen.destroy()
+  assert.equal(controls.isFullScreenSupported(), false)
+  assert.equal(controls.compiledSupport(), false)
+})
+
 test('mini-player motion is sent as one native animation instead of separate browser frames', async () => {
   const f = await fixture({ fullscreen: false })
   const event = new Event('native-player-transition', { cancelable: true })
@@ -189,14 +204,14 @@ test('inline native controls follow the player bounds and shared visibility afte
 })
 
 for (const cancel of [false, true]) {
-  test(`fullscreen rotation waits for the prepared native WebView frame${cancel ? ' and ignores a cancelled entry' : ''}`, async () => {
+  test(`fullscreen rotation starts with native presentation${cancel ? ' and cancels without a late entry' : ''}`, async () => {
     const f = await fixture({ fullscreen: false, deferFullscreen: true })
     const entering = f.screen.show()
-    assert.equal(f.fullscreenEvents.length, 0, 'Do not rotate a snapshot of the inline page before fullscreen has drawn')
+    assert.deepEqual(f.fullscreenEvents, [2], 'Queue native fullscreen and rotation together, before a portrait fullscreen frame is drawn')
     if (cancel) await f.screen.hide()
     f.completeFullscreen[0]()
     await entering
-    assert.equal(f.fullscreenEvents.length, 1)
+    assert.equal(f.fullscreenEvents.length, cancel ? 2 : 1)
     assert.equal(f.screen.isOpen(), !cancel)
     f.screen.destroy()
   })
@@ -211,7 +226,7 @@ for (const teardown of ['reset', 'destroy']) {
     await entering
     assert.equal(f.screen.hasSurface(), false)
     assert.equal(f.screen.isOpen(), false)
-    assert.equal(f.fullscreenEvents.length, 1)
+    assert.equal(f.fullscreenEvents.length, 2)
     f.screen.destroy()
   })
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Reported and reproduced on a Pixel 8 Pro; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Android Nightly hid the player's fullscreen button when WebView reported browser fullscreen as unavailable. Entering fullscreen also showed a portrait fullscreen frame before rotating to landscape.

Use Android's native fullscreen support for Shaka's capability check, and start rotation alongside native fullscreen presentation. Restore the original capability check when the player is destroyed.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a landscape video on Android in portrait orientation. The fullscreen button should remain visible beside Settings when the controls are shown.
2. Enable rotation to landscape on fullscreen entry, then tap fullscreen. Rotation and fullscreen should start together, without a separate portrait-fullscreen pause.
3. Exit fullscreen and repeat. Confirm the button still works, and disabling automatic landscape rotation keeps fullscreen in the current orientation.

## Additional context
<!-- Add any other context about the pull request here. -->
APK shrinking introduced in #1218 removes Capacitor's empty `onHideCustomView` override, exposing the native player's dependency on WebView fullscreen detection. Native Android playback has not appeared in a stable release. Regression coverage includes unavailable browser fullscreen, repeated entry/exit, rotation, cancellation, teardown, and Shaka method restoration. Verified the optimized Nightly build on a Pixel 8 Pro.

Pixel player controls before the fix on top, after the fix below:

![Pixel fullscreen button restored](https://github.com/user-attachments/assets/54573cd5-6aa0-41d6-8be2-acffd79b0363)

Implemented with GPT-6 in the Codex desktop harness.

