### PR TITLE
fix(player): keep B repeat marker visible at video end

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -891,6 +891,52 @@ test('repeats an A-B range and manages it from the player menu', async ({ app, p
   await expect(player.getByRole('button', { name: /^Clear A-B repeat range/ })).not.toBeVisible()
 })
 
+test('keeps the B repeat marker visible and interactive at the end', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  const video = await openMockedVideo(page)
+  const player = page.locator('.ftVideoPlayer')
+
+  await video.evaluate((element) => {
+    element.pause()
+    element.currentTime = 5
+    // Media duration can extend past the last seekable sample.
+    Object.defineProperty(element, 'seekable', {
+      configurable: true,
+      get: () => ({ length: 1, start: () => 0, end: () => element.duration - 0.001 })
+    })
+  })
+  await player.hover()
+  await player.getByRole('button', { name: 'More settings' }).click()
+  await player.getByRole('button', { name: /^Set repeat start/ }).click()
+  await video.evaluate(async (element) => {
+    element.currentTime = element.duration - 0.1
+    await element.play()
+  })
+  await expect.poll(() => video.evaluate(element => element.ended)).toBe(true)
+  await player.hover()
+  await player.getByRole('button', { name: 'More settings' }).click()
+  await player.getByRole('button', { name: /^Set repeat end/ }).click()
+
+  for (const zoom of [1, 1.25]) {
+    await page.evaluate(zoom => window.ftElectron.setZoomFactor(zoom), zoom)
+    await player.hover()
+    const marker = player.locator('.abRepeatMarkerB')
+    await expect(marker).toBeVisible()
+    await expect.poll(() => marker.evaluate((element) => {
+      const bounds = element.getBoundingClientRect()
+      const label = getComputedStyle(element, '::after')
+      const left = bounds.left + Number.parseFloat(label.left)
+      const top = bounds.top + Number.parseFloat(label.top)
+      const width = Number.parseFloat(label.width)
+      const height = Number.parseFloat(label.height)
+      return [left + 1, left + width - 1].every(x => (
+        document.elementFromPoint(x, top + height / 2) === element
+      ))
+    })).toBe(true)
+    await marker.click({ trial: true })
+  }
+})
+
 test('repeats an A-B range when point B is at the end of the video', async ({ app, page }) => {
   await mockPlayableWatchPage(app, page)
   const video = await openMockedVideo(page)

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -9995,12 +9995,15 @@ export default defineComponent({
         return
       }
 
+      // The media duration can extend beyond the last seekable sample.
+      // Keep the saved boundaries visible at the nearest timeline edge.
+      const position = time => Math.min(100, Math.max(0, ((time - start) / duration) * 100))
       const markers = []
       if (hasValidAbRepeatRange()) {
         const range = document.createElement('div')
         range.className = `abRepeatRange${abRepeatEnabled.value ? '' : ' abRepeatRangeInactive'}`
-        range.style.left = `${((abRepeatStart.value - start) / duration) * 100}%`
-        range.style.width = `${((abRepeatEnd.value - abRepeatStart.value) / duration) * 100}%`
+        range.style.left = `${position(abRepeatStart.value)}%`
+        range.style.width = `${position(abRepeatEnd.value) - position(abRepeatStart.value)}%`
         markers.push(range)
       }
 
@@ -10008,12 +10011,12 @@ export default defineComponent({
         ['A', abRepeatStart.value],
         ['B', abRepeatEnd.value],
       ]
-        .filter(([_point, time]) => time !== null && time >= start && time <= end)
+        .filter(([_point, time]) => time !== null)
         .map(([point, time]) => {
           const marker = document.createElement('button')
           marker.type = 'button'
           marker.className = `abRepeatMarker abRepeatMarker${point}${abRepeatEnabled.value ? '' : ' abRepeatMarkerInactive'}`
-          marker.style.left = `calc(${((time - start) / duration) * 100}% - 22px)`
+          marker.style.left = `calc(${position(time)}% - 22px)`
           marker.dataset.point = point
           marker.ariaLabel = t('Video.Player.A-B Repeat.Adjust Point', {
             point,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Setting B after a video ended could hide its repeat marker when the media duration extended past the last seekable sample. Clamp the displayed markers and highlighted range to the timeline edges while preserving the saved repeat timestamps.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Keep the B repeat marker visible when it is set after a video ends.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->


<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a video and use the player menu to set repeat start A.
2. Let playback finish, then use the player menu to set repeat end B.
3. Confirm B remains visible at the right edge of the timeline and can be dragged or adjusted with the arrow keys.
4. Repeat at 125% UI scale.

## Additional context
<!-- Add any other context about the pull request here. -->

Validation: regression reproduced before the fix; 22 focused Electron tests pass after rebasing, including the previously failing Shorts, SponsorBlock, and playlist tests. Unit tests passed before rebasing. Lint passes with one locale configuration warning.

Changes made with GPT-6 in the Codex desktop harness.

Rebased onto development after #1264 merged its CI fixes.
