### PR TITLE
feat(player): show repeat counts and actual playing time with a hide setting

### DIFF
--- a/e2e/tests/offline/repeat-stats.spec.mjs
+++ b/e2e/tests/offline/repeat-stats.spec.mjs
@@ -73,12 +73,14 @@ test('repeat stats count A-B boundaries, ignore range correction seeks, and rese
   await expect(stats).toContainText('A-B repeat')
   await expect(stats.locator('.repeatStatsCount')).toHaveText('0')
   await video.evaluate(element => element.play())
-  await expect.poll(() => stats.locator('.repeatStatsCount').textContent()).toBe('2')
+  // Poll slower than the range to cover skipped counter values on busy CI runners.
+  await expect.poll(async () => Number(await stats.locator('.repeatStatsCount').textContent()), { intervals: [3500] }).toBeGreaterThanOrEqual(2)
   await video.evaluate(element => element.pause())
+  const pausedRepeats = await stats.locator('.repeatStatsCount').textContent()
 
   await video.evaluate(element => { element.currentTime = 15 })
   await expect.poll(() => video.evaluate(element => element.currentTime)).toBe(5)
-  await expect(stats.locator('.repeatStatsCount')).toHaveText('2')
+  await expect(stats.locator('.repeatStatsCount')).toHaveText(pausedRepeats)
   await page.locator('.abRepeatMarkerB').focus()
   await page.keyboard.press('ArrowRight')
   await expect(stats.locator('.repeatStatsCount')).toHaveText('0')
@@ -201,3 +203,39 @@ test('Distraction Free hides repeat stats immediately without disabling looping 
     return latestSettings(contents).hideRepeatStats
   }).toBe(false)
 })
+
+for (const mode of ['scrolling', 'another tab']) {
+  test(`repeat stats hide in the mini player while viewing ${mode} and return with their totals`, async ({ app, page }) => {
+    const video = await openVideo(app, page)
+    await toggleLoop(page)
+    const stats = page.locator('.repeatStats')
+    const player = page.locator('.ftVideoPlayer')
+    await page.evaluate(() => window.ftElectron.setZoomFactor(1.25))
+    await video.evaluate(element => element.play())
+    await expect(stats.locator('.repeatStatsTime')).not.toHaveText('0:00')
+    const spent = await stats.locator('.repeatStatsTime').textContent()
+
+    if (mode === 'scrolling') {
+      await video.evaluate(element => element.pause())
+      await player.evaluate(element => {
+        window.scrollTo(0, window.scrollY + element.getBoundingClientRect().bottom)
+      })
+    } else {
+      await page.evaluate(() => document.querySelector('#app').__vue_app__.config.globalProperties.$store
+        .dispatch('updateScrollMiniPlayerOnAllTabs', true))
+      await page.locator('.tabBar .newTabButton').click()
+      await expect(page.locator('#cross-tab-mini-player-layer .ftVideoPlayer')).toBeVisible()
+    }
+    await expect(player).toHaveClass(/scrollMiniPlayer/)
+    await expect(stats).toHaveCount(0)
+
+    await player.locator('video').evaluate(element => element.pause())
+    if (mode === 'another tab') await page.locator('.tabBar .tab').first().click()
+    await page.evaluate(() => window.scrollTo(0, 0))
+    await expect(player).not.toHaveClass(/scrollMiniPlayer/)
+    await expect(stats).toBeVisible()
+    await expect(stats.locator('.repeatStatsCount')).toHaveText('0')
+    const seconds = text => text.split(':').reduce((total, part) => total * 60 + Number(part), 0)
+    expect(seconds(await stats.locator('.repeatStatsTime').textContent())).toBeGreaterThanOrEqual(seconds(spent))
+  })
+}

--- a/e2e/tests/offline/repeat-stats.spec.mjs
+++ b/e2e/tests/offline/repeat-stats.spec.mjs
@@ -8,7 +8,7 @@ test.use({
     settings: {
       videoPlaybackEngine: 'built-in',
       ytDlpPlaybackEngineDefaultMigration: true,
-      baseTheme: 'openTubeXDark',
+      baseTheme: 'dark',
       useCustomShortsPlayer: true,
       loopShorts: true,
     }

--- a/e2e/tests/offline/repeat-stats.spec.mjs
+++ b/e2e/tests/offline/repeat-stats.spec.mjs
@@ -37,7 +37,6 @@ test('repeat stats count native loops and retain totals across pauses and toggle
   await toggleLoop(page)
   await expect(stats).toBeVisible()
   await expect(stats.locator('.repeatStatsCount')).toHaveText('0')
-  await expect(stats.locator('.repeatStatsPass')).toHaveText('1')
 
   await video.evaluate(element => { element.currentTime = element.duration - 1.5 })
   await expect.poll(() => video.evaluate(element => element.seeking)).toBe(false)
@@ -45,7 +44,6 @@ test('repeat stats count native loops and retain totals across pauses and toggle
   await video.evaluate(element => element.play())
   await expect(stats.locator('.repeatStatsCount')).toHaveText('1')
   await video.evaluate(element => element.pause())
-  await expect(stats.locator('.repeatStatsPass')).toHaveText('2')
   const spent = await stats.locator('.repeatStatsTime').textContent()
   expect(spent).not.toBe('0:00')
 
@@ -77,7 +75,6 @@ test('repeat stats count A-B boundaries, ignore range correction seeks, and rese
   await video.evaluate(element => element.play())
   await expect.poll(() => stats.locator('.repeatStatsCount').textContent()).toBe('2')
   await video.evaluate(element => element.pause())
-  await expect(stats.locator('.repeatStatsPass')).toHaveText('3')
 
   await video.evaluate(element => { element.currentTime = 15 })
   await expect.poll(() => video.evaluate(element => element.currentTime)).toBe(5)
@@ -86,7 +83,6 @@ test('repeat stats count A-B boundaries, ignore range correction seeks, and rese
   await page.keyboard.press('ArrowRight')
   await expect(stats.locator('.repeatStatsCount')).toHaveText('0')
   await expect(stats.locator('.repeatStatsTime')).toHaveText('0:00')
-  await expect(stats.locator('.repeatStatsPass')).toHaveText('1')
   await expect(stats).toContainText('0:06.1')
 })
 

--- a/e2e/tests/offline/repeat-stats.spec.mjs
+++ b/e2e/tests/offline/repeat-stats.spec.mjs
@@ -1,0 +1,207 @@
+import { readFile } from 'node:fs/promises'
+import { expect, goToSettingsSection, latestSettings, sel, setPlayerFullscreen, setWindowSize, test } from '../../helpers/app.mjs'
+import { openMockedVideo, waitForPlayback } from '../../helpers/player.mjs'
+import { mockPlayableWatchPage } from '../../helpers/watch.mjs'
+
+test.use({
+  seed: {
+    settings: {
+      videoPlaybackEngine: 'built-in',
+      ytDlpPlaybackEngineDefaultMigration: true,
+      baseTheme: 'openTubeXDark',
+      useCustomShortsPlayer: true,
+      loopShorts: true,
+    }
+  }
+})
+
+async function openVideo(app, page) {
+  await mockPlayableWatchPage(app, page)
+  const video = await openMockedVideo(page)
+  await video.evaluate(element => element.pause())
+  return video
+}
+
+async function toggleLoop(page) {
+  const player = page.locator('.ftVideoPlayer')
+  await player.hover()
+  await player.getByRole('button', { name: 'More settings' }).click({ force: true })
+  await player.locator('.shaka-overflow-menu .loop-button').click()
+  await page.keyboard.press('Escape')
+}
+
+test('repeat stats count native loops and retain totals across pauses and toggles', async ({ app, page, attachScreenshot }) => {
+  const video = await openVideo(app, page)
+  const stats = page.getByRole('region', { name: 'Repeat stats', exact: true })
+  await expect(stats).toHaveCount(0)
+  await toggleLoop(page)
+  await expect(stats).toBeVisible()
+  await expect(stats.locator('.repeatStatsCount')).toHaveText('0')
+  await expect(stats.locator('.repeatStatsPass')).toHaveText('1')
+
+  await video.evaluate(element => { element.currentTime = element.duration - 1.5 })
+  await expect.poll(() => video.evaluate(element => element.seeking)).toBe(false)
+  await expect(stats.locator('.repeatStatsCount')).toHaveText('0')
+  await video.evaluate(element => element.play())
+  await expect(stats.locator('.repeatStatsCount')).toHaveText('1')
+  await video.evaluate(element => element.pause())
+  await expect(stats.locator('.repeatStatsPass')).toHaveText('2')
+  const spent = await stats.locator('.repeatStatsTime').textContent()
+  expect(spent).not.toBe('0:00')
+
+  await video.evaluate(element => { element.currentTime = 12 })
+  await expect.poll(() => video.evaluate(element => element.seeking)).toBe(false)
+  await video.evaluate(element => { element.currentTime = 0 })
+  await page.waitForTimeout(1200)
+  await expect(stats.locator('.repeatStatsTime')).toHaveText(spent)
+  await expect(stats.locator('.repeatStatsCount')).toHaveText('1')
+  await toggleLoop(page)
+  await expect(stats).toHaveCount(0)
+  await toggleLoop(page)
+  await expect(stats.locator('.repeatStatsTime')).toHaveText(spent)
+  await expect(stats.locator('.repeatStatsCount')).toHaveText('1')
+  await attachScreenshot('repeat stats below the video')
+})
+
+test('repeat stats count A-B boundaries, ignore range correction seeks, and reset after range edits', async ({ app, page }) => {
+  const video = await openVideo(app, page)
+  await video.evaluate(element => { element.currentTime = 5 })
+  await expect.poll(() => video.evaluate(element => element.seeking)).toBe(false)
+  await page.keyboard.press('Shift+A')
+  await video.evaluate(element => { element.currentTime = 6 })
+  await expect.poll(() => video.evaluate(element => element.seeking)).toBe(false)
+  await page.keyboard.press('Shift+B')
+  const stats = page.locator('.repeatStats')
+  await expect(stats).toContainText('A-B repeat')
+  await expect(stats.locator('.repeatStatsCount')).toHaveText('0')
+  await video.evaluate(element => element.play())
+  await expect.poll(() => stats.locator('.repeatStatsCount').textContent()).toBe('2')
+  await video.evaluate(element => element.pause())
+  await expect(stats.locator('.repeatStatsPass')).toHaveText('3')
+
+  await video.evaluate(element => { element.currentTime = 15 })
+  await expect.poll(() => video.evaluate(element => element.currentTime)).toBe(5)
+  await expect(stats.locator('.repeatStatsCount')).toHaveText('2')
+  await page.locator('.abRepeatMarkerB').focus()
+  await page.keyboard.press('ArrowRight')
+  await expect(stats.locator('.repeatStatsCount')).toHaveText('0')
+  await expect(stats.locator('.repeatStatsTime')).toHaveText('0:00')
+  await expect(stats.locator('.repeatStatsPass')).toHaveText('1')
+  await expect(stats).toContainText('0:06.1')
+})
+
+test('repeat stats wrap below the player at fractional UI scale and stay out of fullscreen', async ({ app, page }, testInfo) => {
+  await openVideo(app, page)
+  await toggleLoop(page)
+  await setWindowSize(app, page, { width: 640, height: 800 })
+  await page.evaluate(() => window.ftElectron.setZoomFactor(1.25))
+  const stats = page.locator('.repeatStats')
+  await expect(stats).toBeVisible()
+  await expect.poll(() => stats.evaluate(element => {
+    const bounds = element.getBoundingClientRect()
+    const playerBounds = element.parentElement.querySelector('.ftVideoPlayer').getBoundingClientRect()
+    return bounds.right <= document.documentElement.clientWidth + 0.5 &&
+      bounds.top >= playerBounds.bottom - 0.5 && element.scrollWidth <= element.clientWidth &&
+      [...element.querySelectorAll('dt, dd')].every(child => {
+        const rect = child.getBoundingClientRect()
+        return rect.left >= bounds.left && rect.right <= bounds.right
+      })
+  })).toBe(true)
+  // Electron capturePage uses the window's actual bounds at fractional zoom.
+  const screenshot = await app.electronApp.evaluate(async ({ BrowserWindow }) => {
+    return (await BrowserWindow.getAllWindows()[0].webContents.capturePage()).toPNG().toString('base64')
+  })
+  await testInfo.attach('repeat stats at 125 percent UI scale', {
+    body: Buffer.from(screenshot, 'base64'), contentType: 'image/png'
+  })
+  await setPlayerFullscreen(page, true)
+  await expect(stats).toHaveCount(0)
+  await setPlayerFullscreen(page, false)
+  await expect(stats).toBeVisible()
+})
+
+test('repeat stats observe Android loop toggles and automatic seek completion', async ({ app, page }) => {
+  await openVideo(app, page)
+  const mediaSource = await readFile(new URL('../../../src/renderer/helpers/player/androidMediaElement.js', import.meta.url), 'utf8')
+  await page.addScriptTag({ content: mediaSource.replace('export function ', 'function ') })
+  await page.evaluate(() => {
+    const video = document.querySelector('.ftVideoPlayer video')
+    window.repeatNativeMedia = window.attachAndroidMediaElement(video, {
+      command: async () => {}, load: async () => {}, onError: error => { throw error }
+    })
+    window.repeatNativeMedia.update({ position: 29.8, duration: 30, paused: true, playing: false, ready: true })
+  })
+  await toggleLoop(page)
+  const stats = page.locator('.repeatStats')
+  await expect(stats).toBeVisible()
+  await page.evaluate(() => {
+    window.repeatNativeMedia.update({ position: 29.8, paused: false, playing: true })
+  })
+  await page.waitForTimeout(220)
+  await page.evaluate(() => {
+    window.repeatNativeMedia.update({ position: 0, event: 'seeked' })
+  })
+  await expect(stats.locator('.repeatStatsCount')).toHaveText('1')
+  await toggleLoop(page)
+  await expect(stats).toHaveCount(0)
+  await page.evaluate(() => window.repeatNativeMedia.detach())
+})
+
+test('repeat stats reserve space below Shorts without covering the following content', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  await page.locator(sel.searchInput).fill('https://www.youtube.com/shorts/jNQXAC9IVRw')
+  await page.locator(sel.searchInput).press('Enter')
+  const video = await waitForPlayback(page)
+  await video.evaluate(element => element.pause())
+  await expect(page.locator('.videoLayout')).toHaveClass(/shortsPlayerActive/)
+  const stats = page.locator('.repeatStats')
+  await expect(stats).toBeVisible()
+  const expectContained = () => expect.poll(() => stats.evaluate(element => {
+    const bounds = element.getBoundingClientRect()
+    const host = element.closest('.ftVideoPlayerHost').getBoundingClientRect()
+    const player = element.parentElement.querySelector('.ftVideoPlayer').getBoundingClientRect()
+    return host.bottom >= bounds.bottom - 0.5 && bounds.top >= player.bottom - 0.5 &&
+      element.scrollWidth <= element.clientWidth
+  })).toBe(true)
+  await expectContained()
+  await setWindowSize(app, page, { width: 640, height: 800 })
+  await page.evaluate(() => window.ftElectron.setZoomFactor(1.25))
+  await expectContained()
+  await expect.poll(() => page.locator('.shortsExternalMetadata').evaluate(element => {
+    return element.getBoundingClientRect().top >= document.querySelector('.repeatStats').getBoundingClientRect().bottom - 0.5
+  })).toBe(true)
+})
+
+test('Distraction Free hides repeat stats immediately without disabling looping or losing the session', async ({ app, page }) => {
+  const video = await openVideo(app, page)
+  await toggleLoop(page)
+  const stats = page.locator('.repeatStats')
+  await expect(stats).toBeVisible()
+  await video.evaluate(element => { element.currentTime = element.duration - 0.5 })
+  await expect.poll(() => video.evaluate(element => element.seeking)).toBe(false)
+  await video.evaluate(element => element.play())
+  await expect(stats.locator('.repeatStatsCount')).toHaveText('1')
+  await video.evaluate(element => element.pause())
+  const spent = await stats.locator('.repeatStatsTime').textContent()
+
+  const focus = await goToSettingsSection(page, 'focus')
+  const hideStats = focus.getByRole('checkbox', { name: /^Hide Repeat Stats/ })
+  await expect(hideStats).not.toBeChecked()
+  await hideStats.locator('..').locator('label.switch-label').click()
+  await expect(hideStats).toBeChecked()
+  await expect(stats).toHaveCount(0)
+  await expect.poll(() => video.evaluate(element => element.loop)).toBe(true)
+  await expect.poll(async () => {
+    const contents = await readFile(`${app.userDataDir}/settings.db`, 'utf8')
+    return latestSettings(contents).hideRepeatStats
+  }).toBe(true)
+
+  await hideStats.locator('..').locator('label.switch-label').click()
+  await expect(hideStats).not.toBeChecked()
+  await expect(stats.locator('.repeatStatsCount')).toHaveText('1')
+  await expect(stats.locator('.repeatStatsTime')).toHaveText(spent)
+  await expect.poll(async () => {
+    const contents = await readFile(`${app.userDataDir}/settings.db`, 'utf8')
+    return latestSettings(contents).hideRepeatStats
+  }).toBe(false)
+})

--- a/src/renderer/components/DistractionSettings/DistractionSettings.vue
+++ b/src/renderer/components/DistractionSettings/DistractionSettings.vue
@@ -317,6 +317,13 @@
           @change="updateDisableAbRepeat"
         />
         <FtToggleSwitch
+          :label="t('Settings.Distraction Free Settings.Hide Repeat Stats')"
+          :compact="true"
+          :default-value="hideRepeatStats"
+          setting-key="hideRepeatStats"
+          @change="updateHideRepeatStats"
+        />
+        <FtToggleSwitch
           :label="t('Settings.Distraction Free Settings.Hide End-Screen Annotations')"
           :compact="true"
           :default-value="hideEndScreenAnnotations"
@@ -610,6 +617,14 @@ const disableAbRepeat = computed(() => store.getters.getDisableAbRepeat)
  */
 function updateDisableAbRepeat(value) {
   store.dispatch('updateDisableAbRepeat', value)
+}
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const hideRepeatStats = computed(() => store.getters.getHideRepeatStats)
+
+/** @param {boolean} value */
+function updateHideRepeatStats(value) {
+  store.dispatch('updateHideRepeatStats', value)
 }
 
 /** @type {import('vue').ComputedRef<boolean>} */

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -4066,6 +4066,55 @@ html[data-reduced-motion='reduce'] .musicVisualizerCanvas {
   position: relative;
 }
 
+.repeatStats {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px 24px;
+  padding: 12px 16px;
+  background-color: var(--card-bg-color);
+  color: var(--primary-text-color);
+  border-end-start-radius: calc(8px * var(--ui-roundness));
+  border-end-end-radius: calc(8px * var(--ui-roundness));
+  font-size: 14px;
+  font-variant-numeric: tabular-nums;
+}
+
+.repeatStatsMode,
+.repeatStatsValues,
+.repeatStatsValues > div {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.repeatStatsMode {
+  gap: 8px;
+}
+
+.repeatStatsMode > .ft-icon {
+  color: var(--primary-color);
+}
+
+.repeatStatsValues {
+  gap: 12px 24px;
+  margin: 0;
+}
+
+.repeatStatsValues > div {
+  gap: 6px;
+}
+
+.repeatStatsValues dt {
+  color: var(--secondary-text-color);
+}
+
+.repeatStatsValues dd {
+  order: -1;
+  margin: 0;
+}
+
 .ambientCanvas {
   position: absolute;
   inset: -5% -4% -9%;

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -3,6 +3,7 @@ import { isAppHidden } from '../../helpers/appVisibility.js'
 import { playbackScreenWake } from '../../helpers/playbackScreenWake'
 import { capturePlayerFrame } from '../../helpers/player/capturePlayerFrame'
 import { createAndroidPlayer } from '../../helpers/player/androidPlayer'
+import { createRepeatStatsTracker } from '../../helpers/player/repeatStats'
 import { computed, defineComponent, inject, nextTick, onBeforeUnmount, onMounted, onUnmounted, reactive, ref, shallowRef, watch } from 'vue'
 import FtPaidPromotionBadge from '../FtPaidPromotionBadge/FtPaidPromotionBadge.vue'
 import FtSelect from '../FtSelect/FtSelect.vue'
@@ -3979,6 +3980,35 @@ export default defineComponent({
     const abRepeatStart = ref(null)
     const abRepeatEnd = ref(null)
     const abRepeatEnabled = ref(false)
+    const repeatStats = reactive({ active: false, repeats: 0, seconds: 0 })
+    const hideRepeatStats = computed(() => store.getters.getHideRepeatStats)
+    const repeatStatsTime = computed(() => formatDurationAsTimestamp(repeatStats.seconds))
+    const repeatStatsRange = computed(() => abRepeatEnabled.value
+      ? `${formatAbRepeatTimestamp(abRepeatStart.value)} – ${formatAbRepeatTimestamp(abRepeatEnd.value)}`
+      : '')
+    let repeatStatsTracker = null
+    let repeatStatsLoopObserver = null
+
+    function syncRepeatStatsMode() {
+      const mode = isLive.value
+        ? null
+        : abRepeatEnabled.value && abRepeatAvailable.value
+          ? `ab:${abRepeatStart.value}:${abRepeatEnd.value}`
+          : video.value?.loop ? 'video' : null
+      repeatStatsTracker?.setMode(mode)
+    }
+
+    watch([abRepeatStart, abRepeatEnd, abRepeatEnabled, isLive], syncRepeatStatsMode)
+    onMounted(() => {
+      repeatStatsTracker = createRepeatStatsTracker(video.value, stats => Object.assign(repeatStats, stats))
+      repeatStatsLoopObserver = new MutationObserver(syncRepeatStatsMode)
+      repeatStatsLoopObserver.observe(video.value, { attributes: true, attributeFilter: ['loop'] })
+      syncRepeatStatsMode()
+    })
+    onBeforeUnmount(() => {
+      repeatStatsTracker?.destroy()
+      repeatStatsLoopObserver?.disconnect()
+    })
     const abRepeatDuration = ref(Number.POSITIVE_INFINITY)
     const disableAbRepeat = computed(() => store.getters.getDisableAbRepeat)
     const abRepeatValidation = computed(() => validateAbRepeatRange(
@@ -4153,17 +4183,18 @@ export default defineComponent({
       return abRepeatAvailable.value
     }
 
-    function repeatAbRangeFromStart() {
+    function repeatAbRangeFromStart(countRepeat = false) {
       const videoElement = video.value
       if (!videoElement || !hasValidAbRepeatRange()) {
         return
       }
 
       clearAbRepeatBoundarySchedule()
+      if (countRepeat) repeatStatsTracker?.repeat()
       videoElement.currentTime = abRepeatStart.value
     }
 
-    function checkAbRepeatBoundary() {
+    function checkAbRepeatBoundary(countRepeat = true) {
       clearAbRepeatBoundarySchedule()
       const videoElement = video.value
       if (!videoElement || !abRepeatEnabled.value || !hasValidAbRepeatRange()) {
@@ -4174,7 +4205,8 @@ export default defineComponent({
         videoElement.currentTime < abRepeatStart.value - AB_REPEAT_BOUNDARY_TOLERANCE_SECONDS ||
         videoElement.currentTime >= abRepeatEnd.value - AB_REPEAT_BOUNDARY_TOLERANCE_SECONDS
       ) {
-        repeatAbRangeFromStart()
+        repeatAbRangeFromStart(countRepeat && !videoElement.paused && !videoElement.seeking &&
+          videoElement.currentTime >= abRepeatEnd.value - AB_REPEAT_BOUNDARY_TOLERANCE_SECONDS)
         return
       }
 
@@ -5463,6 +5495,8 @@ export default defineComponent({
 
     watch(() => props.videoId, () => {
       resetAbRepeat()
+      repeatStatsTracker?.reset()
+      syncRepeatStatsMode()
       mediaSessionStopped = false
       voiceOverTranslation.reset()
       showPoster.value = true
@@ -6115,7 +6149,7 @@ export default defineComponent({
 
     function handleEnded() {
       if (abRepeatEnabled.value && hasValidAbRepeatRange()) {
-        repeatAbRangeFromStart()
+        repeatAbRangeFromStart(true)
         video.value.play()
         return
       }
@@ -6162,7 +6196,7 @@ export default defineComponent({
     }
 
     function handleAbRepeatSeeked() {
-      checkAbRepeatBoundary()
+      checkAbRepeatBoundary(false)
     }
 
     function applyPendingPresentationModes() {
@@ -11170,6 +11204,8 @@ export default defineComponent({
      * }>}
      */
     async function destroyPlayer() {
+      repeatStatsTracker?.destroy()
+      repeatStatsLoopObserver?.disconnect()
       screenWakeBinding?.destroy()
       screenWakeBinding = null
       nativePlaybackCleanup?.()
@@ -11394,6 +11430,10 @@ export default defineComponent({
       selectOverlayChapter,
       copyChapterTimestamp,
       fullscreenDockStyle,
+      repeatStats,
+      hideRepeatStats,
+      repeatStatsTime,
+      repeatStatsRange,
       fullscreenDockCanResize,
       fullscreenDockCanReorder,
       fullscreenDockResizing,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -1418,6 +1418,40 @@
     </div>
     </Teleport>
     <!-- eslint-enable vue/html-indent -->
+    <section
+      v-if="repeatStats.active && !hideRepeatStats && !fullWindowEnabled && !isFullscreen"
+      class="repeatStats"
+      :aria-label="$t('Video.Player.Repeat Stats.Repeat Stats')"
+    >
+      <span class="repeatStatsMode">
+        <ft-icon
+          :icon="['fas', 'retweet']"
+          aria-hidden="true"
+        />
+        {{ repeatStatsRange ? $t('Video.Player.A-B Repeat.A-B Repeat') : $t('Video.Player.Repeat Stats.Looping') }}
+        <bdi v-if="repeatStatsRange">{{ repeatStatsRange }}</bdi>
+      </span>
+      <dl class="repeatStatsValues">
+        <div>
+          <dt>{{ $t('Video.Player.Repeat Stats.Repeats') }}</dt>
+          <dd class="repeatStatsCount">
+            {{ repeatStats.repeats.toLocaleString($i18n.locale) }}
+          </dd>
+        </div>
+        <div>
+          <dt>{{ $t('Video.Player.Repeat Stats.Time Spent') }}</dt>
+          <dd class="repeatStatsTime">
+            {{ repeatStatsTime }}
+          </dd>
+        </div>
+        <div>
+          <dt>{{ $t('Video.Player.Repeat Stats.Current Pass') }}</dt>
+          <dd class="repeatStatsPass">
+            {{ (repeatStats.repeats + 1).toLocaleString($i18n.locale) }}
+          </dd>
+        </div>
+      </dl>
+    </section>
   </div>
 </template>
 

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -1444,12 +1444,6 @@
             {{ repeatStatsTime }}
           </dd>
         </div>
-        <div>
-          <dt>{{ $t('Video.Player.Repeat Stats.Current Pass') }}</dt>
-          <dd class="repeatStatsPass">
-            {{ (repeatStats.repeats + 1).toLocaleString($i18n.locale) }}
-          </dd>
-        </div>
       </dl>
     </section>
   </div>

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -1419,7 +1419,8 @@
     </Teleport>
     <!-- eslint-enable vue/html-indent -->
     <section
-      v-if="repeatStats.active && !hideRepeatStats && !fullWindowEnabled && !isFullscreen"
+      v-if="repeatStats.active && !hideRepeatStats && !fullWindowEnabled && !isFullscreen &&
+        !scrollMiniPlayerActive && !scrollMiniPlayerDetached"
       class="repeatStats"
       :aria-label="$t('Video.Player.Repeat Stats.Repeat Stats')"
     >

--- a/src/renderer/helpers/player/androidMediaElement.js
+++ b/src/renderer/helpers/player/androidMediaElement.js
@@ -114,7 +114,14 @@ export function attachAndroidMediaElement(element, { command, load, onError, now
     }
   })
   define('defaultPlaybackRate', { get: () => defaultRate, set: value => { defaultRate = value } })
-  define('loop', { get: () => loop, set(value) { loop = Boolean(value); send('loop', loop ? 1 : 0) } })
+  define('loop', {
+    get: () => loop,
+    set(value) {
+      loop = Boolean(value)
+      element.toggleAttribute('loop', loop)
+      send('loop', loop ? 1 : 0)
+    }
+  })
   define('play', {
     value: () => {
       pendingPause = false
@@ -182,7 +189,10 @@ export function attachAndroidMediaElement(element, { command, load, onError, now
       if (next.duration !== undefined && next.duration !== previous.duration) emit('durationchange')
       if (state.width !== previous.width || state.height !== previous.height) emit('resize')
       if (state.paused !== previous.paused) emit(state.paused ? 'pause' : 'play')
-      if (next.buffering && !previous.buffering) emit('waiting')
+      // Audio-focus suppression stops playback without changing playWhenReady.
+      // Shared media consumers still need a waiting/playing transition.
+      if ((next.buffering && !previous.buffering) ||
+        (previous.playing && !state.playing && !state.paused && !state.ended)) emit('waiting')
       if (state.playing && !previous.playing) emit('playing')
       if (next.event === 'seeked') { seeking = false; emit('seeked') }
       if (next.ended && !previous.ended) emit('ended')

--- a/src/renderer/helpers/player/repeatStats.js
+++ b/src/renderer/helpers/player/repeatStats.js
@@ -1,0 +1,140 @@
+/**
+ * Track one video's repeat session. Time is wall-clock playing time, so playback
+ * speed and seeks cannot turn skipped media time into time spent watching.
+ *
+ * @param {HTMLVideoElement} video
+ * @param {(stats: { active: boolean, repeats: number, seconds: number }) => void} onChange
+ * @param {() => number} [now]
+ */
+export function createRepeatStatsTracker(video, onChange, now = () => performance.now()) {
+  let session = null
+  let mode = null
+  let repeats = 0
+  let milliseconds = 0
+  let waiting = false
+  let playing = !video.paused && !video.seeking && video.readyState >= 3
+  let lastClock = now()
+  let position = null
+
+  function publish() {
+    onChange({ active: mode !== null, repeats, seconds: Math.floor(milliseconds / 1000) })
+  }
+
+  function accountTime() {
+    const clock = now()
+    if (mode !== null && playing) {
+      milliseconds += Math.max(0, clock - lastClock)
+    }
+    lastClock = clock
+  }
+
+  function samplePosition() {
+    position = { time: video.currentTime, clock: now(), rate: video.playbackRate }
+  }
+
+  function start() {
+    accountTime()
+    playing = !waiting && !video.paused && !video.seeking && video.readyState >= 3
+    samplePosition()
+    publish()
+  }
+
+  function stop() {
+    accountTime()
+    playing = false
+    position = null
+    publish()
+  }
+
+  function tick() {
+    // Chromium sends timeupdate during seeks as well as during playback.
+    if (video.seeking) return
+    accountTime()
+    samplePosition()
+    publish()
+  }
+
+  function countNativeRepeat() {
+    // Native looping seeks to zero without firing ended. Require enough natural
+    // playback to have reached the end since the last sample; an ordinary
+    // backwards seek, including one near the end, must not count as a repeat.
+    if (
+      mode === 'video' && playing && position !== null &&
+      Number.isFinite(video.duration) && video.duration > 0 &&
+      video.currentTime <= 0.05 && position.time > video.currentTime &&
+      position.time + (now() - position.clock) / 1000 * position.rate >= video.duration - 0.02
+    ) {
+      repeats++
+    }
+  }
+
+  function seek() {
+    countNativeRepeat()
+    stop()
+  }
+
+  function seeked() {
+    // Android reports automatic repeat discontinuities as seeked only. An
+    // explicit seek already cleared position, so it cannot count again here.
+    countNativeRepeat()
+    start()
+  }
+
+  const listeners = {
+    playing: () => {
+      waiting = false
+      start()
+    },
+    pause: stop,
+    waiting: () => {
+      // A completed seek does not mean playback resumed after buffering or
+      // native audio-focus suppression. Wait for the playing event.
+      waiting = true
+      stop()
+    },
+    ended: stop,
+    emptied: stop,
+    error: stop,
+    seeking: seek,
+    seeked,
+    timeupdate: tick,
+    ratechange: tick,
+  }
+  for (const [event, listener] of Object.entries(listeners)) {
+    video.addEventListener(event, listener)
+  }
+
+  return {
+    /** @param {string | null} nextMode A stable range key, 'video', or null when disabled. */
+    setMode(nextMode) {
+      accountTime()
+      if (nextMode !== null && nextMode !== session) {
+        session = nextMode
+        repeats = 0
+        milliseconds = 0
+      }
+      mode = nextMode
+      samplePosition()
+      publish()
+    },
+    /** Called only when natural A-B playback reaches the repeat boundary. */
+    repeat() {
+      accountTime()
+      if (mode !== null) repeats++
+      publish()
+    },
+    reset() {
+      repeats = 0
+      milliseconds = 0
+      session = null
+      position = null
+      lastClock = now()
+      publish()
+    },
+    destroy() {
+      for (const [event, listener] of Object.entries(listeners)) {
+        video.removeEventListener(event, listener)
+      }
+    },
+  }
+}

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -316,6 +316,7 @@ const state = {
   ytDlpSelectedTemplate: 'video:best',
   ytDlpAutomaticDownloadRules: '{}',
   disableAbRepeat: false,
+  hideRepeatStats: false,
   expandSideBar: false,
   hideActiveSubscriptions: false,
   hideChannelAvatars: false,

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -357,6 +357,18 @@
       border-radius: calc(12px * var(--ui-roundness));
     }
 
+    .videoArea .videoAreaMargin:has(.repeatStats) {
+      grid-template-rows: auto auto auto;
+    }
+
+    .videoArea .videoPlayer:has(.repeatStats) {
+      block-size: auto;
+
+      :deep(.ftVideoPlayer:not(:fullscreen, .fullWindow, .scrollMiniPlayer)) {
+        block-size: var(--shorts-player-height);
+      }
+    }
+
     .videoArea :deep(.ftVideoPlayer),
     .videoArea .videoPlayer:has(.errorContainer) {
       overflow: hidden;

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -792,6 +792,7 @@ Settings:
     Posts Auto Refresh Interval: المشاركات الفاصل الزمني للتحديث التلقائي
     Refresh Subscriptions While App Is Closed: "تحديث الاشتراكات أثناء إغلاق التطبيق"
   Distraction Free Settings:
+    Hide Repeat Stats: إخفاء إحصاءات التكرار
     Sections:
       Visible While Paused: مرئي أثناء الإيقاف المؤقت في نافذة كاملة/شاشة كاملة
     Hide Channel Avatars: إخفاء الصور الرمزية للقناة
@@ -1142,6 +1143,12 @@ Video:
   Live chat replay is enabled. Chat messages will appear here as the video plays.: تم تمكين إعادة تشغيل الدردشة المباشرة.  ستظهر رسائل الدردشة هنا أثناء تشغيل الفيديو.
   Premiere started: العرض الأول قيد التقدم. بدأ {timeAgo}
   Player:
+    Repeat Stats:
+      Repeat Stats: إحصاءات التكرار
+      Looping: التكرار مفعّل
+      Repeats: التكرارات
+      Time Spent: وقت المشاهدة
+      Current Pass: الدورة الحالية
     Voice-over Translation:
       Start: يترجم
       Cancel: يلغي

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -1148,7 +1148,6 @@ Video:
       Looping: التكرار مفعّل
       Repeats: التكرارات
       Time Spent: وقت المشاهدة
-      Current Pass: الدورة الحالية
     Voice-over Translation:
       Start: يترجم
       Cancel: يلغي

--- a/static/locales/ai/az.yaml
+++ b/static/locales/ai/az.yaml
@@ -793,6 +793,7 @@ Settings:
     Hide Home: Ana səhifəni gizlət
     Hide Live Chat Replay: Canlı söhbətin təkrarını gizlət
     Disable A-B Repeat: A-B təkrarını söndür
+    Hide Repeat Stats: Təkrar statistikasını gizlət
     Hide End-Screen Annotations: Son ekran qeydlərini gizlət
     Hide Paid Promotion Badge: Ödənişli tanıtım nişanını gizlət
     Show Player Controls: Pleyer idarəetmələrini göstər
@@ -1145,6 +1146,11 @@ Video:
       Remaining: '{time} qalıb'
       Cancel timer: Taymeri ləğv et
       Timer ended: Yuxu taymerinin vaxtı bitdi
+    Repeat Stats:
+      Repeat Stats: Təkrar statistikası
+      Looping: Təkrarlanır
+      Repeats: Təkrarlar
+      Time Spent: Sərf olunan vaxt
     A-B Repeat:
       A-B Repeat: A-B təkrarı
       'On': 'Aktiv'

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -814,6 +814,7 @@ Settings:
     Posts Auto Refresh Interval: Інтэрвал аўтаматычнага абнаўлення допісаў
     Refresh Subscriptions While App Is Closed: "Абнаўляць падпіскі, калі праграма закрыта"
   Distraction Free Settings:
+    Hide Repeat Stats: Схаваць статыстыку паўтораў
     Sections:
       Visible While Paused: Бачныя падчас паўзы ў поўным акне або поўнаэкранным рэжыме
     Hide Channel Avatars: Хаваць аватары каналаў
@@ -1186,6 +1187,12 @@ Video:
     music offtopic: Не музыка
     filler: Адступленні
   Player:
+    Repeat Stats:
+      Repeat Stats: Статыстыка паўтораў
+      Looping: Паўтор уключаны
+      Repeats: Паўторы
+      Time Spent: Час прагляду
+      Current Pass: Бягучы праход
     Voice-over Translation:
       Start: Перакласці
       Cancel: Скасаваць

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -1192,7 +1192,6 @@ Video:
       Looping: Паўтор уключаны
       Repeats: Паўторы
       Time Spent: Час прагляду
-      Current Pass: Бягучы праход
     Voice-over Translation:
       Start: Перакласці
       Cancel: Скасаваць

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -786,6 +786,7 @@ Settings:
     Posts Auto Refresh Interval: Интервал за автоматично опресняване на публикациите
     Refresh Subscriptions While App Is Closed: "Опресняване на абонаментите при затворено приложение"
   Distraction Free Settings:
+    Hide Repeat Stats: Скриване на статистиката на повторенията
     Sections:
       Visible While Paused: Видими при поставяне на пауза в режим на цял прозорец / цял екран
     Hide Channel Avatars: Скриване на аватарите на каналите
@@ -1123,6 +1124,12 @@ Video:
   Live chat replay is enabled. Chat messages will appear here as the video plays.: Повторението на чата на живо е включено. Съобщенията от чата ще се показват тук при възпроизвеждането на видеоклипа.
   Premiere started: Премиерата е в ход. Започна {timeAgo}
   Player:
+    Repeat Stats:
+      Repeat Stats: Статистика на повторенията
+      Looping: Повтаряне
+      Repeats: Повторения
+      Time Spent: Време на гледане
+      Current Pass: Текущо изпълнение
     Voice-over Translation:
       Start: Превод
       Cancel: Отказ

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -1129,7 +1129,6 @@ Video:
       Looping: Повтаряне
       Repeats: Повторения
       Time Spent: Време на гледане
-      Current Pass: Текущо изпълнение
     Voice-over Translation:
       Start: Превод
       Cancel: Отказ

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -784,6 +784,7 @@ Settings:
     Posts Auto Refresh Interval: "Etrevez adkargañ emgefreek ar pennadoù"
     Refresh Subscriptions While App Is Closed: "Freskañ ar c'houmanantoù pa vez serret an arload"
   Distraction Free Settings:
+    Hide Repeat Stats: Kuzhat stadegoù an adlenn
     Sections:
       Visible While Paused: "Gwelus e-pad un ehan er prenestr leun pe er skramm leun"
     Hide Channel Avatars: "Kuzhat skeudennoù ar chadennoù"
@@ -1125,6 +1126,12 @@ Video:
     music offtopic: "N'eo ket sonerezh"
     filler: "Dihanadennoù"
   Player:
+    Repeat Stats:
+      Repeat Stats: Stadegoù an adlenn
+      Looping: Adlenn oberiant
+      Repeats: Adlennoù
+      Time Spent: Amzer tremenet
+      Current Pass: Tremen bremanel
     Voice-over Translation:
       Start: "Treiñ"
       Cancel: "Nullañ"

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -1131,7 +1131,6 @@ Video:
       Looping: Adlenn oberiant
       Repeats: Adlennoù
       Time Spent: Amzer tremenet
-      Current Pass: Tremen bremanel
     Voice-over Translation:
       Start: "Treiñ"
       Cancel: "Nullañ"

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -1564,7 +1564,6 @@ Video:
       Looping: En bucle
       Repeats: Repeticions
       Time Spent: Temps dedicat
-      Current Pass: Passada actual
     Voice-over Translation:
       Start: Tradueix
       Cancel: Cancel·la

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -1052,6 +1052,7 @@ Settings:
     To: A
     Confirm Before Unsubscribing: Confirma abans de donar-se de baixa
   Distraction Free Settings:
+    Hide Repeat Stats: Amaga les estadístiques de repetició
     Sections:
       Side Bar: Barra lateral
       Subscriptions Page: Pàgina de subscripcions
@@ -1558,6 +1559,12 @@ Video:
       shuffling playlists: barrejar llistes de reproducció
       looping playlists: reproduir llistes de reproducció en bucle
   Player:
+    Repeat Stats:
+      Repeat Stats: Estadístiques de repetició
+      Looping: En bucle
+      Repeats: Repeticions
+      Time Spent: Temps dedicat
+      Current Pass: Passada actual
     Voice-over Translation:
       Start: Tradueix
       Cancel: Cancel·la

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -1120,7 +1120,6 @@ Video:
       Looping: Smyčka zapnuta
       Repeats: Opakování
       Time Spent: Čas sledování
-      Current Pass: Aktuální průchod
     Voice-over Translation:
       Start: Přeložit
       Cancel: Zrušit

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -784,6 +784,7 @@ Settings:
     Posts Auto Refresh Interval: Interval automatického obnovení příspěvků
     Refresh Subscriptions While App Is Closed: "Obnovovat odběry, když je aplikace zavřená"
   Distraction Free Settings:
+    Hide Repeat Stats: Skrýt statistiky opakování
     Sections:
       Visible While Paused: Viditelné při pozastavení v režimu celého okna nebo celé obrazovky
     Hide Channel Avatars: Skrýt avatary kanálů
@@ -1114,6 +1115,12 @@ Video:
   Live chat replay is enabled. Chat messages will appear here as the video plays.: Záznam živého chatu je zapnutý. Zprávy se zde budou zobrazovat během přehrávání videa.
   Premiere started: Probíhá premiéra. Začala {timeAgo}
   Player:
+    Repeat Stats:
+      Repeat Stats: Statistiky opakování
+      Looping: Smyčka zapnuta
+      Repeats: Opakování
+      Time Spent: Čas sledování
+      Current Pass: Aktuální průchod
     Voice-over Translation:
       Start: Přeložit
       Cancel: Zrušit

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -1138,7 +1138,6 @@ Video:
       Looping: Ailadrodd ymlaen
       Repeats: Ailadroddiadau
       Time Spent: Amser a dreuliwyd
-      Current Pass: Cylch presennol
     Voice-over Translation:
       Start: Cyfieithu
       Cancel: Canslo

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -786,6 +786,7 @@ Settings:
     Posts Auto Refresh Interval: Cyfwng adnewyddu postiadau yn awtomatig
     Refresh Subscriptions While App Is Closed: "Adnewyddu tanysgrifiadau pan fydd yr ap ar gau"
   Distraction Free Settings:
+    Hide Repeat Stats: Cuddio ystadegau ailadrodd
     Sections:
       Visible While Paused: Yn weladwy wrth oedi mewn ffenestr lawn / sgrin lawn
     Hide Channel Avatars: Cuddio afatarau sianeli
@@ -1132,6 +1133,12 @@ Video:
     music offtopic: Heb fod yn gerddoriaeth
     filler: Gwyriadau
   Player:
+    Repeat Stats:
+      Repeat Stats: Ystadegau ailadrodd
+      Looping: Ailadrodd ymlaen
+      Repeats: Ailadroddiadau
+      Time Spent: Amser a dreuliwyd
+      Current Pass: Cylch presennol
     Voice-over Translation:
       Start: Cyfieithu
       Cancel: Canslo

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -1181,7 +1181,6 @@ Video:
       Looping: Gentagelse slået til
       Repeats: Gentagelser
       Time Spent: Tid brugt
-      Current Pass: Aktuel gennemspilning
     Voice-over Translation:
       Start: Oversæt
       Cancel: Annuller

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -810,6 +810,7 @@ Settings:
     Refresh Subscriptions While App Is Closed: "Opdater abonnementer, mens appen er lukket"
     Limit the number of videos displayed for each channel: Begræns antallet af viste videoer for hver kanal
   Distraction Free Settings:
+    Hide Repeat Stats: Skjul gentagelsesstatistik
     Sections:
       Visible While Paused: Synligt ved pause i helt vindue eller fuld skærm
     Hide Channel Avatars: Skjul kanalavatarer
@@ -1175,6 +1176,12 @@ Video:
   Sponsor Block category:
     hook: Introduktion/hilsen
   Player:
+    Repeat Stats:
+      Repeat Stats: Gentagelsesstatistik
+      Looping: Gentagelse slået til
+      Repeats: Gentagelser
+      Time Spent: Tid brugt
+      Current Pass: Aktuel gennemspilning
     Voice-over Translation:
       Start: Oversæt
       Cancel: Annuller

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -1153,7 +1153,6 @@ Video:
       Looping: Επανάληψη ενεργή
       Repeats: Επαναλήψεις
       Time Spent: Χρόνος παρακολούθησης
-      Current Pass: Τρέχουσα αναπαραγωγή
     Voice-over Translation:
       Start: Μετάφραση
       Cancel: Ακύρωση

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -797,6 +797,7 @@ Settings:
     Posts Auto Refresh Interval: Διάστημα αυτόματης ανανέωσης αναρτήσεων
     Refresh Subscriptions While App Is Closed: "Ανανέωση συνδρομών όταν η εφαρμογή είναι κλειστή"
   Distraction Free Settings:
+    Hide Repeat Stats: Απόκρυψη στατιστικών επανάληψης
     Sections:
       Visible While Paused: Ορατά κατά την παύση σε πλήρες παράθυρο / πλήρη οθόνη
     Hide Channel Avatars: Απόκρυψη εικόνων προφίλ καναλιών
@@ -1147,6 +1148,12 @@ Video:
   Live chat replay is enabled. Chat messages will appear here as the video plays.: Η επανάληψη ζωντανής συνομιλίας είναι ενεργοποιημένη. Τα μηνύματα θα εμφανίζονται εδώ κατά την αναπαραγωγή του βίντεο.
   Premiere started: Η πρεμιέρα βρίσκεται σε εξέλιξη. Ξεκίνησε {timeAgo}
   Player:
+    Repeat Stats:
+      Repeat Stats: Στατιστικά επανάληψης
+      Looping: Επανάληψη ενεργή
+      Repeats: Επαναλήψεις
+      Time Spent: Χρόνος παρακολούθησης
+      Current Pass: Τρέχουσα αναπαραγωγή
     Voice-over Translation:
       Start: Μετάφραση
       Cancel: Ακύρωση

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -770,6 +770,7 @@ Settings:
     Posts Auto Refresh Interval: Posts Auto Refresh Interval
     Refresh Subscriptions While App Is Closed: "Refresh Subscriptions While App Is Closed"
   Distraction Free Settings:
+    Hide Repeat Stats: Hide Repeat Stats
     Hide Channel Avatars: Hide Channel Avatars
     Shorten View Counts: Shorten View, Comment and Comment Like Counts
     Hide Home: Hide Home
@@ -1090,6 +1091,12 @@ Video:
   Live chat replay is enabled. Chat messages will appear here as the video plays.: Live chat replay is enabled.  Chat messages will appear here as the video plays.
   Premiere started: Premiere in progress. Started {timeAgo}
   Player:
+    Repeat Stats:
+      Repeat Stats: Repeat stats
+      Looping: Looping
+      Repeats: Repeats
+      Time Spent: Time spent
+      Current Pass: Current pass
     Voice-over Translation:
       Start: Translate
       Cancel: Cancel

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -1096,7 +1096,6 @@ Video:
       Looping: Looping
       Repeats: Repeats
       Time Spent: Time spent
-      Current Pass: Current pass
     Voice-over Translation:
       Start: Translate
       Cancel: Cancel

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -868,6 +868,7 @@ Settings:
     Posts Auto Refresh Interval: Intervalo de actualización automática de publicaciones
     Refresh Subscriptions While App Is Closed: "Actualizar suscripciones con la aplicación cerrada"
   Distraction Free Settings:
+    Hide Repeat Stats: Ocultar estadísticas de repetición
     Sections:
       Visible While Paused: Visible al pausar en ventana completa o pantalla completa
     Hide Channel Avatars: Ocultar avatares de canales
@@ -1448,6 +1449,12 @@ Video:
       shuffling playlists: aleatorizar las listas de reproducción
       looping playlists: reproducir en bucle las listas de reproducción
   Player:
+    Repeat Stats:
+      Repeat Stats: Estadísticas de repetición
+      Looping: En bucle
+      Repeats: Repeticiones
+      Time Spent: Tiempo dedicado
+      Current Pass: Reproducción actual
     Voice-over Translation:
       Start: Traducir
       Cancel: Cancelar

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -1454,7 +1454,6 @@ Video:
       Looping: En bucle
       Repeats: Repeticiones
       Time Spent: Tiempo dedicado
-      Current Pass: Reproducción actual
     Voice-over Translation:
       Start: Traducir
       Cancel: Cancelar

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -1396,7 +1396,6 @@ Video:
       Looping: En bucle
       Repeats: Repeticiones
       Time Spent: Tiempo dedicado
-      Current Pass: Reproducción actual
     Voice-over Translation:
       Start: Traducir
       Cancel: Cancelar

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -912,6 +912,7 @@ Settings:
     To: A
     Confirm Before Unsubscribing: Evitar bajas accidentales
   Distraction Free Settings:
+    Hide Repeat Stats: Ocultar estadísticas de repetición
     Sections:
       Side Bar: Barra lateral
       Subscriptions Page: Página de suscripciones
@@ -1390,6 +1391,12 @@ Video:
     Show Original Details: Mostrar Detalles Originales
     Show Modified Details: Mostrar Detalles Modificados
   Player:
+    Repeat Stats:
+      Repeat Stats: Estadísticas de repetición
+      Looping: En bucle
+      Repeats: Repeticiones
+      Time Spent: Tiempo dedicado
+      Current Pass: Reproducción actual
     Voice-over Translation:
       Start: Traducir
       Cancel: Cancelar

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -790,6 +790,7 @@ Settings:
     Posts Auto Refresh Interval: Intervalo de actualización automática de publicaciones
     Refresh Subscriptions While App Is Closed: "Actualizar suscripciones con la aplicación cerrada"
   Distraction Free Settings:
+    Hide Repeat Stats: Ocultar estadísticas de repetición
     Sections:
       Visible While Paused: Visible al pausar en ventana completa o pantalla completa
     Hide Channel Avatars: Ocultar avatares de canales
@@ -1137,6 +1138,12 @@ Video:
   Live chat replay is enabled. Chat messages will appear here as the video plays.: La repetición del chat en directo está activada. Los mensajes aparecerán aquí mientras se reproduce el vídeo.
   Premiere started: Estreno en curso. Empezó {timeAgo}
   Player:
+    Repeat Stats:
+      Repeat Stats: Estadísticas de repetición
+      Looping: En bucle
+      Repeats: Repeticiones
+      Time Spent: Tiempo dedicado
+      Current Pass: Reproducción actual
     Voice-over Translation:
       Start: Traducir
       Cancel: Cancelar

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -1143,7 +1143,6 @@ Video:
       Looping: En bucle
       Repeats: Repeticiones
       Time Spent: Tiempo dedicado
-      Current Pass: Reproducción actual
     Voice-over Translation:
       Start: Traducir
       Cancel: Cancelar

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -784,6 +784,7 @@ Settings:
     Posts Auto Refresh Interval: Postituste automaatse värskendamise intervall
     Refresh Subscriptions While App Is Closed: "Värskenda tellimusi, kui rakendus on suletud"
   Distraction Free Settings:
+    Hide Repeat Stats: Peida korduste statistika
     Sections:
       Visible While Paused: Pausi ajal täisaknas või täisekraanil nähtav
     Hide Channel Avatars: Peida kanalite avatarid
@@ -1116,6 +1117,12 @@ Video:
   Sponsor Block category:
     hook: Sissejuhatus/tervitus
   Player:
+    Repeat Stats:
+      Repeat Stats: Korduste statistika
+      Looping: Kordus sees
+      Repeats: Kordused
+      Time Spent: Vaatamisaeg
+      Current Pass: Praegune esitus
     Voice-over Translation:
       Start: Tõlgi
       Cancel: Tühista

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -1122,7 +1122,6 @@ Video:
       Looping: Kordus sees
       Repeats: Kordused
       Time Spent: Vaatamisaeg
-      Current Pass: Praegune esitus
     Voice-over Translation:
       Start: Tõlgi
       Cancel: Tühista

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -786,6 +786,7 @@ Settings:
     Posts Auto Refresh Interval: Argitalpenen freskatze automatikoaren tartea
     Refresh Subscriptions While App Is Closed: "Freskatu harpidetzak aplikazioa itxita dagoenean"
   Distraction Free Settings:
+    Hide Repeat Stats: Ezkutatu errepikapenen estatistikak
     Sections:
       Visible While Paused: Ikusgai pausatuta dagoenean leiho osoan edo pantaila osoan
     Hide Channel Avatars: Ezkutatu kanalen abatarrak
@@ -1132,6 +1133,12 @@ Video:
     music offtopic: Musikaz bestelakoa
     filler: Gaitik kanpokoak
   Player:
+    Repeat Stats:
+      Repeat Stats: Errepikapenen estatistikak
+      Looping: Begiztan
+      Repeats: Errepikapenak
+      Time Spent: Emandako denbora
+      Current Pass: Uneko erreprodukzioa
     Voice-over Translation:
       Start: Itzuli
       Cancel: Utzi

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -1138,7 +1138,6 @@ Video:
       Looping: Begiztan
       Repeats: Errepikapenak
       Time Spent: Emandako denbora
-      Current Pass: Uneko erreprodukzioa
     Voice-over Translation:
       Start: Itzuli
       Cancel: Utzi

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -814,6 +814,7 @@ Settings:
     Posts Auto Refresh Interval: فاصلهٔ تازه‌سازی خودکار پست‌ها
     Refresh Subscriptions While App Is Closed: "تازه‌سازی اشتراک‌ها هنگام بسته بودن برنامه"
   Distraction Free Settings:
+    Hide Repeat Stats: پنهان کردن آمار تکرار
     Sections:
       Visible While Paused: نمایش هنگام توقف در پنجرهٔ کامل / تمام‌صفحه
     Hide Channel Avatars: پنهان‌کردن آواتار کانال‌ها
@@ -1180,6 +1181,12 @@ Video:
     interaction: یادآوری تعامل
     filler: حاشیه‌روی
   Player:
+    Repeat Stats:
+      Repeat Stats: آمار تکرار
+      Looping: تکرار فعال است
+      Repeats: تکرارها
+      Time Spent: زمان تماشا
+      Current Pass: دور فعلی
     Voice-over Translation:
       Start: ترجمه
       Cancel: لغو

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -1186,7 +1186,6 @@ Video:
       Looping: تکرار فعال است
       Repeats: تکرارها
       Time Spent: زمان تماشا
-      Current Pass: دور فعلی
     Voice-over Translation:
       Start: ترجمه
       Cancel: لغو

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -797,6 +797,7 @@ Settings:
     Posts Auto Refresh Interval: Julkaisujen automaattisen päivityksen aikaväli
     Refresh Subscriptions While App Is Closed: "Päivitä tilaukset sovelluksen ollessa suljettuna"
   Distraction Free Settings:
+    Hide Repeat Stats: Piilota toistotilastot
     Sections:
       Visible While Paused: Näkyvissä keskeytyksen aikana koko ikkunan tai koko näytön tilassa
     Hide Channel Avatars: Piilota kanavien profiilikuvat
@@ -1147,6 +1148,12 @@ Video:
   Live chat replay is enabled. Chat messages will appear here as the video plays.: Livechatin tallenne on käytössä.  Chat-viestit näkyvät tässä videon toiston aikana.
   Premiere started: Ensi-ilta on käynnissä. Alkoi {timeAgo}
   Player:
+    Repeat Stats:
+      Repeat Stats: Toistotilastot
+      Looping: Jatkuva toisto
+      Repeats: Toistokerrat
+      Time Spent: Katseluaika
+      Current Pass: Nykyinen kierros
     Voice-over Translation:
       Start: Käännä
       Cancel: Peruuta

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -1153,7 +1153,6 @@ Video:
       Looping: Jatkuva toisto
       Repeats: Toistokerrat
       Time Spent: Katseluaika
-      Current Pass: Nykyinen kierros
     Voice-over Translation:
       Start: Käännä
       Cancel: Peruuta

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -1119,7 +1119,6 @@ Video:
       Looping: En boucle
       Repeats: Répétitions
       Time Spent: Temps passé
-      Current Pass: Lecture actuelle
     Voice-over Translation:
       Start: Traduire
       Cancel: Annuler

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -784,6 +784,7 @@ Settings:
     Posts Auto Refresh Interval: Intervalle d’actualisation automatique des publications
     Refresh Subscriptions While App Is Closed: "Actualiser les abonnements quand l'application est fermée"
   Distraction Free Settings:
+    Hide Repeat Stats: Masquer les statistiques de répétition
     Sections:
       Visible While Paused: Visible pendant la pause en mode pleine fenêtre ou plein écran
     Hide Channel Avatars: Masquer les avatars des chaînes
@@ -1113,6 +1114,12 @@ Video:
   Live chat replay is enabled. Chat messages will appear here as the video plays.: La rediffusion du chat en direct est activée.  Les messages du chat apparaîtront ici pendant la lecture de la vidéo.
   Premiere started: Première en cours. A commencé {timeAgo}
   Player:
+    Repeat Stats:
+      Repeat Stats: Statistiques de répétition
+      Looping: En boucle
+      Repeats: Répétitions
+      Time Spent: Temps passé
+      Current Pass: Lecture actuelle
     Voice-over Translation:
       Start: Traduire
       Cancel: Annuler

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -792,6 +792,7 @@ Settings:
     Posts Auto Refresh Interval: Intervalo de actualización automática das publicacións
     Refresh Subscriptions While App Is Closed: "Actualizar as subscricións coa aplicación pechada"
   Distraction Free Settings:
+    Hide Repeat Stats: Agochar as estatísticas de repetición
     Sections:
       Visible While Paused: Visibles durante a pausa en xanela completa ou pantalla completa
     Hide Channel Avatars: Ocultar os avatares das canles
@@ -1151,6 +1152,12 @@ Video:
     music offtopic: Contido non musical
     filler: Digresións
   Player:
+    Repeat Stats:
+      Repeat Stats: Estatísticas de repetición
+      Looping: En bucle
+      Repeats: Repeticións
+      Time Spent: Tempo dedicado
+      Current Pass: Reprodución actual
     Voice-over Translation:
       Start: Traducir
       Cancel: Cancelar

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -1157,7 +1157,6 @@ Video:
       Looping: En bucle
       Repeats: Repeticións
       Time Spent: Tempo dedicado
-      Current Pass: Reprodución actual
     Voice-over Translation:
       Start: Traducir
       Cancel: Cancelar

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -1155,7 +1155,6 @@ Video:
       Looping: חזרה פעילה
       Repeats: חזרות
       Time Spent: זמן צפייה
-      Current Pass: סבב נוכחי
     Voice-over Translation:
       Start: תרגום
       Cancel: ביטול

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -797,6 +797,7 @@ Settings:
     Posts Auto Refresh Interval: מרווח ריענון אוטומטי של פוסטים
     Refresh Subscriptions While App Is Closed: "ריענון מינויים כשהיישום סגור"
   Distraction Free Settings:
+    Hide Repeat Stats: הסתרת נתוני חזרה
     Sections:
       Visible While Paused: מוצג בזמן השהיה בחלון מלא או במסך מלא
     Hide Channel Avatars: הסתרת תמונות ערוצים
@@ -1149,6 +1150,12 @@ Video:
   Sponsor Block category:
     hook: פתיח/ברכות
   Player:
+    Repeat Stats:
+      Repeat Stats: נתוני חזרה
+      Looping: חזרה פעילה
+      Repeats: חזרות
+      Time Spent: זמן צפייה
+      Current Pass: סבב נוכחי
     Voice-over Translation:
       Start: תרגום
       Cancel: ביטול

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -1133,7 +1133,6 @@ Video:
       Looping: Ponavljanje uključeno
       Repeats: Ponavljanja
       Time Spent: Provedeno vrijeme
-      Current Pass: Trenutni prolaz
     Voice-over Translation:
       Start: Prevedi
       Cancel: Odustani

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -786,6 +786,7 @@ Settings:
     Posts Auto Refresh Interval: Razmak automatskog osvježavanja objava
     Refresh Subscriptions While App Is Closed: "Osvježavaj pretplate dok je aplikacija zatvorena"
   Distraction Free Settings:
+    Hide Repeat Stats: Sakrij statistiku ponavljanja
     Sections:
       Visible While Paused: Vidljivo tijekom pauze u punom prozoru / preko cijelog zaslona
     Hide Channel Avatars: Sakrij avatare kanala
@@ -1127,6 +1128,12 @@ Video:
   Sponsor Block category short:
     filler: Digresije
   Player:
+    Repeat Stats:
+      Repeat Stats: Statistika ponavljanja
+      Looping: Ponavljanje uključeno
+      Repeats: Ponavljanja
+      Time Spent: Provedeno vrijeme
+      Current Pass: Trenutni prolaz
     Voice-over Translation:
       Start: Prevedi
       Cancel: Odustani

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -1120,7 +1120,6 @@ Video:
       Looping: Ismétlés bekapcsolva
       Repeats: Ismétlések
       Time Spent: Eltöltött idő
-      Current Pass: Jelenlegi kör
     Voice-over Translation:
       Start: Fordítás
       Cancel: Mégse

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -784,6 +784,7 @@ Settings:
     Posts Auto Refresh Interval: Bejegyzések automatikus frissítésének időköze
     Refresh Subscriptions While App Is Closed: "Feliratkozások frissítése bezárt alkalmazásnál"
   Distraction Free Settings:
+    Hide Repeat Stats: Ismétlési statisztikák elrejtése
     Sections:
       Visible While Paused: Szüneteltetéskor látható teljes ablakos vagy teljes képernyős módban
     Hide Channel Avatars: Csatornaavatarok elrejtése
@@ -1114,6 +1115,12 @@ Video:
   Live chat replay is enabled. Chat messages will appear here as the video plays.: Az élő csevegés visszajátszása be van kapcsolva.  A csevegés üzenetei a videó lejátszása közben itt jelennek meg.
   Premiere started: A premier folyamatban van, {timeAgo} kezdődött
   Player:
+    Repeat Stats:
+      Repeat Stats: Ismétlési statisztikák
+      Looping: Ismétlés bekapcsolva
+      Repeats: Ismétlések
+      Time Spent: Eltöltött idő
+      Current Pass: Jelenlegi kör
     Voice-over Translation:
       Start: Fordítás
       Cancel: Mégse

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -1147,7 +1147,6 @@ Video:
       Looping: Pengulangan aktif
       Repeats: Pengulangan
       Time Spent: Waktu menonton
-      Current Pass: Putaran saat ini
     Voice-over Translation:
       Start: Terjemahkan
       Cancel: Batal

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -792,6 +792,7 @@ Settings:
     Posts Auto Refresh Interval: Interval Pembaruan Otomatis Postingan
     Refresh Subscriptions While App Is Closed: "Perbarui Langganan Saat Aplikasi Ditutup"
   Distraction Free Settings:
+    Hide Repeat Stats: Sembunyikan statistik pengulangan
     Sections:
       Visible While Paused: Terlihat Saat Dijeda dalam Jendela Penuh / Layar Penuh
     Hide Channel Avatars: Sembunyikan Avatar Saluran
@@ -1141,6 +1142,12 @@ Video:
   Sponsor Block category:
     hook: Pembuka/Sapaan
   Player:
+    Repeat Stats:
+      Repeat Stats: Statistik pengulangan
+      Looping: Pengulangan aktif
+      Repeats: Pengulangan
+      Time Spent: Waktu menonton
+      Current Pass: Putaran saat ini
     Voice-over Translation:
       Start: Terjemahkan
       Cancel: Batal

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -792,6 +792,7 @@ Settings:
     Posts Auto Refresh Interval: Bil milli sjálfvirkra uppfærslna færslna
     Refresh Subscriptions While App Is Closed: "Uppfæra áskriftir þegar forritið er lokað"
   Distraction Free Settings:
+    Hide Repeat Stats: Fela tölfræði endurtekninga
     Sections:
       Visible While Paused: Sýnilegt þegar gert er hlé í heilum glugga eða á öllum skjánum
     Hide Channel Avatars: Fela auðkennismyndir rása
@@ -1148,6 +1149,12 @@ Video:
     music offtopic: Ekki tónlist
     filler: Útúrdúrar
   Player:
+    Repeat Stats:
+      Repeat Stats: Tölfræði endurtekninga
+      Looping: Endurtekning virk
+      Repeats: Endurtekningar
+      Time Spent: Áhorfstími
+      Current Pass: Núverandi umferð
     Voice-over Translation:
       Start: Þýða
       Cancel: Hætta við

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -1154,7 +1154,6 @@ Video:
       Looping: Endurtekning virk
       Repeats: Endurtekningar
       Time Spent: Áhorfstími
-      Current Pass: Núverandi umferð
     Voice-over Translation:
       Start: Þýða
       Cancel: Hætta við

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -784,6 +784,7 @@ Settings:
     Posts Auto Refresh Interval: Intervallo di aggiornamento automatico dei post
     Refresh Subscriptions While App Is Closed: "Aggiorna le iscrizioni quando l'app è chiusa"
   Distraction Free Settings:
+    Hide Repeat Stats: Nascondi statistiche di ripetizione
     Sections:
       Visible While Paused: Visibile durante la pausa in finestra intera o a schermo intero
     Hide Channel Avatars: Nascondi avatar dei canali
@@ -1114,6 +1115,12 @@ Video:
   Live chat replay is enabled. Chat messages will appear here as the video plays.: La replica della chat dal vivo è abilitata. I messaggi appariranno qui durante la riproduzione del video.
   Premiere started: Première in corso. Iniziata {timeAgo}
   Player:
+    Repeat Stats:
+      Repeat Stats: Statistiche di ripetizione
+      Looping: In ripetizione
+      Repeats: Ripetizioni
+      Time Spent: Tempo trascorso
+      Current Pass: Riproduzione attuale
     Voice-over Translation:
       Start: Traduci
       Cancel: Annulla

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -1120,7 +1120,6 @@ Video:
       Looping: In ripetizione
       Repeats: Ripetizioni
       Time Spent: Tempo trascorso
-      Current Pass: Riproduzione attuale
     Voice-over Translation:
       Start: Traduci
       Cancel: Annulla

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -1120,7 +1120,6 @@ Video:
       Looping: リピート中
       Repeats: リピート回数
       Time Spent: 視聴時間
-      Current Pass: 現在の再生回数
     Voice-over Translation:
       Start: 翻訳
       Cancel: キャンセル

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -784,6 +784,7 @@ Settings:
     Posts Auto Refresh Interval: 投稿の自動更新間隔
     Refresh Subscriptions While App Is Closed: "アプリを閉じている間も登録チャンネルを更新"
   Distraction Free Settings:
+    Hide Repeat Stats: リピート統計を非表示
     Sections:
       Visible While Paused: 全ウィンドウ表示・全画面表示で一時停止中に表示
     Hide Channel Avatars: チャンネルのアバターを非表示
@@ -1114,6 +1115,12 @@ Video:
   Live chat replay is enabled. Chat messages will appear here as the video plays.: ライブチャットのリプレイが有効です。動画の再生に合わせてチャットメッセージがここに表示されます。
   Premiere started: プレミア公開中です。{timeAgo}に開始しました
   Player:
+    Repeat Stats:
+      Repeat Stats: リピート統計
+      Looping: リピート中
+      Repeats: リピート回数
+      Time Spent: 視聴時間
+      Current Pass: 現在の再生回数
     Voice-over Translation:
       Start: 翻訳
       Cancel: キャンセル

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -978,6 +978,7 @@ Settings:
     To: 다음으로
     Confirm Before Unsubscribing: 구독 취소 전 확인
   Distraction Free Settings:
+    Hide Repeat Stats: 반복 통계 숨기기
     Sections:
       Side Bar: 사이드바
       Subscriptions Page: 구독 페이지
@@ -1426,6 +1427,12 @@ Video:
     Show Original Details: 원본 정보 표시
     Show Modified Details: 수정된 정보 표시
   Player:
+    Repeat Stats:
+      Repeat Stats: 반복 통계
+      Looping: 반복 중
+      Repeats: 반복 횟수
+      Time Spent: 시청 시간
+      Current Pass: 현재 재생 회차
     Voice-over Translation:
       Start: 번역
       Cancel: 취소

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -1432,7 +1432,6 @@ Video:
       Looping: 반복 중
       Repeats: 반복 횟수
       Time Spent: 시청 시간
-      Current Pass: 현재 재생 회차
     Voice-over Translation:
       Start: 번역
       Cancel: 취소

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -1467,7 +1467,6 @@ Video:
       Looping: Kartojimas įjungtas
       Repeats: Pakartojimai
       Time Spent: Žiūrėjimo laikas
-      Current Pass: Dabartinis ciklas
     Voice-over Translation:
       Start: Versti
       Cancel: Atšaukti

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -1002,6 +1002,7 @@ Settings:
     To: Iki
     Confirm Before Unsubscribing: Klausti prieš atsisakant prenumeratos
   Distraction Free Settings:
+    Hide Repeat Stats: Slėpti kartojimo statistiką
     Sections:
       Subscriptions Page: Prenumeratų puslapis
       Visible While Paused: Rodoma pristabdžius viso lango arba viso ekrano režimu
@@ -1461,6 +1462,12 @@ Video:
     music offtopic: Ne muzika
     filler: Nukrypimai
   Player:
+    Repeat Stats:
+      Repeat Stats: Kartojimo statistika
+      Looping: Kartojimas įjungtas
+      Repeats: Pakartojimai
+      Time Spent: Žiūrėjimo laikas
+      Current Pass: Dabartinis ciklas
     Voice-over Translation:
       Start: Versti
       Cancel: Atšaukti

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -1129,7 +1129,6 @@ Video:
       Looping: Gjentakelse på
       Repeats: Gjentakelser
       Time Spent: Tid brukt
-      Current Pass: Gjeldende avspilling
     Voice-over Translation:
       Start: Oversett
       Cancel: Avbryt

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -784,6 +784,7 @@ Settings:
     Posts Auto Refresh Interval: Intervall for automatisk oppdatering av innlegg
     Refresh Subscriptions While App Is Closed: "Oppdater abonnementer mens appen er lukket"
   Distraction Free Settings:
+    Hide Repeat Stats: Skjul gjentakelsesstatistikk
     Sections:
       Visible While Paused: Synlig ved pause i fullt vindu / fullskjerm
     Hide Channel Avatars: Skjul kanalavatarer
@@ -1123,6 +1124,12 @@ Video:
   Sponsor Block category short:
     filler: Avsporinger
   Player:
+    Repeat Stats:
+      Repeat Stats: Gjentakelsesstatistikk
+      Looping: Gjentakelse på
+      Repeats: Gjentakelser
+      Time Spent: Tid brukt
+      Current Pass: Gjeldende avspilling
     Voice-over Translation:
       Start: Oversett
       Cancel: Avbryt

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -1161,7 +1161,6 @@ Video:
       Looping: Herhalen ingeschakeld
       Repeats: Herhalingen
       Time Spent: Bestede tijd
-      Current Pass: Huidige afspeelbeurt
     Voice-over Translation:
       Start: Vertalen
       Cancel: Annuleren

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -797,6 +797,7 @@ Settings:
     Posts Auto Refresh Interval: Interval voor automatisch vernieuwen van berichten
     Refresh Subscriptions While App Is Closed: "Abonnementen vernieuwen terwijl de app gesloten is"
   Distraction Free Settings:
+    Hide Repeat Stats: Herhaalstatistieken verbergen
     Sections:
       Visible While Paused: Zichtbaar wanneer gepauzeerd in volledig venster of volledig scherm
     Hide Channel Avatars: Kanaalavatars verbergen
@@ -1155,6 +1156,12 @@ Video:
   Sponsor Block category short:
     filler: Uitweidingen
   Player:
+    Repeat Stats:
+      Repeat Stats: Herhaalstatistieken
+      Looping: Herhalen ingeschakeld
+      Repeats: Herhalingen
+      Time Spent: Bestede tijd
+      Current Pass: Huidige afspeelbeurt
     Voice-over Translation:
       Start: Vertalen
       Cancel: Annuleren

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -1404,7 +1404,6 @@ Video:
       Looping: Gjentaking på
       Repeats: Gjentakingar
       Time Spent: Tid brukt
-      Current Pass: Gjeldande avspeling
     Voice-over Translation:
       Start: Omset
       Cancel: Avbryt

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -945,6 +945,7 @@ Settings:
     To: til
     Confirm Before Unsubscribing: Stadfest før du avsluttar abonnement
   Distraction Free Settings:
+    Hide Repeat Stats: Skjul gjentakingsstatistikk
     Sections:
       Side Bar: Sidestolpe
       Subscriptions Page: Abonnementsside
@@ -1398,6 +1399,12 @@ Video:
   Sponsor Block category short:
     filler: Avsporingar
   Player:
+    Repeat Stats:
+      Repeat Stats: Gjentakingsstatistikk
+      Looping: Gjentaking på
+      Repeats: Gjentakingar
+      Time Spent: Tid brukt
+      Current Pass: Gjeldande avspeling
     Voice-over Translation:
       Start: Omset
       Cancel: Avbryt

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -334,6 +334,7 @@ Settings:
     Show Scheduled Live Streams / Premieres First: Najpierw pokazuj zaplanowane transmisje na żywo i premiery
     Refresh Subscriptions While App Is Closed: "Odświeżaj subskrypcje, gdy aplikacja jest zamknięta"
   Distraction Free Settings:
+    Hide Repeat Stats: Ukryj statystyki powtarzania
     Sections:
       Visible While Paused: Widoczne po wstrzymaniu w trybie pełnego okna lub pełnego ekranu
     Hide Channel Avatars: Ukrywaj awatary kanałów
@@ -553,6 +554,12 @@ Video:
   All Messages: Wszystkie wiadomości
   Live chat replay is enabled. Chat messages will appear here as the video plays.: Powtórka czatu na żywo jest włączona. Wiadomości będą pojawiać się tutaj podczas odtwarzania filmu.
   Player:
+    Repeat Stats:
+      Repeat Stats: Statystyki powtarzania
+      Looping: Zapętlanie włączone
+      Repeats: Powtórzenia
+      Time Spent: Czas oglądania
+      Current Pass: Bieżące odtworzenie
     Voice-over Translation:
       Start: Tłumacz
       Cancel: Anuluj

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -559,7 +559,6 @@ Video:
       Looping: Zapętlanie włączone
       Repeats: Powtórzenia
       Time Spent: Czas oglądania
-      Current Pass: Bieżące odtworzenie
     Voice-over Translation:
       Start: Tłumacz
       Cancel: Anuluj

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -784,6 +784,7 @@ Settings:
     Posts Auto Refresh Interval: Intervalo de atualização automática das publicações
     Refresh Subscriptions While App Is Closed: "Atualizar inscrições com o aplicativo fechado"
   Distraction Free Settings:
+    Hide Repeat Stats: Ocultar estatísticas de repetição
     Sections:
       Visible While Paused: Visível durante a pausa em tela cheia ou tela cheia
     Hide Channel Avatars: Ocultar avatares dos canais
@@ -1114,6 +1115,12 @@ Video:
   Live chat replay is enabled. Chat messages will appear here as the video plays.: A repetição da conversa ao vivo está ativada. As mensagens aparecem aqui à medida que o vídeo é reproduzido.
   Premiere started: Estreia em curso. Começou {timeAgo}
   Player:
+    Repeat Stats:
+      Repeat Stats: Estatísticas de repetição
+      Looping: Em repetição
+      Repeats: Repetições
+      Time Spent: Tempo gasto
+      Current Pass: Reprodução atual
     Voice-over Translation:
       Start: Traduzir
       Cancel: Cancelar

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -1120,7 +1120,6 @@ Video:
       Looping: Em repetição
       Repeats: Repetições
       Time Spent: Tempo gasto
-      Current Pass: Reprodução atual
     Voice-over Translation:
       Start: Traduzir
       Cancel: Cancelar

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -1145,7 +1145,6 @@ Video:
       Looping: Em repetição
       Repeats: Repetições
       Time Spent: Tempo despendido
-      Current Pass: Reprodução atual
     Voice-over Translation:
       Start: Traduzir
       Cancel: Cancelar

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -792,6 +792,7 @@ Settings:
     Posts Auto Refresh Interval: Intervalo de atualização automática das publicações
     Refresh Subscriptions While App Is Closed: "Atualizar subscrições com a aplicação fechada"
   Distraction Free Settings:
+    Hide Repeat Stats: Ocultar estatísticas de repetição
     Sections:
       Visible While Paused: Visível durante a pausa em janela inteira ou ecrã inteiro
     Hide Channel Avatars: Ocultar avatares dos canais
@@ -1139,6 +1140,12 @@ Video:
   Live chat replay is enabled. Chat messages will appear here as the video plays.: A repetição da conversa em direto está ativada. As mensagens aparecem aqui à medida que o vídeo é reproduzido.
   Premiere started: Estreia em curso. Começou {timeAgo}
   Player:
+    Repeat Stats:
+      Repeat Stats: Estatísticas de repetição
+      Looping: Em repetição
+      Repeats: Repetições
+      Time Spent: Tempo despendido
+      Current Pass: Reprodução atual
     Voice-over Translation:
       Start: Traduzir
       Cancel: Cancelar

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -800,6 +800,7 @@ Settings:
     Posts Auto Refresh Interval: Intervalo de atualização automática das publicações
     Refresh Subscriptions While App Is Closed: "Atualizar subscrições com a aplicação fechada"
   Distraction Free Settings:
+    Hide Repeat Stats: Ocultar estatísticas de repetição
     Sections:
       Visible While Paused: Visível durante a pausa em janela inteira ou ecrã inteiro
     Hide Channel Avatars: Ocultar avatares dos canais
@@ -1151,6 +1152,12 @@ Video:
   Live chat replay is enabled. Chat messages will appear here as the video plays.: A repetição da conversa em direto está ativada. As mensagens aparecem aqui à medida que o vídeo é reproduzido.
   Premiere started: Estreia em curso. Começou {timeAgo}
   Player:
+    Repeat Stats:
+      Repeat Stats: Estatísticas de repetição
+      Looping: Em repetição
+      Repeats: Repetições
+      Time Spent: Tempo gasto
+      Current Pass: Reprodução atual
     Voice-over Translation:
       Start: Traduzir
       Cancel: Cancelar

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -1157,7 +1157,6 @@ Video:
       Looping: Em repetição
       Repeats: Repetições
       Time Spent: Tempo gasto
-      Current Pass: Reprodução atual
     Voice-over Translation:
       Start: Traduzir
       Cancel: Cancelar

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -788,6 +788,7 @@ Settings:
     Posts Auto Refresh Interval: Interval de reîmprospătare automată a postărilor
     Refresh Subscriptions While App Is Closed: "Reîmprospătează abonamentele când aplicația este închisă"
   Distraction Free Settings:
+    Hide Repeat Stats: Ascunde statisticile de repetare
     Sections:
       Visible While Paused: Vizibile în pauză în fereastră completă / pe ecran complet
     Hide Channel Avatars: Ascunde avatarurile canalelor
@@ -1142,6 +1143,12 @@ Video:
   Live chat replay is enabled. Chat messages will appear here as the video plays.: Reluarea chatului în direct este activată. Mesajele vor apărea aici pe măsură ce se redă videoclipul.
   Premiere started: Premiera este în curs. A început {timeAgo}
   Player:
+    Repeat Stats:
+      Repeat Stats: Statistici de repetare
+      Looping: Repetare activă
+      Repeats: Repetări
+      Time Spent: Timp petrecut
+      Current Pass: Redarea curentă
     Voice-over Translation:
       Start: Tradu
       Cancel: Anulează

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -1148,7 +1148,6 @@ Video:
       Looping: Repetare activă
       Repeats: Repetări
       Time Spent: Timp petrecut
-      Current Pass: Redarea curentă
     Voice-over Translation:
       Start: Tradu
       Cancel: Anulează

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -769,6 +769,7 @@ Settings:
     Posts Auto Refresh Interval: Интервал автообновления публикаций
     Refresh Subscriptions While App Is Closed: "Обновлять подписки, когда приложение закрыто"
   Distraction Free Settings:
+    Hide Repeat Stats: Скрыть статистику повторов
     Sections:
       Visible While Paused: Показывать во время паузы в полнооконном и полноэкранном режимах
     Hide Channel Avatars: Скрывать аватары каналов
@@ -1119,6 +1120,12 @@ Video:
   Live chat replay is enabled. Chat messages will appear here as the video plays.: Повтор чата трансляции включён.  Сообщения чата будут появляться здесь по мере воспроизведения видео.
   Premiere started: Идёт премьера. Началась {timeAgo}
   Player:
+    Repeat Stats:
+      Repeat Stats: Статистика повторов
+      Looping: Повтор включён
+      Repeats: Повторы
+      Time Spent: Время просмотра
+      Current Pass: Текущий проход
     Voice-over Translation:
       Start: Перевести
       Cancel: Отмена

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -1125,7 +1125,6 @@ Video:
       Looping: Повтор включён
       Repeats: Повторы
       Time Spent: Время просмотра
-      Current Pass: Текущий проход
     Voice-over Translation:
       Start: Перевести
       Cancel: Отмена

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -784,6 +784,7 @@ Settings:
     Posts Auto Refresh Interval: Interval automatického obnovenia príspevkov
     Refresh Subscriptions While App Is Closed: "Obnovovať odbery, keď je aplikácia zatvorená"
   Distraction Free Settings:
+    Hide Repeat Stats: Skryť štatistiky opakovania
     Sections:
       Visible While Paused: Viditeľné počas pozastavenia v režime celého okna alebo celej obrazovky
     Hide Channel Avatars: Skryť avatary kanálov
@@ -1114,6 +1115,12 @@ Video:
   Live chat replay is enabled. Chat messages will appear here as the video plays.: Záznam živého četu je zapnutý. Správy četu sa tu zobrazia počas prehrávania videa.
   Premiere started: Prebieha premiéra. Začala sa {timeAgo}
   Player:
+    Repeat Stats:
+      Repeat Stats: Štatistiky opakovania
+      Looping: Slučka zapnutá
+      Repeats: Opakovania
+      Time Spent: Čas sledovania
+      Current Pass: Aktuálny priechod
     Voice-over Translation:
       Start: Preložiť
       Cancel: Zrušiť

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -1120,7 +1120,6 @@ Video:
       Looping: Slučka zapnutá
       Repeats: Opakovania
       Time Spent: Čas sledovania
-      Current Pass: Aktuálny priechod
     Voice-over Translation:
       Start: Preložiť
       Cancel: Zrušiť

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -1018,6 +1018,7 @@ Settings:
     To: Na
     Confirm Before Unsubscribing: Zahtevaj potrditev pred odjavo
   Distraction Free Settings:
+    Hide Repeat Stats: Skrij statistiko ponavljanja
     Sections:
       Side Bar: Stranska vrstica
       Subscriptions Page: Stran z naročninami
@@ -1536,6 +1537,12 @@ Video:
       shuffling playlists: naključno predvajanje seznamov predvajanja
       looping playlists: ponavljanje seznamov predvajanja
   Player:
+    Repeat Stats:
+      Repeat Stats: Statistika ponavljanja
+      Looping: Ponavljanje vklopljeno
+      Repeats: Ponovitve
+      Time Spent: Čas gledanja
+      Current Pass: Trenutni prehod
     Voice-over Translation:
       Start: Prevedi
       Cancel: Prekliči

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -1542,7 +1542,6 @@ Video:
       Looping: Ponavljanje vklopljeno
       Repeats: Ponovitve
       Time Spent: Čas gledanja
-      Current Pass: Trenutni prehod
     Voice-over Translation:
       Start: Prevedi
       Cancel: Prekliči

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -807,6 +807,7 @@ Settings:
     Posts Auto Refresh Interval: Интервал аутоматског освежавања објава
     Refresh Subscriptions While App Is Closed: "Освежавај претплате док је апликација затворена"
   Distraction Free Settings:
+    Hide Repeat Stats: Сакриј статистику понављања
     Sections:
       Visible While Paused: Видљиво током паузе у целом прозору / преко целог екрана
     Hide Channel Avatars: Сакриј аватаре канала
@@ -1169,6 +1170,12 @@ Video:
   Live chat replay is enabled. Chat messages will appear here as the video plays.: Снимак ћаскања уживо је укључен. Поруке ће се приказивати овде током репродукције видео-снимка.
   Premiere started: Премијера је у току. Почела је {timeAgo}
   Player:
+    Repeat Stats:
+      Repeat Stats: Статистика понављања
+      Looping: Понављање укључено
+      Repeats: Понављања
+      Time Spent: Време гледања
+      Current Pass: Тренутни пролаз
     Voice-over Translation:
       Start: Преведи
       Cancel: Откажи

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -1175,7 +1175,6 @@ Video:
       Looping: Понављање укључено
       Repeats: Понављања
       Time Spent: Време гледања
-      Current Pass: Тренутни пролаз
     Voice-over Translation:
       Start: Преведи
       Cancel: Откажи

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -786,6 +786,7 @@ Settings:
     Posts Auto Refresh Interval: Intervall för automatisk uppdatering av inlägg
     Refresh Subscriptions While App Is Closed: "Uppdatera prenumerationer medan appen är stängd"
   Distraction Free Settings:
+    Hide Repeat Stats: Dölj upprepningsstatistik
     Sections:
       Visible While Paused: Synligt under paus i helfönster eller helskärm
     Hide Channel Avatars: Dölj kanalavatarer
@@ -1123,6 +1124,12 @@ Video:
   Live chat replay is enabled. Chat messages will appear here as the video plays.: Repris av livechatten är aktiverad. Chattmeddelanden visas här medan videon spelas upp.
   Premiere started: Premiären pågår. Startade {timeAgo}
   Player:
+    Repeat Stats:
+      Repeat Stats: Upprepningsstatistik
+      Looping: Upprepning på
+      Repeats: Upprepningar
+      Time Spent: Tid använd
+      Current Pass: Aktuell uppspelning
     Voice-over Translation:
       Start: Översätt
       Cancel: Avbryt

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -1129,7 +1129,6 @@ Video:
       Looping: Upprepning på
       Repeats: Upprepningar
       Time Spent: Tid använd
-      Current Pass: Aktuell uppspelning
     Voice-over Translation:
       Start: Översätt
       Cancel: Avbryt

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -796,6 +796,7 @@ Settings:
     Posts Auto Refresh Interval: இடுகைத் தானியக்கப் புதுப்பிப்பு இடைவெளி
     Refresh Subscriptions While App Is Closed: "செயலி மூடியிருக்கும்போது சந்தாக்களைப் புதுப்பி"
   Distraction Free Settings:
+    Hide Repeat Stats: மீளியக்கப் புள்ளிவிவரங்களை மறை
     Sections:
       Visible While Paused: முழுச் சாளரம் / முழுத்திரையில் இடைநிறுத்தியிருக்கும்போது தெரிபவை
     Hide Channel Avatars: சேனல் அவதார்களை மறை
@@ -1150,6 +1151,12 @@ Video:
   Sponsor Block category short:
     filler: தொடர்பற்றவை
   Player:
+    Repeat Stats:
+      Repeat Stats: மீளியக்கப் புள்ளிவிவரங்கள்
+      Looping: மீளியக்கம் செயலில்
+      Repeats: மீளியக்கங்கள்
+      Time Spent: பார்த்த நேரம்
+      Current Pass: தற்போதைய சுற்று
     Voice-over Translation:
       Start: மொழிபெயர்
       Cancel: ரத்துசெய்

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -1156,7 +1156,6 @@ Video:
       Looping: மீளியக்கம் செயலில்
       Repeats: மீளியக்கங்கள்
       Time Spent: பார்த்த நேரம்
-      Current Pass: தற்போதைய சுற்று
     Voice-over Translation:
       Start: மொழிபெயர்
       Cancel: ரத்துசெய்

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -1118,7 +1118,7 @@ Video:
     Repeat Stats:
       Repeat Stats: Tekrar istatistikleri
       Looping: Döngü açık
-      Repeats: Tekrarlar
+      Repeats: Tekrar
       Time Spent: İzleme süresi
     Voice-over Translation:
       Start: Çevir

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -784,6 +784,7 @@ Settings:
     Posts Auto Refresh Interval: Gönderilerin Otomatik Yenileme Aralığı
     Refresh Subscriptions While App Is Closed: "Uygulama Kapalıyken Abonelikleri Yenile"
   Distraction Free Settings:
+    Hide Repeat Stats: Tekrar istatistiklerini gizle
     Sections:
       Visible While Paused: Tam Pencere / Tam Ekranda Duraklatıldığında Görünür
     Hide Channel Avatars: Kanal Avatarlarını Gizle
@@ -1114,6 +1115,12 @@ Video:
   Live chat replay is enabled. Chat messages will appear here as the video plays.: Canlı sohbet tekrarı etkin. Video oynatıldıkça sohbet mesajları burada görünecek.
   Premiere started: İlk gösterim sürüyor. {timeAgo} başladı
   Player:
+    Repeat Stats:
+      Repeat Stats: Tekrar istatistikleri
+      Looping: Döngü açık
+      Repeats: Tekrarlar
+      Time Spent: İzleme süresi
+      Current Pass: Geçerli oynatma
     Voice-over Translation:
       Start: Çevir
       Cancel: İptal

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -1120,7 +1120,6 @@ Video:
       Looping: Döngü açık
       Repeats: Tekrarlar
       Time Spent: İzleme süresi
-      Current Pass: Geçerli oynatma
     Voice-over Translation:
       Start: Çevir
       Cancel: İptal

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -1148,7 +1148,6 @@ Video:
       Looping: Повтор увімкнено
       Repeats: Повтори
       Time Spent: Час перегляду
-      Current Pass: Поточний прохід
     Voice-over Translation:
       Start: Перекласти
       Cancel: Скасувати

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -792,6 +792,7 @@ Settings:
     Posts Auto Refresh Interval: Інтервал автоматичного оновлення дописів
     Refresh Subscriptions While App Is Closed: "Оновлювати підписки, коли застосунок закрито"
   Distraction Free Settings:
+    Hide Repeat Stats: Приховати статистику повторів
     Sections:
       Visible While Paused: Видимі під час паузи в режимі на все вікно або на весь екран
     Hide Channel Avatars: Приховувати аватари каналів
@@ -1142,6 +1143,12 @@ Video:
   Live chat replay is enabled. Chat messages will appear here as the video plays.: Повтор чату наживо ввімкнено.  Повідомлення чату з’являтимуться тут під час відтворення відео.
   Premiere started: Прем’єра триває. Почалася {timeAgo}
   Player:
+    Repeat Stats:
+      Repeat Stats: Статистика повторів
+      Looping: Повтор увімкнено
+      Repeats: Повтори
+      Time Spent: Час перегляду
+      Current Pass: Поточний прохід
     Voice-over Translation:
       Start: Перекласти
       Cancel: Скасувати

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -1145,7 +1145,6 @@ Video:
       Looping: Đang lặp
       Repeats: Số lần lặp
       Time Spent: Thời gian xem
-      Current Pass: Lượt phát hiện tại
     Voice-over Translation:
       Start: Dịch
       Cancel: Hủy

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -792,6 +792,7 @@ Settings:
     Posts Auto Refresh Interval: Khoảng tự động làm mới bài đăng
     Refresh Subscriptions While App Is Closed: "Làm mới đăng ký khi ứng dụng đã đóng"
   Distraction Free Settings:
+    Hide Repeat Stats: Ẩn thống kê lặp lại
     Sections:
       Visible While Paused: Hiện khi tạm dừng ở chế độ toàn cửa sổ / toàn màn hình
     Hide Channel Avatars: Ẩn ảnh đại diện kênh
@@ -1139,6 +1140,12 @@ Video:
   Live chat replay is enabled. Chat messages will appear here as the video plays.: Đã bật bản phát lại trò chuyện trực tiếp. Tin nhắn trò chuyện sẽ xuất hiện ở đây khi video phát.
   Premiere started: Đang công chiếu. Bắt đầu {timeAgo}
   Player:
+    Repeat Stats:
+      Repeat Stats: Thống kê lặp lại
+      Looping: Đang lặp
+      Repeats: Số lần lặp
+      Time Spent: Thời gian xem
+      Current Pass: Lượt phát hiện tại
     Voice-over Translation:
       Start: Dịch
       Cancel: Hủy

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -1120,7 +1120,6 @@ Video:
       Looping: 循环中
       Repeats: 重复次数
       Time Spent: 观看时长
-      Current Pass: 当前播放轮次
     Voice-over Translation:
       Start: 翻译
       Cancel: 取消

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -784,6 +784,7 @@ Settings:
     Posts Auto Refresh Interval: 帖子自动刷新间隔
     Refresh Subscriptions While App Is Closed: "应用关闭时刷新订阅"
   Distraction Free Settings:
+    Hide Repeat Stats: 隐藏循环统计
     Sections:
       Visible While Paused: 全窗口或全屏暂停时显示
     Hide Channel Avatars: 隐藏频道头像
@@ -1114,6 +1115,12 @@ Video:
   Live chat replay is enabled. Chat messages will appear here as the video plays.: 已启用实时聊天回放。视频播放时，聊天消息会显示在这里。
   Premiere started: 首映正在进行，开始时间：{timeAgo}
   Player:
+    Repeat Stats:
+      Repeat Stats: 循环统计
+      Looping: 循环中
+      Repeats: 重复次数
+      Time Spent: 观看时长
+      Current Pass: 当前播放轮次
     Voice-over Translation:
       Start: 翻译
       Cancel: 取消

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -1127,7 +1127,6 @@ Video:
       Looping: 循環中
       Repeats: 重複次數
       Time Spent: 觀看時間
-      Current Pass: 目前播放輪次
     Voice-over Translation:
       Start: 翻譯
       Cancel: 取消

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -784,6 +784,7 @@ Settings:
     Posts Auto Refresh Interval: 貼文自動重新整理間隔
     Refresh Subscriptions While App Is Closed: "應用程式關閉時重新整理訂閱"
   Distraction Free Settings:
+    Hide Repeat Stats: 隱藏循環統計
     Sections:
       Visible While Paused: 在全視窗／全螢幕模式暫停播放時顯示
     Hide Channel Avatars: 隱藏頻道頭像
@@ -1121,6 +1122,12 @@ Video:
   Sponsor Block category:
     hook: 開場／問候
   Player:
+    Repeat Stats:
+      Repeat Stats: 循環統計
+      Looping: 循環中
+      Repeats: 重複次數
+      Time Spent: 觀看時間
+      Current Pass: 目前播放輪次
     Voice-over Translation:
       Start: 翻譯
       Cancel: 取消

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -1072,6 +1072,7 @@ Settings:
     Import search history formats: 'Unterstützte Formate: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
     Setting object has insufficient data, skipping item: Das Objekt enthält unzureichende Daten, Element wird übersprungen
   Distraction Free Settings:
+    Hide Repeat Stats: Wiederholungsstatistik ausblenden
     Hide Live Chat: Live-Chat ausblenden
     Hide Popular Videos: Beliebte Videos ausblenden
     Hide Trending Videos: Trending-Videos ausblenden
@@ -1748,6 +1749,12 @@ Video:
   Hide Channel: Kanal ausblenden
   More Options: Weitere Optionen
   Player:
+    Repeat Stats:
+      Repeat Stats: Wiederholungsstatistik
+      Looping: Schleife aktiv
+      Repeats: Wiederholungen
+      Time Spent: Wiedergabezeit
+      Current Pass: Aktueller Durchlauf
     Caption Appearance:
       Options: Optionen
       Sample: So sehen Untertitel aus

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -1754,7 +1754,6 @@ Video:
       Looping: Schleife aktiv
       Repeats: Wiederholungen
       Time Spent: Wiedergabezeit
-      Current Pass: Aktueller Durchlauf
     Caption Appearance:
       Options: Optionen
       Sample: So sehen Untertitel aus

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -2045,7 +2045,6 @@ Video:
       Looping: Looping
       Repeats: Repeats
       Time Spent: Time spent
-      Current Pass: Current pass
     Voice-over Translation:
       Start: Translate
       Cancel: Cancel

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1314,6 +1314,7 @@ Settings:
     To: To
     Confirm Before Unsubscribing: Confirm Before Unsubscribing
   Distraction Free Settings:
+    Hide Repeat Stats: Hide Repeat Stats
     Distraction Free Settings: Distraction Free
     Sections:
       Side Bar: Side Bar
@@ -2039,6 +2040,12 @@ Video:
       shuffling playlists: shuffling playlists
       looping playlists: looping playlists
   Player:
+    Repeat Stats:
+      Repeat Stats: Repeat stats
+      Looping: Looping
+      Repeats: Repeats
+      Time Spent: Time spent
+      Current Pass: Current pass
     Voice-over Translation:
       Start: Translate
       Cancel: Cancel

--- a/tests/unit/android-media-element.test.mjs
+++ b/tests/unit/android-media-element.test.mjs
@@ -1,18 +1,34 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { createRepeatStatsTracker } from '../../src/renderer/helpers/player/repeatStats.js'
 import { attachAndroidMediaElement } from '../../src/renderer/helpers/player/androidMediaElement.js'
 
 function fixture() {
   const commands = []
-  const element = Object.assign(new EventTarget(), { style: {}, volume: 0.7, muted: false, playbackRate: 1, defaultPlaybackRate: 1, loop: false, pause() {} })
+  const attributes = new Set()
+  const element = Object.assign(new EventTarget(), {
+    style: {}, volume: 0.7, muted: false, playbackRate: 1, defaultPlaybackRate: 1, loop: false, pause() {},
+    toggleAttribute(name, enabled) { if (enabled) attributes.add(name); else attributes.delete(name) },
+    hasAttribute(name) { return attributes.has(name) },
+  })
   let time = 0
   const media = attachAndroidMediaElement(element, {
     command: async (...args) => { commands.push(args) }, load: async () => {}, onError: assert.fail, now: () => time,
   })
   const ready = { position: 10, duration: 100, paused: false, playing: true, ready: true, buffering: false,
     ended: false, playbackRate: 1, bufferedPosition: 40, width: 640, height: 360 }
-  return { commands, element, media, ready, advance: ms => { time += ms } }
+  return { commands, element, media, ready, advance: ms => { time += ms }, now: () => time }
 }
+
+test('native loop changes reflect the media attribute used by repeat stats and loop controls', () => {
+  const { element, commands } = fixture()
+  element.loop = true
+  assert.equal(element.hasAttribute('loop'), true)
+  assert.deepEqual(commands.at(-1), ['loop', 1])
+  element.loop = false
+  assert.equal(element.hasAttribute('loop'), false)
+  assert.deepEqual(commands.at(-1), ['loop', 0])
+})
 
 test('shared player features observe the native clock and stop extrapolating while paused', () => {
   const { element, media, ready, advance } = fixture()
@@ -182,4 +198,28 @@ test('native dimensions keep layout independent of posters and empty DOM video s
   assert.equal(element.style.aspectRatio, '1080 / 1920')
   media.detach()
   assert.equal(element.style.aspectRatio, '1080 / 1920')
+})
+
+test('repeat time excludes native audio-focus suppression without a user pause', () => {
+  const { element, media, ready, advance, now } = fixture()
+  let stats
+  const tracker = createRepeatStatsTracker(element, value => { stats = value }, now)
+  tracker.setMode('video')
+  media.update(ready)
+  advance(1000)
+  media.update({ position: 11, playing: false })
+  advance(10000)
+  media.update({ position: 11, playing: false })
+  assert.equal(stats.seconds, 1)
+  element.currentTime = 20
+  media.update({ position: 20, event: 'seeked' })
+  advance(10000)
+  media.update({ position: 20, playing: false })
+  assert.equal(stats.seconds, 1, 'seeking while suppressed must not restart the timer')
+  media.update({ playing: true })
+  advance(1000)
+  media.update({ position: 12 })
+  assert.equal(stats.seconds, 2)
+  tracker.destroy()
+  media.detach()
 })

--- a/tests/unit/native-playback-cleanup.test.mjs
+++ b/tests/unit/native-playback-cleanup.test.mjs
@@ -28,6 +28,7 @@ function fixture(native = true) {
   const context = vm.createContext({
     player, localPlayer: player, controls: {}, mediaTabId: 'video',
     nativePlaybackCleanup: null, screenWakeBinding: null,
+    repeatStatsTracker: null, repeatStatsLoopObserver: null,
     store: { getters: reactive({ getContinuePlaybackWhenScreenIsLocked: true }) },
     defaultSkipInterval: ref(5), seekIntervalMultiplyByPlaybackRate: ref(false),
     watch, handleError: assert.fail,

--- a/tests/unit/repeat-stats.test.mjs
+++ b/tests/unit/repeat-stats.test.mjs
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { createRepeatStatsTracker } from '../../src/renderer/helpers/player/repeatStats.js'
+
+function setup() {
+  const video = Object.assign(new EventTarget(), {
+    currentTime: 0, duration: 30, playbackRate: 1,
+    paused: true, seeking: false, readyState: 4,
+  })
+  let clock = 0
+  let stats
+  const tracker = createRepeatStatsTracker(video, value => { stats = value }, () => clock)
+  const event = (name, properties = {}) => {
+    Object.assign(video, properties)
+    video.dispatchEvent(new Event(name))
+  }
+  return { video, tracker, event, advance: ms => { clock += ms }, stats: () => stats }
+}
+
+test('counts only playing time, excluding pauses, buffering, seeking, and disabled looping', () => {
+  const { tracker, event, advance, stats } = setup()
+  tracker.setMode('video')
+  advance(5000)
+  event('playing', { paused: false })
+  advance(2000)
+  event('pause', { paused: true })
+  assert.equal(stats().seconds, 2)
+  advance(10000)
+  event('playing', { paused: false })
+  advance(1000)
+  event('waiting', { readyState: 2 })
+  advance(10000)
+  event('playing', { readyState: 4 })
+  advance(1000)
+  event('seeking', { seeking: true, currentTime: 20 })
+  advance(10000)
+  event('timeupdate')
+  event('seeked', { seeking: false })
+  advance(1000)
+  tracker.setMode(null)
+  advance(10000)
+  event('timeupdate')
+  assert.deepEqual(stats(), { active: false, repeats: 0, seconds: 5 })
+  tracker.setMode('video')
+  assert.equal(stats().seconds, 5)
+})
+
+test('playback speed changes do not multiply time spent', () => {
+  const { tracker, event, advance, stats } = setup()
+  tracker.setMode('video')
+  event('playing', { paused: false })
+  advance(1000)
+  event('ratechange', { playbackRate: 2, currentTime: 1 })
+  advance(1000)
+  event('timeupdate', { currentTime: 3 })
+  assert.equal(stats().seconds, 2)
+})
+
+test('native loop seeking counts once, while normal seeks and seek timeupdates do not', () => {
+  const { tracker, event, advance, stats } = setup()
+  tracker.setMode('video')
+  event('playing', { paused: false, currentTime: 29.8 })
+  advance(100)
+  event('seeking', { seeking: true, currentTime: 0 })
+  assert.equal(stats().repeats, 0, 'seeking near the end is not a completed repeat')
+  event('seeked', { seeking: false })
+  event('seeking', { seeking: true, currentTime: 29.8 })
+  event('seeked', { seeking: false })
+  advance(200)
+  event('seeking', { seeking: true, currentTime: 0 })
+  event('timeupdate')
+  assert.equal(stats().repeats, 1)
+  event('seeked', { seeking: false })
+  event('timeupdate', { currentTime: 0.01 })
+  assert.equal(stats().repeats, 1)
+})
+
+test('native loop detection uses the playback rate and ignores paused seeks', () => {
+  const { tracker, event, advance, stats } = setup()
+  tracker.setMode('video')
+  event('playing', { paused: false, currentTime: 29.8, playbackRate: 2 })
+  advance(100)
+  event('seeking', { seeking: true, currentTime: 0 })
+  assert.equal(stats().repeats, 1)
+  event('seeked', { seeking: false })
+  event('pause', { paused: true, currentTime: 29.8 })
+  advance(1000)
+  event('seeking', { seeking: true, currentTime: 0 })
+  assert.equal(stats().repeats, 1)
+})
+
+test('Android automatic loops report seeked without a preceding seeking event', () => {
+  const { tracker, event, advance, stats } = setup()
+  tracker.setMode('video')
+  event('playing', { paused: false, currentTime: 29.8 })
+  advance(200)
+  event('seeked', { currentTime: 0 })
+  event('timeupdate')
+  assert.equal(stats().repeats, 1)
+  event('seeking', { seeking: true, currentTime: 29.8 })
+  event('seeked', { seeking: false })
+  event('seeking', { seeking: true, currentTime: 0 })
+  event('seeked', { seeking: false })
+  assert.equal(stats().repeats, 1)
+})
+
+test('A-B repeats retain the session when toggled and reset for a different range or video', () => {
+  const { tracker, event, advance, stats } = setup()
+  tracker.setMode('ab:5:10')
+  event('playing', { paused: false, currentTime: 5 })
+  advance(5000)
+  tracker.repeat()
+  event('seeking', { seeking: true, currentTime: 5 })
+  event('seeked', { seeking: false })
+  assert.deepEqual(stats(), { active: true, repeats: 1, seconds: 5 })
+  tracker.setMode(null)
+  advance(5000)
+  tracker.setMode('ab:5:10')
+  assert.deepEqual(stats(), { active: true, repeats: 1, seconds: 5 })
+  tracker.setMode('ab:5:15')
+  assert.deepEqual(stats(), { active: true, repeats: 0, seconds: 0 })
+  tracker.repeat()
+  tracker.setMode('video')
+  assert.equal(stats().repeats, 0)
+  tracker.repeat()
+  tracker.reset()
+  assert.deepEqual(stats(), { active: true, repeats: 0, seconds: 0 })
+})
+
+test('destroy removes media listeners', () => {
+  const { tracker, event, advance, stats } = setup()
+  tracker.setMode('video')
+  event('playing', { paused: false })
+  tracker.destroy()
+  advance(10000)
+  event('timeupdate')
+  assert.equal(stats().seconds, 0)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Requested directly; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Looping gives no indication of how often a video has repeated or how long the viewer has spent watching. Add a row below the player with repeat count and actual playing time for whole-video and A–B loops, including Shorts and Android playback.

Time uses the elapsed playback clock, so changing playback speed does not multiply it. Pauses, buffering, seeks, and Android audio-focus interruptions are excluded. A Distraction Free setting hides the row while retaining the session totals. The row stays hidden in fullscreen, full-window, and mini-player playback.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
See repeat count and time spent below looping videos, with an option to hide the stats in Distraction Free settings.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/0188ff62-d541-4e45-9b61-57df0c5c2895">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/5593941f-b8d3-4898-8d34-62c6ba54f725">
  <img alt="Repeat count and actual playing time in the default theme" src="https://github.com/user-attachments/assets/0188ff62-d541-4e45-9b61-57df0c5c2895">
</picture>

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Play a video and enable Loop from the player menu. A row below the player should show zero repeats. Let playback reach the end; repeats should increase once.
2. Change playback speed and watch the Time spent value. Ten seconds of playing should add ten seconds at any speed; pausing or seeking should not add skipped time.
3. Set an A–B range with Shift+A and Shift+B. Each natural return to A should count once. Changing the range should reset the session. Toggle looping off and back on to check that its totals are retained.
4. In Settings → Distraction Free → Watch Page, enable Hide Repeat Stats. The row should disappear immediately while looping continues. Disable the setting to see the retained totals.
5. Check a Short and a narrow window at 125% UI scale. The row should fit below the player without overlapping the following content. Enter fullscreen or full-window mode and verify that the row is hidden. Scroll the player out of view or switch tabs with the cross-tab mini player enabled; the row should disappear and return with its totals when the video is restored.
6. On Android, interrupt playback with another app that takes audio focus. The interrupted interval should not be included in Time spent.

## Additional context
<!-- Add any other context about the pull request here. -->


Implemented and reviewed with GPT-6 in Codex.






