### PR TITLE
fix: preserve changelog image aspect ratios

### DIFF
--- a/e2e/tests/offline/update-modal.spec.mjs
+++ b/e2e/tests/offline/update-modal.spec.mjs
@@ -168,3 +168,48 @@ test('skipped updates keep a heading per release', async ({ page, attachScreensh
   ])
   await attachScreenshot('update prompt with skipped releases')
 })
+
+test('changelog images preserve their aspect ratio at phone and desktop widths', async ({ page }) => {
+  const imageUrl = 'https://example.com/release-screenshot.svg'
+  await page.route(imageUrl, route => route.fulfill({
+    contentType: 'image/svg+xml',
+    body: '<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900"><rect width="1600" height="900" fill="teal"/></svg>'
+  }))
+  const notes = [
+    `<img src="${imageUrl}" alt="Height only" height="450">`,
+    `<img src="${imageUrl}" alt="Both dimensions" width="800" height="450">`,
+    `<img src="${imageUrl}" alt="Width only" width="800">`,
+    `![Markdown image](${imageUrl})`
+  ].join('\n\n')
+  await showUpdatePrompt(page, [
+    release(`OpenTubeX ${newestUpdateVersion}`, `v${newestUpdateVersion}-beta`, notes)
+  ])
+
+  const images = page.locator('.changeLogText img')
+  await expect(images).toHaveCount(4)
+  await images.evaluateAll(elements => Promise.all(elements.map(image => image.decode())))
+
+  for (const scale of [1, 1.25]) {
+    await page.evaluate(value => window.ftElectron.setZoomFactor(value), scale)
+    for (const viewport of [{ width: 375, height: 800 }, { width: 800, height: 375 }, { width: 1280, height: 900 }]) {
+      await page.setViewportSize(viewport)
+      for (const image of await images.all()) {
+        const dimensions = await image.evaluate(element => {
+          const { width, height } = element.getBoundingClientRect()
+          const container = element.closest('.changeLogText')
+          const style = getComputedStyle(container)
+          return {
+            width,
+            height,
+            expectedHeight: width * element.naturalHeight / element.naturalWidth,
+            availableWidth: container.clientWidth - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight)
+          }
+        })
+        const context = `${await image.getAttribute('alt')}, ${viewport.width}px, ${scale * 100}% scale`
+        expect(dimensions.width, context).toBeGreaterThan(0)
+        expect(dimensions.width, context).toBeLessThanOrEqual(dimensions.availableWidth + 1)
+        expect.soft(Math.abs(dimensions.height - dimensions.expectedHeight), context).toBeLessThanOrEqual(1)
+      }
+    }
+  }
+})

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -293,11 +293,8 @@
 .changeLogText :deep(img) {
   display: block;
   max-inline-size: 100%;
-  margin-block: 8px;
-}
-
-.changeLogText :deep(img[width]) {
   block-size: auto;
+  margin-block: 8px;
 }
 
 .changeLogText :deep(details) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Reported directly in the Codex task; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Changelog images could stretch when their width was constrained while an HTML height attribute stayed fixed. This also affected desktop windows. Apply automatic height to all changelog images so they retain their aspect ratio at narrower widths.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Changelog images now keep their correct proportions on mobile and desktop.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open the update changelog with an image that has a height attribute and no width attribute.
2. Resize the window to phone and desktop widths, then repeat at 125% UI scale. The image should fit the changelog without stretching or horizontal overflow.
3. Check ordinary Markdown images and images with an explicit width; their proportions should remain correct too.

## Additional context
<!-- Add any other context about the pull request here. -->


The regression test failed before the CSS change at 375px, 800px, and 1280px widths with 100% and 125% UI scaling, then passed afterward. All five update-modal E2E tests and 1,446 unit tests passed. Lint reported no errors and one existing warning in an unrelated test. Android uses the shared stylesheet but was not tested on a device.

Implemented and reviewed with GPT-6 in Codex.
