### PR TITLE
fix(android): open existing downloads and restore file actions

### DIFF
--- a/android/app/src/androidTest/java/org/opentubex/app/YtDlpDownloadsTest.java
+++ b/android/app/src/androidTest/java/org/opentubex/app/YtDlpDownloadsTest.java
@@ -148,7 +148,7 @@ public class YtDlpDownloadsTest {
         return DocumentFile.fromTreeUri(context, uri);
     }
 
-    private static void grant(Context context, Uri uri) throws Exception {
+    static void grant(Context context, Uri uri) throws Exception {
         context.sendBroadcast(new android.content.Intent().setComponent(new android.content.ComponentName(InstrumentationRegistry.getInstrumentation().getContext().getPackageName(), YtDlpTestDocumentsProvider.GrantReceiver.class.getName()))
             .addFlags(android.content.Intent.FLAG_INCLUDE_STOPPED_PACKAGES).putExtra("uri", uri.toString()).putExtra("targetPackage", context.getPackageName()));
         long deadline = System.currentTimeMillis() + 5000;

--- a/android/app/src/androidTest/java/org/opentubex/app/YtDlpOpenDownloadTest.java
+++ b/android/app/src/androidTest/java/org/opentubex/app/YtDlpOpenDownloadTest.java
@@ -1,0 +1,105 @@
+package org.opentubex.app;
+
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.Intent;
+import android.net.Uri;
+import android.provider.DocumentsContract;
+import androidx.documentfile.provider.DocumentFile;
+import androidx.test.platform.app.InstrumentationRegistry;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.PluginCall;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class YtDlpOpenDownloadTest {
+    @Test public void opensExistingDownloadWithJsonIntegerId() throws Exception {
+        checkOpen(1);
+    }
+
+    @Test public void opensExistingDownloadWithJsonLongId() throws Exception {
+        checkOpen(2147483648L);
+    }
+
+    private void checkOpen(long id) throws Exception {
+        Context app = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        Uri tree = DocumentsContract.buildTreeDocumentUri(
+            InstrumentationRegistry.getInstrumentation().getContext().getPackageName() + ".documents", "root");
+        YtDlpDownloadsTest.grant(app, tree);
+        DocumentFile document = DocumentFile.fromTreeUri(app, tree).createFile("video/webm", UUID.randomUUID() + ".webm");
+        assertNotNull(document);
+        File state = new File(app.getCacheDir(), "open-download-" + UUID.randomUUID());
+        assertTrue(state.mkdirs());
+        YtDlpPlugin plugin = new YtDlpPlugin();
+        var executor = YtDlpPlugin.class.getDeclaredField("executor");
+        executor.setAccessible(true);
+        try {
+            JSONObject record = new JSONObject().put("id", id).put("status", "completed")
+                .put("destinations", new JSONArray().put(document.getUri().toString()))
+                .put("files", new JSONArray().put(new JSONObject().put("path", document.getUri().toString())));
+            YtDlpFiles.write(new File(state, "yt-dlp-downloads.json"),
+                new JSONObject().put("counter", id).put("records", new JSONArray().put(record)).toString().getBytes(StandardCharsets.UTF_8));
+            YtDlpDownloads downloads = new YtDlpDownloads(app, state, () -> {});
+            assertEquals(document.getUri(), downloads.firstFile(id));
+            var field = YtDlpPlugin.class.getDeclaredField("downloads");
+            field.setAccessible(true);
+            field.set(plugin, downloads);
+            CompletableFuture<Intent> launched = new CompletableFuture<>();
+            Context context = new ContextWrapper(app) {
+                @Override public void startActivity(Intent intent) { launched.complete(intent); }
+            };
+
+            assertTrue("Existing download was reported as missing", open(plugin, context, id).getBoolean("ok"));
+            Intent intent = launched.get(5, TimeUnit.SECONDS);
+            assertEquals(Intent.ACTION_VIEW, intent.getAction());
+            assertEquals(document.getUri(), intent.getData());
+            assertEquals("video/webm", intent.getType());
+            assertTrue((intent.getFlags() & Intent.FLAG_GRANT_READ_URI_PERMISSION) != 0);
+
+            assertTrue(document.delete());
+            assertFalse("Deleted files must still be reported as missing", open(plugin, context, id).getBoolean("ok"));
+            assertFalse(open(plugin, context, id + 1).getBoolean("ok"));
+
+            JSObject retry = new JSObject().put("retryDownloadId", id)
+                .put("payload", new JSObject().put("videoId", "___________").put("mode", "video"))
+                .put("args", new JSONArray().put("https://www.youtube.com/watch?v=___________"))
+                .put("configuration", new JSObject().put("enabled", true).put("folder", tree.toString()));
+            assertEquals("Retry must reuse the existing record", id, call(plugin::download, retry).getLong("id"));
+            assertEquals(1, downloads.list().length());
+            assertTrue("Pause must find the download", call(plugin::control,
+                new JSObject().put("id", id).put("action", "pause")).getBoolean("ok"));
+            assertTrue("Cancel must find the download", call(plugin::control,
+                new JSObject().put("id", id).put("action", "cancel")).getBoolean("ok"));
+            assertTrue("Remove must find the download", call(plugin::remove, new JSObject().put("id", id)).getBoolean("ok"));
+            assertEquals(0, downloads.list().length());
+        } finally {
+            ((ExecutorService) executor.get(plugin)).shutdownNow();
+            document.delete();
+            YtDlpFiles.deleteTree(state);
+        }
+    }
+
+    private JSObject open(YtDlpPlugin plugin, Context context, long id) throws Exception {
+        return call(call -> plugin.open(context, call), new JSObject().put("id", id));
+    }
+
+    private JSObject call(Consumer<PluginCall> invoke, JSObject data) throws Exception {
+        CompletableFuture<JSObject> response = new CompletableFuture<>();
+        // Parse the wire JSON just as Capacitor does; small numbers become Integer.
+        PluginCall call = new PluginCall(null, "YtDlp", "test", "test", new JSObject(data.toString())) {
+            @Override public void resolve(JSObject result) { response.complete(result); }
+            @Override public void reject(String message) { response.completeExceptionally(new AssertionError(message)); }
+        };
+        invoke.accept(call);
+        return response.get(5, TimeUnit.SECONDS);
+    }
+}

--- a/android/app/src/main/java/org/opentubex/app/YtDlpPlugin.java
+++ b/android/app/src/main/java/org/opentubex/app/YtDlpPlugin.java
@@ -65,11 +65,11 @@ public final class YtDlpPlugin extends Plugin {
         });
     }
     @PluginMethod public void download(PluginCall call) {
-        run(call, () -> downloads.add(call.getObject("payload"), call.getArray("args"), call.getObject("configuration"), call.getLong("retryDownloadId", -1L)));
+        run(call, () -> downloads.add(call.getObject("payload"), call.getArray("args"), call.getObject("configuration"), call.getData().optLong("retryDownloadId", -1L)));
     }
     @PluginMethod public void list(PluginCall call) { run(call, () -> new JSONObject().put("downloads", downloads.list())); }
     @PluginMethod public void control(PluginCall call) {
-        run(call, () -> new JSONObject().put("ok", downloads.control(call.getLong("id", -1L), call.getString("action", ""), call.getInt("value", 0))));
+        run(call, () -> new JSONObject().put("ok", downloads.control(call.getData().optLong("id", -1L), call.getString("action", ""), call.getInt("value", 0))));
     }
     @PluginMethod public void queue(PluginCall call) {
         run(call, () -> new JSONObject().put("ok", downloads.queue(call.getString("action", ""), call.getObject("configuration"))));
@@ -83,19 +83,23 @@ public final class YtDlpPlugin extends Plugin {
     }
     @PluginMethod public void remove(PluginCall call) {
         run(call, () -> {
-            long id = call.getLong("id", -1L);
+            long id = call.getData().optLong("id", -1L);
             boolean ok = downloads.remove(id);
             if (ok) notifyListeners("downloadsRemoved", new JSObject().put("ids", new JSONArray().put(id)));
             return new JSONObject().put("ok", ok);
         });
     }
     @PluginMethod public void open(PluginCall call) {
+        open(getContext(), call);
+    }
+
+    void open(Context context, PluginCall call) {
         run(call, () -> {
-            Uri uri = downloads.firstFile(call.getLong("id", -1L));
+            Uri uri = downloads.firstFile(call.getData().optLong("id", -1L));
             if (uri == null) return new JSONObject().put("ok", false);
-            Intent intent = new Intent(Intent.ACTION_VIEW).setDataAndType(uri, getContext().getContentResolver().getType(uri))
+            Intent intent = new Intent(Intent.ACTION_VIEW).setDataAndType(uri, context.getContentResolver().getType(uri))
                 .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_ACTIVITY_NEW_TASK);
-            getContext().startActivity(intent);
+            context.startActivity(intent);
             return new JSONObject().put("ok", true);
         });
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

Android reported existing downloads as missing when the open button was pressed. This fixes download ID decoding so Android can open the file in an external app.

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Capacitor’s `PluginCall.getLong()` rejects JSON values parsed as `Integer`, including the download IDs starting at 1. Read IDs with `JSONObject.optLong()` so both integer sizes work. Apply the same correction to retry, pause/cancel, and removal. The open button keeps its existing external-viewer behavior.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Open downloaded files on Android without a false “file could not be found” error, and fix retrying, pausing, cancelling, and removing downloads.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. On Android, complete a download and press its folder/open button. The downloaded file should open in a compatible external app or Android’s app chooser.
2. Delete the file using a file manager and press the button again. The app should report that the file could not be found.
3. Retry a download, pause it, cancel it, and remove it. Each action should affect the selected download; retry should reuse its existing entry.

## Additional context
<!-- Add any other context about the pull request here. -->


Validation: reproduced the false missing-file response with an Android instrumentation regression before the fix. Afterward, all 5 download instrumentation tests passed on the API 35 emulator, and all 78 Android unit tests passed. Tests intercept the outgoing intent and verify its URI, MIME type, and read grant. Standards and Spec reviews found no issues.

Implemented with GPT-6 in the Codex desktop harness.
