### PR TITLE
feat(subscriptions): mark unseen posts as seen from their menu

### DIFF
--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -399,6 +399,37 @@ test.describe('new subscriptions feed', () => {
     await expect(page.getByRole('option', { name: 'Mark as seen' })).toHaveCount(0)
   })
 
+  test('marks a dotted post as seen from its options menu and persists after restart', async ({ app, page }) => {
+    await goTo(page, 'subscriptions')
+    await page.locator('[data-subscription-feed-tab="posts"]').click()
+
+    const post = page.locator('.ft-list-post').filter({ hasText: 'New community post' })
+    await expect(post.locator('.newContentDot')).toBeVisible()
+    await post.getByRole('button', { name: /^More options$/i }).click()
+    await page.getByRole('option', { name: 'Mark as seen', exact: true }).click()
+
+    await expect(post).toBeVisible()
+    await expect(post.locator('.newContentDot')).toHaveCount(0)
+    await expect(page.getByRole('button', { name: 'Mark all as seen' })).toHaveCount(0)
+
+    await post.getByRole('button', { name: /^More options$/i }).click()
+    await expect(page.getByRole('option', { name: 'Mark as seen', exact: true })).toHaveCount(0)
+    await expect(page.getByRole('option', { name: 'Never show Posts from this channel in feeds again' })).toBeVisible()
+    await page.keyboard.press('Escape')
+    await page.locator('[data-subscription-feed-tab="all"]').click()
+    await expect(post).toHaveCount(0)
+    await expect(page.getByText('New video', { exact: true })).toBeVisible()
+
+    const relaunched = await app.relaunch()
+    await goTo(relaunched.page, 'subscriptions')
+    await relaunched.page.locator('[data-subscription-feed-tab="posts"]').click()
+    const seenPost = relaunched.page.locator('.ft-list-post').filter({ hasText: 'New community post' })
+    await expect(seenPost).toBeVisible()
+    await expect(seenPost.locator('.newContentDot')).toHaveCount(0)
+    await seenPost.getByRole('button', { name: /^More options$/i }).click()
+    await expect(relaunched.page.getByRole('option', { name: 'Mark as seen', exact: true })).toHaveCount(0)
+  })
+
   test('history sync imports seen videos and keeps them seen after refresh and restart', async ({ app, page }) => {
     const key = Buffer.alloc(32, 1).toString('base64')
     const salt = Buffer.alloc(16, 2).toString('base64')
@@ -775,6 +806,28 @@ test.describe('new feed settings and seen state', () => {
     await page.getByRole('option', { name: 'Mark as seen' }).click()
 
     await expect(newFeedVideo).toHaveCount(0)
+  })
+
+  test('marks a post as seen from the New feed even when dots are disabled', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+    await page.locator('[data-subscription-feed-tab="posts"]').click()
+
+    const post = page.locator('.ft-list-post').filter({ hasText: 'New community post' })
+    await post.getByRole('button', { name: /^More options$/i }).click()
+    await expect(page.getByRole('option', { name: 'Mark as seen', exact: true })).toHaveCount(0)
+    await page.keyboard.press('Escape')
+    await page.locator('[data-subscription-feed-tab="all"]').click()
+
+    await post.getByRole('button', { name: /^More options$/i }).click()
+    await page.getByRole('option', { name: 'Mark as seen', exact: true }).focus()
+    await page.keyboard.press('Enter')
+    await expect(post).toHaveCount(0)
+    await expect(page.getByText('New video post', { exact: true })).toBeVisible()
+
+    await page.locator('[data-subscription-feed-tab="posts"]').click()
+    await expect(post).toBeVisible()
+    await post.getByRole('button', { name: /^More options$/i }).click()
+    await expect(page.getByRole('option', { name: 'Mark as seen', exact: true })).toHaveCount(0)
   })
 
   test('keeps YouTube-style Shorts as portrait grid cards in list display mode', async ({ page }) => {

--- a/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
+++ b/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
@@ -161,15 +161,15 @@
         :size="18"
       />
       <FtIconButton
-        v-if="hideSubscriptionFeedTypeOption"
+        v-if="dropdownOptions.length > 0"
         :icon="['fas', 'ellipsis-v']"
         :title="$t('Video.More Options')"
         theme="base-no-default"
         :size="18"
         :use-shadow="false"
         dropdown-position-x="right"
-        :dropdown-options="[hideSubscriptionFeedTypeOption]"
-        @click="hideSubscriptionFeedType"
+        :dropdown-options="dropdownOptions"
+        @click="handleOptionsClick"
       />
     </div>
   </div>
@@ -179,6 +179,7 @@
 import { FtIcon } from '@opentubex/icons'
 import autolinker from 'autolinker'
 import { computed, onActivated, onMounted, useTemplateRef } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import FtListVideo from '../FtListVideo/FtListVideo.vue'
 import FtListPlaylist from '../FtListPlaylist/FtListPlaylist.vue'
@@ -219,6 +220,7 @@ const props = defineProps({
   },
 })
 
+const { t } = useI18n()
 const relativeTimeNow = useRelativeTimeClock()
 const { hideSubscriptionFeedType, hideSubscriptionFeedTypeOption } = useHideSubscriptionFeedType(() => props.data.authorId, true)
 
@@ -245,6 +247,42 @@ const showNewSubscriptionFeedIndicator = computed(() => {
     props.data.isNewInSubscriptionFeed === true &&
     props.data.hideNewSubscriptionFeedIndicator !== true
 })
+
+const showMarkAsSeen = computed(() => {
+  return props.data.isNewInSubscriptionFeed === true &&
+    (props.data.isInNewSubscriptionFeed === true || showNewSubscriptionFeedIndicator.value)
+})
+
+const dropdownOptions = computed(() => {
+  const options = []
+  if (showMarkAsSeen.value) {
+    options.push({
+      label: t('Subscriptions.Mark as Seen'),
+      value: 'markAsSeen',
+      icon: ['fas', 'check']
+    })
+  }
+  if (hideSubscriptionFeedTypeOption.value) {
+    options.push(hideSubscriptionFeedTypeOption.value)
+  }
+  return options
+})
+
+/**
+ * @param {string} option
+ */
+function handleOptionsClick(option) {
+  switch (option) {
+    case 'markAsSeen':
+      if (showMarkAsSeen.value && props.data.postId) {
+        store.dispatch('markSubscriptionPostAsSeen', props.data.postId)
+      }
+      break
+    case 'hideSubscriptionFeedType':
+      hideSubscriptionFeedType()
+      break
+  }
+}
 
 /** @type {import('vue').ComputedRef<'local' | 'invidious'>} */
 const backendPreference = computed(() => {


### PR DESCRIPTION
Unseen subscription posts lack the “Mark as seen” option available on other entry types. This adds it to the post menu with the same visibility rules and persistent seen state.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Requested directly; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Reuses the existing label, checkmark icon, and post seen-state action. Seen posts lose their indicator and leave the New feed while remaining in Posts. The existing channel feed action stays available.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Unseen subscription posts can now be marked as seen from their options menu.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. In the Posts subscription tab, open an unseen post’s options menu and choose “Mark as seen”. Its indicator should disappear while the post stays visible.
2. Reopen the menu. “Mark as seen” should be absent and the channel feed action should remain available. Restart the app and confirm the post stays seen.
3. Disable new-content indicators and open the New feed. Mark an unseen post as seen using the keyboard; it should leave New and remain in Posts.

## Additional context
<!-- Add any other context about the pull request here. -->
Validation: 1,446 unit tests and four targeted Electron E2E tests passed. Lint passed with one existing warning in watch-page.spec.mjs. The two new E2E tests failed on the missing action before the implementation and passed afterward. Standards and spec reviews found no actionable issues.

Changes prepared by GPT-6 in the Codex desktop app.
