### PR TITLE
fix(android): retain startup poster and align SABR request identity

### DIFF
--- a/android/app/src/main/java/org/opentubex/app/NativePlaybackEngine.java
+++ b/android/app/src/main/java/org/opentubex/app/NativePlaybackEngine.java
@@ -112,6 +112,10 @@ final class NativePlaybackEngine implements NativePlaybackSession.Playback {
                 publish("seeked");
             }
 
+            @Override public void onRenderedFirstFrame() {
+                publish("firstframe");
+            }
+
             @Override public void onVideoSizeChanged(VideoSize size) {
                 publish("resize");
             }

--- a/android/app/src/main/java/org/opentubex/app/NativePlaybackEngine.java
+++ b/android/app/src/main/java/org/opentubex/app/NativePlaybackEngine.java
@@ -33,6 +33,7 @@ final class NativePlaybackEngine implements NativePlaybackSession.Playback {
     private final Consumer<JSObject> listener;
     private final DefaultBandwidthMeter bandwidthMeter;
     private Surface surface;
+    private boolean startupFramePresented;
     private boolean videoVisible = true;
     private boolean released;
     private String mimeType;
@@ -110,10 +111,6 @@ final class NativePlaybackEngine implements NativePlaybackSession.Playback {
             ) {
                 updateCaptionCues();
                 publish("seeked");
-            }
-
-            @Override public void onRenderedFirstFrame() {
-                publish("firstframe");
             }
 
             @Override public void onVideoSizeChanged(VideoSize size) {
@@ -232,6 +229,7 @@ final class NativePlaybackEngine implements NativePlaybackSession.Playback {
     }
 
     @Override public void load(String source, long positionMs) {
+        startupFramePresented = false;
         player.setPlayWhenReady(false);
         MediaItem item = new MediaItem.Builder().setUri(source).setMimeType(mimeType).build();
         player.setMediaItem(item, positionMs);
@@ -314,6 +312,14 @@ final class NativePlaybackEngine implements NativePlaybackSession.Playback {
         player.pause();
         player.stop();
         player.clearMediaItems();
+    }
+
+    void onVideoFramePresented() {
+        // Preparing paused media can render a black frame at the starting
+        // position. Keep the poster until a texture update during playback.
+        if (startupFramePresented || !player.isPlaying()) return;
+        startupFramePresented = true;
+        publish("firstframe");
     }
 
     void setSurface(Surface nextSurface) {

--- a/android/app/src/main/java/org/opentubex/app/NativePlaybackScreen.java
+++ b/android/app/src/main/java/org/opentubex/app/NativePlaybackScreen.java
@@ -698,5 +698,7 @@ final class NativePlaybackScreen extends FrameLayout implements TextureView.Surf
     }
 
     @Override public void onSurfaceTextureSizeChanged(SurfaceTexture texture, int width, int height) {}
-    @Override public void onSurfaceTextureUpdated(SurfaceTexture texture) {}
+    @Override public void onSurfaceTextureUpdated(SurfaceTexture texture) {
+        engine.onVideoFramePresented();
+    }
 }

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -6101,7 +6101,9 @@ export default defineComponent({
       // surface while detaching it into native PiP on Windows. Once a real
       // frame is available the poster is no longer needed, so remove it before
       // a later blur-triggered PiP transition.
-      showPoster.value = false
+      // Media3 can start its playback clock before rendering the first frame.
+      // Native playback dismisses the overlay through its firstframe event.
+      if (!process.env.IS_CAPACITOR) showPoster.value = false
       startPaidPromotionTimer()
 
       if (process.env.IS_ELECTRON && window.ftElectron?.tabs?.setPlaybackState) {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -137,6 +137,8 @@
         :poster="!audioPlayerMode && showPoster ? thumbnail : null"
         @play="handlePlay"
         @playing="handlePlaying"
+        @firstframe="showPoster = false"
+        @emptied="showPoster = true"
         @waiting="handleWaiting"
         @pause="handlePause"
         @ended="handleEnded"
@@ -198,7 +200,7 @@
       </template>
       <!-- Native playback hides the video element, including its poster. -->
       <div
-        v-if="showCountdownOverlay && !audioPlayerMode && thumbnail"
+        v-if="(showCountdownOverlay || (useNativePlayback && showPoster)) && !audioPlayerMode && thumbnail"
         class="countdownPoster"
         aria-hidden="true"
       >

--- a/src/renderer/helpers/api/capacitor-http.js
+++ b/src/renderer/helpers/api/capacitor-http.js
@@ -4,7 +4,7 @@ import { classifyRequestFailure } from './requestDiagnostics.js'
 import { withNetworkRecovery } from '../networkRecovery.js'
 import { createAbortError } from './requestErrors.js'
 
-const DESKTOP_USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36'
+export const DESKTOP_USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36'
 const YOUTUBE_AVATAR_HOSTS = new Set([
   'yt3.ggpht.com',
   'yt4.ggpht.com',

--- a/src/renderer/helpers/api/capacitor-sabr-http.js
+++ b/src/renderer/helpers/api/capacitor-sabr-http.js
@@ -1,6 +1,7 @@
 import { registerPlugin } from '@capacitor/core'
 
 import { createAbortError } from './requestErrors.js'
+import { DESKTOP_USER_AGENT } from './capacitor-http.js'
 
 const SabrHttp = registerPlugin('SabrHttp')
 
@@ -24,10 +25,17 @@ export async function capacitorSabrFetch(url, init) {
   }
   if (init.signal?.aborted) throw createAbortError()
 
+  // Metadata uses the WEB client. Keep its identity when native HTTP fetches
+  // the stream instead of letting HttpURLConnection use Android's default.
+  const headers = new Headers(init.headers)
+  if (!headers.has('user-agent')) {
+    headers.set('user-agent', DESKTOP_USER_AGENT)
+  }
+
   const { requestId } = await SabrHttp.prepare({
     url,
     body: bytesToBase64(init.body),
-    headers: Object.fromEntries(new Headers(init.headers))
+    headers: Object.fromEntries(headers)
   })
 
   const onAbort = () => {

--- a/src/renderer/helpers/player/androidMediaElement.js
+++ b/src/renderer/helpers/player/androidMediaElement.js
@@ -194,6 +194,7 @@ export function attachAndroidMediaElement(element, { command, load, onError, now
       if ((next.buffering && !previous.buffering) ||
         (previous.playing && !state.playing && !state.paused && !state.ended)) emit('waiting')
       if (state.playing && !previous.playing) emit('playing')
+      if (next.event === 'firstframe') emit('firstframe')
       if (next.event === 'seeked') { seeking = false; emit('seeked') }
       if (next.ended && !previous.ended) emit('ended')
       emit('timeupdate')

--- a/tests/unit/android-media-element.test.mjs
+++ b/tests/unit/android-media-element.test.mjs
@@ -223,3 +223,18 @@ test('repeat time excludes native audio-focus suppression without a user pause',
   tracker.destroy()
   media.detach()
 })
+
+test('startup poster receives a first-frame event only after native rendering, including paused starts', () => {
+  const { element, media, ready } = fixture()
+  const events = []
+  element.addEventListener('firstframe', () => events.push('firstframe'))
+  media.update(ready)
+  assert.deepEqual(events, [])
+  media.update({ ...ready, event: 'firstframe', paused: true, playing: false })
+  assert.deepEqual(events, ['firstframe'])
+  media.reset()
+  media.update(ready)
+  assert.deepEqual(events, ['firstframe'])
+  media.update({ ...ready, event: 'firstframe' })
+  assert.deepEqual(events, ['firstframe', 'firstframe'])
+})

--- a/tests/unit/android-startup-poster.test.mjs
+++ b/tests/unit/android-startup-poster.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import vm from 'node:vm'
+import test from 'node:test'
+import * as Vue from 'vue'
+
+const source = readFileSync(new URL('../../src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue', import.meta.url), 'utf8')
+const poster = source.match(/<div\s+v-if="[^"]+"\s+class="countdownPoster"[\s\S]*?<\/div>/)[0]
+const render = Vue.compile(poster)
+const script = readFileSync(new URL('../../src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js', import.meta.url), 'utf8')
+
+test('native startup shows the poster outside the SABR countdown until a frame is rendered', () => {
+  const context = { showCountdownOverlay: false, audioPlayerMode: false, thumbnail: 'poster.jpg', useNativePlayback: true, showPoster: true }
+  assert.equal(render(context).type, 'div')
+  context.showPoster = false
+  assert.equal(render(context).type, Vue.Comment)
+  context.showPoster = true
+  context.audioPlayerMode = true
+  assert.equal(render(context).type, Vue.Comment)
+  context.audioPlayerMode = false
+  context.useNativePlayback = false
+  assert.equal(render(context).type, Vue.Comment)
+  context.showCountdownOverlay = true
+  assert.equal(render(context).type, 'div')
+})
+
+test('native playing notification cannot dismiss the poster before the first frame', () => {
+  const body = script.match(/function handlePlaying\(\) \{([\s\S]*?)\n    function handleWaiting/)[1]
+  const context = { hasPlaybackPosition: { value: false }, showPoster: { value: true }, useNativePlayback: true, startPaidPromotionTimer() {}, process: { env: { IS_CAPACITOR: true } } }
+  vm.runInNewContext(`function handlePlaying() {${body}; handlePlaying()`, context)
+  assert.equal(context.showPoster.value, true)
+})
+
+test('poster event bindings reveal the first frame and restore the poster for another load', () => {
+  const bindings = source.match(/@firstframe="[^"]+"/)[0] + ' ' + source.match(/@emptied="[^"]+"/)[0]
+  const renderEvents = Vue.compile(`<video ${bindings} />`)
+  const context = { showPoster: true }
+  const video = renderEvents(context, [])
+  video.props.onFirstframe()
+  assert.equal(context.showPoster, false)
+  video.props.onEmptied()
+  assert.equal(context.showPoster, true)
+})

--- a/tests/unit/capacitor-sabr-http.test.mjs
+++ b/tests/unit/capacitor-sabr-http.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { readFile } from 'node:fs/promises'
+import vm from 'node:vm'
+
+import { capacitorHttpFetch, DESKTOP_USER_AGENT } from '../../src/renderer/helpers/api/capacitor-http.js'
+import { createAbortError } from '../../src/renderer/helpers/api/requestErrors.js'
+
+const source = (await readFile(new URL('../../src/renderer/helpers/api/capacitor-sabr-http.js', import.meta.url), 'utf8'))
+  .replace(/^import .*\n/gm, '')
+  .replace('export async function ', 'async function ')
+
+async function metadataUserAgent(t) {
+  let userAgent
+  t.mock.method(globalThis, 'fetch', async (input, init) => {
+    userAgent = new Request(input, init).headers.get('user-agent')
+    return new Response('{}')
+  })
+  await capacitorHttpFetch('https://www.youtube.com/youtubei/v1/player')
+  return userAgent
+}
+
+function load(prepare) {
+  return vm.runInNewContext(`${source}\ncapacitorSabrFetch`, {
+    registerPlugin: () => ({ prepare, abort: async () => {} }),
+    createAbortError,
+    DESKTOP_USER_AGENT,
+    Uint8Array, Headers, Response, ReadableStream, btoa,
+    location: { origin: 'https://localhost' },
+    fetch: async () => new Response(Uint8Array.of(1, 2, 3)),
+  })
+}
+
+test('Android SABR uses the same browser identity as its YouTube metadata request', async t => {
+  const userAgent = await metadataUserAgent(t)
+  let prepared
+  const fetchSabr = load(async request => {
+    prepared = request
+    return { requestId: 'sabr-request' }
+  })
+  const headers = new Headers({ 'content-type': 'application/x-protobuf' })
+  const response = await fetchSabr('https://example.googlevideo.com/videoplayback', {
+    body: Uint8Array.of(4, 5, 6), headers,
+  })
+  assert.deepEqual(new Uint8Array(await response.arrayBuffer()), Uint8Array.of(1, 2, 3))
+  assert.equal(prepared.headers['user-agent'], userAgent,
+    'the native HTTP stack must not replace the WEB identity with its Android default')
+  assert.equal(prepared.headers['content-type'], 'application/x-protobuf')
+  assert.equal(headers.has('user-agent'), false, 'caller headers must stay unchanged')
+})
+
+test('Android SABR preserves an explicit client user agent', async () => {
+  let prepared
+  const fetchSabr = load(async request => {
+    prepared = request
+    return { requestId: 'sabr-request' }
+  })
+  const response = await fetchSabr('https://example.googlevideo.com/videoplayback', {
+    body: Uint8Array.of(1), headers: { 'User-Agent': 'explicit-client' },
+  })
+  await response.arrayBuffer()
+  assert.equal(prepared.headers['user-agent'], 'explicit-client')
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

Android startup could expose a black frame after the SABR countdown. Keep the poster visible until the native video texture updates during active playback, and use the metadata request’s user agent for native SABR requests.

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description

Forward the first TextureView update during active playback through the media adapter. A decoder first-frame callback during paused preparation can expose a black starting frame while startup is still buffering. Restore the poster on reload and retain the existing audio-mode and countdown behavior. Preserve explicit SABR user-agent headers.

<!-- Please write a clear and concise description of what the pull request does. -->

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing

1. On Android, open a video link with the app closed. The thumbnail should cover startup until the first video frame appears, including after any SABR countdown.
2. Repeat with autoplay disabled, then start playback. The poster should remain while paused and be replaced by the video once playback presents a frame.
3. Switch videos and audio/video modes. Each video load should restore its poster; audio mode should retain its audio surface.

<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

## Additional context

Both standards and spec reviews found no actionable issues. Regression tests failed before the fix and passed afterward. The full unit suite and Android compilation/unit tests passed; the build was installed on the Pixel with app data preserved.

The observed 20.8-second SABR backoff was intermittent on both baseline and modified builds. This change corrects the concrete HTTP identity mismatch; it does not claim to eliminate server backoffs.

A Pixel follow-up reproduced the remaining gap: the decoder reported its first paused frame, the poster disappeared, and playback buffered again before a second first-frame callback about 1.4 seconds later. The video’s frame at 0:00 is black. A second recorded cold launch with the TextureView gate kept the poster through that pause and transitioned directly to video. Native compositor timing was verified through the physical-device recording and debugger trace rather than a synthetic unit test. Android build/unit tests and the existing poster/media-adapter tests passed after the follow-up.

Implemented with GPT-6 in the Codex desktop harness.

<!-- Add any other context about the pull request here. -->

