### PR TITLE
fix(tabs): select new foreground tabs immediately

### DIFF
--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -196,6 +196,36 @@ test.describe('tab bar', () => {
     await expect(page.locator(sel.tabs).nth(1).locator('[data-icon="rss"]')).toBeVisible()
   })
 
+  test('Ctrl+T selects and presents the new tab before main receives mount readiness', async ({ app, page }) => {
+    await app.electronApp.evaluate(({ ipcMain }) => {
+      const channel = 'tabs-mount-ready'
+      const [listener] = ipcMain.listeners(channel)
+      const pending = []
+      const holdMount = (...args) => pending.push(args)
+      ipcMain.removeListener(channel, listener)
+      ipcMain.on(channel, holdMount)
+      ipcMain.once('e2e-release-tab-mounts', () => {
+        ipcMain.removeListener(channel, holdMount)
+        ipcMain.on(channel, listener)
+        for (const args of pending) listener(...args)
+      })
+    })
+
+    try {
+      await page.keyboard.press('Control+t')
+      await expect(page.locator(sel.tabs)).toHaveCount(2)
+      const newTab = page.locator(sel.tabs).nth(1)
+      await expect(newTab).toHaveClass(/active/)
+      const tabId = await newTab.getAttribute('data-tab-id')
+      await expect(page.locator(`.tabContent[data-tab-id="${tabId}"]`)).toBeVisible()
+      const state = await page.evaluate(() => window.ftElectron.tabs.getState())
+      expect(state.activeTabId).toBe(tabId)
+      expect(state.tabs.find(tab => tab.id === tabId).loadState).toBe('mounting')
+    } finally {
+      await app.electronApp.evaluate(({ ipcMain }) => ipcMain.emit('e2e-release-tab-mounts'))
+    }
+  })
+
   test('restarts background tab creation order after a manual move', async ({ page }) => {
     const openerTabId = await page.locator(sel.tabs).getAttribute('data-tab-id')
     const existingTab = await page.evaluate(() => window.ftElectron.tabs.create({

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -106,7 +106,6 @@ let tabPreviewCacheMaintenance = Promise.resolve()
  * @property {boolean} skipSilence
  * @property {TabLoadState} loadState
  * @property {boolean} preloadInBackground
- * @property {boolean} pendingActivation
  * @property {number} mountRevision
  * @property {number} refreshKey
  * @property {number} syncedNavigationRevision
@@ -1137,7 +1136,6 @@ export class TabManager {
       loadState: startsUnloaded ? 'unloaded' : 'mounting',
       mountDeferred: shouldMount && !makeActive && _deferMount,
       preloadInBackground: Boolean(preloadInBackground),
-      pendingActivation: false,
       mountRevision: shouldMount ? 1 : 0,
       refreshKey: 0,
       syncedNavigationRevision: 0,
@@ -1170,24 +1168,12 @@ export class TabManager {
     if (tabInfo.mountDeferred) this._startupMountQueue.add(id)
 
     if (makeActive) {
-      if (this.activeTabId == null) {
-        this.activateTab(id)
-      } else {
-        // Match the current completion-order behavior: newly-created active tabs
-        // join the strip immediately but become selected when their first mount
-        // reports ready.
-        tabInfo.pendingActivation = true
-        tabInfo.preloadInBackground = true
-        if (!_deferUpdates) {
-          this._broadcastStateUpdate()
-          this._saveSession()
-        }
-      }
-    } else {
-      if (!_deferUpdates) {
-        this._broadcastStateUpdate()
-        this._saveSession()
-      }
+      // Select immediately; the renderer keeps the outgoing content visible
+      // until this tab mounts. Mount completion must not steal a later selection.
+      this.activateTab(id)
+    } else if (!_deferUpdates) {
+      this._broadcastStateUpdate()
+      this._saveSession()
     }
 
     return tabInfo
@@ -1205,7 +1191,7 @@ export class TabManager {
       ? options
       : { ...options, route: await TabManager.getStoredLandingRoute() }
 
-    const canBatchRapidCreation = this.activeTabId != null
+    const canBatchRapidCreation = this.activeTabId != null && tabOptions.makeActive === false
     const deferUpdates = canBatchRapidCreation && this._rapidTabCreationBatch != null
     const tab = this.createTab({ ...tabOptions, openPosition, _deferUpdates: deferUpdates })
     if (canBatchRapidCreation) {
@@ -1216,9 +1202,9 @@ export class TabManager {
   }
 
   /**
-   * Publish the first tab in a burst immediately, then coalesce additional tab
-   * creations into one renderer snapshot and session write. The maximum delay
-   * keeps a held shortcut from postponing updates indefinitely.
+   * Publish the first background tab in a burst immediately, then coalesce
+   * additional creations into one renderer snapshot and session write. The
+   * maximum delay keeps continuous creation from postponing updates indefinitely.
    * @param {boolean} updatesDeferred
    * @returns {Promise<void>}
    */
@@ -1309,7 +1295,6 @@ export class TabManager {
     const previousActiveId = this.activeTabId
     if (
       previousActiveId === tabId &&
-      tab.pendingActivation !== true &&
       tab.loadState !== 'unloaded' &&
       !tab.mountDeferred
     ) {
@@ -1344,7 +1329,6 @@ export class TabManager {
       this._startupPriorityLoadingObserved = false
     }
 
-    tab.pendingActivation = false
     tab.preloadInBackground = false
     tab.lastActiveAt = Date.now()
     this.activeTabId = tabId
@@ -1430,11 +1414,7 @@ export class TabManager {
     this._setTabLoadingSource(tab, TAB_LOADING_SOURCE_MOUNT, false)
     this._resolveTabMountWaiters(tabId, mountRevision, true)
 
-    if (tab.pendingActivation) {
-      this.activateTab(tabId)
-    } else {
-      this._broadcastStateUpdate()
-    }
+    this._broadcastStateUpdate()
   }
 
   /**
@@ -1450,7 +1430,6 @@ export class TabManager {
 
     tab.loadState = 'unloaded'
     tab.preloadInBackground = false
-    tab.pendingActivation = false
     this._setTabLoadingSource(tab, TAB_LOADING_SOURCE_MOUNT, false)
     this._resolveTabMountWaiters(tabId, mountRevision, false)
     if (tabId === this._startupPriorityTabId) {
@@ -2670,7 +2649,6 @@ export class TabManager {
     this._startupMountQueue.delete(tabId)
     this._resolveTabMountWaiters(tabId, tab.mountRevision, false)
     tab.preloadInBackground = false
-    tab.pendingActivation = false
     tab.isPlaying = false
     tab.loadingSources = new Set()
     tab.isLoading = false
@@ -2854,7 +2832,6 @@ export class TabManager {
       skipSilence: snapshot.skipSilence === true,
       loadState: 'mounting',
       preloadInBackground: true,
-      pendingActivation: false,
       mountRevision: 1,
       refreshKey: 0,
       syncedNavigationRevision: Number.isInteger(snapshot.syncedNavigationRevision)
@@ -3051,7 +3028,6 @@ export class TabManager {
         groupId: tab.groupId,
         loadState: tab.loadState,
         preloadInBackground: tab.preloadInBackground,
-        pendingActivation: tab.pendingActivation,
         mountRevision: tab.mountRevision,
         refreshKey: tab.refreshKey,
         syncedNavigationRevision: tab.syncedNavigationRevision

--- a/tests/unit/tab-startup.test.mjs
+++ b/tests/unit/tab-startup.test.mjs
@@ -58,6 +58,49 @@ function session(count) {
   }
 }
 
+test('foreground tabs become selected before their content mounts', async t => {
+  const manager = createManager(t)
+  const original = manager.createTab({ route: '/history' })
+  presentActive(manager)
+
+  const tab = await manager.createTabWithPreference({ route: '/subscriptions', makeActive: true })
+  assert.equal(tab.loadState, 'mounting')
+  assert.equal(manager.activeTabId, tab.id)
+  assert.equal(manager.presentedTabId, original.id, 'keeps the previous content until the new content is ready')
+
+  manager.markTabMounted(tab.id, tab.mountRevision)
+  manager.markTabPresented(tab.id, manager.selectionRevision)
+  assert.equal(manager.presentedTabId, tab.id)
+})
+
+test('slow foreground tab mounts cannot steal a newer selection', async t => {
+  const manager = createManager(t)
+  const original = manager.createTab({ route: '/history' })
+  presentActive(manager)
+  const first = await manager.createTabWithPreference({ route: '/subscriptions', makeActive: true })
+  const second = await manager.createTabWithPreference({ route: '/about', makeActive: true })
+  assert.equal(manager.activeTabId, second.id)
+
+  manager.markTabMounted(second.id, second.mountRevision)
+  manager.markTabMounted(first.id, first.mountRevision)
+  assert.equal(manager.activeTabId, second.id)
+
+  const third = await manager.createTabWithPreference({ route: '/playlists', makeActive: true })
+  manager.activateTab(original.id)
+  manager.markTabMounted(third.id, third.mountRevision)
+  assert.equal(manager.activeTabId, original.id)
+})
+
+test('background tab creation and mounting preserve the selected tab', async t => {
+  const manager = createManager(t)
+  const original = manager.createTab({ route: '/history' })
+  presentActive(manager)
+  const tab = await manager.createTabWithPreference({ route: '/subscriptions', makeActive: false })
+  assert.equal(manager.activeTabId, original.id)
+  manager.markTabMounted(tab.id, tab.mountRevision)
+  assert.equal(manager.activeTabId, original.id)
+})
+
 test('restoring many tabs serializes only one initial renderer snapshot', async t => {
   const manager = createManager(t)
   const getState = manager.getState.bind(manager)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Ctrl+T could leave a new foreground tab unselected until its content finished mounting, making it appear to open in the background on a busy system. A delayed mount could also steal focus after the user selected another tab.

Select foreground tabs when they are created and let the renderer keep the outgoing content visible until the new content is ready. Remove mount-triggered activation and retain batching for background tab creation.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
New foreground tabs are selected immediately, and slow-loading tabs no longer steal focus after you switch elsewhere.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Press Ctrl+T or click the new-tab button. The new tab should become selected immediately, with its page appearing when ready.
2. Open several foreground tabs, then select an older tab while they load. Finishing loads must not change your selection.
3. Middle-click a link. Its tab should still open in the background.
4. Restart with a saved multi-tab session and confirm the selected tab is restored.

## Additional context
<!-- Add any other context about the pull request here. -->


Validation: unit tests passed, lint passed with one existing warning, and three focused Electron tests passed after rebuilding the E2E package. The new Electron regression test holds mount acknowledgements and verifies that Ctrl+T still selects and presents the new tab. Unit coverage also checks out-of-order mounts and background selection.

The user tested an isolated build on their laptop and confirmed that tab creation feels better. Four startup comparisons using identical copies of a 38-tab profile found no slowdown: 20.8/22.4 seconds before versus 19.6/22.2 seconds after, measured to the first presented tab under a private X server.

Standards and spec reviews found no actionable findings. Media is omitted because a still image would not demonstrate the timing change.

Implemented with GPT-6 in the Codex desktop app.
