### PR TITLE
perf(tabs): speed up startup with many restored tabs

### DIFF
--- a/e2e/tests/offline/startup-performance.spec.mjs
+++ b/e2e/tests/offline/startup-performance.spec.mjs
@@ -2,6 +2,7 @@ import { rm } from 'node:fs/promises'
 import { test, expect, createUserDataDir, launchApp } from '../../helpers/app.mjs'
 
 test('presents the selected tab before mounting a large restored background session', async () => {
+  test.setTimeout(120_000)
   const tabs = Array.from({ length: 60 }, (_, index) => ({
     id: `startup-${index}`,
     url: 'app://bundle/index.html#/history',
@@ -39,7 +40,7 @@ test('presents the selected tab before mounting a large restored background sess
     await expect.poll(() => app.page.evaluate(async () => {
       const { tabs } = await window.ftElectron.tabs.getState()
       return tabs.filter(tab => tab.loadState === 'loaded').length
-    }), { timeout: 30_000 }).toBe(59)
+    }), { timeout: 90_000 }).toBe(59)
     expect(await app.page.evaluate(async () => {
       const { tabs } = await window.ftElectron.tabs.getState()
       return tabs.find(tab => tab.id === 'startup-58').loadState

--- a/e2e/tests/offline/startup-performance.spec.mjs
+++ b/e2e/tests/offline/startup-performance.spec.mjs
@@ -1,0 +1,51 @@
+import { rm } from 'node:fs/promises'
+import { test, expect, createUserDataDir, launchApp } from '../../helpers/app.mjs'
+
+test('presents the selected tab before mounting a large restored background session', async () => {
+  const tabs = Array.from({ length: 60 }, (_, index) => ({
+    id: `startup-${index}`,
+    url: 'app://bundle/index.html#/history',
+    title: `History ${index}`,
+    isUnloaded: index === 58
+  }))
+  const userDataDir = await createUserDataDir({
+    settings: { startupBehavior: 'restoreTabLoadState' },
+    tabSessions: [{ _id: 'startup-performance', value: { tabs, activeTabId: 'startup-59' } }]
+  })
+  let app
+  try {
+    app = await launchApp(userDataDir, [], {
+      onPhase: async (phase, page) => {
+        if (phase !== 'windowCreated') return
+        const cdp = await page.context().newCDPSession(page)
+        await cdp.send('Emulation.setCPUThrottlingRate', { rate: 4 })
+        const observeMounts = () => {
+          if (window.__startupMounts) return
+          window.__startupMounts = []
+          const observer = new MutationObserver(() => {
+            for (const element of document.querySelectorAll('.tabContent > .routerView')) {
+              const id = element.parentElement.dataset.tabId
+              if (!window.__startupMounts.includes(id)) window.__startupMounts.push(id)
+            }
+          })
+          observer.observe(document, { childList: true, subtree: true })
+        }
+        await page.addInitScript(observeMounts)
+        await page.evaluate(observeMounts)
+      }
+    })
+    await expect(app.page.locator('.tabContent[data-tab-id="startup-59"][aria-hidden="false"] .headingRow')).toBeVisible()
+    expect(await app.page.evaluate(() => window.__startupMounts[0])).toBe('startup-59')
+    await expect.poll(() => app.page.evaluate(async () => {
+      const { tabs } = await window.ftElectron.tabs.getState()
+      return tabs.filter(tab => tab.loadState === 'loaded').length
+    }), { timeout: 30_000 }).toBe(59)
+    expect(await app.page.evaluate(async () => {
+      const { tabs } = await window.ftElectron.tabs.getState()
+      return tabs.find(tab => tab.id === 'startup-58').loadState
+    })).toBe('unloaded')
+  } finally {
+    await app?.electronApp.close()
+    await rm(userDataDir, { recursive: true, force: true })
+  }
+})

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -67,6 +67,7 @@ const TAB_PREVIEW_CAPTURE_STYLE_ID = 'opentubex-tab-preview-capture-style'
 const TAB_PREVIEW_CAPTURE_CLASS = 'opentubex-tab-preview-capturing'
 const TAB_PREVIEW_CACHE_DIR_NAME = 'tab-previews'
 const TAB_TRANSFER_MOUNT_TIMEOUT_MS = 8000
+const STARTUP_TAB_MOUNT_DELAY_MS = 50
 const RAPID_TAB_CREATION_BATCH_DELAY_MS = 40
 const RAPID_TAB_CREATION_BATCH_MAX_DELAY_MS = 100
 const transferringTabIds = new Set()
@@ -94,6 +95,7 @@ let tabPreviewCacheMaintenance = Promise.resolve()
  * @property {boolean} isPlaying
  * @property {boolean} isPinned
  * @property {boolean} isLoading
+ * @property {boolean} mountDeferred
  * @property {Set<string>} loadingSources
  * @property {string | null} color
  * @property {string | null} previewDataUrl
@@ -784,6 +786,9 @@ export class TabManager {
     this._deferredStartupWatchTabIds = new Set()
     this._startupPriorityTabId = null
     this._startupPriorityLoadingObserved = false
+    this._startupMountQueue = new Set()
+    this._startupMountTimer = null
+    this._startupMountRunning = false
     // While a batch runs, state broadcasts and session writes are collapsed into
     // a single one that is emitted once the batch finishes (see runBatched).
     this._batchDepth = 0
@@ -811,6 +816,8 @@ export class TabManager {
     this._installWindowOpenHandler()
 
     browserWindow.on('closed', () => {
+      clearTimeout(this._startupMountTimer)
+      this._startupMountQueue.clear()
       if (this._rapidTabCreationBatch) {
         clearTimeout(this._rapidTabCreationBatch.timeoutId)
         this._rapidTabCreationBatch.resolve()
@@ -1034,6 +1041,10 @@ export class TabManager {
    * @param {number} preferredIndex
    */
   _insertTabEntry(tabId, tabInfo, preferredIndex) {
+    if (!tabInfo.isPinned && preferredIndex >= this.tabs.size) {
+      this.tabs.set(tabId, tabInfo)
+      return
+    }
     const entries = Array.from(this.tabs.entries())
     const pinnedCount = entries.filter(([, tab]) => tab.isPinned).length
     let insertIndex = Math.max(0, Math.min(preferredIndex, entries.length))
@@ -1078,7 +1089,8 @@ export class TabManager {
       groupId = null,
       openerTabId = this.activeTabId,
       _preferredIndex = null,
-      _deferUpdates = false
+      _deferUpdates = false,
+      _deferMount = false
     } = options
 
     // Only trusted callers (session restore, transfers) supply an id; renderer
@@ -1123,6 +1135,7 @@ export class TabManager {
       previewCapturePromise: null,
       skipSilence: skipSilence === true,
       loadState: startsUnloaded ? 'unloaded' : 'mounting',
+      mountDeferred: shouldMount && !makeActive && _deferMount,
       preloadInBackground: Boolean(preloadInBackground),
       pendingActivation: false,
       mountRevision: shouldMount ? 1 : 0,
@@ -1154,6 +1167,7 @@ export class TabManager {
     }
 
     this._insertTabEntry(id, tabInfo, preferredIndex)
+    if (tabInfo.mountDeferred) this._startupMountQueue.add(id)
 
     if (makeActive) {
       if (this.activeTabId == null) {
@@ -1296,10 +1310,14 @@ export class TabManager {
     if (
       previousActiveId === tabId &&
       tab.pendingActivation !== true &&
-      tab.loadState !== 'unloaded'
+      tab.loadState !== 'unloaded' &&
+      !tab.mountDeferred
     ) {
       return
     }
+
+    tab.mountDeferred = false
+    this._startupMountQueue.delete(tabId)
 
     const outgoingTabId = this.presentedTabId ?? previousActiveId
     if (outgoingTabId && outgoingTabId !== tabId) {
@@ -1452,6 +1470,7 @@ export class TabManager {
       ) {
         this.presentedTabId = null
       }
+      this._scheduleStartupMount()
       this._finalizeDeferredDisposals(tabId)
     }
 
@@ -1478,6 +1497,7 @@ export class TabManager {
       this._resolveInitialPresentation()
     }
 
+    this._scheduleStartupMount()
     this._finalizeDeferredDisposals(tabId)
 
     const tab = this.tabs.get(tabId)
@@ -2549,6 +2569,8 @@ export class TabManager {
     const tab = this.tabs.get(tabId)
     if (!tab) return
 
+    tab.mountDeferred = false
+    this._startupMountQueue.delete(tabId)
     tab.loadState = 'mounting'
     tab.preloadInBackground = tab.id !== this.activeTabId
     tab.mountRevision += 1
@@ -2559,15 +2581,18 @@ export class TabManager {
 
   /**
    * @param {string} tabId
+   * @param {boolean} [deferMount]
    * @returns {boolean}
    */
-  loadTab(tabId) {
+  loadTab(tabId, deferMount = false) {
     const tab = this.tabs.get(tabId)
     if (!tab || tab.loadState !== 'unloaded') {
       return false
     }
 
     tab.loadState = 'mounting'
+    tab.mountDeferred = deferMount
+    if (deferMount) this._startupMountQueue.add(tabId)
     tab.preloadInBackground = true
     tab.mountRevision += 1
     this._setTabLoadingSource(tab, TAB_LOADING_SOURCE_MOUNT, true)
@@ -2641,6 +2666,9 @@ export class TabManager {
     }
 
     tab.loadState = 'unloaded'
+    tab.mountDeferred = false
+    this._startupMountQueue.delete(tabId)
+    this._resolveTabMountWaiters(tabId, tab.mountRevision, false)
     tab.preloadInBackground = false
     tab.pendingActivation = false
     tab.isPlaying = false
@@ -2940,11 +2968,49 @@ export class TabManager {
     // one session write rather than waking the shared renderer for every tab.
     this.runBatched(() => {
       for (const tabId of tabIds) {
-        this.loadTab(tabId)
+        this.loadTab(tabId, true)
       }
     }).catch(error => {
       console.error('Failed to resume deferred startup watch tabs:', error)
     })
+    this._scheduleStartupMount()
+  }
+
+  _scheduleStartupMount() {
+    if (
+      this._startupMountRunning || this._startupMountTimer != null ||
+      this._startupMountQueue.size === 0 || this.browserWindow.isDestroyed()
+    ) return
+
+    // Yield between mounts so input and paint can run on slower CPUs. Waiting
+    // for mount acknowledgement also prevents a slow page from piling up work.
+    this._startupMountTimer = setTimeout(async () => {
+      this._startupMountTimer = null
+      this._startupMountRunning = true
+      try {
+        const active = this.tabs.get(this.activeTabId)
+        if (active?.loadState === 'mounting') {
+          await this.waitForTabMount(active.id, active.mountRevision)
+        }
+        if (this.browserWindow.isDestroyed()) return
+
+        for (const tabId of this._startupMountQueue) {
+          this._startupMountQueue.delete(tabId)
+          const tab = this.tabs.get(tabId)
+          if (!tab?.mountDeferred || tab.loadState !== 'mounting') continue
+
+          tab.mountDeferred = false
+          this._broadcastStateUpdate()
+          await this.waitForTabMount(tabId, tab.mountRevision)
+          break
+        }
+      } catch (error) {
+        console.error('Failed to mount restored background tab:', error)
+      } finally {
+        this._startupMountRunning = false
+        this._scheduleStartupMount()
+      }
+    }, STARTUP_TAB_MOUNT_DELAY_MS)
   }
 
   /**
@@ -2976,6 +3042,7 @@ export class TabManager {
         isActive: tab.id === this.activeTabId,
         isActivatable: this._isTabActivatable(tab),
         isUnloaded: tab.loadState === 'unloaded',
+        mountDeferred: tab.mountDeferred === true,
         isLoading: this._getTabLoadingState(tab),
         isPlaying: tab.isPlaying || false,
         skipSilence: tab.skipSilence === true,
@@ -3381,73 +3448,86 @@ export class TabManager {
       const prioritizeActiveWatchTab = activeTabData != null &&
         TabManager.getRouteFromUrl(activeTabData.url).path.startsWith('/watch/')
       const deferredStartupWatchTabIds = new Set()
-
+      const avatars = new Map()
       for (const tabData of sessionData.tabs) {
-        const makeActive = tabData.id === sessionData.activeTabId
-        const hasSavedTitle = typeof tabData.title === 'string' && tabData.title.trim().length > 0
-        const previewFileName = normalizeTabPreviewFileName(tabData.previewFileName)
-        const avatarFileName = normalizeTabPreviewFileName(tabData.avatarFileName)
-        const avatarDataUrl = await this._loadTabPreviewDataUrl(avatarFileName)
-        const loadInBackground = loadInactiveTabs || (restoreTabLoadState && tabData.isUnloaded === false)
-        const deferForActiveWatchTab = prioritizeActiveWatchTab &&
-          !makeActive &&
-          loadInBackground &&
-          TabManager.getRouteFromUrl(tabData.url).path.startsWith('/watch/')
-        const restoreAsUnloaded = deferForActiveWatchTab || (!loadInactiveTabs && !makeActive && (
-          (restoreTabLoadState && tabData.isUnloaded === true) ||
-          (!loadInBackground && hasSavedTitle)
-        ))
-
-        const tab = this.createTab({
-          id: typeof tabData.id === 'string' ? tabData.id : undefined,
-          // Strip here as well to heal sessions persisted before the strip on save existed
-          url: TabManager.stripOneTimeTimestampFromUrl(tabData.url),
-          title: hasSavedTitle ? tabData.title : undefined,
-          avatarDataUrl,
-          avatarFileName: avatarDataUrl == null ? null : avatarFileName,
-          isPinned: tabData.isPinned === true,
-          color: tabData.color,
-          groupId: tabData.groupId,
-          // Legacy sessions did not persist this field and must retain the old
-          // disabled behavior instead of inheriting the new-tab default.
-          skipSilence: tabData.skipSilence === true,
-          // Preview images are only needed when the switcher asks for them.
-          // Keep the cache reference and let getTabPreview load it on demand
-          // instead of serially reading every restored tab before first paint.
-          previewCapturedAt: previewFileName != null && Number.isFinite(tabData.previewCapturedAt)
-            ? tabData.previewCapturedAt
-            : 0,
-          previewFileName,
-          history: restoreNavigationHistory ? tabData.history : null,
-          historyIndex: restoreNavigationHistory ? tabData.historyIndex : null,
-          persistHistory: restoreNavigationHistory,
-          makeActive,
-          openPosition: 'end',
-          openerTabId: typeof tabData.placementOpenerTabId === 'string'
-            ? tabData.placementOpenerTabId
-            : null,
-          lazyLoad: restoreAsUnloaded,
-          preloadInBackground: loadInBackground && !makeActive && !deferForActiveWatchTab
-        })
-        if (deferForActiveWatchTab) {
-          deferredStartupWatchTabIds.add(tab.id)
+        const fileName = normalizeTabPreviewFileName(tabData.avatarFileName)
+        if (fileName != null && !avatars.has(fileName)) {
+          avatars.set(fileName, this._loadTabPreviewDataUrl(fileName))
         }
       }
+      await Promise.all([...avatars].map(async ([fileName, data]) => {
+        avatars.set(fileName, await data)
+      }))
 
-      if (deferredStartupWatchTabIds.size > 0) {
-        this._deferredStartupWatchTabIds = deferredStartupWatchTabIds
-        this._startupPriorityTabId = this.activeTabId
-        this._startupPriorityLoadingObserved = false
-      }
+      await this.runBatched(() => {
+        for (const tabData of sessionData.tabs) {
+          const makeActive = tabData.id === sessionData.activeTabId
+          const hasSavedTitle = typeof tabData.title === 'string' && tabData.title.trim().length > 0
+          const previewFileName = normalizeTabPreviewFileName(tabData.previewFileName)
+          const avatarFileName = normalizeTabPreviewFileName(tabData.avatarFileName)
+          const avatarDataUrl = avatars.get(avatarFileName) ?? null
+          const loadInBackground = loadInactiveTabs || (restoreTabLoadState && tabData.isUnloaded === false)
+          const deferForActiveWatchTab = prioritizeActiveWatchTab &&
+            !makeActive &&
+            loadInBackground &&
+            TabManager.getRouteFromUrl(tabData.url).path.startsWith('/watch/')
+          const restoreAsUnloaded = deferForActiveWatchTab || (!loadInactiveTabs && !makeActive && (
+            (restoreTabLoadState && tabData.isUnloaded === true) ||
+            (!loadInBackground && hasSavedTitle)
+          ))
 
-      restoreTabPlacementOpeners(this.tabs, sessionData.tabs)
-
-      if (!this.activeTabId) {
-        const firstTabId = this.tabs.keys().next().value
-        if (firstTabId) {
-          this.activateTab(firstTabId)
+          const tab = this.createTab({
+            id: typeof tabData.id === 'string' ? tabData.id : undefined,
+            // Strip here as well to heal sessions persisted before the strip on save existed
+            url: TabManager.stripOneTimeTimestampFromUrl(tabData.url),
+            title: hasSavedTitle ? tabData.title : undefined,
+            avatarDataUrl,
+            avatarFileName: avatarDataUrl == null ? null : avatarFileName,
+            isPinned: tabData.isPinned === true,
+            color: tabData.color,
+            groupId: tabData.groupId,
+            // Legacy sessions did not persist this field and must retain the old
+            // disabled behavior instead of inheriting the new-tab default.
+            skipSilence: tabData.skipSilence === true,
+            // Preview images are only needed when the switcher asks for them.
+            // Keep the cache reference and let getTabPreview load it on demand
+            // instead of serially reading every restored tab before first paint.
+            previewCapturedAt: previewFileName != null && Number.isFinite(tabData.previewCapturedAt)
+              ? tabData.previewCapturedAt
+              : 0,
+            previewFileName,
+            history: restoreNavigationHistory ? tabData.history : null,
+            historyIndex: restoreNavigationHistory ? tabData.historyIndex : null,
+            persistHistory: restoreNavigationHistory,
+            makeActive,
+            openPosition: 'end',
+            openerTabId: typeof tabData.placementOpenerTabId === 'string'
+              ? tabData.placementOpenerTabId
+              : null,
+            lazyLoad: restoreAsUnloaded,
+            _deferMount: !makeActive,
+            preloadInBackground: loadInBackground && !makeActive && !deferForActiveWatchTab
+          })
+          if (deferForActiveWatchTab) {
+            deferredStartupWatchTabIds.add(tab.id)
+          }
         }
-      }
+
+        if (deferredStartupWatchTabIds.size > 0) {
+          this._deferredStartupWatchTabIds = deferredStartupWatchTabIds
+          this._startupPriorityTabId = this.activeTabId
+          this._startupPriorityLoadingObserved = false
+        }
+
+        restoreTabPlacementOpeners(this.tabs, sessionData.tabs)
+
+        if (!this.activeTabId) {
+          const firstTabId = this.tabs.keys().next().value
+          if (firstTabId) {
+            this.activateTab(firstTabId)
+          }
+        }
+      })
 
       return this.tabs.size > 0
     } finally {

--- a/src/renderer/components/TabContent/TabContent.vue
+++ b/src/renderer/components/TabContent/TabContent.vue
@@ -59,7 +59,7 @@ const props = defineProps({
 const navigation = getTabNavigationService()
 const tabContentRef = useTemplateRef('tabContentRef')
 const isPresented = computed(() => store.getters.getPresentedTabId === props.tab.id)
-const shouldMount = computed(() => props.tab.loadState !== 'unloaded' && props.tab.loadState !== 'unloading')
+const shouldMount = computed(() => !props.tab.mountDeferred && props.tab.loadState !== 'unloaded' && props.tab.loadState !== 'unloading')
 const initialized = ref(shouldMount.value)
 const routerFacade = navigation.createRouterFacade(props.tab.id)
 // Main metadata snapshots replace the containing tab object frequently (title,

--- a/tests/unit/tab-startup.test.mjs
+++ b/tests/unit/tab-startup.test.mjs
@@ -1,0 +1,214 @@
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { registerHooks } from 'node:module'
+import test from 'node:test'
+
+const hooks = registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier === 'electron') {
+      return { shortCircuit: true, url: 'data:text/javascript,' + encodeURIComponent(`
+        export const BrowserWindow = {}, ipcMain = {}, nativeImage = {}, shell = {};
+        export const app = { getName: () => 'OpenTubeX' };
+      `) }
+    }
+    if (specifier.endsWith('/datastores/handlers/base.js')) {
+      return { shortCircuit: true, url: 'data:text/javascript,' + encodeURIComponent(`
+        export const settings = { _findOne: async () => null };
+        export const tabSession = { save: async () => {} };
+      `) }
+    }
+    return nextResolve(specifier, context)
+  }
+})
+const { TabManager } = await import('../../src/main/tabs/TabManager.js')
+hooks.deregister()
+const { createTabAvatarFileName } = await import('../../src/main/tabs/tabPreviewCache.js')
+
+function createManager(t) {
+  const window = new EventEmitter()
+  window.id = 1
+  window.webContents = Object.assign(new EventEmitter(), {
+    isDestroyed: () => false,
+    setWindowOpenHandler() {},
+    send() {}
+  })
+  window.setTitle = () => {}
+  window.getBounds = () => ({ x: 0, y: 0, width: 1200, height: 800 })
+  window.isDestroyed = () => false
+  window.isMaximized = () => false
+  window.isFullScreen = () => false
+  const manager = new TabManager(window, 'app://bundle/index.html')
+  manager._tabPreviewsEnabled = false
+  t.after(() => {
+    window.isDestroyed = () => true
+    window.emit('closed')
+  })
+  return manager
+}
+
+function session(count) {
+  return {
+    tabs: Array.from({ length: count }, (_, index) => ({
+      id: `tab-${index}`,
+      url: 'app://bundle/index.html#/history',
+      title: `History ${index}`,
+      isUnloaded: false
+    })),
+    activeTabId: `tab-${count - 1}`
+  }
+}
+
+test('restoring many tabs serializes only one initial renderer snapshot', async t => {
+  const manager = createManager(t)
+  const getState = manager.getState.bind(manager)
+  let serializedTabs = 0
+  manager.getState = (...args) => {
+    const state = getState(...args)
+    serializedTabs += state.tabs.length
+    return state
+  }
+  const started = performance.now()
+  await manager.restoreFromData(session(100), { restoreTabLoadState: true })
+  t.diagnostic(`100 tabs: ${(performance.now() - started).toFixed(1)} ms, ${serializedTabs} serialized tab records`)
+  assert.equal(serializedTabs, 100)
+})
+
+test('restored background pages do not compete with the initial selected page mount', async t => {
+  const manager = createManager(t)
+  await manager.restoreFromData(session(10), { restoreTabLoadState: true })
+  assert.deepEqual([...manager.tabs.values()].filter(tab => tab.loadState === 'mounting' && !tab.mountDeferred).map(tab => tab.id), ['tab-9'])
+  assert.ok(manager.getSyncSession().tabs.every(tab => !tab.isUnloaded), 'queued tabs keep their saved loaded state')
+})
+
+async function tick(t, milliseconds = 50) {
+  t.mock.timers.tick(milliseconds)
+  await new Promise(setImmediate)
+}
+
+function presentActive(manager) {
+  const tab = manager.tabs.get(manager.activeTabId)
+  manager.markTabMounted(tab.id, tab.mountRevision)
+  manager.markTabPresented(tab.id, manager.selectionRevision)
+}
+
+test('loads background pages one at a time after presentation and mount acknowledgement', async t => {
+  t.mock.timers.enable({ apis: ['setTimeout'] })
+  const manager = createManager(t)
+  await manager.restoreFromData(session(4), { restoreTabLoadState: true })
+  await tick(t, 1000)
+  assert.equal(manager.tabs.get('tab-0').mountDeferred, true)
+  presentActive(manager)
+  await tick(t)
+  assert.equal(manager.tabs.get('tab-0').mountDeferred, false)
+  assert.equal(manager.tabs.get('tab-1').mountDeferred, true)
+  await tick(t, 1000)
+  assert.equal(manager.tabs.get('tab-1').mountDeferred, true, 'waits for slow mount')
+  manager.markTabMounted('tab-0', 1)
+  await tick(t, 0)
+  await tick(t)
+  assert.equal(manager.tabs.get('tab-1').mountDeferred, false)
+  manager.markTabMountFailed('tab-1', 1)
+  await tick(t, 0)
+  await tick(t)
+  assert.equal(manager.tabs.get('tab-2').mountDeferred, false, 'continues after failure')
+  manager.markTabMounted('tab-2', 1)
+  await tick(t, 0)
+  assert.equal(manager._startupMountQueue.size, 0)
+})
+
+test('selecting or reloading a queued tab bypasses the startup queue', async t => {
+  const manager = createManager(t)
+  await manager.restoreFromData(session(4), { loadInactiveTabs: true })
+  manager.activateTab('tab-2')
+  assert.equal(manager.tabs.get('tab-2').mountDeferred, false)
+  assert.equal(manager.activeTabId, 'tab-2')
+  assert.equal(manager._startupMountQueue.has('tab-2'), false)
+  manager.reloadTab('tab-1')
+  assert.equal(manager.tabs.get('tab-1').mountDeferred, false)
+  assert.equal(manager._startupMountQueue.has('tab-1'), false)
+})
+
+test('skips tabs unloaded while queued and preserves originally unloaded tabs', async t => {
+  t.mock.timers.enable({ apis: ['setTimeout'] })
+  const manager = createManager(t)
+  const saved = session(4)
+  saved.tabs[1].isUnloaded = true
+  await manager.restoreFromData(saved, { restoreTabLoadState: true })
+  await manager.unloadTab('tab-0')
+  presentActive(manager)
+  await tick(t)
+  assert.equal(manager.tabs.get('tab-0').loadState, 'unloaded')
+  assert.equal(manager.tabs.get('tab-1').loadState, 'unloaded')
+  assert.equal(manager.tabs.get('tab-2').mountDeferred, false)
+  assert.deepEqual(manager.getSyncSession().tabs.map(tab => tab.isUnloaded), [true, true, false, false])
+})
+
+test('unloading a background tab during its mount releases the next queued tab', async t => {
+  t.mock.timers.enable({ apis: ['setTimeout'] })
+  const manager = createManager(t)
+  await manager.restoreFromData(session(3), { restoreTabLoadState: true })
+  presentActive(manager)
+  await tick(t)
+  assert.equal(manager.tabs.get('tab-0').mountDeferred, false)
+  await manager.unloadTab('tab-0')
+  await tick(t, 0)
+  await tick(t)
+  assert.equal(manager.tabs.get('tab-1').mountDeferred, false)
+})
+
+test('a missing selected tab falls back to a tab that can mount immediately', async t => {
+  const manager = createManager(t)
+  const saved = session(4)
+  saved.activeTabId = 'missing'
+  await manager.restoreFromData(saved, { restoreTabLoadState: true })
+  assert.equal(manager.activeTabId, 'tab-0')
+  assert.equal(manager.tabs.get('tab-0').mountDeferred, false)
+})
+
+test('a stalled mount cannot block the rest of the session forever', async t => {
+  t.mock.timers.enable({ apis: ['setTimeout'] })
+  const manager = createManager(t)
+  await manager.restoreFromData(session(3), { restoreTabLoadState: true })
+  presentActive(manager)
+  await tick(t)
+  await tick(t, 8000)
+  await tick(t)
+  assert.equal(manager.tabs.get('tab-1').mountDeferred, false)
+})
+
+test('reads each shared avatar once and starts independent reads together', async t => {
+  const manager = createManager(t)
+  const saved = session(4)
+  const avatar = createTabAvatarFileName(Buffer.from('avatar'))
+  const missingAvatar = createTabAvatarFileName(Buffer.from('missing'))
+  saved.tabs[0].avatarFileName = avatar
+  saved.tabs[1].avatarFileName = avatar
+  saved.tabs[2].avatarFileName = missingAvatar
+  const reads = new Map()
+  manager._loadTabPreviewDataUrl = fileName => {
+    assert.ok(!reads.has(fileName), 'shared file is read only once')
+    return new Promise(resolve => reads.set(fileName, resolve))
+  }
+  const restored = manager.restoreFromData(saved)
+  await new Promise(setImmediate)
+  assert.deepEqual([...reads.keys()], [avatar, missingAvatar])
+  const dataUrl = 'data:image/jpeg;base64,YXZhdGFy'
+  reads.get(avatar)(dataUrl)
+  reads.get(missingAvatar)(null)
+  await restored
+  assert.equal(manager.tabs.get('tab-0').avatarDataUrl, dataUrl)
+  assert.equal(manager.tabs.get('tab-1').avatarDataUrl, dataUrl)
+  assert.equal(manager.tabs.get('tab-2').avatarFileName, null)
+})
+
+test('closing the window cancels pending background mounts', async t => {
+  t.mock.timers.enable({ apis: ['setTimeout'] })
+  const manager = createManager(t)
+  await manager.restoreFromData(session(3), { loadInactiveTabs: true })
+  presentActive(manager)
+  manager.browserWindow.isDestroyed = () => true
+  manager.browserWindow.emit('closed')
+  await tick(t, 10_000)
+  assert.equal(manager.tabs.get('tab-0').mountDeferred, true)
+  assert.equal(manager._pendingTabMountWaiters.size, 0)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Requested in a Codex task; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Restoring many loaded tabs delays the selected page and makes startup particularly slow on weaker CPUs. Restore the tab metadata in one batch, read shared avatars once with concurrent reads, and mount background pages one at a time after the selected page appears. Selecting or reloading a queued tab starts it immediately; tabs saved as unloaded remain unloaded.

Canceled mounts release the queue immediately, and failed or stalled mounts cannot block the remaining tabs indefinitely.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Faster startup when restoring many loaded tabs, especially on slower CPUs.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open several dozen tabs, leave some unloaded, select a tab near the end, and choose the startup option that restores each tab's loaded state.
2. Restart the app. The selected page should appear first, then the other loaded pages should initialize gradually. Previously unloaded tabs should stay unloaded.
3. While restoration is in progress, select or reload a waiting tab. It should start immediately. Unloading a tab while it is mounting should let restoration continue with the next tab.
4. Repeat with a video selected. Other restored video tabs should still wait for the selected video's initial load to finish.

## Additional context
<!-- Add any other context about the pull request here. -->

A local benchmark with 60 history tabs and 4× renderer CPU throttling reduced median time to the selected page from 10.5 s to 2.9 s across three runs per version. This measures selected-page availability, not completion of all background loading. Real-world results depend on tab contents and hardware.

Regression coverage includes initial snapshot batching, selected-page priority, mount sequencing and cancellation, unloaded-state preservation, avatar deduplication, and window shutdown. The performance regression runs with CPU throttling in Electron.

Implemented and reviewed with GPT-6 through the Codex desktop harness.
