### PR TITLE
fix(tabs): keep video links clickable during new-tab animations

### DIFF
--- a/e2e/tests/network/search.spec.mjs
+++ b/e2e/tests/network/search.spec.mjs
@@ -135,11 +135,25 @@ test.describe('search', () => {
     await page.locator(sel.searchInput).press('Enter')
     await expect(page.locator('.ft-list-video').first()).toBeVisible({ timeout: 30_000 })
 
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateUiScale', 95)
+    })
+
+    // Keep the animation running while subsequent real pointer clicks land.
+    await page.addStyleTag({
+      content: `
+      ::view-transition-group(*), ::view-transition-old(*), ::view-transition-new(*) {
+        animation-duration: 60s !important;
+      }
+    `
+    })
     await page.evaluate(() => {
       window.__viewTransitionSnapshots = []
       const startViewTransition = document.startViewTransition.bind(document)
       document.startViewTransition = (update) => {
         const snapshot = {
+          finished: false,
           sourceName: document.querySelector('.ft-list-video .thumbnailImage')?.style.viewTransitionName
         }
         window.__viewTransitionSnapshots.push(snapshot)
@@ -151,6 +165,7 @@ test.describe('search', () => {
           () => { snapshot.ready = true },
           error => { snapshot.readyError = String(error) }
         )
+        transition.finished.then(() => { snapshot.finished = true })
         return transition
       }
     })
@@ -164,15 +179,27 @@ test.describe('search', () => {
     expect(await page.evaluate(() => window.__viewTransitionSnapshots[0])).toEqual({
       sourceName: 'new-tab-thumbnail-morph',
       targetName: 'new-tab-thumbnail-morph',
-      ready: true
+      ready: true,
+      finished: false
     })
+
+    for (const index of [1, 2]) {
+      expect(await page.evaluate(index => window.__viewTransitionSnapshots[index - 1].finished, index)).toBe(false)
+      const video = page.locator('.ft-list-video').nth(index)
+      const link = video.locator(index === 1 ? '.title' : '.thumbnailLink')
+      const box = await link.boundingBox()
+      // Do not let locator.click wait for the animation overlay to disappear.
+      await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2, { button: 'middle' })
+      await expect(page.locator(sel.tabs)).toHaveCount(index + 2, { timeout: 3000 })
+      await expect.poll(() => page.evaluate(index => window.__viewTransitionSnapshots[index]?.ready, index)).toBe(true)
+    }
 
     await page.evaluate(() => {
       document.documentElement.dataset.reducedMotion = 'reduce'
     })
     await page.locator('.ft-list-video .title').nth(1).click({ button: 'middle' })
-    await expect(page.locator(sel.tabs)).toHaveCount(3)
-    expect(await page.evaluate(() => window.__viewTransitionSnapshots)).toHaveLength(1)
+    await expect(page.locator(sel.tabs)).toHaveCount(5)
+    expect(await page.evaluate(() => window.__viewTransitionSnapshots)).toHaveLength(3)
 
     await page.locator(sel.tabs).nth(1).click()
     await expect(page).toHaveURL(/#\/watch\//)

--- a/src/renderer/helpers/viewTransitions.js
+++ b/src/renderer/helpers/viewTransitions.js
@@ -98,6 +98,7 @@ export async function morphThumbnailIntoNewTab(linkElement, createTab) {
       }
     })
 
+    transition.types.add(NEW_TAB_THUMBNAIL_MORPH_NAME)
     transition.finished.then(cleanup, cleanup)
     await transition.updateCallbackDone
   } catch (error) {

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -2287,6 +2287,18 @@ a:visited {
   animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+/* Background-tab animations must let subsequent clicks reach the live links.
+   Chromium otherwise hit-tests the snapshot overlay as the document root,
+   where middle clicks can start autoscroll instead of opening another video. */
+:root:active-view-transition-type(new-tab-thumbnail-morph) {
+  view-transition-name: none;
+}
+
+:root:active-view-transition-type(new-tab-thumbnail-morph)::view-transition,
+:root:active-view-transition-type(new-tab-thumbnail-morph)::view-transition-group(*) {
+  pointer-events: none;
+}
+
 :root.utilityWindowMorphActive .utilityWindowMorphTarget {
   view-transition-name: utility-window-morph;
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

Middle-clicking several videos could start autoscroll instead of opening another tab while the thumbnail-to-tab animation was running, especially under load. Keep the page interactive throughout that animation.

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Tag background-tab transitions so CSS excludes the page root from snapshot capture and lets pointer input pass through the animation. The thumbnail still morphs into the new tab. Other transitions are unchanged.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed middle clicks starting autoscroll instead of opening videos while a new-tab animation is running.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a list of videos with animations enabled.
2. Quickly middle-click several titles and thumbnails while the preceding thumbnail is still moving into the tab bar. Each click should open a background tab without starting autoscroll.
3. Repeat at 95% UI scale, then with reduced motion enabled. The current page should stay selected.

## Additional context
<!-- Add any other context about the pull request here. -->

Validation: the Electron regression failed before the fix and passes afterward with animations extended to 60 seconds. It covers titles, thumbnails, 95% UI scale, and reduced motion. Unit tests passed; lint passed with one existing warning.

Reviewed independently for repository standards and the reported behavior; neither review found issues.

Implemented with GPT-6 in the Codex desktop harness.
