### PR TITLE
feat: add Geist as the default app font

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,7 @@ updates:
       - dependency-name: "@capawesome/capacitor-screen-orientation"
       - dependency-name: "@capawesome/capacitor-settings-launcher"
       - dependency-name: "@capawesome/capacitor-volume"
+      - dependency-name: "@fontsource-variable/geist"
       - dependency-name: "@hpke/core"
       - dependency-name: "@iconify-json/material-symbols"
       - dependency-name: "@iconify-json/ri"

--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -321,19 +321,46 @@ test.describe('default appearance', () => {
     })
   })
 
+  test('uses bundled Geist by default and keeps Roboto selectable', async ({ app, page }) => {
+    await goToSettingsSection(page, 'theme')
+
+    const appFont = page.getByRole('combobox', { name: 'App font' })
+    await expect(appFont).toHaveText('Geist')
+    expect(await page.evaluate(async () => {
+      const faces = await document.fonts.load('16px "Geist Variable"')
+      return faces.length > 0 && faces.every(face => face.status === 'loaded')
+    })).toBe(true)
+    expect(await page.locator('body').evaluate(body => getComputedStyle(body).fontFamily))
+      .toContain('Geist Variable')
+
+    await appFont.click()
+    const fontOptions = page.getByRole('option')
+    await expect(fontOptions.nth(0)).toHaveText('Geist')
+    await expect(fontOptions.nth(1)).toHaveText('Roboto')
+    await expect(fontOptions.nth(2)).toHaveText('System default')
+    await page.getByRole('option', { name: 'Roboto', exact: true }).click()
+    await expect(appFont).toHaveText('Roboto')
+
+    ;({ page } = await app.relaunch())
+    expect(await page.locator('body').evaluate(body => getComputedStyle(body).fontFamily))
+      .toContain('Roboto')
+  })
+
   test('lists installed fonts and persists the selected app font', async ({ app, page }) => {
     await goToSettingsSection(page, 'theme')
 
     const appFont = page.getByRole('combobox', { name: 'App font' })
-    await expect(appFont).toHaveText('Roboto')
+    await expect(appFont).toHaveText('Geist')
     await expect(page.locator('.select').filter({ has: appFont }).locator('.select-icon')).toBeVisible()
     await appFont.click()
 
     const fontDropdown = page.locator(`#${await appFont.getAttribute('aria-controls')}`)
     const fontOptions = fontDropdown.getByRole('option')
     await expect.poll(() => fontOptions.count()).toBeGreaterThan(3)
-    await expect(fontOptions.nth(0)).toHaveText('Roboto')
-    await expect(fontOptions.nth(1)).toHaveText('System default')
+    await expect(fontOptions.getByText('Roboto', { exact: true })).toHaveCount(1)
+    await expect(fontOptions.nth(0)).toHaveText('Geist')
+    await expect(fontOptions.nth(1)).toHaveText('Roboto')
+    await expect(fontOptions.nth(2)).toHaveText('System default')
     await expect(fontDropdown).toHaveClass(/below/)
     expect(await page.evaluate(([buttonId, dropdownId]) => {
       const button = document.getElementById(buttonId).getBoundingClientRect()
@@ -374,8 +401,9 @@ test.describe('default appearance', () => {
       .toContain(selectedFont)
 
     await appFont.click()
-    await expect(fontOptions.nth(0)).toHaveText('Roboto')
-    await expect(fontOptions.nth(1)).toHaveText('System default')
+    await expect(fontOptions.nth(0)).toHaveText('Geist')
+    await expect(fontOptions.nth(1)).toHaveText('Roboto')
+    await expect(fontOptions.nth(2)).toHaveText('System default')
     await expect(fontOptions.nth(3)).toHaveText(selectedFont)
     await expect(fontOptions.nth(3)).toHaveAttribute('aria-selected', 'true')
     await appFont.click()
@@ -397,8 +425,9 @@ test.describe('default appearance', () => {
     const relaunchedFontOptions = page.locator(`#${await relaunchedAppFont.getAttribute('aria-controls')}`)
       .getByRole('option')
     await expect.poll(() => relaunchedFontOptions.count()).toBeGreaterThan(3)
-    await expect(relaunchedFontOptions.nth(0)).toHaveText('Roboto')
-    await expect(relaunchedFontOptions.nth(1)).toHaveText('System default')
+    await expect(relaunchedFontOptions.nth(0)).toHaveText('Geist')
+    await expect(relaunchedFontOptions.nth(1)).toHaveText('Roboto')
+    await expect(relaunchedFontOptions.nth(2)).toHaveText('System default')
     await expect(relaunchedFontOptions.nth(3)).toHaveText(selectedFont)
     await expect(relaunchedFontOptions.nth(3)).toHaveAttribute('aria-selected', 'true')
   })

--- a/e2e/tests/offline/profiles.spec.mjs
+++ b/e2e/tests/offline/profiles.spec.mjs
@@ -378,6 +378,23 @@ test.describe('profile manager', () => {
       buffer: Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" fill="currentColor"/></svg>')
     })
     await expect(page.getByRole('heading', { name: 'Crop Image' })).toBeVisible()
+    const zoom = page.locator('.cropZoom').getByRole('slider')
+    const zoomLabel = page.locator('.cropZoom .label')
+    await zoomLabel.evaluate(element => Promise.all(
+      element.closest('.promptCard').getAnimations().map(animation => animation.finished)
+    ))
+    for (const scale of [1, 0.95]) {
+      await page.evaluate(value => window.ftElectron.setZoomFactor(value), scale)
+      await zoom.fill('1')
+      const initialWidth = (await zoomLabel.boundingBox()).width
+      for (const value of ['1.01', '2.5', '4', '1']) {
+        await zoom.fill(value)
+        await expect.poll(async () => (await zoomLabel.boundingBox()).width)
+          .toBeCloseTo(initialWidth, 0)
+        await expect(zoomLabel).toContainText(Number(value).toFixed(2))
+      }
+    }
+    await page.evaluate(() => window.ftElectron.setZoomFactor(1))
     await page.getByRole('button', { name: 'Apply Crop' }).click()
 
     const preview = page.locator('.profilePreviewIcon')

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -2488,7 +2488,7 @@ test.describe('settings', () => {
     expect(tooltipBounds.y).toBeGreaterThanOrEqual(7)
     expect(tooltipBounds.x + tooltipBounds.width).toBeLessThanOrEqual(viewport.width - 7)
     expect(tooltipBounds.y + tooltipBounds.height).toBeLessThanOrEqual(viewport.height - 7)
-    expect(fontFamily).toContain('Roboto')
+    expect(fontFamily).toContain('Geist')
   })
 
   test('keeps an open help tooltip aligned and visible in fullscreen', async ({ page }) => {
@@ -2589,7 +2589,7 @@ test.describe('settings', () => {
       }
     })
 
-    expect(appearance.fontFamily).toContain('Roboto')
+    expect(appearance.fontFamily).toContain('Geist')
     expect(appearance.cursor).toBe('default')
     expect(appearance.menuTop).toBeGreaterThanOrEqual(appearance.chromeBottom)
 

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@capawesome/capacitor-screen-orientation": "^8.0.3",
     "@capawesome/capacitor-settings-launcher": "^0.1.2",
     "@capawesome/capacitor-volume": "^0.1.3",
+    "@fontsource-variable/geist": "^5.3.0",
     "@hpke/core": "^1.9.0",
     "@iconify/vue": "^5.0.1",
     "@seald-io/nedb": "^4.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
       '@capawesome/capacitor-volume':
         specifier: ^0.1.3
         version: 0.1.3(@capacitor/core@8.5.1)
+      '@fontsource-variable/geist':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@hpke/core':
         specifier: ^1.9.0
         version: 1.9.0
@@ -1085,6 +1088,9 @@ packages:
   '@hpke/common@1.10.1':
     resolution: {integrity: sha512-moJwhmtLtuxiUzzNp1jpfBfx8yefKoO9D/RCR9dmwrnc7qjJqId1rEtQz+lSlU5cabX8daToMSx/7HayXOiaFw==}
     engines: {node: '>=16.0.0'}
+
+  '@fontsource-variable/geist@5.3.0':
+    resolution: {integrity: sha512-j0m+vLQuG5XAYoHtGCVu0spvlGreR3EzpECUVzkFmI1mTVnAO38l/NEPDCFgZ177JxzYJCLSmTQibIiYPilGrA==}
 
   '@hpke/core@1.9.0':
     resolution: {integrity: sha512-pFxWl1nNJeQCSUFs7+GAblHvXBCjn9EPN65vdKlYQil2aURaRxfGMO6vBKGqm1YHTKwiAxJQNEI70PbSowMP9Q==}
@@ -6639,6 +6645,8 @@ snapshots:
     dependencies:
       '@eslint/core': 1.2.1
       levn: 0.4.1
+
+  '@fontsource-variable/geist@5.3.0': {}
 
   '@hpke/common@1.10.1': {}
 

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -478,6 +478,7 @@
 </template>
 
 <script setup>
+import '@fontsource-variable/geist'
 import FtRetryImage from './components/FtRetryImage.vue'
 import { initializeAndroidYtDlp, ytDlp } from './helpers/ytDlp'
 import { parseAutomaticDownloadRules } from './helpers/automaticDownloadRules'

--- a/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
+++ b/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
@@ -723,7 +723,10 @@ onBeforeUnmount(() => {
 
 .darkThemeControl {
   flex: 0 0 auto;
-  padding-block-start: 31px;
+  display: flex;
+  align-items: center;
+  block-size: 45px;
+  padding-block-start: 30px;
 }
 
 .themeNameField input {

--- a/src/renderer/components/DownloadSettings.vue
+++ b/src/renderer/components/DownloadSettings.vue
@@ -181,6 +181,18 @@ async function chooseDownloadFolder() {
   margin-block-start: 16px;
 }
 
+.downloadQueueInputs :deep(.ft-input-component) {
+  margin-block-start: 30px;
+}
+
+.downloadQueueInputs :deep(.selectLabel) {
+  position: absolute;
+  inset-block-start: -20px;
+  inset-inline-start: 0;
+  font-size: 14px;
+  line-height: 1;
+}
+
 .downloadQueueInputs :deep(.select.containsTooltip) {
   margin-inline-end: 0;
 }

--- a/src/renderer/components/FtSlider/FtSlider.css
+++ b/src/renderer/components/FtSlider/FtSlider.css
@@ -20,10 +20,17 @@
   align-items: center;
 }
 
-/* Same reason as the padding in the component: equal-width digits keep the
-   label from changing size as the value does. */
+/* Equal-width digits keep the value stable as the slider moves. */
 .label {
   font-variant-numeric: tabular-nums;
+}
+
+.value {
+  white-space: nowrap;
+}
+
+.valueNumber {
+  display: inline-block;
 }
 
 .input {

--- a/src/renderer/components/FtSlider/FtSlider.vue
+++ b/src/renderer/components/FtSlider/FtSlider.vue
@@ -16,7 +16,7 @@
             <span
               class="valueNumber"
               :style="{ minInlineSize: `${valueWidth}ch` }"
-            >{{ currentValue }}</span>{{ valueExtension }}
+            >{{ displayValue }}</span>{{ valueExtension }}
           </span>
         </template>
       </I18nT>
@@ -110,10 +110,17 @@ watch(() => props.defaultValue, (value) => {
   }
 }, { flush: 'post' })
 
+const valuePrecision = computed(() => {
+  const [coefficient, exponent = '0'] = String(props.step).split('e')
+  return Math.max(0, (coefficient.split('.')[1]?.length ?? 0) - Number(exponent))
+})
+
+const displayValue = computed(() => currentValue.value.toFixed(valuePrecision.value))
+
 // Reserve digit width without relying on a font's figure-space glyph.
 const valueWidth = computed(() => Math.max(
-  String(props.minValue).length,
-  String(props.maxValue).length
+  props.minValue.toFixed(valuePrecision.value).length,
+  props.maxValue.toFixed(valuePrecision.value).length
 ))
 
 function change() {

--- a/src/renderer/components/FtSlider/FtSlider.vue
+++ b/src/renderer/components/FtSlider/FtSlider.vue
@@ -4,9 +4,22 @@
     :for="id"
   >
     <span class="labelRow">
-      <span class="label">
-        {{ $t('Display Label', {label: label, value: displayLabel}) }}
-      </span>
+      <I18nT
+        keypath="Display Label"
+        tag="span"
+        class="label"
+        scope="global"
+      >
+        <template #label>{{ label }}</template>
+        <template #value>
+          <span class="value">
+            <span
+              class="valueNumber"
+              :style="{ minInlineSize: `${valueWidth}ch` }"
+            >{{ currentValue }}</span>{{ valueExtension }}
+          </span>
+        </template>
+      </I18nT>
       <FtPerformanceImpact :setting-key="settingKey" />
       <FtTooltip
         v-if="tooltip !== ''"
@@ -36,6 +49,7 @@
 
 <script setup>
 import { computed, ref, useId, watch } from 'vue'
+import { Translation as I18nT } from 'vue-i18n'
 
 import FtTooltip from '../FtTooltip/FtTooltip.vue'
 import FtPerformanceImpact from '../FtPerformanceImpact/FtPerformanceImpact.vue'
@@ -86,9 +100,6 @@ const props = defineProps({
 
 const emit = defineEmits(['change', 'input', 'reset'])
 
-// U+2007, as wide as a digit
-const FIGURE_SPACE = '\u2007'
-
 const id = useId()
 const currentValue = ref(props.defaultValue)
 
@@ -99,28 +110,11 @@ watch(() => props.defaultValue, (value) => {
   }
 }, { flush: 'post' })
 
-/**
- * @param {number} value
- */
-function formatValue(value) {
-  return props.valueExtension === null
-    ? `${value}`
-    : `${value}${props.valueExtension}`
-}
-
-/** The widest value the slider can show, in characters. */
+// Reserve digit width without relying on a font's figure-space glyph.
 const valueWidth = computed(() => Math.max(
-  formatValue(props.minValue).length,
-  formatValue(props.maxValue).length
+  String(props.minValue).length,
+  String(props.maxValue).length
 ))
-
-/*
- * Padding shorter values out to that width keeps the label the same size all
- * the way along the slider, so dragging it can't make the label wrap and
- * unwrap. Figure spaces are as wide as a digit and, unlike ordinary spaces,
- * are neither collapsed nor a place to break the line.
- */
-const displayLabel = computed(() => formatValue(currentValue.value).padEnd(valueWidth.value, FIGURE_SPACE))
 
 function change() {
   emit('change', currentValue.value)

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -506,18 +506,20 @@ let systemFontsPromise = null
 const appFont = computed(() => normalizeAppFont(store.getters.getAppFont))
 const fontValues = computed(() => [
   DEFAULT_APP_FONT,
+  'Roboto',
   SYSTEM_APP_FONT,
   ...[...new Set([
     ...IS_CAPACITOR ? [] : [appFont.value],
     ...systemFonts.value
   ])]
-    .filter(font => font !== DEFAULT_APP_FONT && font !== SYSTEM_APP_FONT)
+    .filter(font => font !== DEFAULT_APP_FONT && font !== 'Roboto' && font !== SYSTEM_APP_FONT)
     .toSorted(new Intl.Collator([locale.value, 'en'], { sensitivity: 'base' }).compare)
 ])
 const fontNames = computed(() => [
-  DEFAULT_APP_FONT,
+  'Geist',
+  'Roboto',
   t('Settings.Theme Settings.Font.System Default'),
-  ...fontValues.value.slice(2)
+  ...fontValues.value.slice(3)
 ])
 
 function updateAppFont(value) {

--- a/src/renderer/helpers/appFont.js
+++ b/src/renderer/helpers/appFont.js
@@ -1,4 +1,4 @@
-export const DEFAULT_APP_FONT = 'Roboto'
+export const DEFAULT_APP_FONT = 'Geist Variable'
 export const SYSTEM_APP_FONT = 'system'
 
 const APP_FONT_FALLBACKS = "system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'"

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -7,7 +7,7 @@ body {
   background-image: var(--bg-image);
   background-attachment: fixed;
 
-  --app-font-family: 'Roboto', system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --app-font-family: 'Geist Variable', system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   --ui-roundness: 1;
 
   /* Optional decorative layers, separate from colors used by contrast checks


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
Requested directly; no linked issue.
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Geist was missing from the available app fonts. Bundle it through `@fontsource-variable/geist` and make it the default for users without a saved font preference. Keep saved choices and pin the picker order to Geist, Roboto, System default, followed by installed fonts alphabetically. Dependabot tracks the font package for updates. Font-independent label alignment and slider-value sizing keep settings controls stable with Geist.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Geist is the new default app font. Roboto remains available in Theme settings.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open this branch in dev mode with a fresh profile. Theme settings should show Geist as the selected app font.
2. Open the font picker. Its first entries should be Geist, Roboto, and System default, followed by installed fonts alphabetically.
3. Select Roboto or an installed font and restart the app. The chosen font should remain selected.
4. Open the app offline and confirm Geist still renders.
5. Check Downloads and the custom theme editor at 100% and 95% UI scale. Labels and controls should stay aligned. Drag the Scrollbar Width slider between single- and double-digit values; its label and icons should stay in place.

## Additional context
<!-- Add any other context about the pull request here. -->
Implemented and reviewed with GPT-6 in the Codex desktop app.
