### PR TITLE
fix: prevent audio/video desync from mismatched stream edits

### DIFF
--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -5,6 +5,7 @@ import { enrichFallbackInvidiousPublicationDates } from './invidious-channel-vid
 import { getInvidiousCommentAuthorThumbnail } from './invidious-comments'
 import { filterUnavailableInvidiousPlaylistVideos } from './invidious-playlists'
 import { classifyInvidiousMusicMediaType } from '../player/musicMediaType'
+import { getCompatibleAdaptiveFormats } from '../player/compatibleAdaptiveFormats'
 import autolinker from 'autolinker'
 import { FormatUtils, Misc, Player } from 'youtubei.js'
 
@@ -977,7 +978,7 @@ export async function generateInvidiousDashManifestLocally(formats) {
   }
 
   return await FormatUtils.toDash({
-    adaptive_formats: formats
+    adaptive_formats: getCompatibleAdaptiveFormats(formats)
   }, false, urlTransformer, undefined, undefined, player)
 }
 

--- a/src/renderer/helpers/player/compatibleAdaptiveFormats.js
+++ b/src/renderer/helpers/player/compatibleAdaptiveFormats.js
@@ -1,0 +1,31 @@
+// Allow normal differences in encoder padding and duration rounding.
+const DURATION_TOLERANCE_MS = 1000
+
+/**
+ * YouTube can serve different edits of a video across codecs. Only exclude
+ * duration outliers when the audio agrees and a matching video is available.
+ * @param {import('youtubei.js').Misc.Format[]} formats
+ * @returns {import('youtubei.js').Misc.Format[]}
+ */
+export function getCompatibleAdaptiveFormats(formats) {
+  const audioDurations = formats
+    .filter(format => format.has_audio && !format.has_video)
+    .map(format => format.approx_duration_ms)
+  if (audioDurations.length === 0 || audioDurations.some(duration => !Number.isFinite(duration) || duration <= 0)) {
+    return formats
+  }
+
+  if (Math.max(...audioDurations) - Math.min(...audioDurations) > DURATION_TOLERANCE_MS) {
+    return formats
+  }
+
+  const matchesAudio = format => audioDurations.some(duration =>
+    Math.abs(format.approx_duration_ms - duration) <= DURATION_TOLERANCE_MS)
+
+  if (!formats.some(format => format.has_video && !format.has_audio && matchesAudio(format))) {
+    return formats
+  }
+
+  return formats.filter(format => !format.has_video || format.has_audio ||
+    !Number.isFinite(format.approx_duration_ms) || format.approx_duration_ms <= 0 || matchesAudio(format))
+}

--- a/src/renderer/helpers/player/ytDlpPlayback.js
+++ b/src/renderer/helpers/player/ytDlpPlayback.js
@@ -3,6 +3,7 @@ import { FormatUtils, Misc } from 'youtubei.js'
 
 import { MANIFEST_TYPE_DASH, MANIFEST_TYPE_HLS } from './utils'
 import { probeStreamByteRanges } from './streamByteRanges'
+import { getCompatibleAdaptiveFormats } from './compatibleAdaptiveFormats'
 import { generateAudioTrackField } from '../api/local'
 import { waitForYtDlpFormatAvailability } from './ytDlpFormatAvailability'
 import { getEarliestYtDlpFormatExpiry, YtDlpPlaybackSourceCache } from './ytDlpPlaybackCache'
@@ -686,7 +687,7 @@ async function loadYtDlpPlaybackSource(
     // the DVR window possible
     if (!isLive) {
       const adaptiveFormats = httpFormats.filter(format => !(isVideoFormat(format) && isAudioFormat(format)))
-      const localFormats = await convertAdaptiveFormats(adaptiveFormats, info.duration)
+      const localFormats = getCompatibleAdaptiveFormats(await convertAdaptiveFormats(adaptiveFormats, info.duration))
 
       if (localFormats.some(format => format.has_video) && localFormats.some(format => format.has_audio)) {
         const manifest = await FormatUtils.toDash({ adaptive_formats: localFormats })

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -93,6 +93,7 @@ import {
 } from '../../helpers/player/ytDlpPlaybackPreload'
 import { getMusicTrackArtist, MUSIC_MEDIA_TYPE } from '../../helpers/player/musicMediaType'
 import { resolveAndroidBackgroundPlaybackFormat } from '../../helpers/player/androidBackgroundPlayback'
+import { getCompatibleAdaptiveFormats } from '../../helpers/player/compatibleAdaptiveFormats'
 import { selectSponsorBlockFullVideoLabel } from '../../helpers/player/sponsorBlockFullVideo'
 import {
   buildSubscriptionShortsFeed,
@@ -5469,7 +5470,9 @@ export default defineComponent({
      * @param {boolean} includeThumbnails
      */
     createLocalDashManifest: async function (videoInfo, includeThumbnails = false) {
+      const formats = new Set(getCompatibleAdaptiveFormats(videoInfo.streaming_data.adaptive_formats))
       const xmlData = await videoInfo.toDash({
+        format_filter: format => format.has_video && !format.has_audio && !formats.has(format),
         manifest_options: {
           include_thumbnails: includeThumbnails,
         },
@@ -5491,7 +5494,8 @@ export default defineComponent({
       // needs its own scheme so one SABR player cannot replace or unregister
       // another player's request handler.
       const scheme = `sabr${nextSabrSchemeId++}`
-      const formatDurationsMs = videoInfo.streaming_data.adaptive_formats
+      const formats = getCompatibleAdaptiveFormats(videoInfo.streaming_data.adaptive_formats)
+      const formatDurationsMs = formats
         .map(format => format.approx_duration_ms)
         .filter(Number.isFinite)
       const fallbackDurationSeconds = Number.isFinite(videoInfo.basic_info.duration)
@@ -5514,7 +5518,7 @@ export default defineComponent({
         duration: formatDurationsMs.length > 0
           ? Math.min(...formatDurationsMs) / 1000
           : fallbackDurationSeconds,
-        formats: videoInfo.streaming_data.adaptive_formats.map((format) => ({
+        formats: formats.map((format) => ({
           itag: format.itag,
           lastModified: format.last_modified_ms,
           mimeType: format.mime_type,

--- a/tests/unit/compatible-adaptive-formats.test.mjs
+++ b/tests/unit/compatible-adaptive-formats.test.mjs
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { readFileSync } from 'node:fs'
+import { FormatUtils, Misc } from 'youtubei.js'
+import { getCompatibleAdaptiveFormats } from '../../src/renderer/helpers/player/compatibleAdaptiveFormats.js'
+
+function format(itag, duration, codec = 'avc1.4d401f') {
+  const audio = codec === 'mp4a.40.2'
+  return new Misc.Format({
+    itag,
+    mimeType: `${audio ? 'audio' : 'video'}/mp4; codecs="${codec}"`,
+    bitrate: 128000,
+    url: `https://example.com/videoplayback?itag=${itag}`,
+    approxDurationMs: duration,
+    initRange: { start: 0, end: 99 },
+    indexRange: { start: 100, end: 199 },
+    ...(audio
+      ? { audioQuality: 'AUDIO_QUALITY_MEDIUM', audioSampleRate: 44100, audioChannels: 2 }
+      : { qualityLabel: '480p', width: 854, height: 480, fps: 30 })
+  })
+}
+
+test('excludes the stale AV1 edit from the DASH manifest for issue #1263', async () => {
+  // Durations from w9P1BPt16-A. Around 02:00:03, AV1 contains 24 extra
+  // seconds of footage absent from H.264, VP9 and every audio rendition.
+  const formats = [
+    format(140, 11570386, 'mp4a.40.2'),
+    format(135, 11570336),
+    format(397, 11594326, 'av01.0.04M.08')
+  ]
+  const manifest = await FormatUtils.toDash({
+    adaptive_formats: getCompatibleAdaptiveFormats(formats)
+  })
+  assert.match(manifest, /Representation id="135"/)
+  assert.match(manifest, /Representation id="140"/)
+  assert.doesNotMatch(manifest, /Representation id="397"/)
+  assert.equal(formats.length, 3, 'does not mutate the extracted formats')
+})
+
+test('retains encoder padding differences and matching AV1 streams', () => {
+  const formats = [format(140, 600150, 'mp4a.40.2'), format(135, 600000), format(397, 600050, 'av01.0.04M.08')]
+  assert.deepEqual(getCompatibleAdaptiveFormats(formats), formats)
+})
+
+test('the built-in DASH path excludes stale video using youtubei.js filter semantics', async () => {
+  const source = readFileSync(new URL('../../src/renderer/views/Watch/Watch.js', import.meta.url), 'utf8')
+  const method = source.match(/createLocalDashManifest: (async function \(videoInfo, includeThumbnails = false\) \{[\s\S]*?\n    \}),/)[1]
+  const createManifest = new Function('getCompatibleAdaptiveFormats', `return (${method})`)(getCompatibleAdaptiveFormats)
+  const streamingData = { adaptive_formats: [
+    format(140, 11570386, 'mp4a.40.2'), format(135, 11570336), format(397, 11594326, 'av01.0.04M.08')
+  ] }
+  const uri = await createManifest({
+    streaming_data: streamingData,
+    toDash: options => FormatUtils.toDash(streamingData, false, undefined, options.format_filter)
+  })
+  const manifest = decodeURIComponent(uri.slice(uri.indexOf(',') + 1))
+  assert.match(manifest, /Representation id="135"/)
+  assert.match(manifest, /Representation id="140"/)
+  assert.doesNotMatch(manifest, /Representation id="397"/)
+})
+
+test('does not guess when durations are missing, audio disagrees, or no video matches', () => {
+  for (const formats of [
+    [format(135, 600000), format(397, 624000)],
+    [format(140, undefined, 'mp4a.40.2'), format(135, 600000), format(397, 624000)],
+    [format(140, 600000, 'mp4a.40.2'), format(141, 624000, 'mp4a.40.2'), format(135, 600000), format(397, 624000)],
+    [format(140, 600000, 'mp4a.40.2'), format(397, 624000)],
+    [format(140, 600000, 'mp4a.40.2'), format(135, 600000), format(397, undefined)]
+  ]) {
+    assert.deepEqual(getCompatibleAdaptiveFormats(formats), formats)
+  }
+})
+
+test('excludes mismatched video regardless of codec or whether it is shorter', () => {
+  const audio = format(140, 600000, 'mp4a.40.2')
+  const matching = format(397, 600000, 'av01.0.04M.08')
+  assert.deepEqual(getCompatibleAdaptiveFormats([audio, format(135, 576000), matching]), [audio, matching])
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #1263

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Long videos can lose audio/video sync when YouTube serves different edits across codecs. For the reported title, AV1 contains 24 extra seconds near 02:00:03 compared with H.264, VP9, and audio. Changing resolution can keep selecting the same mismatched codec.

Exclude video formats whose durations disagree with the audio when the audio durations agree and a matching video format is available. Apply the shared filter to yt-dlp, locally generated Invidious DASH, built-in DASH, and SABR playback. Preserve normal encoder padding differences and leave ambiguous or incomplete metadata unchanged.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Prevent audio/video desynchronisation when YouTube serves mismatched edits across video formats.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run this branch in dev mode and open https://www.youtube.com/watch?v=w9P1BPt16-A using yt-dlp. This is the video matching the reported title; the URL in the issue points to an unrelated short video.
2. Seek before and after two hours, including 01:59:59, 02:00:05, and 02:00:30. Audio and video should remain aligned. Try both 480p and 1080p60.
3. Repeat using Invidious and the built-in source. For this video, the mismatched AV1 formats should be unavailable while matching H.264 and VP9 formats remain available.
4. Open an unaffected video with matching AV1 and audio durations. AV1 should remain available.

## Additional context
<!-- Add any other context about the pull request here. -->


Direct yt-dlp extraction and a self-hosted Invidious instance returned the same duration mismatch. Decoded frame comparisons matched at identical timestamps through 02:00:02; after that, the corresponding AV1 frames appeared 24 seconds later. Existing cached yt-dlp manifests may retain old formats until their signed URLs expire.

Validation: the full unit suite passed with 1,570 tests passing and two skipped. Lint passed with one existing warning. Regression tests cover manifest generation, built-in DASH filter semantics, padding differences, ambiguous metadata, and mismatches in either duration direction. Windows playback has not been verified.

Implemented with GPT-6 in the Codex harness.
