### PR TITLE
fix(themes): tint OpenTubeX seekbar progress

### DIFF
--- a/e2e/tests/offline/theme-contrast.spec.mjs
+++ b/e2e/tests/offline/theme-contrast.spec.mjs
@@ -86,7 +86,7 @@ for (const theme of ['openTubeXLight', 'openTubeXDark']) {
     test.describe(`${theme} control contrast at ${scale}%`, () => {
       test.use({ seed: { settings: { baseTheme: theme, currentLocale: 'en-US', uiScale: scale } } })
 
-      test('seekbar progress stays neutral and SponsorBlock categories remain visible', async ({ app, page }) => {
+      test('seekbar progress keeps a subtle teal tint and SponsorBlock categories remain visible', async ({ app, page }) => {
         await mockPlayableWatchPage(app, page)
         // An aborted label lookup would queue later SponsorBlock requests behind
         // network recovery. A 404 is the API's normal "no labels" response.
@@ -133,8 +133,9 @@ for (const theme of ['openTubeXLight', 'openTubeXDark']) {
           ]
         })
         const [played, unplayed, ...markers] = await sampleColors(app, bar, points)
-        expect(Math.max(...played) - Math.min(...played), `neutral progress: ${played}`).toBeLessThanOrEqual(2)
-        expect(Math.min(...played), `soft white progress: ${played}`).toBeGreaterThanOrEqual(200)
+        expect(played[1] - played[0], `teal progress: ${played}`).toBeGreaterThanOrEqual(10)
+        expect(played[2] - played[0], `teal progress: ${played}`).toBeGreaterThanOrEqual(8)
+        expect(Math.min(...played), `soft teal progress: ${played}`).toBeGreaterThanOrEqual(190)
         expect(Math.max(...played), `retain marker colors: ${played}`).toBeLessThanOrEqual(235)
         expect(Math.max(...played.map((value, index) => Math.abs(value - unplayed[index])))).toBeGreaterThanOrEqual(20)
         for (const [index, marker] of markers.entries()) {

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -2356,8 +2356,8 @@ body .os-scrollbar {
    their own primary and secondary colors. */
 .openTubeXLight,
 .openTubeXDark {
-  /* Leave enough tonal headroom for SponsorBlock's color-blended markers. */
-  --seekbar-played-color: #ddd;
+  /* Keep a pale teal tint while leaving tonal headroom for SponsorBlock markers. */
+  --seekbar-played-color: #c4d8d4;
   --toggle-track-color: #758b87;
   --toggle-checked-track-color: #4e9185;
   --toggle-thumb-color: #e6f4f1;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No related issue. Requested directly during review of the recent OpenTubeX theme changes.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The OpenTubeX themes recently changed the played portion of the seekbar to soft white. It could blend into bright or white video frames.

This changes the shared OpenTubeX seekbar color to a pale teal. The color remains light enough for SponsorBlock category markers to retain their hue and contrast. The existing theme test now checks the tint and marker visibility in both OpenTubeX themes at 100% and 125% UI scale.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Select OpenTubeX Light, play a video with bright and dark scenes, and confirm that the played portion of the seekbar has a subtle teal tint.
2. Repeat with OpenTubeX Dark and at a non-default UI scale. The seekbar should remain visible without appearing strongly colored.
3. Enable SponsorBlock seekbar segments and confirm that each category remains distinguishable from the played portion.

## Additional context
<!-- Add any other context about the pull request here. -->

The soft-white seekbar color exists only on the current development branch, so this follow-up is not noteworthy for release notes.

Implemented by GPT-5 in the Codex desktop app.
