### PR TITLE
fix(android): honor encrypted sync transfer timeouts

### DIFF
--- a/src/renderer/helpers/sync-server.js
+++ b/src/renderer/helpers/sync-server.js
@@ -43,10 +43,12 @@ const MAX_ENCRYPTED_SYNC_TIMEOUT_MS = 5 * 60 * 1000
 const DEFAULT_CHANNEL_AVATAR = 'https://yt3.googleusercontent.com/ytc/default'
 const YOUTUBE_VIDEO_THUMBNAIL_REGEX = /^https?:\/\/i\.ytimg\.com\/vi(?:_webp)?\//
 
-function syncServerFetch(input, init) {
+function syncServerFetch(input, init, timeoutMs) {
   return process.env.IS_CAPACITOR
     ? capacitorHttpFetch(input, {
         ...init,
+        // Encrypted transfers may outlast the native client's 30-second default.
+        nativeTimeoutMs: timeoutMs,
         headers: applySyncServerUserAgent(Object.fromEntries(new Headers(init.headers))),
       })
     : fetch(input, init)
@@ -118,7 +120,7 @@ export class SyncServerClient {
         headers,
         body: options.body == null ? undefined : JSON.stringify(options.body),
         signal: controller.signal,
-      })
+      }, timeoutMs)
       const text = await response.text()
 
       if (!response.ok) {

--- a/tests/unit/sync-server-request.test.mjs
+++ b/tests/unit/sync-server-request.test.mjs
@@ -2,13 +2,15 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { readFile } from 'node:fs/promises'
 import vm from 'node:vm'
+import { setImmediate as nextEventLoopTurn } from 'node:timers/promises'
 
 import { withNetworkRecovery } from '../../src/renderer/helpers/networkRecovery.js'
 import { applySyncServerUserAgent } from '../../src/syncServerUserAgent.js'
 import { createSyncServerRequestHeaders } from '../../src/renderer/helpers/sync-server-request.js'
 import * as errors from '../../src/renderer/helpers/sync-server-errors.js'
+import { createAbortError } from '../../src/renderer/helpers/api/requestErrors.js'
 
-async function loadClient(env, version, requests) {
+async function loadClient(env, version, requests, nativeRequest) {
   const context = vm.createContext({
     ...errors,
     withNetworkRecovery,
@@ -16,10 +18,12 @@ async function loadClient(env, version, requests) {
     packageDetails: { version },
     createSyncServerRequestHeaders,
     applySyncServerUserAgent,
+    createAbortError,
     URL, URLSearchParams, Request, Response, Headers, AbortController, setTimeout, clearTimeout,
     CapacitorHttp: {
       request: async options => {
         requests.push(options)
+        if (nativeRequest) return nativeRequest(options)
         return { status: 200, data: '{}', headers: {} }
       },
     },
@@ -37,6 +41,69 @@ async function loadClient(env, version, requests) {
   }
   return vm.runInContext('new SyncServerClient("https://sync.example")', context)
 }
+
+for (const [operation, run] of [
+  ['manifest', client => client.getEncryptedSyncManifest()],
+  ['collection download', client => client.getEncryptedSyncCollection('history')],
+  ['legacy download', client => client.getLegacyEncryptedSync()],
+  ['large collection upload', client => client.putEncryptedSyncCollection('history', 1, 'a'.repeat(4 * 1024 * 1024))],
+]) {
+  test(`Android encrypted sync ${operation} can take longer than 30 seconds`, async t => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+    const client = await loadClient({ IS_CAPACITOR: true }, '0.34.0', [], options => new Promise((resolve, reject) => {
+      const responseTimer = setTimeout(() => {
+        clearTimeout(timeoutTimer)
+        resolve({ status: 200, data: '{"revision":2}', headers: {} })
+      }, 31_000)
+      const timeoutTimer = setTimeout(() => {
+        clearTimeout(responseTimer)
+        reject(Object.assign(new Error('timeout'), { code: 'SocketTimeoutException' }))
+      }, options.readTimeout)
+    }))
+    const result = run(client)
+    const completed = assert.doesNotReject(async () => {
+      assert.equal((await result).revision, 2)
+    })
+    await nextEventLoopTurn()
+    t.mock.timers.tick(31_000)
+    await completed
+  })
+}
+
+for (const [operation, run, timeoutMs] of [
+  ['health check', client => client.health(), 20_000],
+  ['collection download', client => client.getEncryptedSyncCollection('history'), 300_000],
+  ['small collection upload', client => client.putEncryptedSyncCollection('history', 1, 'encrypted'), 20_000],
+  ['large collection upload', client => client.putEncryptedSyncCollection('history', 1, 'a'.repeat(4 * 1024 * 1024)), 47_000],
+]) {
+  test(`Android sync ${operation} still stops at its request deadline`, async t => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+    const requests = []
+    const client = await loadClient({ IS_CAPACITOR: true }, '0.34.0', requests, () => new Promise(() => {}))
+    let settled = false
+    const result = run(client).finally(() => { settled = true })
+    const rejected = assert.rejects(result, { message: 'Sync server request timed out' })
+    await nextEventLoopTurn()
+    assert.equal(requests[0].connectTimeout, timeoutMs)
+    assert.equal(requests[0].readTimeout, timeoutMs)
+    t.mock.timers.tick(timeoutMs - 1)
+    await nextEventLoopTurn()
+    assert.equal(settled, false)
+    t.mock.timers.tick(1)
+    await rejected
+    assert.equal(client.requestControllers.size, 0)
+  })
+}
+
+test('Android encrypted sync can be cancelled before the extended deadline', async () => {
+  const client = await loadClient({ IS_CAPACITOR: true }, '0.34.0', [], () => new Promise(() => {}))
+  const result = client.getEncryptedSyncCollection('history')
+  const rejected = assert.rejects(result, errors.SyncServerCancelledError)
+  await nextEventLoopTurn()
+  client.cancel()
+  await rejected
+  assert.equal(client.requestControllers.size, 0)
+})
 
 for (const version of ['0.34.0', '0.34.0-nightly-976']) {
   test(`Android sync sends ${version} through native HTTP on public and authenticated requests`, async () => {
@@ -66,6 +133,7 @@ test('browser sync does not send native app version headers', async () => {
   await client.health()
 
   const headers = new Headers(requests[0].headers)
+  assert.equal(Object.hasOwn(requests[0], 'nativeTimeoutMs'), false)
   assert.equal(headers.has('User-Agent'), false)
   assert.equal(headers.has('OpenTubeX-Client-Version'), false)
 })
@@ -76,6 +144,7 @@ test('Electron sync retains its version marker for the main process', async () =
   await client.health()
 
   const headers = new Headers(requests[0].headers)
+  assert.equal(Object.hasOwn(requests[0], 'nativeTimeoutMs'), false)
   assert.equal(headers.get('OpenTubeX-Client-Version'), '0.34.0')
   assert.equal(headers.has('User-Agent'), false)
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Reported directly while syncing an already configured account on a Pixel 8 Pro.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Android sync could show a red `timeout` error because its native HTTP client stopped waiting after 30 seconds, even when encrypted sync allowed a longer transfer. Pass each sync request's existing timeout to the native client so encrypted transfers get their intended allowance, up to five minutes. Existing request deadlines and cancellation remain in effect.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Android encrypted sync now honors its transfer timeout instead of failing after 30 seconds.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. On Android, connect an account with enhanced privacy enabled and run Sync now. Verify that sync completes and updates the last-synced time.
2. With a test sync server delaying an encrypted download response by 31 seconds, run sync again. It should complete without the previous `timeout` error. A response delayed beyond the five-minute request deadline should still fail.

## Additional context
<!-- Add any other context about the pull request here. -->

Regression tests reproduced the native timeout before the fix and pass afterward. Coverage includes encrypted downloads and uploads, request deadlines, cancellation, and unchanged browser/Electron request options. The Pixel retry succeeded on the unchanged nightly, so the intermittent device failure has not been verified against an installed patched build.

Changes made with GPT-6 in the Codex harness.
