### PR TITLE
fix(android): prevent video-end crashes and fix fullscreen rotation and overlays

### DIFF
--- a/android/app/src/androidTest/java/org/opentubex/app/AndroidMediaSessionLifecycleTest.java
+++ b/android/app/src/androidTest/java/org/opentubex/app/AndroidMediaSessionLifecycleTest.java
@@ -22,6 +22,27 @@ import java.util.Arrays;
 
 @RunWith(AndroidJUnit4.class)
 public class AndroidMediaSessionLifecycleTest {
+    @Test public void finalPositionUpdateAfterClearDoesNotCrashTheProcess() {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(activity -> {
+                activity.getBridge().getWebView().loadUrl("about:blank");
+                // ended clears the notification; the final timeupdate can still
+                // request foreground startup before Android delivers that clear.
+                context.startService(new Intent(context, AndroidMediaSessionService.class)
+                    .setAction(AndroidMediaSessionService.ACTION_UPDATE)
+                    .putExtra(AndroidMediaSessionService.EXTRA_STATE, "{\"playbackState\":\"none\"}"));
+                ContextCompat.startForegroundService(context, new Intent(context, AndroidMediaSessionService.class)
+                    .setAction(AndroidMediaSessionService.ACTION_UPDATE)
+                    .putExtra(AndroidMediaSessionService.EXTRA_STATE,
+                        "{\"title\":\"Final position regression\",\"playbackState\":\"paused\"}"));
+            });
+            awaitForeground(context);
+            SystemClock.sleep(10000);
+            assertTrue("A newer playback request must survive the earlier clear", hasForegroundNotification(context));
+        }
+    }
+
     @Test public void activityTeardownAfterUpdateDoesNotCrashTheProcess() throws Exception {
         assertActivityTeardown(false);
     }

--- a/android/app/src/main/java/org/opentubex/app/AndroidMediaSessionService.java
+++ b/android/app/src/main/java/org/opentubex/app/AndroidMediaSessionService.java
@@ -144,13 +144,13 @@ public class AndroidMediaSessionService extends Service {
         }
 
         if (ACTION_STOP.equals(action)) {
-            stopPlaybackService();
+            stopPlaybackService(startId);
             return START_NOT_STICKY;
         }
 
         String serializedState = intent == null ? null : intent.getStringExtra(EXTRA_STATE);
         if (!ACTION_UPDATE.equals(action) || serializedState == null) {
-            stopPlaybackService();
+            stopPlaybackService(startId);
             return START_NOT_STICKY;
         }
 
@@ -162,26 +162,26 @@ public class AndroidMediaSessionService extends Service {
                     // before stopping, or Android terminates the entire process.
                     startForeground(NOTIFICATION_ID, buildNotification(nextState, java.util.Collections.emptySet()));
                     stopSelf(startId);
-                } else applyState(currentState, true);
+                } else applyState(currentState, startId);
                 return START_NOT_STICKY;
             }
             currentState = nextState;
             mediaSession.setActive(true);
-            applyState(currentState, true);
+            applyState(currentState, startId);
         } catch (JSONException error) {
-            stopPlaybackService();
+            stopPlaybackService(startId);
         }
         return START_NOT_STICKY;
     }
 
     private void applyState(JSONObject state) {
-        applyState(state, false);
+        applyState(state, 0);
     }
 
-    private void applyState(JSONObject state, boolean foregroundStart) {
+    private void applyState(JSONObject state, int startId) {
         String playbackState = state.optString("playbackState", "none");
         if ("none".equals(playbackState)) {
-            stopPlaybackService();
+            stopPlaybackService(startId);
             return;
         }
 
@@ -234,7 +234,7 @@ public class AndroidMediaSessionService extends Service {
         );
         // Every startForegroundService request needs an acknowledgement, even
         // when Android demoted an existing service whose notification is unchanged.
-        if (foregroundStart || !nextNotificationSignature.equals(notificationSignature)) {
+        if (startId != 0 || !nextNotificationSignature.equals(notificationSignature)) {
             startForeground(NOTIFICATION_ID, buildNotification(state, actions));
             notificationSignature = nextNotificationSignature;
         }
@@ -570,6 +570,10 @@ public class AndroidMediaSessionService extends Service {
     }
 
     private void stopPlaybackService() {
+        stopPlaybackService(0);
+    }
+
+    private void stopPlaybackService(int startId) {
         String nativeOwner = currentState == null ? "" : currentState.optString("nativeOwner", "");
         currentState = null;
         AndroidPlaybackPlugin.pauseOwner(nativeOwner);
@@ -581,7 +585,9 @@ public class AndroidMediaSessionService extends Service {
         releasePlaybackWakeLock.run();
         mediaSession.setActive(false);
         stopForeground(STOP_FOREGROUND_REMOVE);
-        stopSelf();
+        // A later foreground start may already be queued when a clear arrives.
+        // Leave that start alive so onStartCommand can acknowledge it.
+        if (startId == 0) stopSelf(); else stopSelf(startId);
     }
 
     @Override

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -6096,7 +6096,7 @@ export default defineComponent({
 
       tabMediaCoordinator.setPlaybackState(
         mediaTabId,
-        mediaSessionStopped ? 'none' : 'paused'
+        mediaSessionStopped || video.value?.ended ? 'none' : 'paused'
       )
 
       if (process.env.IS_ELECTRON && window.ftElectron?.tabs?.setPlaybackState) {
@@ -6199,11 +6199,17 @@ export default defineComponent({
       // Re-evaluate auto-PiP now that PiP is actually allowed (the video was possibly
       // in a hidden tab / scrolled out of view while still loading).
       updateAutoPip()
+      handleVideoResize()
+      videoLayoutReady.value = true
+    }
+
+    function handleVideoResize() {
       updateAnnotationVideoAspectRatio()
       updateScrollMiniVideoAspectRatio()
       updateScrollMiniPlayer()
-      videoLayoutReady.value = true
 
+      // Native dimensions can arrive after canplay, including when fullscreen
+      // was entered while waiting for the first media segment.
       if (isActiveTab.value && isNativeFullscreenActive()) {
         setFullscreenOrientation(
           true,
@@ -6364,7 +6370,7 @@ export default defineComponent({
           position: Math.min(videoElement.duration, Math.max(0, videoElement.currentTime)),
           playbackRate: videoElement.playbackRate,
         },
-        mediaSessionStopped ? 'none' : videoElement.paused ? 'paused' : 'playing'
+        mediaSessionStopped || videoElement.ended ? 'none' : videoElement.paused ? 'paused' : 'playing'
       )
     }
 
@@ -11517,6 +11523,7 @@ export default defineComponent({
       handlePause,
       syncPlayPauseControlIcons,
       handleCanPlay,
+      handleVideoResize,
       handleEnded,
       handleSeeking,
       handleAbRepeatSeeked,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -143,6 +143,7 @@
         @seeking="handleSeeking"
         @seeked="handleAbRepeatSeeked"
         @canplay="handleCanPlay"
+        @resize="handleVideoResize"
         @volumechange="updateVolume"
         @timeupdate="handleTimeupdate"
         @ratechange="syncMediaSessionPosition"

--- a/src/renderer/helpers/player/androidNativeScreen.js
+++ b/src/renderer/helpers/player/androidNativeScreen.js
@@ -220,6 +220,7 @@ export function createAndroidNativeScreen({ element, container, getController, g
       controlsHeight: controlBounds.height,
       videoVisible: visible,
       controlsVisible: visible && controlBounds.width > 0 && controlBounds.height > 0 &&
+        !container.querySelector('.endedScreen') &&
         !container.classList.contains('scrollMiniPlayer') && sharedControls?.hasAttribute('shown') === true &&
         (!centerElement || container.contains(centerElement)),
       menus: menus.map(({ x, y, width, height, pageScroll = false }) => ({ x, y: pageScroll ? nativeY(y) : y, width, height, pageScroll })),

--- a/tests/unit/android-ended-media-session.test.mjs
+++ b/tests/unit/android-ended-media-session.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import vm from 'node:vm'
+import { attachAndroidMediaElement } from '../../src/renderer/helpers/player/androidMediaElement.js'
+
+const source = await readFile(new URL('../../src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js', import.meta.url), 'utf8')
+const start = source.indexOf('    function syncMediaSessionPosition()')
+const body = source.slice(start, source.indexOf('\n    }', start) + 6)
+
+test('the final native timeupdate cannot restore media controls after ended', () => {
+  const states = []
+  const element = Object.assign(new EventTarget(), {
+    style: {}, volume: 1, muted: false, playbackRate: 1, pause() {},
+  })
+  const media = attachAndroidMediaElement(element, {
+    command: async () => {}, load: async () => {}, onError: error => { throw error },
+  })
+  const sync = vm.runInNewContext(`${body}\nsyncMediaSessionPosition`, {
+    video: { value: element }, mediaSessionStopped: false, mediaTabId: 'test',
+    tabMediaCoordinator: { setPositionState: (tab, position, state) => states.push(state) },
+  })
+  element.addEventListener('timeupdate', sync)
+  element.addEventListener('ended', () => states.push('none'))
+  media.update({ duration: 20, position: 19, ready: true, playing: true, paused: false })
+  states.length = 0
+  media.update({ position: 20, playing: false, paused: false, ended: true })
+  assert.deepEqual(states, ['none', 'none'], 'ExoPlayer retains playWhenReady after the video ends')
+  media.update({ paused: true })
+  assert.equal(states.at(-1), 'none', 'The ensuing native pause must not restore the notification')
+  media.update({ position: 0, paused: false, playing: true, ended: false })
+  assert.equal(states.at(-1), 'playing', 'Replay must restore media controls')
+  media.detach()
+})

--- a/tests/unit/android-fullscreen-orientation.test.mjs
+++ b/tests/unit/android-fullscreen-orientation.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import vm from 'node:vm'
+import { attachAndroidMediaElement } from '../../src/renderer/helpers/player/androidMediaElement.js'
+import { shouldRotateFullscreenToLandscape } from '../../src/renderer/helpers/capacitorUi.js'
+
+const source = await readFile(new URL('../../src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js', import.meta.url), 'utf8')
+const template = await readFile(new URL('../../src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue', import.meta.url), 'utf8')
+
+for (const [label, width, height, active, fullscreen, enabled, fromRotation, expected] of [
+  ['late landscape dimensions', 1920, 1080, true, true, true, false, true],
+  ['late portrait dimensions', 1080, 1920, true, true, true, false, false],
+  ['inline playback', 1920, 1080, true, false, true, false, null],
+  ['inactive tab', 1920, 1080, false, true, true, false, null],
+  ['disabled rotation', 1920, 1080, true, true, false, false, false],
+  ['sensor fullscreen', 1920, 1080, true, true, true, true, false],
+]) {
+  test(`fullscreen orientation follows ${label} after canplay`, () => {
+    const rotations = []
+    const element = Object.assign(new EventTarget(), {
+      style: {}, volume: 1, muted: false, playbackRate: 1, pause() {},
+    })
+    const media = attachAndroidMediaElement(element, {
+      command: async () => {}, load: async () => {}, onError: error => { throw error },
+    })
+    // Android may become ready before ExoPlayer reports its video size.
+    media.update({ ready: true, width: 0, height: 0 })
+    const handlerName = template.match(/@resize="(\w+)"/)?.[1]
+    assert.ok(handlerName, 'Video dimension changes must recheck fullscreen orientation')
+    const start = source.indexOf(`    function ${handlerName}(`)
+    const body = source.slice(start, source.indexOf('\n    }', start) + 6)
+    const handler = vm.runInNewContext(`${body}\n${handlerName}`, {
+      video: { value: element }, isActiveTab: { value: active },
+      isNativeFullscreenActive: () => fullscreen,
+      rotateFullscreenToLandscape: { value: enabled },
+      player: { nativePlayback: { isFullscreenFromRotation: () => fromRotation } },
+      setFullscreenOrientation: async (...args) => rotations.push(shouldRotateFullscreenToLandscape(...args)),
+      updateAnnotationVideoAspectRatio() {}, updateScrollMiniVideoAspectRatio() {}, updateScrollMiniPlayer() {},
+    })
+    element.addEventListener('resize', handler)
+    media.update({ width, height })
+    assert.deepEqual(rotations, expected === null ? [] : [expected])
+    media.detach()
+  })
+}

--- a/tests/unit/android-native-screen.test.mjs
+++ b/tests/unit/android-native-screen.test.mjs
@@ -18,6 +18,7 @@ async function fixture({ fullscreen = true, chrome = [], deferTransitions = fals
   let shown = true
   let menu = false
   let panel = false
+  let recommendations = false
   let animating = false
   let id = 0
   const bounds = { x: 0, y: 0, width: 640, height: 360 }
@@ -31,6 +32,7 @@ async function fixture({ fullscreen = true, chrome = [], deferTransitions = fals
     querySelectorAll(selector) { return menu && selector.includes('shaka-overflow-menu') ? [{ getAnimations: () => [], getBoundingClientRect: () => ({ x: 400, y: 100, width: 200, height: 240 }) }] : [] },
     querySelector(selector) {
       if (selector === '.shaka-controls-container') return controlsElement
+      if (selector === '.endedScreen' && recommendations) return { getBoundingClientRect: () => bounds }
       return null
     },
   })
@@ -67,8 +69,9 @@ async function fixture({ fullscreen = true, chrome = [], deferTransitions = fals
   if (fullscreen) await screen.show()
   else await screen.attach()
   await flush()
-  return { screen, container, layouts, presentations, completeTransitions, completeFullscreen, fullscreenEvents, bounds, observers, flush, change({ visible = shown, menuOpen = menu, panelOpen = panel, containerAnimating = animating }) {
+  return { screen, container, layouts, presentations, completeTransitions, completeFullscreen, fullscreenEvents, bounds, observers, flush, change({ visible = shown, menuOpen = menu, panelOpen = panel, containerAnimating = animating, endedRecommendations = recommendations }) {
     shown = visible; menu = menuOpen; panel = panelOpen
+    recommendations = endedRecommendations
     animating = containerAnimating
     for (const observer of observers) observer.callback()
   } }
@@ -152,6 +155,25 @@ test('native controls follow shared shown state, including paused tap-to-hide', 
   assert.equal(f.layouts.at(-1).controlsVisible, true)
   f.screen.destroy()
 })
+
+for (const fullscreen of [false, true]) {
+  test(`end-screen recommendations hide native transport controls ${fullscreen ? 'in fullscreen' : 'inline'}`, async () => {
+    const f = await fixture({ fullscreen })
+    assert.equal(f.layouts.at(-1).controlsVisible, true)
+    f.change({ endedRecommendations: true })
+    await f.flush()
+    assert.equal(f.layouts.at(-1).controlsVisible, false, 'Native play and seek buttons must not cover recommendation links')
+    f.change({ visible: false })
+    await f.flush()
+    f.change({ visible: true })
+    await f.flush()
+    assert.equal(f.layouts.at(-1).controlsVisible, false, 'Revealing the shared toolbar must not restore the overlapping native buttons')
+    f.change({ endedRecommendations: false })
+    await f.flush()
+    assert.equal(f.layouts.at(-1).controlsVisible, true, 'Replay and end screens without recommendations retain native controls')
+    f.screen.destroy()
+  })
+}
 
 test('side panels and menus retain transport controls inside the video column', async () => {
   const f = await fixture()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Reported while testing the installed Android nightly on a Pixel 8 Pro.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Finishing a video could crash Android when a media-service clear overtook a newer foreground-start request. Entering fullscreen before loading could also miss landscape rotation, and native play/seek buttons covered the end-screen recommendations.

Respect service start IDs when stopping, keep ended videos marked as stopped during final position/pause updates, recheck orientation when video dimensions arrive, and hide native transport controls while recommendations are visible.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. In OpenTubeX Dev on Android, play a video through its end. The app should stay open and the media notification should disappear.
2. Enter fullscreen while playback is loading, with landscape rotation enabled. A landscape video should rotate once its dimensions arrive.
3. Check recommendations after playback ends, inline and fullscreen. The center play/seek buttons should be hidden; revealing the bottom toolbar should keep them hidden. Seek backward to restore playback controls.

## Additional context
<!-- Add any other context about the pull request here. -->

Regression tests failed before their respective fixes and passed afterward. Validation includes the JavaScript unit suite, lint, 78 native unit tests, six Android media-service lifecycle tests, and Pixel 8 Pro checks of the original video, early fullscreen entry, recommendation visibility, and control restoration.

The native Android player has not appeared in a stable release.

Implemented with GPT-6 in Codex.

