### PR TITLE
fix(themes): improve Hot Pink settings and comment thread contrast

### DIFF
--- a/e2e/tests/offline/theme-contrast.spec.mjs
+++ b/e2e/tests/offline/theme-contrast.spec.mjs
@@ -1,4 +1,4 @@
-import { test, expect, goToSettingsSection } from '../../helpers/app.mjs'
+import { test, expect, goToSettingsSection, setPlayerFullscreen } from '../../helpers/app.mjs'
 import { sampleColors } from '../../helpers/colors.mjs'
 import { openMockedVideo } from '../../helpers/player.mjs'
 import { mockPlayableWatchPage } from '../../helpers/watch.mjs'
@@ -44,6 +44,39 @@ for (const theme of ['openTubeXLight', 'openTubeXDark']) {
   for (const scale of [100, 125]) {
     test.describe(`${theme} control contrast at ${scale}%`, () => {
       test.use({ seed: { settings: { baseTheme: theme, currentLocale: 'en-US', uiScale: scale } } })
+
+      for (const fullscreen of [false, true]) {
+        test(`comment thread lines and reply connectors remain visible in ${fullscreen ? 'fullscreen' : 'watch page'}`, async ({ app, page, attachScreenshot }) => {
+          await mockPlayableWatchPage(app, page)
+          await openMockedVideo(page)
+          if (fullscreen) {
+            await setPlayerFullscreen(page, true)
+            await page.locator('.fullscreenCommentsToggle').click({ force: true })
+            await expect(page.locator('.fullscreenCommentsOverlay.open')).toBeVisible()
+          }
+          const thread = page.locator('.commentThread').first()
+          const connector = thread.locator('.commentReplyConnector').first()
+
+          for (const [element, pseudo] of [[thread, '::before'], [connector, null]]) {
+            if (!pseudo) {
+              await thread.locator(':scope > .commentReplyRootToggle button').click()
+            }
+            await expect(element).toBeVisible()
+            await page.mouse.move(0, 0)
+            await element.scrollIntoViewIfNeeded()
+            const points = await element.evaluate((element, pseudo) => {
+              const style = getComputedStyle(element, pseudo)
+              const x = pseudo ? parseFloat(style.insetInlineStart) : 0
+              const y = pseudo ? parseFloat(style.insetBlockStart) + 10 : 3
+              return [[x - 4, y], ...[-0.5, 0.5, 1.5].map(offset => [x + offset, y])]
+            }, pseudo)
+            const [surface, ...edge] = await sampleColors(app, element, points)
+            const ratio = Math.max(...edge.map(color => contrastRatio(color, surface)))
+            expect.soft(ratio, `${pseudo ? 'thread' : 'reply connector'} ${JSON.stringify({ surface, edge })}`).toBeGreaterThanOrEqual(3)
+          }
+          await attachScreenshot(`${theme} comment thread contrast at ${scale}% ${fullscreen ? 'fullscreen' : 'watch page'}`)
+        })
+      }
 
       test('seekbar progress stays neutral and SponsorBlock categories remain visible', async ({ app, page }) => {
         await mockPlayableWatchPage(app, page)

--- a/e2e/tests/offline/theme-contrast.spec.mjs
+++ b/e2e/tests/offline/theme-contrast.spec.mjs
@@ -208,16 +208,27 @@ for (const scale of [100, 125]) {
       await goToSettingsSection(page, 'general')
       const toggle = page.getByRole('checkbox', { name: 'Keep relative timestamps updated' })
       const tracks = []
+      const thumbs = []
       for (const checked of [true, false]) {
         if (await toggle.isChecked() !== checked) await toggle.locator('..').locator('.switch-label').click()
         await expect(toggle).toBeChecked({ checked })
         const contrast = await switchContrast(app, toggle.locator('..').locator('.switch-label'), checked)
         tracks.push(contrast.track)
+        thumbs.push(contrast.thumb)
+        const label = toggle.locator('..').locator('.switch-label')
+        const height = await label.evaluate(element => element.getBoundingClientRect().height)
+        // The outline separates the white thumb from the light off track.
+        // Sample its vertical edge where it crosses the track.
+        const edge = await sampleColors(app, label, [-0.5, 0.5, 1.5].map(offset => [
+          (checked ? 21 : 24) + offset, height / 2
+        ]))
+        const thumbRatio = Math.max(contrast.thumbRatio, ...edge.map(color => contrastRatio(color, contrast.track)))
         expect.soft(contrast.trackRatio, `track and background ${JSON.stringify(contrast)}`).toBeGreaterThanOrEqual(3)
-        expect.soft(contrast.thumbRatio, `thumb and track ${JSON.stringify(contrast)}`).toBeGreaterThanOrEqual(3)
+        expect.soft(thumbRatio, `thumb boundary and track ${JSON.stringify({ contrast, edge })}`).toBeGreaterThanOrEqual(3)
         expect.soft(contrast.thumbSurfaceRatio, `thumb and background ${JSON.stringify(contrast)}`).toBeGreaterThanOrEqual(3)
       }
       expect(contrastRatio(...tracks), 'on and off tracks').toBeGreaterThanOrEqual(3)
+      expect(thumbs[0], 'thumb color stays consistent').toEqual(thumbs[1])
     })
 
     test('settings category titles and descriptions remain readable in every state', async ({ page }) => {

--- a/e2e/tests/offline/theme-contrast.spec.mjs
+++ b/e2e/tests/offline/theme-contrast.spec.mjs
@@ -40,7 +40,7 @@ async function controlContrast(app, control, kind) {
   return { surface, edge, ratio: Math.max(...edge.map(color => contrastRatio(color, surface))) }
 }
 
-for (const theme of ['openTubeXLight', 'openTubeXDark', 'hotPink']) {
+for (const theme of ['openTubeXLight', 'openTubeXDark']) {
   for (const scale of [100, 125]) {
     test.describe(`${theme} comment contrast at ${scale}%`, () => {
       test.use({ seed: { settings: { baseTheme: theme, currentLocale: 'en-US', uiScale: scale } } })

--- a/e2e/tests/offline/theme-contrast.spec.mjs
+++ b/e2e/tests/offline/theme-contrast.spec.mjs
@@ -40,9 +40,9 @@ async function controlContrast(app, control, kind) {
   return { surface, edge, ratio: Math.max(...edge.map(color => contrastRatio(color, surface))) }
 }
 
-for (const theme of ['openTubeXLight', 'openTubeXDark']) {
+for (const theme of ['openTubeXLight', 'openTubeXDark', 'hotPink']) {
   for (const scale of [100, 125]) {
-    test.describe(`${theme} control contrast at ${scale}%`, () => {
+    test.describe(`${theme} comment contrast at ${scale}%`, () => {
       test.use({ seed: { settings: { baseTheme: theme, currentLocale: 'en-US', uiScale: scale } } })
 
       for (const fullscreen of [false, true]) {
@@ -77,9 +77,20 @@ for (const theme of ['openTubeXLight', 'openTubeXDark']) {
           await attachScreenshot(`${theme} comment thread contrast at ${scale}% ${fullscreen ? 'fullscreen' : 'watch page'}`)
         })
       }
+    })
+  }
+}
+
+for (const theme of ['openTubeXLight', 'openTubeXDark']) {
+  for (const scale of [100, 125]) {
+    test.describe(`${theme} control contrast at ${scale}%`, () => {
+      test.use({ seed: { settings: { baseTheme: theme, currentLocale: 'en-US', uiScale: scale } } })
 
       test('seekbar progress stays neutral and SponsorBlock categories remain visible', async ({ app, page }) => {
         await mockPlayableWatchPage(app, page)
+        // An aborted label lookup would queue later SponsorBlock requests behind
+        // network recovery. A 404 is the API's normal "no labels" response.
+        await page.route('**/api/videoLabels/**', route => route.fulfill({ status: 404 }))
         const categories = ['sponsor', 'selfpromo', 'interaction', 'intro', 'outro', 'preview', 'hook', 'music_offtopic', 'filler', 'poi_highlight']
         await page.route('**/api/skipSegments/**', route => route.fulfill({
           json: [{
@@ -187,4 +198,85 @@ for (const theme of ['openTubeXLight', 'openTubeXDark']) {
       })
     })
   }
+}
+
+for (const scale of [100, 125]) {
+  test.describe(`hotPink contrast at ${scale}%`, () => {
+    test.use({ seed: { settings: { baseTheme: 'hotPink', currentLocale: 'en-US', uiScale: scale } } })
+
+    test('toggle thumbs remain distinct in both states', async ({ app, page }) => {
+      await goToSettingsSection(page, 'general')
+      const toggle = page.getByRole('checkbox', { name: 'Keep relative timestamps updated' })
+      const tracks = []
+      for (const checked of [true, false]) {
+        if (await toggle.isChecked() !== checked) await toggle.locator('..').locator('.switch-label').click()
+        await expect(toggle).toBeChecked({ checked })
+        const contrast = await switchContrast(app, toggle.locator('..').locator('.switch-label'), checked)
+        tracks.push(contrast.track)
+        expect.soft(contrast.trackRatio, `track and background ${JSON.stringify(contrast)}`).toBeGreaterThanOrEqual(3)
+        expect.soft(contrast.thumbRatio, `thumb and track ${JSON.stringify(contrast)}`).toBeGreaterThanOrEqual(3)
+        expect.soft(contrast.thumbSurfaceRatio, `thumb and background ${JSON.stringify(contrast)}`).toBeGreaterThanOrEqual(3)
+      }
+      expect(contrastRatio(...tracks), 'on and off tracks').toBeGreaterThanOrEqual(3)
+    })
+
+    test('settings category titles and descriptions remain readable in every state', async ({ page }) => {
+      await goToSettingsSection(page, 'theme')
+      const pageColors = await page.locator('body').evaluate(element => {
+        const style = getComputedStyle(element)
+        const rgb = color => color.match(/[\d.]+/g).slice(0, 3).map(Number)
+        return { foreground: rgb(style.color), background: rgb(style.backgroundColor) }
+      })
+      expect.soft(contrastRatio(pageColors.foreground, pageColors.background), 'page text').toBeGreaterThanOrEqual(4.5)
+      const category = page.locator('.settingsMenu .title[data-section="playback"]')
+      const selected = page.locator('.settingsMenu .title.active')
+      for (const state of ['normal', 'selected', 'hover', 'focus']) {
+        const button = state === 'selected' ? selected : category
+        if (state === 'hover') await button.hover()
+        if (state === 'focus') {
+          await page.mouse.move(0, 0)
+          await page.keyboard.press('Tab')
+          await button.focus()
+        }
+        const colors = await button.evaluate(element => {
+          const rgb = color => color.match(/[\d.]+/g).slice(0, 3).map(Number)
+          const style = getComputedStyle(element)
+          const background = style.backgroundColor === 'rgba(0, 0, 0, 0)'
+            ? getComputedStyle(element.closest('.settingsMenu')).backgroundColor
+            : style.backgroundColor
+          return {
+            background: rgb(background),
+            title: rgb(getComputedStyle(element.querySelector('.titleText')).color),
+            description: rgb(getComputedStyle(element.querySelector('.titleDescription')).color)
+          }
+        })
+        for (const part of ['title', 'description']) {
+          expect.soft(contrastRatio(colors[part], colors.background), `${state} ${part} ${JSON.stringify(colors)}`).toBeGreaterThanOrEqual(4.5)
+        }
+      }
+    })
+
+    test('slider tracks and hovered header controls remain visible', async ({ app, page }) => {
+      await goToSettingsSection(page, 'theme')
+      const input = page.getByRole('slider', { name: /UI Roundness/ })
+      const slider = await controlContrast(app, input, 'slider')
+      expect.soft(slider.ratio, `slider ${JSON.stringify(slider)}`).toBeGreaterThanOrEqual(3)
+      const points = await input.evaluate(element => {
+        const rect = element.getBoundingClientRect()
+        const fraction = (Number(element.value) - Number(element.min)) / (Number(element.max) - Number(element.min))
+        return [[1 + fraction * (rect.width - 2), rect.height / 2], [rect.width * 0.85, rect.height / 2]]
+      })
+      const [thumb, track] = await sampleColors(app, input, points)
+      expect.soft(contrastRatio(thumb, track), `slider thumb ${JSON.stringify({ thumb, track })}`).toBeGreaterThanOrEqual(3)
+      const button = page.getByRole('button', { name: 'Show performance impact indicators', exact: true })
+      if (await button.getAttribute('aria-pressed') === 'true') await button.click()
+      await button.hover()
+      const colors = await button.evaluate(element => {
+        const style = getComputedStyle(element)
+        const rgb = color => color.match(/[\d.]+/g).slice(0, 3).map(Number)
+        return { foreground: rgb(style.color), background: rgb(style.backgroundColor) }
+      })
+      expect.soft(contrastRatio(colors.foreground, colors.background), `header hover ${JSON.stringify(colors)}`).toBeGreaterThanOrEqual(3)
+    })
+  })
 }

--- a/src/renderer/components/FtSettingsMenu/FtSettingsMenu.css
+++ b/src/renderer/components/FtSettingsMenu/FtSettingsMenu.css
@@ -35,7 +35,7 @@
 
 .title:hover,
 .title:focus-visible {
-  color: var(--primary-text-color);
+  color: var(--side-nav-hover-text-color);
   background: var(--side-nav-hover-color);
 }
 
@@ -76,7 +76,7 @@
 }
 
 .titleDescription {
-  color: var(--tertiary-text-color);
+  color: inherit;
   font-size: 11px;
   font-weight: 400;
 }

--- a/src/renderer/components/FtToggleSwitch/FtToggleSwitch.scss
+++ b/src/renderer/components/FtToggleSwitch/FtToggleSwitch.scss
@@ -61,7 +61,8 @@
   &::after {
     background-color: var(--toggle-thumb-color, #fafafa);
     border-radius: 50%;
-    box-shadow: 0 3px 1px -2px rgb(0 0 0 / 14%), 0 2px 2px 0 rgb(0 0 0 / 9.8%), 0 1px 5px 0 rgb(0 0 0 / 8.4%);
+    box-shadow: inset 0 0 0 1px var(--toggle-thumb-outline-color, transparent),
+      0 3px 1px -2px rgb(0 0 0 / 14%), 0 2px 2px 0 rgb(0 0 0 / 9.8%), 0 1px 5px 0 rgb(0 0 0 / 8.4%);
     block-size: 20px;
     inset-inline-start: 5px;
     inline-size: 20px;

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -2397,7 +2397,7 @@ body .os-scrollbar {
 }
 
 /* Resolve the color on the thread so fullscreen docks can supply their palette. */
-:is(.openTubeXLight, .openTubeXDark, .hotPink) .comment.commentThread {
+:is(.openTubeXLight, .openTubeXDark) .comment.commentThread {
   --comment-thread-line-color: var(--tertiary-text-color);
 }
 

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -353,18 +353,22 @@ it can be safely elided. This looks quite pleasant on this theme. */
 }
 
 .hotPink {
+  --toggle-track-color: #ddd;
+  --toggle-thumb-color: #000;
+  --toggle-checked-thumb-color: #fff;
+  --slider-track-color: #fff;
   --primary-text-color: #ffff;
   --secondary-text-color: #ffff;
   --tertiary-text-color: #ffff;
   --title-color: #000;
-  --bg-color: #ff008a;
+  --bg-color: #dd197f;
   --favorite-icon-color: #6eaa73;
   --card-bg-color: #de1c85;
   --secondary-card-bg-color: rgb(0 0 0 / 75%);
   --scrollbar-color: #fff;
   --scrollbar-color-hover: #c0f6ff;
   --scrollbar-text-color-hover: #000;
-  --side-nav-color: #ee1e90;
+  --side-nav-color: #dd197f;
   --side-nav-hover-color: #fff;
   --side-nav-hover-text-color: #000;
   --side-nav-active-color: #959595;
@@ -383,8 +387,8 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --text-with-main-color: #fff !important;
   --text-with-accent-color: #fff !important;
   --accent-color: #000 !important;
-  --accent-color-hover: #808080 !important;
-  --accent-color-active: #6a739a !important;
+  --accent-color-hover: #000 !important;
+  --accent-color-active: #000 !important;
   --accent-color-light: #000 !important;
   --accent-color-visited: #000 !important;
   --accent-color-opacity1: rgb(0 0 0 / 4%) !important;
@@ -2392,7 +2396,7 @@ body .os-scrollbar {
 }
 
 /* Resolve the color on the thread so fullscreen docks can supply their palette. */
-:is(.openTubeXLight, .openTubeXDark) .comment.commentThread {
+:is(.openTubeXLight, .openTubeXDark, .hotPink) .comment.commentThread {
   --comment-thread-line-color: var(--tertiary-text-color);
 }
 

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -354,8 +354,9 @@ it can be safely elided. This looks quite pleasant on this theme. */
 
 .hotPink {
   --toggle-track-color: #ddd;
-  --toggle-thumb-color: #000;
+  --toggle-thumb-color: #fff;
   --toggle-checked-thumb-color: #fff;
+  --toggle-thumb-outline-color: #000;
   --slider-track-color: #fff;
   --primary-text-color: #ffff;
   --secondary-text-color: #ffff;

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -2391,6 +2391,11 @@ body .os-scrollbar {
   --logo-text: url('../../_icons/textWhiteSmall.svg');
 }
 
+/* Resolve the color on the thread so fullscreen docks can supply their palette. */
+:is(.openTubeXLight, .openTubeXDark) .comment.commentThread {
+  --comment-thread-line-color: var(--tertiary-text-color);
+}
+
 .openTubeXLight {
   --toggle-track-color: #b7c9c5;
   --toggle-checked-track-color: #8cbaae;

--- a/src/renderer/views/Settings/Settings.css
+++ b/src/renderer/views/Settings/Settings.css
@@ -215,7 +215,7 @@
 .settingsHeaderButton:hover,
 .settingsHeaderButton:focus-visible,
 .settingsHeaderButton.active {
-  color: var(--primary-text-color);
+  color: var(--side-nav-hover-text-color);
   background: var(--side-nav-hover-color);
 }
 


### PR DESCRIPTION
Hot Pink had black-on-black switches, invisible selected settings descriptions, and faint controls. OpenTubeX Light and Dark also had barely visible comment-thread lines. This fixes those contrast problems.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Reported directly in this task; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Hot Pink now has distinct on/off switch tracks with consistent outlined white thumbs, visible slider tracks, readable settings descriptions and hover states, and stronger page/sidebar text contrast. Comment-thread lines use the local muted text color in OpenTubeX Light and Dark, including fullscreen comments.

Hot Pink’s existing fixed-color behavior is unchanged; its color pickers were already disabled in v0.34.0-beta.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Improved comment-thread contrast in OpenTubeX Light and Dark, and switch, slider, and settings text contrast in Hot Pink.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Select Hot Pink and open Appearance settings. The selected category’s description and hovered category/header icons should remain readable.
2. Toggle a switch off and on. The thumb stays white with a dark outline in both states. Off uses a light gray track; on uses a black track. Slider tracks should be visible against the pink background.
3. Open a video with comments and expand replies in OpenTubeX Light and OpenTubeX Dark. Check the vertical lines and curved reply connectors in both the watch page and fullscreen comments panel.
4. Repeat at 125% UI Scale. Clicking a thread line should still expand and collapse replies.

## Additional context
<!-- Add any other context about the pull request here. -->

Validation: theme-contrast checks cover 100% and 125% UI Scale. Unit tests and lint pass. Lint reports one existing warning. Existing comment-line mouse/keyboard checks also passed.

The seekbar fixture now returns the API’s normal 404 response for absent SponsorBlock video labels. Aborting that unmocked request previously blocked segment requests behind network recovery.

Implemented with GPT-6 in Codex.


