### PR TITLE
feat: show an early themed startup splash with curtain reveal

### DIFF
--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -189,7 +189,14 @@ const config = {
     new HtmlWebpackPlugin({
       filename: 'index.html',
       template: path.resolve(__dirname, '../src/index.ejs'),
-      templateParameters: sigFrameTemplateParameters
+      templateParameters: {
+        ...sigFrameTemplateParameters,
+        startupSplash: {
+          styles: readFileSync(path.join(__dirname, '../src/renderer/startup/splash.css'), 'utf8'),
+          script: readFileSync(path.join(__dirname, '../src/renderer/startup/boot.js'), 'utf8'),
+          logo: readFileSync(path.join(__dirname, '../_icons/iconColorSmall.svg'), 'utf8').replaceAll('#212121', 'currentColor')
+        }
+      }
     }),
     new VueLoaderPlugin(),
     new MiniCssExtractPlugin({

--- a/e2e/tests/offline/home-recommendations.spec.mjs
+++ b/e2e/tests/offline/home-recommendations.spec.mjs
@@ -150,7 +150,11 @@ async function mockCandidates(page) {
     }
   })
 
-  await page.route(/^https?:\/\//, route => route.abort())
+  // An unmocked endpoint is an HTTP error, not a disconnected server. A
+  // transport abort would pause this entire origin in network recovery.
+  await page.route(/^https?:\/\//, route => route.fulfill({
+    status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'Unmocked endpoint' }),
+  }))
   await page.route('**/vi/**', route => route.fulfill({
     contentType: 'image/svg+xml',
     body: thumbnailSvg,
@@ -928,6 +932,11 @@ test.describe('local related discovery', () => {
   test.use({ seed: { settings: { ...settings, backendPreference: 'local' }, history: [historyEntry('jNQXAC9IVRw')] } })
   test('parses recorded YouTube related videos without fetching players or streams', async ({ app, page }) => {
     await mockWatchPage(app, page)
+    // This fixture covers related videos. Channel and search data are unavailable,
+    // but must not trigger an origin-wide outage that stalls the /next calls.
+    await page.route(/\/youtubei\/v1\/(?:browse|search)(?:\?|$)/, route => route.fulfill({
+      status: 404, contentType: 'application/json', body: JSON.stringify({ error: { code: 404, message: 'No discovery fixture' } }),
+    }))
     const requests = []
     page.on('request', request => requests.push(request.url()))
     await goTo(page, 'home')

--- a/e2e/tests/offline/startup-splash.spec.mjs
+++ b/e2e/tests/offline/startup-splash.spec.mjs
@@ -185,8 +185,10 @@ test.describe('startup splash with a system-selected OpenTubeX theme', () => {
 test.describe('slow initial route', () => {
   test.use({ seed: { settings: { landingPage: 'history' } } })
 
-  for (const fails of [false, true]) {
-    test(`keeps the splash closed until the initial route chunk ${fails ? 'fails' : 'loads'}`, async ({ page }) => {
+  for (const outcome of ['loads', 'fails', 'stalls']) {
+    test(outcome === 'stalls'
+      ? 'releases the app when the initial route chunk stalls'
+      : `keeps the splash closed until the initial route chunk ${outcome}`, async ({ page }) => {
       const dist = new URL('../../../dist-e2e/', import.meta.url)
       const chunks = await Promise.all((await readdir(dist)).filter(name => /^\d+\.js$/.test(name)).map(async name => ({
         name, source: await readFile(new URL(name, dist), 'utf8')
@@ -197,7 +199,7 @@ test.describe('slow initial route', () => {
       const gate = new Promise(resolve => { releaseChunks = resolve })
       await page.route(`**/${historyChunk}`, async route => {
         await gate
-        if (fails) await route.abort('failed')
+        if (outcome === 'fails') await route.abort('failed')
         else await route.continue()
       })
       try {
@@ -209,10 +211,11 @@ test.describe('slow initial route', () => {
         await page.waitForTimeout(850)
         await expect(page.locator('#startup-splash')).toBeVisible()
         await expect(page.locator('#startup-splash')).not.toHaveAttribute('data-revealing')
-        releaseChunks()
-        await expect(page.locator('#startup-splash')).toHaveCount(0)
+        if (outcome !== 'stalls') releaseChunks()
+        await expect(page.locator('#startup-splash')).toHaveCount(0, { timeout: 8000 })
         await expect(page.locator('#app')).not.toHaveAttribute('inert')
-        if (!fails) await expect(page.locator('.tabContent[aria-hidden="false"] > .routerView')).toBeVisible()
+        releaseChunks()
+        if (outcome !== 'fails') await expect(page.locator('.tabContent[aria-hidden="false"] > .routerView')).toBeVisible()
       } finally {
         releaseChunks()
         await page.unrouteAll({ behavior: 'wait' })

--- a/e2e/tests/offline/startup-splash.spec.mjs
+++ b/e2e/tests/offline/startup-splash.spec.mjs
@@ -1,0 +1,222 @@
+import { readFile, readdir } from 'node:fs/promises'
+import { test, expect } from '../../helpers/app.mjs'
+
+for (const [theme, background, zoom] of [
+  ['dark', 'rgb(15, 15, 15)', 1.25],
+  ['light', 'rgb(241, 241, 241)', 0.8],
+  ['openTubeXDark', 'rgb(11, 20, 22)', 1.25],
+  ['openTubeXLight', 'rgb(232, 242, 240)', 0.8],
+  ['hotPink', 'rgb(255, 0, 138)', 1],
+  ['pastelPink', 'rgb(255, 234, 221)', 1],
+]) {
+  test.describe(`startup splash in ${theme} mode`, () => {
+    test.use({ seed: { settings: { baseTheme: theme, currentLocale: 'de-DE', landingPage: 'history', uiScale: zoom * 100 } } })
+
+    test('paints before the renderer and reveals the first presented tab', async ({ page, app }, testInfo) => {
+      await expect(page.locator('#startup-splash')).toHaveCount(0)
+      await page.evaluate(factor => window.ftElectron.setZoomFactor(factor), zoom)
+      let releaseRenderer
+      const rendererGate = new Promise(resolve => { releaseRenderer = resolve })
+      await page.route('**/renderer.js', async route => {
+        await rendererGate
+        await route.continue()
+      })
+      try {
+        await page.reload({ waitUntil: 'commit' })
+        await expect(page.locator('#startup-splash')).toBeVisible()
+        await expect(page.locator('.topNav')).toHaveCount(0)
+        await expect(page.locator('#app')).toHaveAttribute('inert', '')
+        expect(await page.locator('.startupCurtain').first().evaluate(element => getComputedStyle(element).backgroundColor)).toBe(background)
+        await expect(page.locator('.startupLabel')).toHaveText('Wird geladen…')
+        const geometry = await page.locator('#startup-splash').evaluate(element => {
+          const bounds = element.getBoundingClientRect()
+          const logo = element.querySelector('.startupLogo').getBoundingClientRect()
+          const animation = element.querySelector('.startupProgress').getAnimations()[0]
+          return {
+            width: bounds.width,
+            height: bounds.height,
+            viewportWidth: innerWidth,
+            viewportHeight: innerHeight,
+            logoX: logo.x + logo.width / 2,
+            logoY: logo.y + logo.height / 2,
+            easing: animation.effect.getTiming().easing
+          }
+        })
+        expect(Math.abs(geometry.width - geometry.viewportWidth)).toBeLessThanOrEqual(1)
+        expect(Math.abs(geometry.height - geometry.viewportHeight)).toBeLessThanOrEqual(1)
+        expect(Math.abs(geometry.logoX - geometry.width / 2)).toBeLessThan(1)
+        expect(Math.abs(geometry.logoY - geometry.height / 2)).toBeLessThan(1)
+        expect(geometry.easing).toBe('linear')
+        await testInfo.attach(`${theme}-startup`, { body: await page.screenshot(), contentType: 'image/png' })
+        await page.evaluate(() => {
+          window.__startupReveal = null
+          window.__startupColors = []
+          window.__startupPalettes = []
+          const sampleColors = () => {
+            const curtain = document.querySelector('.startupCurtain')
+            if (!curtain) return
+            window.__startupColors.push(getComputedStyle(curtain).backgroundColor)
+            window.__startupPalettes.push(JSON.stringify({
+              folds: getComputedStyle(curtain).backgroundImage,
+              label: getComputedStyle(document.querySelector('.startupLabel')).color,
+              progress: getComputedStyle(document.querySelector('.startupProgress')).backgroundImage
+            }))
+            requestAnimationFrame(sampleColors)
+          }
+          sampleColors()
+          const splash = document.getElementById('startup-splash')
+          new MutationObserver(() => {
+            if (splash.dataset.revealing && !window.__startupReveal) {
+              const canvas = splash.querySelector('.startupFabric')
+              window.__startupReveal = {
+                presented: !!document.querySelector('.tabContent[aria-hidden="false"] > .routerView'),
+                painted: !canvas.hidden && canvas.getContext('2d').getImageData(1, 1, 1, 1).data[3] > 0,
+                started: performance.now()
+              }
+            }
+            if (!splash.isConnected && window.__startupReveal) {
+              window.__startupReveal.duration = performance.now() - window.__startupReveal.started
+            }
+          }).observe(document.body, { attributes: true, childList: true, subtree: true })
+        })
+        releaseRenderer()
+        await expect(page.locator('#startup-splash')).toHaveCount(0)
+        await expect(page.locator('#app')).not.toHaveAttribute('inert')
+        await expect(page.locator('.topNav')).toBeVisible()
+        const reveal = await page.evaluate(() => window.__startupReveal)
+        expect(await page.evaluate(() => [...new Set(window.__startupColors)])).toEqual([background])
+        expect(await page.evaluate(() => new Set(window.__startupPalettes).size)).toBe(1)
+        expect(reveal.presented).toBe(true)
+        expect(reveal.painted).toBe(true)
+        expect(reveal.duration).toBeLessThan(850)
+        expect(await app.electronApp.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0].isVisible())).toBe(true)
+      } finally {
+        releaseRenderer()
+        await page.unrouteAll({ behavior: 'wait' })
+      }
+    })
+  })
+}
+
+test('reduced motion skips the curtain animation and releases the app', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'reduce' })
+  await page.addInitScript(() => {
+    window.__startupCanvasDraws = 0
+    const drawImage = CanvasRenderingContext2D.prototype.drawImage
+    CanvasRenderingContext2D.prototype.drawImage = function (...args) {
+      if (this.canvas.classList.contains('startupFabric')) window.__startupCanvasDraws++
+      return drawImage.apply(this, args)
+    }
+  })
+  await page.reload()
+  await expect(page.locator('.topNav')).toBeVisible()
+  await expect(page.locator('#startup-splash')).toHaveCount(0)
+  await expect(page.locator('#app')).not.toHaveAttribute('inert')
+  expect(await page.evaluate(() => window.__startupCanvasDraws)).toBe(0)
+})
+
+test('shows a new window before its renderer loads and respects hiding during startup', async ({ app, page }) => {
+  let releaseRenderer
+  const gate = new Promise(resolve => { releaseRenderer = resolve })
+  const context = app.electronApp.context()
+  await context.route('**/renderer.js', async route => {
+    await gate
+    await route.continue()
+  })
+  try {
+    const created = app.electronApp.waitForEvent('window')
+    await page.evaluate(() => window.ftElectron.openInNewWindow('/history'))
+    const nextPage = await created
+    await expect(nextPage.locator('#startup-splash')).toBeVisible()
+    await expect(nextPage.locator('.topNav')).toHaveCount(0)
+    const browserWindow = await app.electronApp.browserWindow(nextPage)
+    await expect.poll(() => browserWindow.evaluate(window => window.isVisible())).toBe(true)
+    await browserWindow.evaluate(window => window.hide())
+    releaseRenderer()
+    await nextPage.waitForLoadState('load')
+    await expect(nextPage.locator('.topNav')).toBeVisible()
+    await expect(nextPage.locator('#startup-splash')).toHaveCount(0)
+    expect(await browserWindow.evaluate(window => window.isVisible())).toBe(false)
+    await browserWindow.evaluate(window => window.destroy())
+  } finally {
+    releaseRenderer()
+    await context.unrouteAll({ behavior: 'wait' })
+  }
+})
+
+test.describe('startup splash with a system-selected OpenTubeX theme', () => {
+  test.use({
+    seed: {
+      settings: {
+        baseTheme: 'system', systemDarkTheme: 'openTubeXDark', systemLightTheme: 'openTubeXLight', landingPage: 'history'
+      }
+    }
+  })
+
+  for (const [mode, background] of [['dark', 'rgb(11, 20, 22)'], ['light', 'rgb(232, 242, 240)']]) {
+    test(`uses the resolved ${mode} theme before loading the renderer`, async ({ page, app }) => {
+      await app.electronApp.evaluate(({ nativeTheme }, source) => { nativeTheme.themeSource = source }, mode)
+      let releaseRenderer
+      const gate = new Promise(resolve => { releaseRenderer = resolve })
+      const context = app.electronApp.context()
+      await context.route('**/renderer.js', async route => {
+        await gate
+        await route.continue()
+      })
+      try {
+        const created = app.electronApp.waitForEvent('window')
+        await page.evaluate(() => window.ftElectron.openInNewWindow('/history'))
+        const nextPage = await created
+        await expect(nextPage.locator('#startup-splash')).toBeVisible()
+        expect(await nextPage.locator('.startupCurtain').first().evaluate(element => getComputedStyle(element).backgroundColor))
+          .toBe(background)
+        releaseRenderer()
+        await expect(nextPage.locator('#startup-splash')).toHaveCount(0)
+        const browserWindow = await app.electronApp.browserWindow(nextPage)
+        await browserWindow.evaluate(window => window.destroy())
+      } finally {
+        releaseRenderer()
+        await context.unrouteAll({ behavior: 'wait' })
+      }
+    })
+  }
+})
+
+test.describe('slow initial route', () => {
+  test.use({ seed: { settings: { landingPage: 'history' } } })
+
+  for (const fails of [false, true]) {
+    test(`keeps the splash closed until the initial route chunk ${fails ? 'fails' : 'loads'}`, async ({ page }) => {
+      const dist = new URL('../../../dist-e2e/', import.meta.url)
+      const chunks = await Promise.all((await readdir(dist)).filter(name => /^\d+\.js$/.test(name)).map(async name => ({
+        name, source: await readFile(new URL(name, dist), 'utf8')
+      })))
+      const historyChunk = chunks.find(({ source }) => source.includes('History.Mark All As Watched'))?.name
+      expect(historyChunk).toBeTruthy()
+      let releaseChunks
+      const gate = new Promise(resolve => { releaseChunks = resolve })
+      await page.route(`**/${historyChunk}`, async route => {
+        await gate
+        if (fails) await route.abort('failed')
+        else await route.continue()
+      })
+      try {
+        await page.reload({ waitUntil: 'commit' })
+        await expect(page.locator('.topNav')).toBeVisible()
+        await expect(page.locator('.tabContent [data-tab-loading-indicator]').first()).toBeAttached()
+        // Outlast the full reveal to distinguish real route readiness from the
+        // container's earlier mount acknowledgement.
+        await page.waitForTimeout(850)
+        await expect(page.locator('#startup-splash')).toBeVisible()
+        await expect(page.locator('#startup-splash')).not.toHaveAttribute('data-revealing')
+        releaseChunks()
+        await expect(page.locator('#startup-splash')).toHaveCount(0)
+        await expect(page.locator('#app')).not.toHaveAttribute('inert')
+        if (!fails) await expect(page.locator('.tabContent[aria-hidden="false"] > .routerView')).toBeVisible()
+      } finally {
+        releaseChunks()
+        await page.unrouteAll({ behavior: 'wait' })
+      }
+    })
+  }
+})

--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -202,7 +202,8 @@ test.describe('subscriptions feed from cache', () => {
       const videoId = new URL(route.request().url()).searchParams.get('v')
       requests.push(videoId)
       if (failRequests) {
-        await route.abort()
+        // Exercise a failed poll, not network recovery's transport retry loop.
+        await route.fulfill({ status: 503, body: 'Premiere metadata unavailable' })
         return
       }
       const player = {
@@ -245,7 +246,15 @@ test.describe('subscriptions feed from cache', () => {
     const premiere = page.locator('.ft-list-video').filter({ hasText: 'Upcoming premiere video' })
     await expect(premiere.locator('.viewCount')).toContainText('2.5k watching')
     failRequests = true
+    // Both polls must finish before advancing to the next interval. The existing
+    // view count alone cannot show whether the failed requests have settled.
+    const failedResponses = Promise.all(['aaaaaaaaaa3', 'aaaaaaaaaa4'].map(videoId =>
+      page.waitForResponse(response =>
+        response.url() === `https://www.youtube.com/watch?v=${videoId}` && response.status() === 503
+      ).then(response => response.finished())
+    ))
     await page.clock.fastForward(61_000)
+    await failedResponses
     await page.clock.runFor(200)
     await expect(premiere.locator('.viewCount')).toContainText('2.5k watching')
     await expect(premiere.locator('.videoDuration')).toHaveText('Premiere')

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,6 @@
 // IPC Channels
 const IpcChannels = {
+  STARTUP_SPLASH_READY: 'startup-splash-ready',
   ENABLE_PROXY: 'enable-proxy',
   DISABLE_PROXY: 'disable-proxy',
   GET_DEVICE_NAME: 'get-device-name',

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -11,10 +11,24 @@
     <link rel="manifest" href="static/manifest.json" />
     <% } %>
     <title></title>
+    <% if (typeof startupSplash !== 'undefined') { %>
+    <style><%= startupSplash.styles %></style>
+    <% } %>
   </head>
 
   <body<% if (!process.env.IS_CAPACITOR) { %> data-overlayscrollbars-initialize<% } %>>
-    <div id="app"></div>
+    <div id="app"<% if (typeof startupSplash !== 'undefined') { %> inert<% } %>></div>
+    <% if (typeof startupSplash !== 'undefined') { %>
+    <div id="startup-splash" class="startupSplash" role="status" aria-label="OpenTubeX" aria-busy="true">
+      <div class="startupCurtain startupCurtainLeft" aria-hidden="true"></div>
+      <div class="startupCurtain startupCurtainRight" aria-hidden="true"></div>
+      <canvas class="startupFabric" aria-hidden="true" hidden></canvas>
+      <div class="startupLogo" aria-hidden="true"><%= startupSplash.logo %></div>
+      <div class="startupLabel">OpenTubeX</div>
+      <div class="startupTrack" aria-hidden="true"><div class="startupProgress"></div></div>
+    </div>
+    <script><%= startupSplash.script %></script>
+    <% } %>
     <% if (process.env.IS_ELECTRON || process.env.IS_CAPACITOR) { %>
     <iframe
       id="sigFrame"

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -2631,17 +2631,23 @@ function runApp() {
     } = { }) {
     // Syncing new window background to theme choice.
     const windowBackground = await baseHandlers.settings._findOne('baseTheme').then(async (setting) => {
-      if (!setting) {
-        return nativeTheme.shouldUseDarkColors ? '#0f0f0f' : '#f1f1f1'
+      let theme = setting?.value ?? 'system'
+      if (theme === 'system') {
+        const classification = nativeTheme.shouldUseDarkColors ? 'dark' : 'light'
+        const selected = await baseHandlers.settings._findOne(
+          classification === 'dark' ? 'systemDarkTheme' : 'systemLightTheme'
+        )
+        const customThemes = isCustomThemeValue(selected?.value) ? await loadCustomThemes() : []
+        theme = resolveSystemTheme(selected?.value, classification, customThemes)
       }
 
       // Determine window color to be shown (shown most prominently during initial app load)
       // Uses the --bg-color for each corresponding theme
-      if (isCustomThemeValue(setting.value)) {
-        return (await getSelectedCustomTheme(setting.value))?.colors.background ??
+      if (isCustomThemeValue(theme)) {
+        return (await getSelectedCustomTheme(theme))?.colors.background ??
           (nativeTheme.shouldUseDarkColors ? '#0f0f0f' : '#f1f1f1')
       }
-      switch (setting.value) {
+      switch (theme) {
         case 'dark':
           return '#0f0f0f'
         case 'light':
@@ -2656,10 +2662,10 @@ function runApp() {
           return '#282a36'
         case 'catppuccin-mocha':
           return '#1e1e2e'
-        case 'pastel-pink':
-          return '#ffd1dc'
-        case 'hot-pink':
-          return '#de1c85'
+        case 'pastelPink':
+          return '#ffeadd'
+        case 'hotPink':
+          return '#ff008a'
         case 'nordic':
           return '#2b2f3a'
         case 'solarized-dark':
@@ -2733,9 +2739,7 @@ function runApp() {
     }
 
     const newWindow = new BrowserWindow({
-      // Always wait for the shared renderer's first logical presentation. Even
-      // explicitly requested windows otherwise expose a blank shell while the
-      // initial container is mounting.
+      // The initial HTML paints a splash before the shared renderer boots.
       show: false,
       backgroundColor: windowBackground,
       icon: process.env.NODE_ENV === 'development'
@@ -2746,6 +2750,10 @@ function runApp() {
       webPreferences: {
         webSecurity: false,
         backgroundThrottling: false,
+        additionalArguments: [
+          `--startup-background=${windowBackground}`,
+          `--startup-dark=${nativeTheme.shouldUseDarkColors}`
+        ],
         preload: process.env.NODE_ENV === 'development'
           ? path.resolve(__dirname, '../../dist/preload.js')
           : path.resolve(__dirname, 'preload.js')
@@ -2915,7 +2923,12 @@ function runApp() {
       setMenu()
     }
 
+    let startupWindowShown = false
     const showWindow = () => {
+      // A later load/presentation callback must not resurface a window the user
+      // already minimized or hid while its splash was visible.
+      if (newWindow.isDestroyed() || startupWindowShown) return
+      startupWindowShown = true
       if (newWindow.isVisible()) {
         // only open the dev tools if they aren't already open
         if (process.env.NODE_ENV === 'development' && !newWindow.webContents.isDevToolsOpened()) {
@@ -2936,6 +2949,9 @@ function runApp() {
         newWindow.webContents.openDevTools({ activate: false })
       }
     }
+
+    newWindow.once('ready-to-show', showWindow)
+    newWindow.webContents.ipc.once(IpcChannels.STARTUP_SPLASH_READY, showWindow)
 
     // Initialize tabs - try to restore session or create initial tab
     const initializeTabs = async () => {

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -45,6 +45,11 @@ ipcRenderer.on(IpcChannels.VIDEO_METADATA_CACHE_CLEARED, () => {
 })
 
 export default {
+  startupSplashReady: () => ipcRenderer.send(IpcChannels.STARTUP_SPLASH_READY),
+  startupAppearance: {
+    background: process.argv.find(argument => argument.startsWith('--startup-background='))?.slice('--startup-background='.length),
+    dark: process.argv.includes('--startup-dark=true')
+  },
   isFlatpak: process.env.FLATPAK_ID !== undefined,
   runtimeVersions: Object.freeze({
     electron: process.versions.electron,

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -462,6 +462,7 @@ import {
 } from './helpers/mobileLinkActions'
 import { startProgressBarOperation } from './helpers/progressBar'
 import { initializePlatformInfo, isLinuxWayland } from './helpers/platform'
+import { revealStartupSplash, updateStartupSplashLabel } from './helpers/startupSplash'
 import {
   shouldShowProgressStartToast,
   shouldUseProgressToast,
@@ -1280,6 +1281,8 @@ onMounted(async () => {
   })
   updateTheme()
 
+  if (isElectron) updateStartupSplashLabel(t('Theme Discovery.Loading'))
+
   if (defaultInvidiousInstance.value === '') {
     await store.dispatch('setRandomCurrentInvidiousInstance')
   }
@@ -1513,6 +1516,29 @@ watch([activeTabId, selectionRevision], ([tabId, revision]) => {
     navigation.requestPresentation(tabId, revision)
   }
 }, { immediate: true })
+
+watch([
+  dataReady,
+  presentedTabId,
+  () => store.getters.getActiveTab?.loadState,
+  () => store.getters.getTabById(presentedTabId.value)?.route.fullPath,
+], async ([ready, presented, loadState, fullPath], _, onCleanup) => {
+  if (!isElectron || !ready || (!presented && loadState !== 'unloaded') || !document.getElementById('startup-splash')) return
+  let cancelled = false
+  onCleanup(() => { cancelled = true })
+  if (presented && fullPath) {
+    try {
+      // Tab presentation acknowledges its container before an async route has
+      // loaded. Keep the splash until that route can render real content.
+      await preloadResolvedRoute(router.resolve(fullPath))
+    } catch (error) {
+      // A failed route must still expose the shell so navigation can recover.
+      console.error('Failed to load the startup route', error)
+    }
+  }
+  await nextTick()
+  if (!cancelled) revealStartupSplash()
+}, { flush: 'post' })
 
 watch(presentedTabId, async (tabId, previousTabId) => {
   if (!isElectron || tabId === previousTabId) {

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -1517,6 +1517,8 @@ watch([activeTabId, selectionRevision], ([tabId, revision]) => {
   }
 }, { immediate: true })
 
+const STARTUP_PRELOAD_TIMEOUT_MS = 5000
+
 watch([
   dataReady,
   presentedTabId,
@@ -1525,15 +1527,24 @@ watch([
 ], async ([ready, presented, loadState, fullPath], _, onCleanup) => {
   if (!isElectron || !ready || (!presented && loadState !== 'unloaded') || !document.getElementById('startup-splash')) return
   let cancelled = false
-  onCleanup(() => { cancelled = true })
+  let preloadTimeout
+  onCleanup(() => {
+    cancelled = true
+    clearTimeout(preloadTimeout)
+  })
   if (presented && fullPath) {
     try {
       // Tab presentation acknowledges its container before an async route has
-      // loaded. Keep the splash until that route can render real content.
-      await preloadResolvedRoute(router.resolve(fullPath))
+      // loaded. Wait for its content, but expose the shell if the chunk stalls.
+      await Promise.race([
+        preloadResolvedRoute(router.resolve(fullPath)),
+        new Promise(resolve => { preloadTimeout = setTimeout(resolve, STARTUP_PRELOAD_TIMEOUT_MS) })
+      ])
     } catch (error) {
       // A failed route must still expose the shell so navigation can recover.
       console.error('Failed to load the startup route', error)
+    } finally {
+      clearTimeout(preloadTimeout)
     }
   }
   await nextTick()

--- a/src/renderer/helpers/startupSplash.js
+++ b/src/renderer/helpers/startupSplash.js
@@ -1,0 +1,129 @@
+export const STARTUP_REVEAL_DURATION_MS = 600
+
+/** Fraction of the curtain remaining at a given height, measured from the rail. */
+export function curtainExtent(elapsedMs, depth) {
+  const time = elapsedMs / 1000
+  const localTime = Math.max(0, time - 0.16 * Math.pow(depth, 1.25))
+  const frequency = 23 - 7 * depth
+  const damping = 0.98 - 0.26 * depth
+  const oscillation = frequency * Math.sqrt(1 - damping * damping)
+  const response = Math.exp(-damping * frequency * localTime) *
+    (Math.cos(oscillation * localTime) + damping * frequency / oscillation * Math.sin(oscillation * localTime))
+  // Pull the gathered fabric offscreen while the hem catches up, without the
+  // preview's long pause at the edges.
+  const exit = Math.min(1, Math.max(0, (time - 0.32) / 0.28))
+  return Math.max(0, Math.min(1, 0.08 + 0.92 * response - 0.15 * exit * exit * (3 - 2 * exit)))
+}
+
+export function updateStartupSplashLabel(label) {
+  const element = document.querySelector('#startup-splash .startupLabel')
+  if (element) element.textContent = label
+  try {
+    localStorage.setItem('startup-loading-label', label)
+  } catch {
+    // Storage is optional; the current window still has its translated label.
+  }
+}
+
+export function revealStartupSplash() {
+  const splash = document.getElementById('startup-splash')
+  if (!splash || splash.dataset.revealing) return
+  splash.dataset.revealing = 'true'
+  splash.setAttribute('aria-busy', 'false')
+
+  let frame = 0
+  let timeout
+  const animations = []
+  const finish = () => {
+    cancelAnimationFrame(frame)
+    clearTimeout(timeout)
+    animations.forEach(animation => animation.cancel())
+    document.removeEventListener('visibilitychange', onVisibilityChange)
+    splash.remove()
+    document.getElementById('app')?.removeAttribute('inert')
+  }
+  const onVisibilityChange = () => {
+    if (document.hidden) finish()
+  }
+  if (document.hidden || matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    finish()
+    return
+  }
+
+  try {
+    const canvas = splash.querySelector('.startupFabric')
+    const curtain = splash.querySelector('.startupCurtain')
+    const bounds = splash.getBoundingClientRect()
+    // Soft folds need no high-DPI backing store. Bound the paint cost on large
+    // displays and at fractional UI scales; CSS still covers the full window.
+    const scale = Math.min(1, 1200 / bounds.width, 600 / bounds.height)
+    const width = canvas.width = Math.max(1, Math.ceil(bounds.width * scale))
+    const height = canvas.height = Math.max(1, Math.ceil(bounds.height * scale))
+    const context = canvas.getContext('2d')
+    if (!context) {
+      finish()
+      return
+    }
+    const texture = document.createElement('canvas')
+    texture.width = 500
+    texture.height = 1
+    const painter = texture.getContext('2d')
+    if (!painter) {
+      finish()
+      return
+    }
+    const colors = ['shadow', 'background', 'face', 'highlight', 'face', 'background', 'shadow'].map(name => {
+      // Resolve theme functions such as color-mix() before passing them to Canvas.
+      curtain.style.color = `var(--splash-${name})`
+      return getComputedStyle(curtain).color
+    })
+    curtain.style.removeProperty('color')
+    const stops = [0, 0.12, 0.32, 0.49, 0.64, 0.85, 1]
+    const gradient = painter.createLinearGradient(0, 0, 500, 0)
+    for (let fold = 0; fold < 5; fold++) {
+      stops.forEach((position, index) => gradient.addColorStop((fold + position) / 5, colors[index]))
+    }
+    painter.fillStyle = gradient
+    painter.fillRect(0, 0, 500, 1)
+
+    const draw = elapsed => {
+      context.clearRect(0, 0, width, height)
+      let visible = false
+      for (let y = 0; y < height; y++) {
+        const extent = (width / 2 + 0.5) * curtainExtent(elapsed, y / height)
+        if (extent <= 0) continue
+        visible = true
+        // Each scanline gathers at its own speed, so the folds bend with the
+        // trailing hem instead of sliding or clipping a rigid rectangle.
+        context.drawImage(texture, 0, 0, 500, 1, 0, y, extent, 1.2)
+        context.drawImage(texture, 0, 0, 500, 1, width - extent, y, extent, 1.2)
+      }
+      return visible
+    }
+    draw(0)
+    canvas.hidden = false
+    splash.querySelectorAll('.startupCurtain').forEach(element => { element.hidden = true })
+    for (const element of splash.querySelectorAll('.startupLogo, .startupLabel, .startupTrack')) {
+      animations.push(element.animate([{ opacity: 1 }, { opacity: 0 }], { duration: 120, fill: 'forwards' }))
+    }
+    const start = performance.now()
+    const render = now => {
+      try {
+        const elapsed = now - start
+        if (elapsed >= STARTUP_REVEAL_DURATION_MS || !draw(elapsed)) {
+          finish()
+        } else {
+          frame = requestAnimationFrame(render)
+        }
+      } catch {
+        finish()
+      }
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    timeout = setTimeout(finish, STARTUP_REVEAL_DURATION_MS + 100)
+    frame = requestAnimationFrame(render)
+  } catch {
+    // A failed or disabled graphics context must never block the ready app.
+    finish()
+  }
+}

--- a/src/renderer/startup/boot.js
+++ b/src/renderer/startup/boot.js
@@ -1,0 +1,19 @@
+// Inlined before the deferred renderer bundle, so the first paint needs no Vue
+// initialization, locale fetch, or separate image request.
+(() => {
+  const appearance = window.ftElectron?.startupAppearance
+  const root = document.documentElement
+  if (appearance?.background) {
+    root.style.setProperty('--startup-background', appearance.background)
+    root.style.setProperty('--startup-foreground', appearance.dark ? '#eeeeee' : '#212121')
+  }
+  try {
+    const label = localStorage.getItem('startup-loading-label')
+    if (label) document.querySelector('#startup-splash .startupLabel').textContent = label
+  } catch {
+    // A fresh profile or unavailable storage still has the logo and progress bar.
+  }
+  // Electron's ready-to-show can wait for deferred scripts. Announce the
+  // splash's own frame so the native window need not wait for the main bundle.
+  requestAnimationFrame(() => window.ftElectron?.startupSplashReady())
+})()

--- a/src/renderer/startup/splash.css
+++ b/src/renderer/startup/splash.css
@@ -1,0 +1,95 @@
+.startupSplash {
+  /* Keep the initial palette throughout startup: the renderer applies its
+     default theme before the saved settings have finished loading. */
+  --splash-background: var(--startup-background, #0f0f0f);
+  --splash-foreground: var(--startup-foreground, #eee);
+  --splash-shadow: color-mix(in srgb, var(--splash-background) 78%, #000);
+  --splash-face: color-mix(in srgb, var(--splash-background) 94%, var(--splash-foreground));
+  --splash-highlight: color-mix(in srgb, var(--splash-background) 85%, var(--splash-foreground));
+
+  position: fixed;
+  z-index: 2147483647;
+  inset: 0;
+  overflow: clip;
+  color: var(--splash-foreground);
+  font-family: system-ui, sans-serif;
+  direction: ltr;
+}
+
+.startupCurtain {
+  position: absolute;
+  inset-block: 0;
+  inline-size: calc(50% + 0.5px);
+  background-color: var(--splash-background);
+  background-image:
+    linear-gradient(to bottom, var(--splash-shadow), transparent 24px),
+    linear-gradient(90deg, var(--splash-shadow) 0%, var(--splash-background) 12%, var(--splash-face) 32%, var(--splash-highlight) 49%, var(--splash-face) 64%, var(--splash-background) 85%, var(--splash-shadow) 100%);
+  background-size: 100% 100%, 20% 100%;
+  background-repeat: no-repeat, repeat-x;
+}
+
+.startupCurtainLeft {
+  inset-inline-start: 0;
+}
+
+.startupCurtainRight {
+  inset-inline-end: 0;
+}
+
+.startupFabric {
+  position: absolute;
+  inset: 0;
+  inline-size: 100%;
+  block-size: 100%;
+}
+
+.startupLogo {
+  position: absolute;
+  inset-block-start: 50%;
+  inset-inline-start: 50%;
+  inline-size: 104px;
+  block-size: 104px;
+  transform: translate(-50%, -50%);
+}
+
+.startupLogo svg {
+  inline-size: 100%;
+  block-size: 100%;
+}
+
+.startupLabel {
+  position: absolute;
+  inset-block-end: 22px;
+  inline-size: 100%;
+  text-align: center;
+  color: var(--splash-foreground);
+  font-size: 12px;
+}
+
+.startupTrack {
+  position: absolute;
+  inset-block-end: 0;
+  inline-size: 100%;
+  block-size: 3px;
+  overflow: clip;
+  background: color-mix(in srgb, var(--splash-foreground) 20%, var(--splash-background));
+}
+
+.startupProgress {
+  inline-size: 200%;
+  block-size: 100%;
+  background: linear-gradient(to right, var(--splash-foreground) 0 16%, transparent 16% 50%, var(--splash-foreground) 50% 66%, transparent 66% 100%);
+  animation: startup-progress 1.4s linear infinite;
+}
+
+@keyframes startup-progress {
+  from { transform: translateX(-50%); }
+  to { transform: translateX(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .startupProgress {
+    animation: none;
+    transform: translateX(-35%);
+  }
+}

--- a/tests/unit/startup-splash.test.mjs
+++ b/tests/unit/startup-splash.test.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import vm from 'node:vm'
+import { curtainExtent, STARTUP_REVEAL_DURATION_MS } from '../../src/renderer/helpers/startupSplash.js'
+
+test('curtains cover the window initially and open from the rail before the hem', () => {
+  for (const depth of [0, 0.25, 0.5, 0.75, 1]) assert.equal(curtainExtent(0, depth), 1)
+  assert.equal(curtainExtent(100, 1), 1, 'the hem initially trails the rail')
+  for (const elapsed of [100, 180, 260]) {
+    assert.ok(curtainExtent(elapsed, 0) < curtainExtent(elapsed, 0.5))
+    assert.ok(curtainExtent(elapsed, 0.5) < curtainExtent(elapsed, 1))
+  }
+})
+
+test('all fabric leaves the viewport within the shortened reveal', () => {
+  assert.ok(STARTUP_REVEAL_DURATION_MS <= 600)
+  for (let row = 0; row <= 100; row++) {
+    assert.equal(curtainExtent(STARTUP_REVEAL_DURATION_MS, row / 100), 0)
+    for (let elapsed = 0; elapsed <= 1000; elapsed += 10) {
+      const extent = curtainExtent(elapsed, row / 100)
+      assert.ok(Number.isFinite(extent) && extent >= 0 && extent <= 1)
+    }
+  }
+})
+
+test('the initial splash uses native appearance and cached plain-text localization without the renderer', async () => {
+  const properties = new Map()
+  const label = { textContent: 'OpenTubeX' }
+  const script = await readFile(new URL('../../src/renderer/startup/boot.js', import.meta.url), 'utf8')
+  let presented = false
+  let paint
+  const context = {
+    window: { ftElectron: {
+      startupAppearance: { background: '#1e1e2e', dark: true },
+      startupSplashReady: () => { presented = true }
+    } },
+    requestAnimationFrame: callback => { paint = callback },
+    document: {
+      documentElement: { style: { setProperty: (name, value) => properties.set(name, value) } },
+      querySelector: () => label
+    },
+    localStorage: { getItem: () => 'Wird geladen…' }
+  }
+  vm.runInNewContext(script, context)
+  assert.equal(properties.get('--startup-background'), '#1e1e2e')
+  assert.equal(properties.get('--startup-foreground'), '#eeeeee')
+  assert.equal(label.textContent, 'Wird geladen…')
+  assert.equal(presented, false)
+  paint()
+  assert.equal(presented, true)
+  context.localStorage.getItem = () => { throw new Error('Storage unavailable') }
+  assert.doesNotThrow(() => vm.runInNewContext(script, context))
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Requested and refined directly in the originating task; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

On slower laptops, startup exposes an empty background while the renderer loads. Show the OpenTubeX logo and a continuous loading bar in the initial desktop HTML, then reveal the ready app with curtains whose tops move before their trailing hems. The reveal finishes within 600 ms and respects reduced motion.

Resolve the saved theme before showing the window and keep the splash colors stable while settings initialize, including system-selected OpenTubeX themes. Hidden windows stay hidden when startup completes. If the initial route chunk stalls, release the splash after five seconds so the shell remains accessible.

Correct the recommendation and premiere E2E fixtures to return HTTP failures for unavailable responses. Their transport aborts triggered origin-wide network recovery and stalled unrelated requests, also on development.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Desktop startup now shows a themed splash with a continuous loading bar and a curtain reveal when the app is ready.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260909T142128Z-dark-dark-db93424277.webp">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260909T142128Z-light-light-5608fea747.webp">
  <img alt="Startup splash and curtain reveal in the default system theme" src="https://github.com/OpenTubeX/media/releases/download/attachments/20260909T142128Z-dark-dark-db93424277.webp">
</picture>

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Restart the desktop app with the default system theme in dark and light mode. The logo and continuous loading bar should appear while the renderer loads, then the curtains should open with their tops leading the hems.
2. Save an OpenTubeX theme and restart. The splash should use that theme immediately without flashing the default colors.
3. Enable reduced motion and restart. The app should appear without the curtain animation.

## Additional context
<!-- Add any other context about the pull request here. -->

- `pnpm run test:unit`: 1,531 passed, 2 skipped.
- `pnpm run lint`: passed; one existing i18n warning in `watch-page.spec.mjs`.
- Fresh `pnpm run test:e2e:pack`, then the splash and startup-performance Playwright files under private Xvfb: 13 passed. Covers early native-window visibility, stable built-in/system-theme colors, fractional zoom, reduced motion, delayed/failed initial route chunks, and 60 restored tabs at 4× CPU throttle.
- Recommendation, subscription, and connection-recovery suites: 74 tests passed; after synchronizing the remaining premiere test with its failed responses, it passed 10 consecutive runs. ESLint passed for both changed fixture files.
- Manually inspect the splash and reveal by restarting with a saved theme. The recordings hold the renderer for one second to show the loading state; they are not startup benchmarks.

Review follow-up: the stalled initial-route regression failed before the fix. All 13 splash E2E tests and three splash unit tests pass after the fix; lint passes with the existing i18n warning.

Implemented with GPT-6 in Codex.


