### PR TITLE
fix: repair Shorts controls and history, chapter centering, and tutorial focus

### DIFF
--- a/e2e/helpers/app.mjs
+++ b/e2e/helpers/app.mjs
@@ -221,6 +221,7 @@ export async function waitForAppReady(page) {
   // The top nav is rendered once Vue has mounted and the locale has loaded.
   await expect(page.locator('.topNav')).toBeVisible({ timeout: 30_000 })
   await expect(page.locator('.tabBar')).toBeVisible()
+  await expect(page.locator('#startup-splash')).toHaveCount(0)
 }
 
 /** Opens a new app window through the tab bar's empty-space context menu. */

--- a/e2e/helpers/watch.mjs
+++ b/e2e/helpers/watch.mjs
@@ -152,6 +152,9 @@ export async function mockWatchPage(app, page, {
   await stubPoToken(app.electronApp)
 
   await page.route(/^https?:\/\//, (route) => route.abort())
+  // A missing optional label is an HTTP 404, not a lost connection. Aborting
+  // it would leave other SponsorBlock requests waiting for network recovery.
+  await page.route('**/api/videoLabels/**', route => route.fulfill({ status: 404, body: '' }))
   await routeIframeApi(page)
   await routeWatchPageHtml(page)
 
@@ -280,7 +283,7 @@ export async function mockWatchPage(app, page, {
         return route.fulfill({ status: 200, contentType: 'application/json', body })
       }
       console.warn(`[e2e] Missing watch page fixture: ${key}`)
-      return route.abort()
+      return route.fulfill({ status: 404, contentType: 'application/json', body: '{}' })
     }
 
     return route.fallback()

--- a/e2e/tests/network/multi-tab.spec.mjs
+++ b/e2e/tests/network/multi-tab.spec.mjs
@@ -14,24 +14,23 @@ async function openVideoInActiveTab(page, url) {
 }
 
 async function setWindowMinimized(electronApp, minimized) {
-  await electronApp.evaluate(({ BrowserWindow }, shouldMinimize) => {
-    const window = BrowserWindow.getAllWindows()[0]
-    if (shouldMinimize) {
-      window.minimize()
-    } else {
-      window.restore()
-    }
-  }, minimized)
+  // Xvfb has no window manager to honour minimize()/restore(). Emit the native
+  // events so the main process forwards the same state as in production.
+  await electronApp.evaluate(({ BrowserWindow }, event) => {
+    BrowserWindow.getAllWindows()[0].emit(event)
+  }, minimized ? 'minimize' : 'restore')
 }
 
-async function setRendererFocused(page, focused) {
+async function setWindowFocused(app, page, focused) {
   await page.evaluate((hasFocus) => {
     Object.defineProperty(document, 'hasFocus', {
       configurable: true,
       value: () => hasFocus,
     })
-    window.dispatchEvent(new Event(hasFocus ? 'focus' : 'blur'))
   }, focused)
+  await app.electronApp.evaluate(({ BrowserWindow }, event) => {
+    BrowserWindow.getAllWindows()[0].emit(event)
+  }, focused ? 'focus' : 'blur')
 }
 
 async function expectPictureInPicture(video, active) {
@@ -86,6 +85,10 @@ test.describe('automatic picture-in-picture', () => {
     }
   })
 
+  test.beforeEach(async ({ app, page }) => {
+    await setWindowFocused(app, page, true)
+  })
+
   // Regression: the blur emitted while minimizing kept the blur trigger active
   // after restore, so the automatically opened PiP window never closed (#265).
   test('exits PiP after restoring a minimized window', async ({ app, page, innertube }) => {
@@ -103,18 +106,18 @@ test.describe('automatic picture-in-picture', () => {
 
   // Regression: Chromium on Windows can briefly stretch the poster across the
   // compositor surface when blur-triggered PiP detaches a playing video (#362).
-  test('removes the poster before blur-triggered PiP', async ({ page, innertube }) => {
+  test('removes the poster before blur-triggered PiP', async ({ app, page, innertube }) => {
     test.skip(innertube.replay, 'no recorded fixtures for these videos')
     test.slow()
 
     const video = await openVideoInActiveTab(page, VIDEO_ONE)
     await expect(video).not.toHaveAttribute('poster')
 
-    await setRendererFocused(page, false)
+    await setWindowFocused(app, page, false)
     await expectPictureInPicture(video, true)
     await expect(video).not.toHaveAttribute('poster')
 
-    await setRendererFocused(page, true)
+    await setWindowFocused(app, page, true)
     await expectPictureInPicture(video, false)
   })
 
@@ -124,7 +127,9 @@ test.describe('automatic picture-in-picture', () => {
     test.skip(innertube.replay, 'no recorded fixtures for these videos')
     test.slow()
 
-    const video = await openVideoInActiveTab(page, VIDEO_ONE)
+    await openVideoInActiveTab(page, VIDEO_ONE)
+    // Keep targeting the original player after another tab becomes active.
+    const video = page.locator('.tabContent').first().locator('video')
 
     await page.locator(sel.newTabButton).click()
     await expect(page.locator(sel.tabs)).toHaveCount(2)

--- a/e2e/tests/network/playlist-dock.spec.mjs
+++ b/e2e/tests/network/playlist-dock.spec.mjs
@@ -4,14 +4,22 @@ import { waitForPlaybackOrSkip } from '../../helpers/player.mjs'
 const PLAYLIST_URL = 'https://youtu.be/g4OXlrxqIx0?list=UULFSMOQeBJ2RAnuFungnQOxLg'
 
 async function clickAndMeasureNextPaint(locator) {
-  const page = locator.page()
-  const start = await page.evaluate(() => performance.now())
-  await locator.click()
-
-  return page.evaluate(async (clickStart) => {
-    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))
-    return performance.now() - clickStart
-  }, start)
+  const videoBox = await locator.page().locator('.ftVideoPlayer video').boundingBox()
+  await locator.page().mouse.move(videoBox.x + videoBox.width / 2, videoBox.y + videoBox.height / 2)
+  const measurement = await locator.page().evaluateHandle(() => ({
+    nextPaint: new Promise(resolve => {
+      document.addEventListener('click', () => {
+        const start = performance.now()
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve(performance.now() - start)))
+      }, { capture: true, once: true })
+    })
+  }))
+  try {
+    await locator.click()
+    return await measurement.evaluate(value => value.nextPaint)
+  } finally {
+    await measurement.dispose()
+  }
 }
 
 test('large fullscreen playlist dock remains responsive and preserves its state', async ({ page, innertube }) => {
@@ -76,7 +84,8 @@ test('large fullscreen playlist dock remains responsive and preserves its state'
     element.style.removeProperty('inline-size')
   })
 
-  await waitForPlaybackOrSkip(test, page)
+  const video = await waitForPlaybackOrSkip(test, page)
+  await video.evaluate(element => element.pause())
 
   await sidebar.evaluate((element) => { element.scrollTop = 420 })
   await expect.poll(async () => sidebar.evaluate((element) => element.scrollTop)).toBe(420)

--- a/e2e/tests/network/sync-server.spec.mjs
+++ b/e2e/tests/network/sync-server.spec.mjs
@@ -908,7 +908,13 @@ test.describe('OpenTubeX sync server', () => {
 
     const syncSection = await goToSettingsSection(page, 'sync')
     const serverUrlInput = syncSection.getByLabel('Server URL')
-    await page.route('https://not-a-sync-server.invalid/**', route => route.abort())
+    // A connection abort waits for network recovery; an HTTP error rejects
+    // this endpoint immediately because it is not a sync server.
+    await page.route('https://not-a-sync-server.invalid/**', route => route.fulfill({
+      status: 404,
+      contentType: 'text/plain',
+      body: 'Not found'
+    }))
     await serverUrlInput.fill('https://not-a-sync-server.invalid')
     await serverUrlInput.press('Tab')
     await expect(syncSection.getByText(/Unable to connect to this sync server/)).toBeVisible()

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -325,9 +325,6 @@ test.describe('watch page', () => {
     await openVideo(page)
     await waitForPlaybackOrSkip(test, page)
 
-    const loadComments = page.locator('.getCommentsTitle')
-    await loadComments.scrollIntoViewIfNeeded()
-    await loadComments.click()
     await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
 
     await setPlayerFullscreen(page, true)
@@ -570,9 +567,19 @@ test.describe('watch page', () => {
     test.skip(innertube.replay, 'watch page hydration needs the real API')
     await openVideo(page)
 
+    const video = await waitForPlaybackOrSkip(test, page)
+    await video.evaluate(async element => {
+      element.pause()
+      element.currentTime = element.duration * 20.5 / 40
+      if (element.seeking) {
+        await new Promise(resolve => element.addEventListener('seeked', resolve, { once: true }))
+      }
+    })
+
     const currentChapterIndex = 20
+    const chapterDuration = await video.evaluate(element => element.duration / 40)
     const watchComponent = await page.evaluateHandle(findWatchComponent)
-    await page.evaluate(async ({ component, chapterIndex }) => {
+    await page.evaluate(async ({ component, chapterIndex, chapterDuration }) => {
       const watchView = component.proxy
       if (!watchView) {
         throw new Error('Unable to access the watch view')
@@ -581,13 +588,13 @@ test.describe('watch page', () => {
       watchView.videoChapters = Array.from({ length: 40 }, (_, index) => ({
         title: `Test chapter ${index + 1}`,
         timestamp: `${index}:00`,
-        startSeconds: index * 60,
-        endSeconds: (index + 1) * 60
+        startSeconds: index * chapterDuration,
+        endSeconds: (index + 1) * chapterDuration
       }))
       watchView.videoCurrentChapterIndex = chapterIndex
       watchView.showSidebarChapters = true
       await watchView.$nextTick()
-    }, { component: watchComponent, chapterIndex: currentChapterIndex })
+    }, { component: watchComponent, chapterIndex: currentChapterIndex, chapterDuration })
 
     const panel = page.locator('.watchVideoChaptersPanel')
     await expect(panel).toBeVisible()
@@ -609,10 +616,7 @@ test.describe('watch page', () => {
     await expect(panel).toHaveCount(0)
 
     await setPlayerFullscreen(page, true)
-    await page.evaluate(async (component) => {
-      component.refs.player.showChaptersOverlay = true
-      await component.proxy.$nextTick()
-    }, watchComponent)
+    await page.locator('.shaka-controls-button-panel .ft-chapters-button').click({ force: true })
 
     const overlay = page.locator('.chapterOverlay')
     await expect(overlay).toBeVisible()
@@ -768,15 +772,13 @@ test.describe('watch page', () => {
   test('fullscreen comments dock preserves its active state and scroll position', async ({ page, innertube }) => {
     test.skip(innertube.replay, 'watch page hydration needs the real API')
     await openVideo(page)
-    await waitForPlaybackOrSkip(test, page)
+    const video = await waitForPlaybackOrSkip(test, page)
+    await video.evaluate(element => element.pause())
 
-    const loadComments = page.locator('.getCommentsTitle')
-    await loadComments.scrollIntoViewIfNeeded()
-    await loadComments.click()
     await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
 
     await setPlayerFullscreen(page, true)
-    await page.locator('.fullscreenCommentsToggle').click({ force: true })
+    await page.locator('.fullscreenCommentsToggle').evaluate(button => button.click())
 
     const comments = page.locator('.fullscreenCommentsOverlay .commentsContentWrapper')
     await expect(comments).toBeVisible()
@@ -786,7 +788,7 @@ test.describe('watch page', () => {
 
     await page.locator('.fullscreenCommentHeader .fullscreenCommentAction').last().click()
     await expect(page.locator('.fullscreenCommentsOverlay.open')).toHaveCount(0)
-    await page.locator('.fullscreenCommentsToggle').click({ force: true })
+    await page.locator('.fullscreenCommentsToggle').evaluate(button => button.click())
     await expect(comments).toBeVisible()
     await expect.poll(async () => comments.evaluate((element) => element.scrollTop)).toBe(300)
 
@@ -846,7 +848,7 @@ test.describe('watch page', () => {
     await expect(video).toHaveJSProperty('muted', true)
     await expect.poll(() => video.evaluate(element => element.currentTime)).toBeLessThan(10)
 
-    const muteNotification = page.locator('.skippedSegment').filter({ hasText: 'Muted Sponsor segment' })
+    const muteNotification = page.locator('.skippedSegment').filter({ hasText: 'Sponsor Muted' })
     await expect(muteNotification).toBeVisible()
     await expect(muteNotification.locator('.skippedSegmentTimer')).toHaveText('7s')
     await muteNotification.getByRole('button', { name: /Unmute/ }).click()
@@ -1303,8 +1305,9 @@ test.describe('watch page', () => {
 
     test('shows the progress preview above the content viewport', async ({ page, innertube }) => {
       test.skip(innertube.replay, 'watch page hydration needs the real API')
-      await openVideo(page)
       await openFullscreenPlaylistVideo(page)
+      const video = await waitForPlaybackOrSkip(test, page)
+      await video.evaluate(element => element.pause())
       await expect(page.locator('.watchVideoPlaylist.resizablePlaylist')).toBeVisible()
 
       await page.locator('.full-window-button').click({ force: true })
@@ -1314,6 +1317,7 @@ test.describe('watch page', () => {
       const content = dock.locator('.fullscreenPlaylistContent')
       const progress = dock.locator('.playlistProgressBarContainer')
       await expect(dock).toBeVisible()
+      await progress.hover()
       const progressBox = await progress.boundingBox()
       await page.mouse.move(progressBox.x + 1, progressBox.y + (progressBox.height / 2))
 
@@ -1349,11 +1353,12 @@ test.describe('watch page', () => {
   test('full window playlist action shows its popover above the player', async ({ page, innertube }) => {
     test.skip(innertube.replay, 'watch page hydration needs the real API')
     await openVideo(page)
-    await waitForPlaybackOrSkip(test, page)
+    const video = await waitForPlaybackOrSkip(test, page)
+    await video.evaluate(element => element.pause())
 
-    await page.locator('.full-window-button').click({ force: true })
+    await page.locator('.full-window-button').click()
     await expect(page.locator('.ftVideoPlayer.fullWindow')).toBeVisible()
-    await page.locator('.fullscreenPlaylistAction .iconButton').click({ force: true })
+    await page.locator('.fullscreenPlaylistAction .iconButton').click()
 
     const popover = page.locator('.fullscreenPlaylistAction .iconDropdown')
     await expect(popover.locator('.dropdownHeader')).toBeVisible()
@@ -1362,7 +1367,7 @@ test.describe('watch page', () => {
     await page.keyboard.press('Escape')
     await expect(popover).toHaveCount(0)
 
-    await page.locator('.fullscreenQuickBookmarkAction').click({ force: true })
+    await page.locator('.fullscreenQuickBookmarkAction').click()
     const toastHolder = page.locator('.toast-holder')
     await expect(toastHolder.locator('.toast')).toBeVisible()
     expect(await toastHolder.evaluate(element => Number(getComputedStyle(element).zIndex))).toBeGreaterThan(1000)
@@ -1615,7 +1620,8 @@ test.describe('custom Shorts player', () => {
 
     await setPlayerFullscreen(page, false)
     await setWindowWidth(app, 600)
-    await player.evaluate(element => element.classList.add('fullWindow'))
+    await page.keyboard.press('s')
+    await expect(player).toHaveClass(/fullWindow/)
     await expect(player).toHaveCSS('width', '600px')
     const [narrowVideoBounds, narrowSeekBarBounds] = await Promise.all([
       videoSpace.boundingBox(),
@@ -1742,6 +1748,7 @@ test.describe('custom Shorts player', () => {
     await page.keyboard.press('Escape')
 
     const volumeControl = player.locator('.shortsVolumeControl')
+    await expect(contextMenu).toBeHidden()
     await volumeControl.hover()
     await expect(volumeControl.locator('.shortsVolumeSlider')).toBeVisible()
 
@@ -1779,11 +1786,12 @@ test.describe('custom Shorts player', () => {
       name: 'Video information'
     })
     await expect(videoInfoMenuButton).toBeVisible()
-    await videoInfoMenuButton.click()
+    await videoInfoMenuButton.evaluate(element => element.click())
     await expect(page.locator('.shortsAuxPanel')).toHaveClass(/shortsAuxPanelOpen/)
-    await page.getByRole('button', { name: 'Close video information' }).click()
+    await page.getByRole('button', { name: 'Close video information' }).evaluate(element => element.click())
     await expect(page.locator('.shortsAuxPanel')).not.toHaveClass(/shortsAuxPanelOpen/)
 
+    await expect(page).toHaveURL(/#\/watch\/w1WKmSqwM8I\?short=true/)
     for (const label of ['Share Video', 'Add to Playlist']) {
       const action = page.locator('.shortsComponentAction').filter({ hasText: label })
       const actionButton = action.getByRole('button', { name: label })
@@ -1791,25 +1799,27 @@ test.describe('custom Shorts player', () => {
         return getComputedStyle(element).backgroundColor
       })
 
-      await actionButton.click()
+      await actionButton.evaluate(element => element.click())
       await expect(actionButton).toHaveAttribute('aria-expanded', 'true')
       await expect.poll(() => actionButton.evaluate(element => {
         return getComputedStyle(element).backgroundColor
       })).not.toBe(idleBackground)
-      await actionButton.click()
+      await actionButton.evaluate(element => element.click())
     }
 
-    const commentsButton = page.getByRole('button', { name: 'Show Comments' })
-    await commentsButton.click()
+    await expect(page).toHaveURL(/#\/watch\/w1WKmSqwM8I\?short=true/)
+    const commentsButton = page.locator('.shortsCommentsAction').getByRole('button')
+    await commentsButton.evaluate(element => element.click())
     await expect(commentsButton).toHaveAttribute('aria-pressed', 'true')
     await expect(commentsButton).toHaveAccessibleName('Hide Comments')
     await expect(page.locator('.shortsCommentsPanel')).toHaveClass(/shortsCommentsPanelOpen/)
-    await commentsButton.click()
+    await commentsButton.evaluate(element => element.click())
     await expect(commentsButton).toHaveAttribute('aria-pressed', 'false')
 
+    await expect(page).toHaveURL(/#\/watch\/w1WKmSqwM8I\?short=true/)
     const quickBookmark = page.locator('.shortsQuickBookmark')
     if (await quickBookmark.count()) {
-      await quickBookmark.locator('.iconButton').click()
+      await quickBookmark.locator('.iconButton').evaluate(element => element.click())
       await expect(quickBookmark).toHaveClass(/shortsQuickBookmarked/)
     }
 
@@ -1875,13 +1885,18 @@ test.describe('custom Shorts player', () => {
       test.skip(true, `Shorts watch page unavailable from the live API: ${await errorMessage.textContent()}`)
     }
 
+    const playingVideo = await waitForPlaybackOrSkip(test, page)
+    await playingVideo.evaluate(element => element.pause())
     const captionTrackCount = await player.evaluate(element => {
       return element.ui.getControls().getPlayer().getTextTracks().length
     })
     await expect(player.locator('.shortsCaptionsControl')).toHaveCount(captionTrackCount > 0 ? 1 : 0)
 
     const overflowMenu = player.locator('.shaka-overflow-menu')
-    await player.getByRole('button', { name: 'More Options' }).click()
+    const menuButton = player.getByRole('button', { name: 'More Options' })
+    const menuBounds = await menuButton.boundingBox()
+    await page.mouse.move(menuBounds.x + menuBounds.width / 2, menuBounds.y + menuBounds.height / 2)
+    await menuButton.evaluate(button => button.click())
     await expect(overflowMenu).toBeVisible()
     await expect(overflowMenu.getByRole('button', { name: /Autoplay/ })).toHaveCount(0)
 
@@ -1902,7 +1917,7 @@ test.describe('custom Shorts player', () => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       const entry = store.getters.getHistoryCacheById.w1WKmSqwM8I
       return {
-        nearEnd: entry?.watchProgress >= expectedDuration - 0.5,
+        nearEnd: document.querySelector('.ftVideoPlayer.shortsPlayer video').currentTime >= expectedDuration - 0.5,
         full: entry?.watchProgress === entry?.lengthSeconds
       }
     }, duration)).toEqual({ nearEnd: true, full: false })
@@ -1949,395 +1964,5 @@ test.describe('custom Shorts player', () => {
 
     await expect(page).toHaveURL(/#\/watch\/[^?]+\?[^#]*\bshort=true\b/)
     await expect(page.locator('.autoplayCountdownOverlay')).toHaveCount(0)
-  })
-
-  test('scrolls through the cached subscriptions Shorts feed', async ({ page }) => {
-    const shortsTab = page
-      .locator('.tabContent[aria-hidden="false"]')
-      .locator('[data-subscription-feed-tab="shorts"]')
-    await shortsTab.click()
-    await page.getByText('First seeded Short', { exact: true }).click()
-    await expect(page).toHaveURL(
-      /#\/watch\/w1WKmSqwM8I\?short=true&shortSource=subscriptions/
-    )
-
-    const player = page.locator('.ftVideoPlayer.shortsPlayer')
-    const errorMessage = page.locator('.errorMessage')
-    await expect(player.or(errorMessage)).toBeVisible({ timeout: 30_000 })
-    if (await errorMessage.isVisible()) {
-      test.skip(true, `Shorts watch page unavailable from the live API: ${await errorMessage.textContent()}`)
-    }
-
-    const previous = page.locator('.shortsNavigationButton').first()
-    const next = page.locator('.shortsNavigationButton').last()
-    await expect(previous).toBeDisabled()
-    await expect(next).toBeEnabled()
-    await expect(page.locator('.shortsNextPreview')).toBeVisible()
-    await expect(page.locator('.shortsNextPreview')).toHaveAttribute(
-      'style',
-      /RZ6PG5QATg4\/frame0\.jpg\?selected=1/
-    )
-    await expect(page.locator('.shortsExternalMetadata')).toBeVisible()
-    await expect(page.locator('.shortsActionRail')).toBeVisible()
-
-    const commentsButton = page.locator('.shortsCommentsAction').getByRole('button')
-    await commentsButton.click()
-    const commentsPanel = page.locator('.shortsCommentsPanel')
-    await expect(commentsPanel).toHaveClass(/shortsCommentsPanelOpen/)
-    const commentsScroller = commentsPanel.locator('.commentsContentWrapper')
-    const firstComment = commentsPanel.locator('.comment').first()
-    const loadComments = commentsPanel.locator('.getCommentsTitle')
-    await expect(firstComment.or(loadComments)).toBeVisible()
-    if (await loadComments.isVisible()) {
-      await loadComments.click()
-    }
-    await expect(firstComment).toBeVisible({ timeout: 30_000 })
-    await expect.poll(() => commentsScroller.evaluate(element => {
-      return element.scrollHeight > element.clientHeight
-    })).toBe(true)
-    const commentsScrollTop = await commentsScroller.evaluate(element => element.scrollTop)
-    await commentsPanel.hover()
-    await page.mouse.wheel(0, 120)
-    await expect.poll(() => commentsScroller.evaluate(element => element.scrollTop))
-      .toBeGreaterThan(commentsScrollTop)
-    await expect(page).toHaveURL(
-      /#\/watch\/w1WKmSqwM8I\?short=true&shortSource=subscriptions/
-    )
-    await page.keyboard.press('ArrowDown')
-    await expect(page).toHaveURL(
-      /#\/watch\/w1WKmSqwM8I\?short=true&shortSource=subscriptions/
-    )
-
-    await page.evaluate(() => window.scrollTo({
-      top: document.documentElement.scrollHeight
-    }))
-    await expect(page).toHaveURL(
-      /#\/watch\/RZ6PG5QATg4\?short=true&shortSource=subscriptions/
-    )
-    await expect(commentsPanel).toHaveClass(/shortsCommentsPanelOpen/)
-
-    await page.waitForTimeout(500)
-    await previous.click()
-    await expect(page).toHaveURL(
-      /#\/watch\/w1WKmSqwM8I\?short=true&shortSource=subscriptions/
-    )
-    await expect(commentsPanel).toHaveClass(/shortsCommentsPanelOpen/)
-    await commentsPanel.getByRole('button', { name: 'Hide Comments' }).click()
-
-    const auxPanel = page.locator('.shortsAuxPanel')
-    const sponsorBlockButton = page.getByRole('button', { name: 'Open SponsorBlock info' })
-    await sponsorBlockButton.click()
-    await expect(sponsorBlockButton).toHaveAttribute('aria-pressed', 'true')
-    await expect(auxPanel).toHaveClass(/shortsAuxPanelOpen/)
-    const sponsorBlockContent = auxPanel.locator('.sponsorBlockContent')
-    await expect(sponsorBlockContent).toHaveCSS('overscroll-behavior', 'contain')
-    await sponsorBlockContent.hover()
-    await page.mouse.wheel(0, 2000)
-    await expect(page).toHaveURL(
-      /#\/watch\/w1WKmSqwM8I\?short=true&shortSource=subscriptions/
-    )
-
-    await page.waitForTimeout(500)
-    await page.evaluate(() => window.scrollTo({
-      top: document.documentElement.scrollHeight
-    }))
-    await expect(page).toHaveURL(
-      /#\/watch\/RZ6PG5QATg4\?short=true&shortSource=subscriptions/
-    )
-    await expect(auxPanel).toHaveClass(/shortsAuxPanelOpen/)
-    await expect(sponsorBlockButton).toHaveAttribute('aria-pressed', 'true')
-
-    await page.waitForTimeout(500)
-    await previous.click()
-    await expect(page).toHaveURL(
-      /#\/watch\/w1WKmSqwM8I\?short=true&shortSource=subscriptions/
-    )
-    await expect(auxPanel).toHaveClass(/shortsAuxPanelOpen/)
-    await expect(sponsorBlockButton).toHaveAttribute('aria-pressed', 'true')
-    await auxPanel.locator('.sponsorBlockHeader').getByRole('button', { name: 'Close' }).click()
-
-    const transcriptButton = page.locator('.shortsComponentAction')
-      .filter({ hasText: 'Transcript' })
-      .getByRole('button')
-    await transcriptButton.click()
-    const transcriptCard = auxPanel.locator('.watchVideoTranscript')
-    const transcriptTarget = auxPanel.locator('.shortsAuxPanelTarget')
-    await expect(transcriptCard).toBeVisible()
-    await expect(transcriptTarget).toHaveCSS('overscroll-behavior', 'contain')
-    await expect.poll(async () => {
-      const [cardHeight, targetHeight] = await Promise.all([
-        transcriptCard.evaluate(element => element.offsetHeight),
-        transcriptTarget.evaluate(element => element.clientHeight),
-      ])
-      return Math.abs(cardHeight - targetHeight)
-    }).toBeLessThanOrEqual(32)
-    await transcriptTarget.hover()
-    await page.mouse.wheel(0, 2000)
-    await expect(page).toHaveURL(
-      /#\/watch\/w1WKmSqwM8I\?short=true&shortSource=subscriptions/
-    )
-
-    await page.waitForTimeout(500)
-    await page.evaluate(() => window.scrollTo({
-      top: document.documentElement.scrollHeight
-    }))
-    await expect(page).toHaveURL(
-      /#\/watch\/RZ6PG5QATg4\?short=true&shortSource=subscriptions/
-    )
-    await expect(auxPanel).toHaveClass(/shortsAuxPanelOpen/)
-    await expect(transcriptButton).toHaveAttribute('aria-pressed', 'true')
-    await expect.poll(async () => {
-      const [cardHeight, targetHeight] = await Promise.all([
-        transcriptCard.evaluate(element => element.offsetHeight),
-        transcriptTarget.evaluate(element => element.clientHeight),
-      ])
-      return Math.abs(cardHeight - targetHeight)
-    }).toBeLessThanOrEqual(32)
-
-    await page.waitForTimeout(500)
-    await previous.click()
-    await expect(page).toHaveURL(
-      /#\/watch\/w1WKmSqwM8I\?short=true&shortSource=subscriptions/
-    )
-    await auxPanel.getByRole('button', { name: 'Close transcript' }).click()
-
-    const [playerBounds, videoAreaBounds, metadataBounds, actionBounds, previewBounds, navigationBounds] =
-      await Promise.all([
-        player.boundingBox(),
-        page.locator('.videoArea').boundingBox(),
-        page.locator('.shortsExternalMetadata').boundingBox(),
-        page.locator('.shortsActionRail').boundingBox(),
-        page.locator('.shortsNextPreview').boundingBox(),
-        page.locator('.shortsNavigation').boundingBox(),
-      ])
-    expect(metadataBounds.x + metadataBounds.width).toBeLessThanOrEqual(playerBounds.x)
-    expect(actionBounds.x).toBeGreaterThanOrEqual(playerBounds.x + playerBounds.width)
-    expect(previewBounds.y).toBeGreaterThanOrEqual(playerBounds.y + playerBounds.height)
-    expect(previewBounds.width).toBeCloseTo(playerBounds.width, 0)
-    expect(playerBounds.x + playerBounds.width / 2)
-      .toBeCloseTo(videoAreaBounds.x + videoAreaBounds.width / 2, 0)
-    expect(navigationBounds.x).toBeGreaterThan(actionBounds.x)
-
-    // Narrow layouts move the rail over the player and grow it upwards, so the
-    // navigation joins the same column above the actions instead of landing on
-    // top of them.
-    await page.setViewportSize({ width: 900, height: 700 })
-    await expect(page.locator('.shortsExternalChannel')).toHaveCSS('opacity', '1')
-    expect(await page.locator('.shortsExternalChannel').evaluate(element => {
-      return getComputedStyle(element).color === getComputedStyle(document.body).color
-    })).toBe(true)
-    await expect.poll(async () => {
-      const [rail, navigation, firstAction] = await Promise.all([
-        page.locator('.shortsActionRail').boundingBox(),
-        page.locator('.shortsNavigation').boundingBox(),
-        page.locator('.shortsAction').first().boundingBox()
-      ])
-
-      return {
-        navigationAboveActions: navigation.y + navigation.height <= firstAction.y,
-        centeredInRail: Math.abs(
-          (navigation.x + navigation.width / 2) - (rail.x + rail.width / 2)
-        ) <= 1,
-        insideRail: navigation.x >= rail.x && navigation.x + navigation.width <= rail.x + rail.width
-      }
-    }).toEqual({ navigationAboveActions: true, centeredInRail: true, insideRail: true })
-
-    await page.setViewportSize({ width: 1280, height: 900 })
-    await expect.poll(async () => {
-      const [rail, navigation] = await Promise.all([
-        page.locator('.shortsActionRail').boundingBox(),
-        page.locator('.shortsNavigation').boundingBox()
-      ])
-
-      return navigation.x > rail.x + rail.width
-    }).toBe(true)
-
-    await page.evaluate(() => {
-      window.__shortsNavigationDisappeared = false
-      const observer = new MutationObserver(() => {
-        if (!document.querySelector('.shortsNavigation')) {
-          window.__shortsNavigationDisappeared = true
-        }
-      })
-      observer.observe(document.body, { childList: true, subtree: true })
-    })
-
-    await next.click()
-    await expect(page.locator('.videoPlayerPlaceholder.ft-shimmer')).toHaveCount(0)
-    await expect(page).toHaveURL(
-      /#\/watch\/RZ6PG5QATg4\?short=true&shortSource=subscriptions/
-    )
-    expect(await page.evaluate(() => window.__shortsNavigationDisappeared)).toBe(false)
-
-    await page.waitForTimeout(500)
-    await page.keyboard.press('ArrowUp')
-    await expect(page).toHaveURL(
-      /#\/watch\/w1WKmSqwM8I\?short=true&shortSource=subscriptions/
-    )
-
-    await page.waitForTimeout(500)
-    // Browser middle-button autoscroll moves the window instead of emitting a
-    // wheel event, so window scrolling must navigate Shorts too.
-    await page.evaluate(() => window.scrollTo({
-      top: document.documentElement.scrollHeight
-    }))
-    await expect(page).toHaveURL(
-      /#\/watch\/RZ6PG5QATg4\?short=true&shortSource=subscriptions/
-    )
-
-    await page.waitForTimeout(500)
-    await page.keyboard.press('ArrowUp')
-    await expect(page).toHaveURL(
-      /#\/watch\/w1WKmSqwM8I\?short=true&shortSource=subscriptions/
-    )
-
-    await page.waitForTimeout(500)
-    const scrollbarHandle = page.locator(
-      'body > .os-scrollbar-vertical .os-scrollbar-handle'
-    )
-    const handleBounds = await scrollbarHandle.boundingBox()
-    await page.mouse.move(
-      handleBounds.x + handleBounds.width / 2,
-      handleBounds.y + handleBounds.height / 2
-    )
-    await page.mouse.down()
-    await page.mouse.move(
-      handleBounds.x + handleBounds.width / 2,
-      handleBounds.y + handleBounds.height / 2 + 50
-    )
-    await page.mouse.up()
-    await expect(page).toHaveURL(
-      /#\/watch\/RZ6PG5QATg4\?short=true&shortSource=subscriptions/
-    )
-  })
-
-  test('does not show a stale loading indicator after leaving a loaded Shorts tab', async ({ app, page }) => {
-    await page.locator(sel.newTabButton).click()
-    await expect(page.locator(sel.tabs)).toHaveCount(2)
-    const shortTab = page.locator(sel.tabs).first()
-    await shortTab.click()
-
-    const shortsFeedTab = page
-      .locator('.tabContent[aria-hidden="false"]')
-      .locator('[data-subscription-feed-tab="shorts"]')
-    await shortsFeedTab.click()
-    await page.getByText('First seeded Short', { exact: true }).click()
-    await expect(page).toHaveURL(
-      /#\/watch\/w1WKmSqwM8I\?short=true&shortSource=subscriptions/
-    )
-
-    const player = page.locator('.ftVideoPlayer.shortsPlayer')
-    const errorMessage = page.locator('.errorMessage')
-    await expect(player.or(errorMessage)).toBeVisible({ timeout: 30_000 })
-    if (await errorMessage.isVisible()) {
-      test.skip(true, `Shorts watch page unavailable from the live API: ${await errorMessage.textContent()}`)
-    }
-
-    await expect(shortTab).not.toHaveClass(/loading/)
-    await shortTab.evaluate((tab) => {
-      window.__shortTabShowedLoadingWhileScrolling = false
-      new MutationObserver(() => {
-        if (tab.classList.contains('loading')) {
-          window.__shortTabShowedLoadingWhileScrolling = true
-        }
-      }).observe(tab, { attributes: true, attributeFilter: ['class'] })
-    })
-    await page.evaluate(() => window.scrollTo({
-      top: document.documentElement.scrollHeight
-    }))
-    await expect(page).toHaveURL(
-      /#\/watch\/RZ6PG5QATg4\?short=true&shortSource=subscriptions/
-    )
-    await expect.poll(() => page.evaluate(
-      () => window.__shortTabShowedLoadingWhileScrolling
-    )).toBe(true)
-    await expect(player).toBeVisible()
-    await expect(
-      page.locator('.tabContent[aria-hidden="false"] [data-tab-loading-indicator]')
-    ).toHaveCount(0)
-
-    await expect(shortTab).not.toHaveClass(/loading/)
-    await shortTab.evaluate((tab) => {
-      window.__shortTabShowedLoadingAfterDeactivation = false
-      window.__shortTabLoadingTransitions = []
-      new MutationObserver(() => {
-        window.__shortTabLoadingTransitions.push({
-          loading: tab.classList.contains('loading'),
-          markers: [...document.querySelectorAll(
-            `[data-tab-id="${tab.dataset.tabId}"] [data-tab-loading-indicator]`
-          )].map(element => element.className),
-        })
-        if (tab.classList.contains('loading')) {
-          window.__shortTabShowedLoadingAfterDeactivation = true
-        }
-      }).observe(tab, { attributes: true, attributeFilter: ['class'] })
-    })
-
-    const shortTabId = await shortTab.getAttribute('data-tab-id')
-    await page.evaluate((tabId) => {
-      const app = document.querySelector('#app')?.__vue_app__
-      const findWatchView = (vnode) => {
-        if (
-          vnode?.component?.type?.name === 'Watch' &&
-          vnode.component.proxy?.tabId === tabId
-        ) {
-          return vnode.component.proxy
-        }
-        if (vnode?.component?.subTree) {
-          const match = findWatchView(vnode.component.subTree)
-          if (match) return match
-        }
-        if (Array.isArray(vnode?.children)) {
-          for (const child of vnode.children) {
-            const match = findWatchView(child)
-            if (match) return match
-          }
-        }
-        return null
-      }
-      const watchView = findWatchView(app?._container?._vnode)
-      if (!watchView) throw new Error('Unable to access the Shorts watch view')
-
-      // Reproduce a delayed placeholder appearing while the first tab switch
-      // begins. Once hidden, it must never contribute to the tab loader.
-      watchView.shortsTransitionPreview = ''
-      window.setTimeout(() => {
-        watchView.isLoading = true
-      }, 250)
-    }, shortTabId)
-
-    await app.electronApp.evaluate(({ BrowserWindow, Menu }) => {
-      const findMenuItem = (items, label) => {
-        for (const item of items) {
-          if (item.label === label) return item
-          const match = findMenuItem(item.submenu?.items ?? [], label)
-          if (match) return match
-        }
-        return null
-      }
-      const menuItem = findMenuItem(Menu.getApplicationMenu()?.items ?? [], 'Next Tab')
-      const browserWindow = BrowserWindow.getFocusedWindow()
-      if (!menuItem || !browserWindow) {
-        throw new Error('Next Tab application-menu item was not found')
-      }
-      menuItem.click(undefined, browserWindow, undefined)
-    })
-    await expect(page.locator(sel.tabs)).toHaveCount(2)
-    await page.waitForTimeout(5000)
-    const loadingResult = await page.evaluate(() => ({
-      showed: window.__shortTabShowedLoadingAfterDeactivation,
-      transitions: window.__shortTabLoadingTransitions,
-    }))
-    expect(loadingResult.showed, JSON.stringify(loadingResult.transitions)).toBe(false)
-    await expect(shortTab).not.toHaveClass(/loading/)
-
-    await shortTab.click()
-    await expect(page).toHaveURL(
-      /#\/watch\/RZ6PG5QATg4\?short=true&shortSource=subscriptions/
-    )
-    await expect(shortTab).toHaveClass(/loading/)
-    await expect(
-      page.locator('.tabContent[aria-hidden="false"] [data-tab-loading-indicator]')
-    ).toHaveCount(1)
   })
 })

--- a/e2e/tests/offline/collaborators-modal-animation.spec.mjs
+++ b/e2e/tests/offline/collaborators-modal-animation.spec.mjs
@@ -256,7 +256,8 @@ test.describe('while collaborators are loading', () => {
     })
     await page.route(/^https?:\/\//, async route => {
       await requestsReleased
-      await route.abort()
+      // A terminal error finishes loading instead of waiting for network recovery.
+      await route.fulfill({ status: 404, json: { error: 'Not found' } })
     })
 
     await goTo(page, 'subscriptions')

--- a/e2e/tests/offline/gamepad-navigation.spec.mjs
+++ b/e2e/tests/offline/gamepad-navigation.spec.mjs
@@ -283,7 +283,7 @@ test('keeps a changed quick settings slider focused', async ({ attachScreenshot,
 
   await expect(slider).not.toHaveValue(initialValue)
   await expect(slider).toBeFocused()
-  await expect.poll(() => slider.evaluate(element => element.matches(':focus-visible'))).toBe(true)
+  await expect(slider.locator('..')).toHaveCSS('box-shadow', /inset/)
   await expect(slider).toHaveAttribute('data-gamepad-active', 'true')
   await expect(menu).not.toBeFocused()
   await attachScreenshot('active quick settings gamepad slider')

--- a/e2e/tests/offline/playlist-loading.spec.mjs
+++ b/e2e/tests/offline/playlist-loading.spec.mjs
@@ -1,10 +1,14 @@
 import { test, expect, goTo, sel } from '../../helpers/app.mjs'
+import { fulfillVisualFixture } from '../../helpers/visual-fixtures.mjs'
 
 test.use({
   seed: {
     settings: {
       backendPreference: 'invidious',
       backendFallback: false,
+      // Suggestions would contact the fake instance and block playlist requests
+      // while network recovery waits for that unrelated request to succeed.
+      enableSearchSuggestions: false,
       defaultInvidiousInstance: 'https://invidious.test',
       generalAutoLoadMorePaginatedItemsEnabled: true
     }
@@ -57,6 +61,7 @@ async function openPlaylistTab(page, route) {
 }
 
 test('loads an Invidious Mix response from the playlist endpoint', async ({ page, attachScreenshot }) => {
+  await page.route('https://invidious.test/vi/**', route => fulfillVisualFixture(route, 'video-thumbnail'))
   const playlistId = 'RDnGusAJYHcjo'
   const errors = []
   page.on('console', message => {

--- a/e2e/tests/offline/playlist-skip-buttons.spec.mjs
+++ b/e2e/tests/offline/playlist-skip-buttons.spec.mjs
@@ -110,12 +110,12 @@ function readSkipAvailability(page) {
 }
 
 test('playlist counter stays below the title when expanded and collapsed', async ({ page, attachScreenshot }) => {
-  await page.route(/^https?:\/\//, (route) => route.abort())
+  await page.route(/^https?:\/\//, (route) => route.fulfill({ status: 404, body: '' }))
   await goTo(page, 'userplaylists')
   await page.getByText('Skip button playlist').click()
   await page.getByText(VIDEO_TITLES[1]).first().click()
 
-  const playlist = page.locator('.watchVideoPlaylist')
+  const playlist = page.locator('.watchVideoPlaylist.resizablePlaylist')
   const counter = playlist.locator('.playlistIndex label')
   await expect(counter).toHaveText('2 / 3')
 
@@ -147,7 +147,7 @@ test('playlist counter stays below the title when expanded and collapsed', async
 })
 
 test('only offers skipping to playlist videos that exist', async ({ page, attachScreenshot }) => {
-  await page.route(/^https?:\/\//, (route) => route.abort())
+  await page.route(/^https?:\/\//, (route) => route.fulfill({ status: 404, body: '' }))
 
   await goTo(page, 'userplaylists')
   await page.getByText('Skip button playlist').click()
@@ -167,7 +167,7 @@ test('only offers skipping to playlist videos that exist', async ({ page, attach
   await attachScreenshot('first playlist video')
 
   // Loop wraps the playlist around in both directions
-  const loopButton = page.locator('.watchVideoPlaylist').getByRole('button', { name: 'Loop Playlist' })
+  const loopButton = page.locator('.watchVideoPlaylist.resizablePlaylist').getByRole('button', { name: 'Loop Playlist' })
   await loopButton.click()
   await expect.poll(() => readSkipAvailability(page)).toEqual({
     canPlayNext: true,
@@ -217,7 +217,7 @@ test('continues a playlist after a Short ends', async ({ app, page }) => {
 })
 
 test('offers skipping to a queued video without a playlist', async ({ page }) => {
-  await page.route(/^https?:\/\//, (route) => route.abort())
+  await page.route(/^https?:\/\//, (route) => route.fulfill({ status: 404, body: '' }))
 
   await goTo(page, 'history')
 

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -742,7 +742,7 @@ test.describe('settings', () => {
     await expectDownloadQueueSettingsAlignment(page)
   })
 
-  test('hides the redundant Privacy heading and keeps the original Distraction Free headings', async ({ page }) => {
+  test('hides the redundant Privacy heading and keeps the Distraction Free group headings', async ({ page }) => {
     const privacy = await goToSettingsSection(page, 'privacy')
     const mainPrivacySection = privacy.locator('.settingsSection').first()
     const privacyHeading = mainPrivacySection.locator('.sectionTitle')
@@ -755,7 +755,6 @@ test.describe('settings', () => {
     await expect(focus.locator('h4.groupTitle')).toHaveText([
       'General',
       'Visible While Paused in Full Window / Full Screen',
-      'Side bar',
       'Subscriptions page',
       'Channel Page',
       'Watch Page'

--- a/e2e/tests/offline/subscriptions-context-menu.spec.mjs
+++ b/e2e/tests/offline/subscriptions-context-menu.spec.mjs
@@ -28,8 +28,8 @@ test.use({
 })
 
 test('subscription tabs expose feed-specific reload actions', async ({ page }) => {
-  // The reload actions start real refreshes, which fail immediately offline
-  await page.route(/^https?:\/\//, (route) => route.abort())
+  // HTTP failures finish the refresh; network failures now retry until recovery.
+  await page.route(/^https?:\/\//, route => route.fulfill({ status: 404, body: '' }))
   await goTo(page, 'subscriptions')
 
   await page.evaluate(() => {

--- a/e2e/tests/offline/subscriptions-refresh.spec.mjs
+++ b/e2e/tests/offline/subscriptions-refresh.spec.mjs
@@ -623,7 +623,7 @@ test.describe('cancelling a subscription feed refresh', () => {
   })
 
   test('stops a running refresh and keeps what was already fetched', async ({ page }) => {
-    await routeFeeds(page, () => 4_000)
+    await routeFeeds(page, index => index === 0 ? 0 : 4_000)
     await goTo(page, 'subscriptions')
     await expect(page.getByText('Cached video 0', { exact: true })).toBeVisible()
 
@@ -631,10 +631,10 @@ test.describe('cancelling a subscription feed refresh', () => {
 
     const cancelRefresh = page.getByRole('button', { name: 'Cancel refresh' })
     await expect(cancelRefresh).toBeVisible()
+    await expect(page.getByText('Fresh video 0', { exact: true })).toBeVisible()
     await cancelRefresh.click()
 
-    // The channels that were in flight still finish, the remaining ones are
-    // skipped instead of being fetched
+    // Completed channels stay cached; pending and queued channels are cancelled.
     await expect(page.locator('.tabsProgressBar')).toHaveCount(0, { timeout: 20_000 })
     await expect(cancelRefresh).toHaveCount(0)
     await expect(page.getByText('Fresh video 0', { exact: true })).toBeVisible()
@@ -643,7 +643,7 @@ test.describe('cancelling a subscription feed refresh', () => {
   })
 
   test('offers the cancellation in the feed tab context menu', async ({ page }) => {
-    await routeFeeds(page, () => 4_000)
+    await routeFeeds(page, index => index === 0 ? 0 : 4_000)
     await goTo(page, 'subscriptions')
     await expect(page.getByText('Cached video 0', { exact: true })).toBeVisible()
 
@@ -652,6 +652,7 @@ test.describe('cancelling a subscription feed refresh', () => {
     await menu.getByRole('menuitem', { name: 'Reload Videos' }).click()
 
     await expect(page.getByRole('button', { name: 'Cancel refresh' })).toBeVisible()
+    await expect(page.getByText('Fresh video 0', { exact: true })).toBeVisible()
 
     await page.locator('[data-subscription-feed-tab="videos"]').click({ button: 'right' })
     await expect(menu.getByRole('menuitem', { name: 'Reload Videos' })).toHaveCount(0)

--- a/e2e/tests/offline/update-modal.spec.mjs
+++ b/e2e/tests/offline/update-modal.spec.mjs
@@ -75,8 +75,13 @@ test('the update notification stays dismissed for the current app session', asyn
   await expect(dismissButton.locator('[data-icon="xmark"]')).toBeVisible()
   expect(await notification.evaluate(element => element.scrollWidth <= element.clientWidth)).toBe(true)
 
-  const dismissBox = await dismissButton.boundingBox()
-  const updateBox = await updateButton.boundingBox()
+  // Read both controls in the same frame while the toast animates into place.
+  const [dismissBox, updateBox] = await notification.evaluate(element =>
+    ['Dismiss', 'See changes and update'].map(label => {
+      const button = Array.from(element.querySelectorAll('button')).find(button => button.textContent.trim() === label)
+      return button.getBoundingClientRect().toJSON()
+    })
+  )
   expect(dismissBox).not.toBeNull()
   expect(updateBox).not.toBeNull()
   expect(Math.abs(dismissBox.x - updateBox.x)).toBeLessThanOrEqual(1)

--- a/e2e/tests/offline/video-metadata-history.spec.mjs
+++ b/e2e/tests/offline/video-metadata-history.spec.mjs
@@ -131,7 +131,8 @@ test('stores and presents every previous metadata version', async ({ app, page }
   try {
     const { port } = thumbnailServer.address()
     await mockPlayableWatchPage(app, page)
-    await openMockedVideo(page)
+    const video = await openMockedVideo(page)
+    await video.evaluate(element => element.pause())
 
     const thumbnailBaseUrl = `http://127.0.0.1:${port}`
     await page.evaluate(async ({ action, url }) => {

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -1,5 +1,5 @@
 import crypto from 'node:crypto'
-import { goTo, sel, setPlayerFullscreen, setWindowSize, test, expect } from '../../helpers/app.mjs'
+import { sel, setPlayerFullscreen, setWindowSize, test, expect } from '../../helpers/app.mjs'
 import { activeTab, findWatchComponent, openMockedVideo, waitForPlayback } from '../../helpers/player.mjs'
 import { mockPlayableWatchPage, watchViewHandle } from '../../helpers/watch.mjs'
 import {
@@ -1358,6 +1358,97 @@ test.describe('Shorts transcript navigation', () => {
     }
   })
 
+  test('pausing and seeking near the end does not complete a Short', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await page.locator(sel.searchInput).fill(`https://www.youtube.com/shorts/${CAPTIONED_SHORT_IDS[0]}`)
+    await page.locator(sel.searchInput).press('Enter')
+    const video = await waitForPlayback(page)
+    await video.evaluate(async element => {
+      element.pause()
+      element.currentTime = element.duration - 0.25
+      await new Promise(resolve => element.addEventListener('seeked', resolve, { once: true }))
+    })
+    const view = await watchViewHandle(page)
+    await expect.poll(() => view.evaluate(view => ({
+      complete: view.shortsPlaybackCompleted,
+      progress: view.historyEntry?.watchProgress,
+      full: view.historyEntry?.watchProgress === view.historyEntry?.lengthSeconds
+    }))).toEqual({ complete: false, progress: expect.any(Number), full: false })
+    await video.evaluate(async element => {
+      element.currentTime = element.duration - 2
+      await new Promise(resolve => element.addEventListener('seeked', resolve, { once: true }))
+      await element.play()
+    })
+    await expect.poll(() => view.evaluate(view => view.shortsPlaybackCompleted)).toBe(true)
+    await view.dispose()
+  })
+
+  for (const zoom of [1, 1.25]) {
+    test(`Escape dismisses the Shorts context menu before exiting full window at ${zoom} scale`, async ({ app, page }) => {
+      await mockPlayableWatchPage(app, page)
+      await page.evaluate(zoom => window.ftElectron.setZoomFactor(zoom), zoom)
+      await page.locator(sel.searchInput).fill(`https://www.youtube.com/shorts/${CAPTIONED_SHORT_IDS[0]}`)
+      await page.locator(sel.searchInput).press('Enter')
+      const video = await waitForPlayback(page)
+      await video.evaluate(element => element.pause())
+      const player = page.locator('.ftVideoPlayer.shortsPlayer')
+      await page.keyboard.press('s')
+      await expect(player).toHaveClass(/fullWindow/)
+      await player.click({ button: 'right', position: { x: 100, y: 100 } })
+      const menu = player.locator('.shaka-context-menu')
+      await expect(menu).toBeVisible()
+      await page.keyboard.press('Escape')
+      await expect(menu).toBeHidden()
+      await expect(player).toHaveClass(/fullWindow/)
+      const volume = player.locator('.shortsVolumeControl')
+      await volume.hover()
+      await expect(volume.locator('.shortsVolumeSlider')).toBeVisible()
+      await page.keyboard.press('Escape')
+      await expect(player).not.toHaveClass(/fullWindow/)
+    })
+
+    test(`Shorts information panels contain wheel input with and without overflow at ${zoom} scale`, async ({ app, page }) => {
+      await mockPlayableWatchPage(app, page)
+      await page.evaluate(zoom => window.ftElectron.setZoomFactor(zoom), zoom)
+      await page.locator('[data-subscription-feed-tab="shorts"]').click()
+      await page.getByText('Transcript Short 1', { exact: true }).click()
+      const video = await waitForPlayback(page)
+      await video.evaluate(element => element.pause())
+      const view = await watchViewHandle(page)
+      await view.evaluate(async view => {
+        view.videoDescription = 'Short description'
+        view.videoDescriptionHtml = ''
+        view.toggleShortsMetadata()
+        await view.$nextTick()
+      })
+      const panel = page.locator('.shortsAuxPanel')
+      const scroller = panel.locator('.shortsAuxPanelTarget')
+      await expect(panel).toHaveClass(/shortsAuxPanelOpen/)
+      const originalUrl = page.url()
+      const bounds = await scroller.boundingBox()
+      await page.mouse.move(bounds.x + 20, bounds.y + 20)
+      await page.mouse.wheel(0, 2000)
+      await page.waitForTimeout(300)
+      await expect(page).toHaveURL(originalUrl)
+      await view.evaluate(async view => {
+        view.toggleShortsMetadata()
+        await view.$nextTick()
+        view.videoDescription = Array(200).fill('Long description').join('\n')
+        view.toggleShortsMetadata()
+      })
+      await expect.poll(() => scroller.evaluate(element => element.scrollHeight - element.clientHeight)).toBeGreaterThan(100)
+      const longBounds = await scroller.boundingBox()
+      await page.mouse.move(longBounds.x + 20, longBounds.y + 20)
+      await page.mouse.wheel(0, 120)
+      await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+      await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
+      await page.mouse.wheel(0, 2000)
+      await page.waitForTimeout(300)
+      await expect(page).toHaveURL(originalUrl)
+      await view.dispose()
+    })
+  }
+
   test('keeps the current Short from expanding when YouTube-style Shorts are disabled', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
     await page.evaluate(async () => {
@@ -1375,7 +1466,12 @@ test.describe('Shorts transcript navigation', () => {
     const shortsBounds = await player.boundingBox()
     expect(shortsBounds).not.toBeNull()
 
-    await goTo(page, 'settings')
+    // Avoid Playwright scrolling the Shorts feed to bring menu controls into view.
+    await page.locator('.profileTrigger').evaluate(button => button.click())
+    await expect(page.locator('.quickSettingsMenu')).toBeVisible()
+    await page.locator('.allSettingsShortcut').evaluate(button => button.click())
+    await expect(page.locator('.settingsWindow')).toBeVisible()
+    await expect(page).toHaveURL(new RegExp(CAPTIONED_SHORT_IDS[0]))
     await page.locator('.settingsMenu [data-section="playback"]').click()
     const toggle = page.getByRole('checkbox', { name: 'Use YouTube-style Shorts' })
     await expect(toggle).toBeChecked()
@@ -1383,6 +1479,7 @@ test.describe('Shorts transcript navigation', () => {
       .filter({ hasText: 'Use YouTube-style Shorts' })
       .click()
     await expect(toggle).not.toBeChecked()
+    await expect(page).toHaveURL(new RegExp(CAPTIONED_SHORT_IDS[0]))
     await expect(player).toHaveClass(/shortsPlayer/)
 
     const bounds = await player.boundingBox()
@@ -1390,7 +1487,8 @@ test.describe('Shorts transcript navigation', () => {
     expect(bounds.width).toBeLessThanOrEqual(shortsBounds.width + 1)
 
     await page.locator('.settingsWindow').getByRole('button', { name: 'Close' }).click()
-    await page.locator('.shortsNavigationButton').last().click()
+    await expect(page).toHaveURL(new RegExp(CAPTIONED_SHORT_IDS[0]))
+    await page.locator('.shortsNavigationButton').last().evaluate(element => element.click())
     await expect(page).toHaveURL(new RegExp(`#\\/watch\\/${CAPTIONED_SHORT_IDS[1]}\\?short=true`))
     await waitForPlayback(page)
     await expect(player).not.toHaveClass(/shortsPlayer/)
@@ -1656,60 +1754,111 @@ test.describe('Shorts transcript navigation', () => {
     ))).toEqual([])
   })
 
-  test('keeps the Shorts player, action rail, and comments inside a Capacitor phone viewport', async ({ app, page }) => {
-    await mockPlayableWatchPage(app, page)
-    await page.locator(sel.searchInput)
-      .fill(`https://www.youtube.com/shorts/${CAPTIONED_SHORT_IDS[0]}`)
-    await page.locator(sel.searchInput).press('Enter')
-    await waitForPlayback(page)
-    await setWindowSize(app, page, { width: 461, height: 1026 })
-    await page.locator('.app').evaluate((element) => {
-      element.classList.add('capacitorTabs', 'capacitorPhoneLayout')
-      element.classList.remove('topTabs', 'bottomTabs', 'verticalTabs')
-      document.querySelector('.tabBar')?.style.setProperty('display', 'none')
+  for (const zoom of [1, 1.25]) {
+    test(`keeps the Shorts player, action rail, and comments inside a Capacitor phone viewport at ${zoom} scale`, async ({ app, page }) => {
+      await mockPlayableWatchPage(app, page)
+      await page.evaluate(zoom => window.ftElectron.setZoomFactor(zoom), zoom)
+      await page.locator(sel.searchInput)
+        .fill(`https://www.youtube.com/shorts/${CAPTIONED_SHORT_IDS[0]}`)
+      await page.locator(sel.searchInput).press('Enter')
+      await waitForPlayback(page)
+      await setWindowSize(app, page, { width: 461, height: 1026 })
+      await page.locator('.app').evaluate((element) => {
+        element.classList.add('capacitorTabs', 'capacitorPhoneLayout')
+        element.classList.remove('topTabs', 'bottomTabs', 'verticalTabs')
+        document.querySelector('.tabBar')?.style.setProperty('display', 'none')
+      })
+
+      const player = page.locator('.ftVideoPlayer.shortsPlayer')
+      const rail = page.locator('.shortsActionRail')
+      const commentsPanel = page.locator('.shortsCommentsPanel')
+      await expect(player).toBeVisible()
+      await expect(rail).toBeVisible()
+      await page.locator('.shortsCommentsAction .iconButton').click()
+      await expect(commentsPanel).toHaveClass(/shortsCommentsPanelOpen/)
+
+      const geometry = await page.evaluate(() => {
+        const playerBounds = document.querySelector('.ftVideoPlayer.shortsPlayer').getBoundingClientRect()
+        const railBounds = document.querySelector('.shortsActionRail').getBoundingClientRect()
+        const commentsBounds = document.querySelector('.shortsCommentsPanel').getBoundingClientRect()
+        const actionLabels = [...document.querySelectorAll('.shortsAction > span')]
+        return {
+          commentsLeft: commentsBounds.left,
+          commentsRight: commentsBounds.right,
+          documentClientWidth: document.documentElement.clientWidth,
+          documentScrollWidth: document.documentElement.scrollWidth,
+          labelsHidden: actionLabels.every(label => getComputedStyle(label).display === 'none'),
+          railBottom: railBounds.bottom,
+          railLeft: railBounds.left,
+          railRight: railBounds.right,
+          playerBottom: playerBounds.bottom,
+          playerLeft: playerBounds.left,
+          playerRight: playerBounds.right,
+          viewportWidth: window.innerWidth,
+        }
+      })
+
+      expect(geometry.labelsHidden).toBe(true)
+      expect(geometry.documentScrollWidth).toBeLessThanOrEqual(geometry.documentClientWidth + 1)
+      expect(geometry.playerLeft).toBeGreaterThanOrEqual(0)
+      expect(geometry.playerRight).toBeLessThanOrEqual(geometry.viewportWidth)
+      expect(geometry.commentsLeft).toBeGreaterThanOrEqual(0)
+      expect(geometry.commentsRight).toBeLessThanOrEqual(geometry.viewportWidth)
+      expect(geometry.railLeft).toBeGreaterThanOrEqual(geometry.playerLeft)
+      expect(geometry.railRight).toBeLessThanOrEqual(geometry.playerRight)
+      expect(geometry.railRight).toBeLessThanOrEqual(geometry.viewportWidth)
+      expect(geometry.railBottom).toBeLessThanOrEqual(geometry.playerBottom)
     })
+  }
+})
 
-    const player = page.locator('.ftVideoPlayer.shortsPlayer')
-    const rail = page.locator('.shortsActionRail')
-    const commentsPanel = page.locator('.shortsCommentsPanel')
-    await expect(player).toBeVisible()
-    await expect(rail).toBeVisible()
-    await page.locator('.shortsCommentsAction .iconButton').click()
-    await expect(commentsPanel).toHaveClass(/shortsCommentsPanelOpen/)
-
-    const geometry = await page.evaluate(() => {
-      const playerBounds = document.querySelector('.ftVideoPlayer.shortsPlayer').getBoundingClientRect()
-      const railBounds = document.querySelector('.shortsActionRail').getBoundingClientRect()
-      const commentsBounds = document.querySelector('.shortsCommentsPanel').getBoundingClientRect()
-      const actionLabels = [...document.querySelectorAll('.shortsAction > span')]
-      return {
-        commentsLeft: commentsBounds.left,
-        commentsRight: commentsBounds.right,
-        documentClientWidth: document.documentElement.clientWidth,
-        documentScrollWidth: document.documentElement.scrollWidth,
-        labelsHidden: actionLabels.every(label => getComputedStyle(label).display === 'none'),
-        railBottom: railBounds.bottom,
-        railLeft: railBounds.left,
-        railRight: railBounds.right,
-        playerBottom: playerBounds.bottom,
-        playerLeft: playerBounds.left,
-        playerRight: playerBounds.right,
-        viewportWidth: window.innerWidth,
+for (const zoom of [1, 1.25]) {
+  test(`chapters stay centered through layout changes until manually scrolled at ${zoom} scale`, async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await page.evaluate(zoom => window.ftElectron.setZoomFactor(zoom), zoom)
+    const video = await openMockedVideo(page)
+    await video.evaluate(async element => {
+      element.pause()
+      element.currentTime = element.duration * 20.5 / 40
+      if (element.seeking) {
+        await new Promise(resolve => element.addEventListener('seeked', resolve, { once: true }))
       }
     })
-
-    expect(geometry.labelsHidden).toBe(true)
-    expect(geometry.documentScrollWidth).toBeLessThanOrEqual(geometry.documentClientWidth + 1)
-    expect(geometry.playerLeft).toBeGreaterThanOrEqual(0)
-    expect(geometry.playerRight).toBeLessThanOrEqual(geometry.viewportWidth)
-    expect(geometry.commentsLeft).toBeGreaterThanOrEqual(0)
-    expect(geometry.commentsRight).toBeLessThanOrEqual(geometry.viewportWidth)
-    expect(geometry.railLeft).toBeGreaterThanOrEqual(geometry.playerLeft)
-    expect(geometry.railRight).toBeLessThanOrEqual(geometry.playerRight)
-    expect(geometry.railRight).toBeLessThanOrEqual(geometry.viewportWidth)
-    expect(geometry.railBottom).toBeLessThanOrEqual(geometry.playerBottom)
+    const chapterDuration = await video.evaluate(element => element.duration / 40)
+    const view = await watchViewHandle(page)
+    await view.evaluate(async (view, chapterDuration) => {
+      view.videoChapters = Array.from({ length: 40 }, (_, index) => ({
+        title: `Chapter ${index + 1}`,
+        timestamp: `${index}:00`,
+        startSeconds: index * chapterDuration
+      }))
+      view.videoCurrentChapterIndex = 20
+      view.showSidebarChapters = true
+      await view.$nextTick()
+    }, chapterDuration)
+    const scroller = page.locator('.watchVideoChaptersPanel .chaptersWrapper')
+    const expectCentered = () => expect.poll(() => scroller.evaluate(element => {
+      const row = element.querySelector('.chapter.current').getBoundingClientRect()
+      const viewport = element.getBoundingClientRect()
+      return Math.abs(row.top + row.height / 2 - viewport.top - viewport.height / 2)
+    })).toBeLessThan(2)
+    await expectCentered()
+    await scroller.evaluate(element => { element.style.maxBlockSize = '240px' })
+    await expectCentered()
+    await scroller.hover()
+    await page.mouse.wheel(0, 2000)
+    await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
+    await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBeGreaterThan(2000)
+    await scroller.evaluate(element => { element.style.maxBlockSize = '480px' })
+    await expect.poll(() => scroller.evaluate(element => (
+      Math.abs(element.scrollTop - (element.scrollHeight - element.clientHeight))
+    ))).toBeLessThan(2)
+    await view.evaluate(view => { view.videoChapters = view.videoChapters.slice(0, 3) })
+    await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBe(0)
+    await expect(scroller.locator(':scope > .os-scrollbar-vertical')).toHaveClass(/os-scrollbar-unusable/)
+    await view.dispose()
   })
-})
+}
 
 test('a background watch tab stays loading until its cached avatar is ready', async ({ app, page }) => {
   await mockPlayableWatchPage(app, page)
@@ -3866,11 +4015,28 @@ test.describe('watch page', () => {
 
   test('fullscreen SponsorBlock uses one content scrollbar', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
+    await page.route('**/api/skipSegments/**', route => route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify([{
+        videoID: 'jNQXAC9IVRw',
+        segments: Array.from({ length: 20 }, (_, index) => ({
+          UUID: `scrollbar-segment-${index}`,
+          actionType: 'skip',
+          category: 'sponsor',
+          description: '',
+          locked: 0,
+          segment: [index, index + 0.5],
+          videoDuration: 30,
+          votes: 1
+        }))
+      }])
+    }))
     await page.evaluate(() => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       store.commit('setUseSponsorBlock', true)
     })
-    await openMockedVideo(page)
+    const video = await openMockedVideo(page)
+    await video.evaluate(element => element.pause())
     await setPlayerFullscreen(page, true)
     await page.locator('.fullscreenSponsorBlockToggle').click({ force: true })
 
@@ -5703,5 +5869,422 @@ test.describe('manual comment loading', () => {
     // rendered, so the position has to still be at the top a moment later.
     await page.waitForTimeout(1000)
     expect(await comments.evaluate((element) => element.scrollTop)).toBe(0)
+  })
+})
+
+test.describe('Shorts feed navigation', () => {
+  const SHORTS_CHANNEL = 'UC-transcript-shorts'
+  const FIRST_SHORT_THUMBNAIL = 'https://i.ytimg.com/vi/jNQXAC9IVRw/frame0.jpg?selected=1'
+  const SECOND_SHORT_THUMBNAIL = 'https://i.ytimg.com/vi/captioned-short-2/frame0.jpg?selected=1'
+
+  test.use({
+    seed: {
+      settings: {
+        ...WATCH_PAGE_SEED,
+        useCustomShortsPlayer: true,
+        useSponsorBlock: true,
+        fetchSubscriptionsAutomatically: false,
+        playNextVideo: true,
+        defaultInterval: 0
+      },
+      profiles: [{
+        _id: 'allChannels',
+        name: 'All Channels',
+        bgColor: '#000000',
+        textColor: '#FFFFFF',
+        subscriptions: [{
+          id: SHORTS_CHANNEL,
+          name: 'Shorts Channel',
+          thumbnail: ''
+        }]
+      }],
+      subscriptionCache: [{
+        _id: SHORTS_CHANNEL,
+        shorts: [
+          {
+            type: 'video',
+            videoId: 'jNQXAC9IVRw',
+            title: 'First seeded Short',
+            author: 'Shorts Channel',
+            authorId: SHORTS_CHANNEL,
+            published: 2,
+            isShort: true,
+            lengthSeconds: '',
+            thumbnailUrl: FIRST_SHORT_THUMBNAIL
+          },
+          {
+            type: 'video',
+            videoId: 'captioned-short-2',
+            title: 'Second seeded Short',
+            author: 'Shorts Channel',
+            authorId: SHORTS_CHANNEL,
+            published: 1,
+            isShort: true,
+            lengthSeconds: '',
+            thumbnailUrl: SECOND_SHORT_THUMBNAIL
+          }
+        ],
+        shortsTimestamp: new Date().toISOString()
+      }]
+    }
+  })
+
+  test('scrolls through the cached subscriptions Shorts feed', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page, { captionVideoIds: ['jNQXAC9IVRw', 'captioned-short-2'] })
+    await page.route('**/api/skipSegments**', route => route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }))
+    const shortsTab = page
+      .locator('.tabContent[aria-hidden="false"]')
+      .locator('[data-subscription-feed-tab="shorts"]')
+    await shortsTab.click()
+    await page.getByText('First seeded Short', { exact: true }).click()
+    await expect(page).toHaveURL(
+      /#\/watch\/jNQXAC9IVRw\?short=true&shortSource=subscriptions/
+    )
+
+    const player = page.locator('.ftVideoPlayer.shortsPlayer')
+    await expect(player).toBeVisible({ timeout: 30_000 })
+
+    const previous = page.locator('.shortsNavigationButton').first()
+    const next = page.locator('.shortsNavigationButton').last()
+    await expect(previous).toBeDisabled()
+    await expect(next).toBeEnabled()
+    await expect(page.locator('.shortsNextPreview')).toBeVisible()
+    await expect(page.locator('.shortsNextPreview')).toHaveAttribute(
+      'style',
+      /captioned-short-2\/frame0\.jpg\?selected=1/
+    )
+    await expect(page.locator('.shortsExternalMetadata')).toBeVisible()
+    await expect(page.locator('.shortsActionRail')).toBeVisible()
+
+    const commentsButton = page.locator('.shortsCommentsAction').getByRole('button')
+    await commentsButton.click()
+    const commentsPanel = page.locator('.shortsCommentsPanel')
+    await expect(commentsPanel).toHaveClass(/shortsCommentsPanelOpen/)
+    const commentsScroller = commentsPanel.locator('.commentsContentWrapper')
+    const firstComment = commentsPanel.locator('.comment').first()
+    const loadComments = commentsPanel.locator('.getCommentsTitle')
+    await expect(firstComment.or(loadComments)).toBeVisible()
+    if (await loadComments.isVisible()) {
+      await loadComments.click()
+    }
+    await expect(firstComment).toBeVisible({ timeout: 30_000 })
+    await expect.poll(() => commentsScroller.evaluate(element => {
+      return element.scrollHeight > element.clientHeight
+    })).toBe(true)
+    const commentsScrollTop = await commentsScroller.evaluate(element => element.scrollTop)
+    const commentsBounds = await commentsScroller.boundingBox()
+    await page.mouse.move(commentsBounds.x + commentsBounds.width / 2, commentsBounds.y + commentsBounds.height / 2)
+    await page.mouse.wheel(0, 120)
+    await expect.poll(() => commentsScroller.evaluate(element => element.scrollTop))
+      .toBeGreaterThan(commentsScrollTop)
+    await expect(page).toHaveURL(
+      /#\/watch\/jNQXAC9IVRw\?short=true&shortSource=subscriptions/
+    )
+    await page.keyboard.press('ArrowDown')
+    await expect(page).toHaveURL(
+      /#\/watch\/jNQXAC9IVRw\?short=true&shortSource=subscriptions/
+    )
+
+    await page.evaluate(() => window.scrollTo({
+      top: document.documentElement.scrollHeight
+    }))
+    await expect(page).toHaveURL(
+      /#\/watch\/captioned-short-2\?short=true&shortSource=subscriptions/
+    )
+    await expect(commentsPanel).toHaveClass(/shortsCommentsPanelOpen/)
+
+    await page.waitForTimeout(500)
+    await previous.click()
+    await expect(page).toHaveURL(
+      /#\/watch\/jNQXAC9IVRw\?short=true&shortSource=subscriptions/
+    )
+    await expect(commentsPanel).toHaveClass(/shortsCommentsPanelOpen/)
+    await commentsPanel.getByRole('button', { name: 'Hide Comments' }).click()
+
+    const auxPanel = page.locator('.shortsAuxPanel')
+    const sponsorBlockButton = page.getByRole('button', { name: 'Open SponsorBlock info' })
+    await sponsorBlockButton.click()
+    await expect(sponsorBlockButton).toHaveAttribute('aria-pressed', 'true')
+    await expect(auxPanel).toHaveClass(/shortsAuxPanelOpen/)
+    const sponsorBlockContent = auxPanel.locator('.sponsorBlockContent')
+    await expect(sponsorBlockContent).toHaveCSS('overscroll-behavior', 'contain')
+    const sponsorBlockBounds = await sponsorBlockContent.boundingBox()
+    await page.mouse.move(sponsorBlockBounds.x + 20, sponsorBlockBounds.y + 20)
+    await page.mouse.wheel(0, 2000)
+    await expect(page).toHaveURL(
+      /#\/watch\/jNQXAC9IVRw\?short=true&shortSource=subscriptions/
+    )
+
+    await page.waitForTimeout(500)
+    await page.evaluate(() => window.scrollTo({
+      top: document.documentElement.scrollHeight
+    }))
+    await expect(page).toHaveURL(
+      /#\/watch\/captioned-short-2\?short=true&shortSource=subscriptions/
+    )
+    await expect(auxPanel).toHaveClass(/shortsAuxPanelOpen/)
+    await expect(sponsorBlockButton).toHaveAttribute('aria-pressed', 'true')
+
+    await page.waitForTimeout(500)
+    await previous.click()
+    await expect(page).toHaveURL(
+      /#\/watch\/jNQXAC9IVRw\?short=true&shortSource=subscriptions/
+    )
+    await expect(auxPanel).toHaveClass(/shortsAuxPanelOpen/)
+    await expect(sponsorBlockButton).toHaveAttribute('aria-pressed', 'true')
+    await auxPanel.locator('.sponsorBlockHeader').getByRole('button', { name: 'Close' }).click()
+
+    const transcriptButton = page.locator('.shortsComponentAction')
+      .filter({ hasText: 'Transcript' })
+      .getByRole('button')
+    await transcriptButton.click()
+    const transcriptCard = auxPanel.locator('.watchVideoTranscript')
+    const transcriptTarget = auxPanel.locator('.shortsAuxPanelTarget')
+    await expect(transcriptCard).toBeVisible()
+    await expect(transcriptTarget).toHaveCSS('overscroll-behavior', 'contain')
+    await expect.poll(async () => {
+      const [cardHeight, targetHeight] = await Promise.all([
+        transcriptCard.evaluate(element => element.offsetHeight),
+        transcriptTarget.evaluate(element => element.clientHeight),
+      ])
+      return Math.abs(cardHeight - targetHeight)
+    }).toBeLessThanOrEqual(32)
+    const transcriptBounds = await transcriptTarget.boundingBox()
+    await page.mouse.move(transcriptBounds.x + 20, transcriptBounds.y + 20)
+    await page.mouse.wheel(0, 2000)
+    await expect(page).toHaveURL(
+      /#\/watch\/jNQXAC9IVRw\?short=true&shortSource=subscriptions/
+    )
+
+    await page.waitForTimeout(500)
+    await page.evaluate(() => window.scrollTo({
+      top: document.documentElement.scrollHeight
+    }))
+    await expect(page).toHaveURL(
+      /#\/watch\/captioned-short-2\?short=true&shortSource=subscriptions/
+    )
+    await expect(auxPanel).toHaveClass(/shortsAuxPanelOpen/)
+    await expect(transcriptButton).toHaveAttribute('aria-pressed', 'true')
+    await expect.poll(async () => {
+      const [cardHeight, targetHeight] = await Promise.all([
+        transcriptCard.evaluate(element => element.offsetHeight),
+        transcriptTarget.evaluate(element => element.clientHeight),
+      ])
+      return Math.abs(cardHeight - targetHeight)
+    }).toBeLessThanOrEqual(32)
+
+    await page.waitForTimeout(500)
+    await previous.click()
+    await expect(page).toHaveURL(
+      /#\/watch\/jNQXAC9IVRw\?short=true&shortSource=subscriptions/
+    )
+    await auxPanel.getByRole('button', { name: 'Close transcript' }).click()
+
+    const [playerBounds, videoAreaBounds, metadataBounds, actionBounds, previewBounds, navigationBounds] =
+      await Promise.all([
+        player.boundingBox(),
+        page.locator('.videoArea').boundingBox(),
+        page.locator('.shortsExternalMetadata').boundingBox(),
+        page.locator('.shortsActionRail').boundingBox(),
+        page.locator('.shortsNextPreview').boundingBox(),
+        page.locator('.shortsNavigation').boundingBox(),
+      ])
+    expect(metadataBounds.x + metadataBounds.width).toBeLessThanOrEqual(playerBounds.x)
+    expect(actionBounds.x).toBeGreaterThanOrEqual(playerBounds.x + playerBounds.width)
+    expect(previewBounds.y).toBeGreaterThanOrEqual(playerBounds.y + playerBounds.height)
+    expect(previewBounds.width).toBeCloseTo(playerBounds.width, 0)
+    expect(playerBounds.x + playerBounds.width / 2)
+      .toBeCloseTo(videoAreaBounds.x + videoAreaBounds.width / 2, 0)
+    expect(navigationBounds.x).toBeGreaterThan(actionBounds.x)
+
+    // Narrow layouts move the rail over the player and grow it upwards, so the
+    // navigation joins the same column above the actions instead of landing on
+    // top of them.
+    await page.setViewportSize({ width: 900, height: 700 })
+    await expect(page.locator('.shortsExternalChannel')).toHaveCSS('opacity', '1')
+    expect(await page.locator('.shortsExternalChannel').evaluate(element => {
+      return getComputedStyle(element).color === getComputedStyle(document.body).color
+    })).toBe(true)
+    await expect.poll(async () => {
+      const [rail, navigation, firstAction] = await Promise.all([
+        page.locator('.shortsActionRail').boundingBox(),
+        page.locator('.shortsNavigation').boundingBox(),
+        page.locator('.shortsAction').first().boundingBox()
+      ])
+
+      return {
+        navigationAboveActions: navigation.y + navigation.height <= firstAction.y,
+        centeredInRail: Math.abs(
+          (navigation.x + navigation.width / 2) - (rail.x + rail.width / 2)
+        ) <= 1,
+        insideRail: navigation.x >= rail.x && navigation.x + navigation.width <= rail.x + rail.width
+      }
+    }).toEqual({ navigationAboveActions: true, centeredInRail: true, insideRail: true })
+
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await expect.poll(async () => {
+      const [rail, navigation] = await Promise.all([
+        page.locator('.shortsActionRail').boundingBox(),
+        page.locator('.shortsNavigation').boundingBox()
+      ])
+
+      return navigation.x > rail.x + rail.width
+    }).toBe(true)
+
+    await page.evaluate(() => {
+      window.__shortsNavigationDisappeared = false
+      const observer = new MutationObserver(() => {
+        if (!document.querySelector('.shortsNavigation')) {
+          window.__shortsNavigationDisappeared = true
+        }
+      })
+      observer.observe(document.body, { childList: true, subtree: true })
+    })
+
+    await next.click()
+    await expect(page.locator('.videoPlayerPlaceholder.ft-shimmer')).toHaveCount(0)
+    await expect(page).toHaveURL(
+      /#\/watch\/captioned-short-2\?short=true&shortSource=subscriptions/
+    )
+    expect(await page.evaluate(() => window.__shortsNavigationDisappeared)).toBe(false)
+
+    await page.waitForTimeout(500)
+    await page.keyboard.press('ArrowUp')
+    await expect(page).toHaveURL(
+      /#\/watch\/jNQXAC9IVRw\?short=true&shortSource=subscriptions/
+    )
+
+    await page.waitForTimeout(500)
+    // Browser middle-button autoscroll moves the window instead of emitting a
+    // wheel event, so window scrolling must navigate Shorts too.
+    await page.evaluate(() => window.scrollTo({
+      top: document.documentElement.scrollHeight
+    }))
+    await expect(page).toHaveURL(
+      /#\/watch\/captioned-short-2\?short=true&shortSource=subscriptions/
+    )
+
+    await page.waitForTimeout(500)
+    await page.keyboard.press('ArrowUp')
+    await expect(page).toHaveURL(
+      /#\/watch\/jNQXAC9IVRw\?short=true&shortSource=subscriptions/
+    )
+
+    await page.waitForTimeout(500)
+    const scrollbarHandle = page.locator(
+      'body > .os-scrollbar-vertical .os-scrollbar-handle'
+    )
+    const handleBounds = await scrollbarHandle.boundingBox()
+    await page.mouse.move(
+      handleBounds.x + handleBounds.width / 2,
+      handleBounds.y + handleBounds.height / 2
+    )
+    await page.mouse.down()
+    await page.mouse.move(
+      handleBounds.x + handleBounds.width / 2,
+      handleBounds.y + handleBounds.height / 2 + 50
+    )
+    await page.mouse.up()
+    await expect(page).toHaveURL(
+      /#\/watch\/captioned-short-2\?short=true&shortSource=subscriptions/
+    )
+  })
+
+  test('does not show a stale loading indicator after leaving a loaded Shorts tab', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await page.route('**/api/skipSegments**', route => route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }))
+    await page.locator(sel.newTabButton).click()
+    await expect(page.locator(sel.tabs)).toHaveCount(2)
+    const shortTab = page.locator(sel.tabs).first()
+    await shortTab.click()
+
+    const shortsFeedTab = page
+      .locator('.tabContent[aria-hidden="false"]')
+      .locator('[data-subscription-feed-tab="shorts"]')
+    await shortsFeedTab.click()
+    await page.getByText('First seeded Short', { exact: true }).click()
+    await expect(page).toHaveURL(
+      /#\/watch\/jNQXAC9IVRw\?short=true&shortSource=subscriptions/
+    )
+
+    const player = page.locator('.ftVideoPlayer.shortsPlayer')
+    await expect(player).toBeVisible({ timeout: 30_000 })
+
+    await expect(shortTab).not.toHaveClass(/loading/)
+    await shortTab.evaluate((tab) => {
+      window.__shortTabShowedLoadingWhileScrolling = false
+      new MutationObserver(() => {
+        if (tab.classList.contains('loading')) {
+          window.__shortTabShowedLoadingWhileScrolling = true
+        }
+      }).observe(tab, { attributes: true, attributeFilter: ['class'] })
+    })
+    await page.evaluate(() => window.scrollTo({
+      top: document.documentElement.scrollHeight
+    }))
+    await expect(page).toHaveURL(
+      /#\/watch\/captioned-short-2\?short=true&shortSource=subscriptions/
+    )
+    await expect.poll(() => page.evaluate(
+      () => window.__shortTabShowedLoadingWhileScrolling
+    )).toBe(true)
+    await expect(
+      page.locator('.tabContent[aria-hidden="false"] [data-tab-loading-indicator]')
+    ).toHaveCount(0)
+    await expect(player).toBeVisible({ timeout: 30_000 })
+    const video = await waitForPlayback(page)
+    await video.evaluate(element => element.pause())
+
+    await expect(shortTab).not.toHaveClass(/loading/)
+    await shortTab.evaluate((tab) => {
+      window.__shortTabShowedLoadingAfterDeactivation = false
+      window.__shortTabLoadingTransitions = []
+      new MutationObserver(() => {
+        window.__shortTabLoadingTransitions.push({
+          loading: tab.classList.contains('loading'),
+          markers: [...document.querySelectorAll(
+            `[data-tab-id="${tab.dataset.tabId}"] [data-tab-loading-indicator]`
+          )].map(element => element.className),
+        })
+        if (tab.classList.contains('loading')) {
+          window.__shortTabShowedLoadingAfterDeactivation = true
+        }
+      }).observe(tab, { attributes: true, attributeFilter: ['class'] })
+    })
+
+    await app.electronApp.evaluate(({ BrowserWindow, Menu }) => {
+      const findMenuItem = (items, label) => {
+        for (const item of items) {
+          if (item.label === label) return item
+          const match = findMenuItem(item.submenu?.items ?? [], label)
+          if (match) return match
+        }
+        return null
+      }
+      const menuItem = findMenuItem(Menu.getApplicationMenu()?.items ?? [], 'Next Tab')
+      const browserWindow = BrowserWindow.getFocusedWindow()
+      if (!menuItem || !browserWindow) {
+        throw new Error('Next Tab application-menu item was not found')
+      }
+      menuItem.click(undefined, browserWindow, undefined)
+    })
+    await expect(page.locator(sel.tabs)).toHaveCount(2)
+    await page.waitForTimeout(5000)
+    const loadingResult = await page.evaluate(() => ({
+      showed: window.__shortTabShowedLoadingAfterDeactivation,
+      transitions: window.__shortTabLoadingTransitions,
+    }))
+    expect(loadingResult.showed, JSON.stringify(loadingResult.transitions)).toBe(false)
+    await expect(shortTab).not.toHaveClass(/loading/)
+
+    await shortTab.click()
+    await expect(page).toHaveURL(
+      /#\/watch\/captioned-short-2\?short=true&shortSource=subscriptions/
+    )
+    await expect(shortTab).not.toHaveClass(/loading/)
+    await expect(player).toBeVisible()
+    await expect(
+      page.locator('.tabContent[aria-hidden="false"] [data-tab-loading-indicator]')
+    ).toHaveCount(0)
   })
 })

--- a/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
+++ b/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
@@ -332,6 +332,10 @@ const highlightStyle = computed(() => {
   }
 })
 
+function focusPrimaryButton() {
+  primaryButtonRef.value?.$el.focus()
+}
+
 onMounted(() => {
   lastActiveElement = document.activeElement
   lockBodyScroll()
@@ -339,9 +343,10 @@ onMounted(() => {
   window.addEventListener('resize', schedulePositionUpdate)
   window.addEventListener('scroll', schedulePositionUpdate, true)
   document.addEventListener('keydown', handleDocumentKeydown, true)
+  document.addEventListener('startup-splash-hidden', focusPrimaryButton)
   updatePosition()
   nextTick(() => {
-    primaryButtonRef.value?.$el.focus()
+    focusPrimaryButton()
     observeTutorialContent()
   })
 })
@@ -351,6 +356,7 @@ onBeforeUnmount(() => {
   window.removeEventListener('resize', schedulePositionUpdate)
   window.removeEventListener('scroll', schedulePositionUpdate, true)
   document.removeEventListener('keydown', handleDocumentKeydown, true)
+  document.removeEventListener('startup-splash-hidden', focusPrimaryButton)
   contentResizeObserver?.disconnect()
   targetResizeObserver?.disconnect()
   store.commit('removeOpenPrompt', promptId)

--- a/src/renderer/components/WatchVideoChapters/WatchVideoChapters.vue
+++ b/src/renderer/components/WatchVideoChapters/WatchVideoChapters.vue
@@ -6,6 +6,9 @@
     class="chaptersWrapper"
     :class="{ compact }"
     role="list"
+    @wheel.passive="followCurrentChapter = false"
+    @pointerdown="followCurrentChapter = false"
+    @keydown="followCurrentChapter = false"
     @keydown.arrow-up.stop.prevent="navigateChapters('up')"
     @keydown.arrow-down.stop.prevent="navigateChapters('down')"
   >
@@ -90,6 +93,7 @@ const emit = defineEmits(['copy-timestamp', 'timestamp-event'])
 const chaptersWrapper = useTemplateRef('chaptersWrapper')
 const chaptersContent = useTemplateRef('chaptersContent')
 let scrollFrame = null
+let followCurrentChapter = true
 const resizeObserver = new ResizeObserver(scheduleScrollClamp)
 
 function scheduleScrollClamp() {
@@ -98,6 +102,7 @@ function scheduleScrollClamp() {
     scrollFrame = null
     if (chaptersWrapper.value && chaptersContent.value) {
       clampOverlayScrollTop(chaptersWrapper.value, chaptersContent.value)
+      if (followCurrentChapter) scrollToCurrentChapter(0)
     }
   })
 }
@@ -115,6 +120,7 @@ const currentIndex = ref(props.currentChapterIndex)
 watch(() => props.currentChapterIndex, (value) => {
   if (currentIndex.value !== value) {
     currentIndex.value = value
+    followCurrentChapter = true
     scrollToCurrentChapter()
   }
 })
@@ -176,6 +182,7 @@ const observeVisibilityOptions = {
     if (isVisible) {
       // Wait for the panel/dock layout to settle; centering with a zero-height
       // container would scroll by half a row and clip the first chapter.
+      followCurrentChapter = true
       requestAnimationFrame(() => scrollToCurrentChapter())
     }
   },

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -9622,6 +9622,11 @@ export default defineComponent({
           blurTooltipButtons()
           break
         case event.key.toLowerCase() === 'escape':
+          if (ui?.getControls().anyContextMenusAreOpen()) {
+            event.preventDefault()
+            ui.getControls().hideContextMenus()
+            break
+          }
           // Exit full window
           if (fullWindowEnabled.value) {
             event.preventDefault()

--- a/src/renderer/helpers/startupSplash.js
+++ b/src/renderer/helpers/startupSplash.js
@@ -41,6 +41,7 @@ export function revealStartupSplash() {
     document.removeEventListener('visibilitychange', onVisibilityChange)
     splash.remove()
     document.getElementById('app')?.removeAttribute('inert')
+    document.dispatchEvent(new Event('startup-splash-hidden'))
   }
   const onVisibilityChange = () => {
     if (document.hidden) finish()

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -3880,6 +3880,10 @@ export default defineComponent({
         !this.isUpcoming &&
         !this.isLive &&
         this.videoLengthSeconds > 0 &&
+        // pause() queues a timeupdate before a subsequent seek's seeking event.
+        // That update already sees the new time, but is not played content.
+        this.$refs.player?.hasLoaded &&
+        !this.$refs.player.isPaused() &&
         shortReachedEnd
       ) {
         this.shortsPlaybackCompleted = true

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -1394,7 +1394,9 @@
   position: relative;
   grid-column: 1;
   grid-row: 1;
-  place-self: end;
+  place-self: start end;
+  block-size: var(--shorts-player-height);
+  justify-content: flex-end;
   inset: auto;
   inline-size: auto;
   margin: 0;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Reported while checking development's failing E2E tests.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Development's E2E failures include app regressions and outdated test assumptions. This fixes chapter centering after layout changes, Escape dismissing a Shorts context menu before leaving full-window mode, paused seeks incorrectly completing Shorts, tutorial focus after the startup splash, and the phone Shorts action rail extending below the player.

Update request mocks for network recovery, wait for startup to become interactive, preserve results fetched before subscription refresh cancellation, and correct focus, animation, and Shorts navigation test interactions. Move two cached Shorts-feed checks to deterministic offline fixtures.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed chapter centering, Shorts menu dismissal and completion tracking, phone Shorts controls, and startup tutorial keyboard focus.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

Run this branch in dev mode, then:

1. Open a chaptered video and resize its chapter panel at 100% and 125% UI scale. The active chapter stays centered until you scroll manually, and shortening the list leaves no empty scroll area.
2. In a Short, enter full-window mode, open the context menu, and press Escape. The menu closes first; a second Escape exits full-window mode. Pause and seek near the end, then confirm the Short is not marked complete until it actually plays through the end.
3. In the phone layout, confirm the Shorts action buttons remain within the player's height. Open the returning-user tutorial after startup and confirm its primary action receives keyboard focus.
4. Refresh subscriptions, wait for a channel to finish, then cancel. Completed results remain while pending channels retain their cached entries.

## Additional context
<!-- Add any other context about the pull request here. -->
Validation: 17 focused checks failed on development without the security changes. All 46 targeted E2E checks passed on the isolated branch. Changed-file JavaScript, Vue, and style lint passed. After rebasing onto the latest development commit, both phone layout scales passed again. The full suite was not rerun.

CI follow-up: all five failed cases from this PR passed after updating the error mocks, disabling unrelated search suggestions in the offline playlist tests, mocking Mix thumbnails, and removing the obsolete Side bar heading expectation. The 12 failed cases reported by #1265 also passed on this branch, with the phone layout checked at both 100% and 125% scale, for 13 checks. The network/mock fixes are also applied to the original local working tree, where all 17 affected offline checks passed after retaining its older Side bar heading expectation. The heading removal applies to the newer development base used by this PR and also fixes the sole E2E failure in #1220. Changed-file ESLint passed. Only affected tests were run; the full local suite was not repeated.

Authored with GPT-6 in Codex.


