### PR TITLE
feat: add distraction-free option to hide the startup splash

### DIFF
--- a/e2e/tests/offline/startup-splash.spec.mjs
+++ b/e2e/tests/offline/startup-splash.spec.mjs
@@ -1,5 +1,6 @@
 import { readFile, readdir } from 'node:fs/promises'
-import { test, expect } from '../../helpers/app.mjs'
+import { test, expect, goToSettingsSection, latestSettings } from '../../helpers/app.mjs'
+import path from 'node:path'
 
 for (const [theme, background, zoom] of [
   ['dark', 'rgb(15, 15, 15)', 1.25],
@@ -221,5 +222,59 @@ test.describe('slow initial route', () => {
         await page.unrouteAll({ behavior: 'wait' })
       }
     })
+  }
+})
+
+test('distraction-free switch disables the early splash in new windows and can restore it', async ({ page, app }, testInfo) => {
+  const settings = await goToSettingsSection(page, 'focus')
+  const toggle = settings.getByRole('checkbox', { name: /^Hide Startup Splash/ })
+  await expect(toggle).not.toBeChecked()
+
+  for (const hidden of [true, false]) {
+    await settings.locator('label.switch-label').filter({ hasText: 'Hide Startup Splash' }).click()
+    await expect(toggle).toBeChecked({ checked: hidden })
+    await expect.poll(async () => latestSettings(
+      await readFile(path.join(app.userDataDir, 'settings.db'), 'utf8')
+    ).hideStartupSplash).toBe(hidden)
+    if (hidden) {
+      for (const colorScheme of ['dark', 'light']) {
+        await page.emulateMedia({ colorScheme })
+        await expect(page.locator('body')).toHaveClass(new RegExp(`\\b${colorScheme}\\b`))
+        await testInfo.attach(`hide-startup-splash-setting-${colorScheme}`, {
+          body: await settings.locator('.switchColumnGrid').first().screenshot(), contentType: 'image/png'
+        })
+      }
+    }
+
+    let releaseRenderer
+    const gate = new Promise(resolve => { releaseRenderer = resolve })
+    const context = app.electronApp.context()
+    await context.route('**/renderer.js', async route => {
+      await gate
+      await route.continue()
+    })
+    try {
+      const created = app.electronApp.waitForEvent('window')
+      await page.evaluate(() => window.ftElectron.openInNewWindow('/history'))
+      const nextPage = await created
+      const browserWindow = await app.electronApp.browserWindow(nextPage)
+      await expect.poll(() => browserWindow.evaluate(window => window.isVisible())).toBe(true)
+      await expect(nextPage.locator('.topNav')).toHaveCount(0)
+      if (hidden) {
+        await expect(nextPage.locator('#startup-splash')).toHaveCount(0)
+        await expect(nextPage.locator('#app')).not.toHaveAttribute('inert')
+      } else {
+        await expect(nextPage.locator('#startup-splash')).toBeVisible()
+        await expect(nextPage.locator('#app')).toHaveAttribute('inert', '')
+      }
+      releaseRenderer()
+      await expect(nextPage.locator('.topNav')).toBeVisible()
+      await expect(nextPage.locator('#startup-splash')).toHaveCount(0)
+      await expect(nextPage.locator('#app')).not.toHaveAttribute('inert')
+      await browserWindow.evaluate(window => window.destroy())
+    } finally {
+      releaseRenderer()
+      await context.unrouteAll({ behavior: 'wait' })
+    }
   }
 })

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -2738,6 +2738,8 @@ function runApp() {
       }
     }
 
+    const hideStartupSplash = (await baseHandlers.settings._findOne('hideStartupSplash'))?.value === true
+
     const newWindow = new BrowserWindow({
       // The initial HTML paints a splash before the shared renderer boots.
       show: false,
@@ -2752,7 +2754,8 @@ function runApp() {
         backgroundThrottling: false,
         additionalArguments: [
           `--startup-background=${windowBackground}`,
-          `--startup-dark=${nativeTheme.shouldUseDarkColors}`
+          `--startup-dark=${nativeTheme.shouldUseDarkColors}`,
+          `--hide-startup-splash=${hideStartupSplash}`
         ],
         preload: process.env.NODE_ENV === 'development'
           ? path.resolve(__dirname, '../../dist/preload.js')

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -48,7 +48,8 @@ export default {
   startupSplashReady: () => ipcRenderer.send(IpcChannels.STARTUP_SPLASH_READY),
   startupAppearance: {
     background: process.argv.find(argument => argument.startsWith('--startup-background='))?.slice('--startup-background='.length),
-    dark: process.argv.includes('--startup-dark=true')
+    dark: process.argv.includes('--startup-dark=true'),
+    hideSplash: process.argv.includes('--hide-startup-splash=true')
   },
   isFlatpak: process.env.FLATPAK_ID !== undefined,
   runtimeVersions: Object.freeze({

--- a/src/renderer/components/DistractionSettings/DistractionSettings.vue
+++ b/src/renderer/components/DistractionSettings/DistractionSettings.vue
@@ -10,6 +10,14 @@
     <div class="switchColumnGrid">
       <div class="switchColumn">
         <FtToggleSwitch
+          v-if="isElectron"
+          :label="t('Settings.Distraction Free Settings.Hide Startup Splash')"
+          :compact="true"
+          :default-value="hideStartupSplash"
+          setting-key="hideStartupSplash"
+          @change="updateHideStartupSplash"
+        />
+        <FtToggleSwitch
           :label="t('Settings.Distraction Free Settings.Hide Video Views')"
           :compact="true"
           :default-value="hideVideoViews"
@@ -395,8 +403,16 @@ import { showToast } from '../../helpers/utils'
 import { checkYoutubeChannelId, findChannelTagInfo } from '../../helpers/channels'
 
 const { t } = useI18n()
+const isElectron = process.env.IS_ELECTRON
 
 const channelHiderDisabled = ref(false)
+
+const hideStartupSplash = computed(() => store.getters.getHideStartupSplash)
+
+/** @param {boolean} value */
+function updateHideStartupSplash(value) {
+  store.dispatch('updateHideStartupSplash', value)
+}
 
 /** @type {import('vue').ComputedRef<'local' | 'invidious'>} */
 const backendPreference = computed(() => store.getters.getBackendPreference)

--- a/src/renderer/helpers/settingsSearch.js
+++ b/src/renderer/helpers/settingsSearch.js
@@ -281,6 +281,7 @@ function isSettingsSearchMessageVisible(sectionType, path, options) {
   }
 
   if (sectionType === 'distraction') {
+    if (group === 'Hide Startup Splash') return usingElectron
     if (group === 'Show Added Items') {
       return store.getters.getChannelsHiddenParsed.length > 0 ||
         store.getters.getForbiddenTitlesParsed.length > 0

--- a/src/renderer/startup/boot.js
+++ b/src/renderer/startup/boot.js
@@ -7,9 +7,14 @@
     root.style.setProperty('--startup-background', appearance.background)
     root.style.setProperty('--startup-foreground', appearance.dark ? '#eeeeee' : '#212121')
   }
+  if (appearance?.hideSplash) {
+    document.getElementById('startup-splash')?.remove()
+    document.getElementById('app')?.removeAttribute('inert')
+  }
   try {
     const label = localStorage.getItem('startup-loading-label')
-    if (label) document.querySelector('#startup-splash .startupLabel').textContent = label
+    const element = document.querySelector('#startup-splash .startupLabel')
+    if (label && element) element.textContent = label
   } catch {
     // A fresh profile or unavailable storage still has the logo and progress bar.
   }

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -343,6 +343,7 @@ const state = {
   hideLiveChatReplay: false,
   hideLiveStreams: false,
   hideHeaderLogo: false,
+  hideStartupSplash: false,
   // Former navigation switches remain loadable so older settings can migrate.
   hideHome: false,
   // This also controls playlist actions outside navigation.

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -793,6 +793,7 @@ Settings:
     Posts Auto Refresh Interval: المشاركات الفاصل الزمني للتحديث التلقائي
     Refresh Subscriptions While App Is Closed: "تحديث الاشتراكات أثناء إغلاق التطبيق"
   Distraction Free Settings:
+    Hide Startup Splash: إخفاء شاشة بدء التشغيل
     Hide Repeat Stats: إخفاء إحصاءات التكرار
     Sections:
       Visible While Paused: مرئي أثناء الإيقاف المؤقت في نافذة كاملة/شاشة كاملة

--- a/static/locales/ai/az.yaml
+++ b/static/locales/ai/az.yaml
@@ -787,6 +787,7 @@ Settings:
     Posts Auto Refresh Interval: Paylaşımların avtomatik yenilənmə aralığı
     Refresh Subscriptions While App Is Closed: Tətbiq bağlı olarkən abunəlikləri yenilə
   Distraction Free Settings:
+    Hide Startup Splash: Başlanğıc ekranını gizlət
     Sections:
       Visible While Paused: Tam pəncərədə / tam ekranda fasilə zamanı görünənlər
     Hide Channel Avatars: Kanal avatarlarını gizlət

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -815,6 +815,7 @@ Settings:
     Posts Auto Refresh Interval: Інтэрвал аўтаматычнага абнаўлення допісаў
     Refresh Subscriptions While App Is Closed: "Абнаўляць падпіскі, калі праграма закрыта"
   Distraction Free Settings:
+    Hide Startup Splash: Схаваць стартавы экран
     Hide Repeat Stats: Схаваць статыстыку паўтораў
     Sections:
       Visible While Paused: Бачныя падчас паўзы ў поўным акне або поўнаэкранным рэжыме

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -787,6 +787,7 @@ Settings:
     Posts Auto Refresh Interval: Интервал за автоматично опресняване на публикациите
     Refresh Subscriptions While App Is Closed: "Опресняване на абонаментите при затворено приложение"
   Distraction Free Settings:
+    Hide Startup Splash: Скриване на началния екран
     Hide Repeat Stats: Скриване на статистиката на повторенията
     Sections:
       Visible While Paused: Видими при поставяне на пауза в режим на цял прозорец / цял екран

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -785,6 +785,7 @@ Settings:
     Posts Auto Refresh Interval: "Etrevez adkargañ emgefreek ar pennadoù"
     Refresh Subscriptions While App Is Closed: "Freskañ ar c'houmanantoù pa vez serret an arload"
   Distraction Free Settings:
+    Hide Startup Splash: Kuzhat ar skramm locʼhañ
     Hide Repeat Stats: Kuzhat stadegoù an adlenn
     Sections:
       Visible While Paused: "Gwelus e-pad un ehan er prenestr leun pe er skramm leun"

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -1053,6 +1053,7 @@ Settings:
     To: A
     Confirm Before Unsubscribing: Confirma abans de donar-se de baixa
   Distraction Free Settings:
+    Hide Startup Splash: Amaga la pantalla d’inici
     Hide Repeat Stats: Amaga les estadístiques de repetició
     Sections:
       Side Bar: Barra lateral

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -785,6 +785,7 @@ Settings:
     Posts Auto Refresh Interval: Interval automatického obnovení příspěvků
     Refresh Subscriptions While App Is Closed: "Obnovovat odběry, když je aplikace zavřená"
   Distraction Free Settings:
+    Hide Startup Splash: Skrýt úvodní obrazovku
     Hide Repeat Stats: Skrýt statistiky opakování
     Sections:
       Visible While Paused: Viditelné při pozastavení v režimu celého okna nebo celé obrazovky

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -787,6 +787,7 @@ Settings:
     Posts Auto Refresh Interval: Cyfwng adnewyddu postiadau yn awtomatig
     Refresh Subscriptions While App Is Closed: "Adnewyddu tanysgrifiadau pan fydd yr ap ar gau"
   Distraction Free Settings:
+    Hide Startup Splash: Cuddio’r sgrin gychwyn
     Hide Repeat Stats: Cuddio ystadegau ailadrodd
     Sections:
       Visible While Paused: Yn weladwy wrth oedi mewn ffenestr lawn / sgrin lawn

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -811,6 +811,7 @@ Settings:
     Refresh Subscriptions While App Is Closed: "Opdater abonnementer, mens appen er lukket"
     Limit the number of videos displayed for each channel: Begræns antallet af viste videoer for hver kanal
   Distraction Free Settings:
+    Hide Startup Splash: Skjul opstartsskærm
     Hide Repeat Stats: Skjul gentagelsesstatistik
     Sections:
       Visible While Paused: Synligt ved pause i helt vindue eller fuld skærm

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -798,6 +798,7 @@ Settings:
     Posts Auto Refresh Interval: Διάστημα αυτόματης ανανέωσης αναρτήσεων
     Refresh Subscriptions While App Is Closed: "Ανανέωση συνδρομών όταν η εφαρμογή είναι κλειστή"
   Distraction Free Settings:
+    Hide Startup Splash: Απόκρυψη οθόνης εκκίνησης
     Hide Repeat Stats: Απόκρυψη στατιστικών επανάληψης
     Sections:
       Visible While Paused: Ορατά κατά την παύση σε πλήρες παράθυρο / πλήρη οθόνη

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -771,6 +771,7 @@ Settings:
     Posts Auto Refresh Interval: Posts Auto Refresh Interval
     Refresh Subscriptions While App Is Closed: "Refresh Subscriptions While App Is Closed"
   Distraction Free Settings:
+    Hide Startup Splash: Hide Startup Splash
     Hide Repeat Stats: Hide Repeat Stats
     Hide Channel Avatars: Hide Channel Avatars
     Shorten View Counts: Shorten View, Comment and Comment Like Counts

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -869,6 +869,7 @@ Settings:
     Posts Auto Refresh Interval: Intervalo de actualización automática de publicaciones
     Refresh Subscriptions While App Is Closed: "Actualizar suscripciones con la aplicación cerrada"
   Distraction Free Settings:
+    Hide Startup Splash: Ocultar pantalla de inicio
     Hide Repeat Stats: Ocultar estadísticas de repetición
     Sections:
       Visible While Paused: Visible al pausar en ventana completa o pantalla completa

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -913,6 +913,7 @@ Settings:
     To: A
     Confirm Before Unsubscribing: Evitar bajas accidentales
   Distraction Free Settings:
+    Hide Startup Splash: Ocultar pantalla de inicio
     Hide Repeat Stats: Ocultar estadísticas de repetición
     Sections:
       Side Bar: Barra lateral

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -791,6 +791,7 @@ Settings:
     Posts Auto Refresh Interval: Intervalo de actualización automática de publicaciones
     Refresh Subscriptions While App Is Closed: "Actualizar suscripciones con la aplicación cerrada"
   Distraction Free Settings:
+    Hide Startup Splash: Ocultar pantalla de inicio
     Hide Repeat Stats: Ocultar estadísticas de repetición
     Sections:
       Visible While Paused: Visible al pausar en ventana completa o pantalla completa

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -785,6 +785,7 @@ Settings:
     Posts Auto Refresh Interval: Postituste automaatse värskendamise intervall
     Refresh Subscriptions While App Is Closed: "Värskenda tellimusi, kui rakendus on suletud"
   Distraction Free Settings:
+    Hide Startup Splash: Peida käivituskuva
     Hide Repeat Stats: Peida korduste statistika
     Sections:
       Visible While Paused: Pausi ajal täisaknas või täisekraanil nähtav

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -787,6 +787,7 @@ Settings:
     Posts Auto Refresh Interval: Argitalpenen freskatze automatikoaren tartea
     Refresh Subscriptions While App Is Closed: "Freskatu harpidetzak aplikazioa itxita dagoenean"
   Distraction Free Settings:
+    Hide Startup Splash: Ezkutatu abio-pantaila
     Hide Repeat Stats: Ezkutatu errepikapenen estatistikak
     Sections:
       Visible While Paused: Ikusgai pausatuta dagoenean leiho osoan edo pantaila osoan

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -815,6 +815,7 @@ Settings:
     Posts Auto Refresh Interval: فاصلهٔ تازه‌سازی خودکار پست‌ها
     Refresh Subscriptions While App Is Closed: "تازه‌سازی اشتراک‌ها هنگام بسته بودن برنامه"
   Distraction Free Settings:
+    Hide Startup Splash: پنهان کردن صفحهٔ آغازین
     Hide Repeat Stats: پنهان کردن آمار تکرار
     Sections:
       Visible While Paused: نمایش هنگام توقف در پنجرهٔ کامل / تمام‌صفحه

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -798,6 +798,7 @@ Settings:
     Posts Auto Refresh Interval: Julkaisujen automaattisen päivityksen aikaväli
     Refresh Subscriptions While App Is Closed: "Päivitä tilaukset sovelluksen ollessa suljettuna"
   Distraction Free Settings:
+    Hide Startup Splash: Piilota käynnistysruutu
     Hide Repeat Stats: Piilota toistotilastot
     Sections:
       Visible While Paused: Näkyvissä keskeytyksen aikana koko ikkunan tai koko näytön tilassa

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -785,6 +785,7 @@ Settings:
     Posts Auto Refresh Interval: Intervalle d’actualisation automatique des publications
     Refresh Subscriptions While App Is Closed: "Actualiser les abonnements quand l'application est fermée"
   Distraction Free Settings:
+    Hide Startup Splash: Masquer l’écran de démarrage
     Hide Repeat Stats: Masquer les statistiques de répétition
     Sections:
       Visible While Paused: Visible pendant la pause en mode pleine fenêtre ou plein écran

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -793,6 +793,7 @@ Settings:
     Posts Auto Refresh Interval: Intervalo de actualización automática das publicacións
     Refresh Subscriptions While App Is Closed: "Actualizar as subscricións coa aplicación pechada"
   Distraction Free Settings:
+    Hide Startup Splash: Agochar a pantalla de inicio
     Hide Repeat Stats: Agochar as estatísticas de repetición
     Sections:
       Visible While Paused: Visibles durante a pausa en xanela completa ou pantalla completa

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -798,6 +798,7 @@ Settings:
     Posts Auto Refresh Interval: מרווח ריענון אוטומטי של פוסטים
     Refresh Subscriptions While App Is Closed: "ריענון מינויים כשהיישום סגור"
   Distraction Free Settings:
+    Hide Startup Splash: הסתרת מסך הפתיחה
     Hide Repeat Stats: הסתרת נתוני חזרה
     Sections:
       Visible While Paused: מוצג בזמן השהיה בחלון מלא או במסך מלא

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -787,6 +787,7 @@ Settings:
     Posts Auto Refresh Interval: Razmak automatskog osvježavanja objava
     Refresh Subscriptions While App Is Closed: "Osvježavaj pretplate dok je aplikacija zatvorena"
   Distraction Free Settings:
+    Hide Startup Splash: Sakrij početni zaslon
     Hide Repeat Stats: Sakrij statistiku ponavljanja
     Sections:
       Visible While Paused: Vidljivo tijekom pauze u punom prozoru / preko cijelog zaslona

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -785,6 +785,7 @@ Settings:
     Posts Auto Refresh Interval: Bejegyzések automatikus frissítésének időköze
     Refresh Subscriptions While App Is Closed: "Feliratkozások frissítése bezárt alkalmazásnál"
   Distraction Free Settings:
+    Hide Startup Splash: Indítóképernyő elrejtése
     Hide Repeat Stats: Ismétlési statisztikák elrejtése
     Sections:
       Visible While Paused: Szüneteltetéskor látható teljes ablakos vagy teljes képernyős módban

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -793,6 +793,7 @@ Settings:
     Posts Auto Refresh Interval: Interval Pembaruan Otomatis Postingan
     Refresh Subscriptions While App Is Closed: "Perbarui Langganan Saat Aplikasi Ditutup"
   Distraction Free Settings:
+    Hide Startup Splash: Sembunyikan Layar Pembuka
     Hide Repeat Stats: Sembunyikan statistik pengulangan
     Sections:
       Visible While Paused: Terlihat Saat Dijeda dalam Jendela Penuh / Layar Penuh

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -793,6 +793,7 @@ Settings:
     Posts Auto Refresh Interval: Bil milli sjálfvirkra uppfærslna færslna
     Refresh Subscriptions While App Is Closed: "Uppfæra áskriftir þegar forritið er lokað"
   Distraction Free Settings:
+    Hide Startup Splash: Fela upphafsskjá
     Hide Repeat Stats: Fela tölfræði endurtekninga
     Sections:
       Visible While Paused: Sýnilegt þegar gert er hlé í heilum glugga eða á öllum skjánum

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -785,6 +785,7 @@ Settings:
     Posts Auto Refresh Interval: Intervallo di aggiornamento automatico dei post
     Refresh Subscriptions While App Is Closed: "Aggiorna le iscrizioni quando l'app è chiusa"
   Distraction Free Settings:
+    Hide Startup Splash: Nascondi la schermata di avvio
     Hide Repeat Stats: Nascondi statistiche di ripetizione
     Sections:
       Visible While Paused: Visibile durante la pausa in finestra intera o a schermo intero

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -785,6 +785,7 @@ Settings:
     Posts Auto Refresh Interval: 投稿の自動更新間隔
     Refresh Subscriptions While App Is Closed: "アプリを閉じている間も登録チャンネルを更新"
   Distraction Free Settings:
+    Hide Startup Splash: 起動画面を非表示
     Hide Repeat Stats: リピート統計を非表示
     Sections:
       Visible While Paused: 全ウィンドウ表示・全画面表示で一時停止中に表示

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -979,6 +979,7 @@ Settings:
     To: 다음으로
     Confirm Before Unsubscribing: 구독 취소 전 확인
   Distraction Free Settings:
+    Hide Startup Splash: 시작 화면 숨기기
     Hide Repeat Stats: 반복 통계 숨기기
     Sections:
       Side Bar: 사이드바

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -1003,6 +1003,7 @@ Settings:
     To: Iki
     Confirm Before Unsubscribing: Klausti prieš atsisakant prenumeratos
   Distraction Free Settings:
+    Hide Startup Splash: Slėpti paleidimo ekraną
     Hide Repeat Stats: Slėpti kartojimo statistiką
     Sections:
       Subscriptions Page: Prenumeratų puslapis

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -785,6 +785,7 @@ Settings:
     Posts Auto Refresh Interval: Intervall for automatisk oppdatering av innlegg
     Refresh Subscriptions While App Is Closed: "Oppdater abonnementer mens appen er lukket"
   Distraction Free Settings:
+    Hide Startup Splash: Skjul oppstartsskjerm
     Hide Repeat Stats: Skjul gjentakelsesstatistikk
     Sections:
       Visible While Paused: Synlig ved pause i fullt vindu / fullskjerm

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -798,6 +798,7 @@ Settings:
     Posts Auto Refresh Interval: Interval voor automatisch vernieuwen van berichten
     Refresh Subscriptions While App Is Closed: "Abonnementen vernieuwen terwijl de app gesloten is"
   Distraction Free Settings:
+    Hide Startup Splash: Opstartscherm verbergen
     Hide Repeat Stats: Herhaalstatistieken verbergen
     Sections:
       Visible While Paused: Zichtbaar wanneer gepauzeerd in volledig venster of volledig scherm

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -946,6 +946,7 @@ Settings:
     To: til
     Confirm Before Unsubscribing: Stadfest før du avsluttar abonnement
   Distraction Free Settings:
+    Hide Startup Splash: Gøym oppstartsskjerm
     Hide Repeat Stats: Skjul gjentakingsstatistikk
     Sections:
       Side Bar: Sidestolpe

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -335,6 +335,7 @@ Settings:
     Show Scheduled Live Streams / Premieres First: Najpierw pokazuj zaplanowane transmisje na żywo i premiery
     Refresh Subscriptions While App Is Closed: "Odświeżaj subskrypcje, gdy aplikacja jest zamknięta"
   Distraction Free Settings:
+    Hide Startup Splash: Ukryj ekran startowy
     Hide Repeat Stats: Ukryj statystyki powtarzania
     Sections:
       Visible While Paused: Widoczne po wstrzymaniu w trybie pełnego okna lub pełnego ekranu

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -785,6 +785,7 @@ Settings:
     Posts Auto Refresh Interval: Intervalo de atualização automática das publicações
     Refresh Subscriptions While App Is Closed: "Atualizar inscrições com o aplicativo fechado"
   Distraction Free Settings:
+    Hide Startup Splash: Ocultar tela de inicialização
     Hide Repeat Stats: Ocultar estatísticas de repetição
     Sections:
       Visible While Paused: Visível durante a pausa em tela cheia ou tela cheia

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -793,6 +793,7 @@ Settings:
     Posts Auto Refresh Interval: Intervalo de atualização automática das publicações
     Refresh Subscriptions While App Is Closed: "Atualizar subscrições com a aplicação fechada"
   Distraction Free Settings:
+    Hide Startup Splash: Ocultar ecrã de arranque
     Hide Repeat Stats: Ocultar estatísticas de repetição
     Sections:
       Visible While Paused: Visível durante a pausa em janela inteira ou ecrã inteiro

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -801,6 +801,7 @@ Settings:
     Posts Auto Refresh Interval: Intervalo de atualização automática das publicações
     Refresh Subscriptions While App Is Closed: "Atualizar subscrições com a aplicação fechada"
   Distraction Free Settings:
+    Hide Startup Splash: Ocultar ecrã de arranque
     Hide Repeat Stats: Ocultar estatísticas de repetição
     Sections:
       Visible While Paused: Visível durante a pausa em janela inteira ou ecrã inteiro

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -789,6 +789,7 @@ Settings:
     Posts Auto Refresh Interval: Interval de reîmprospătare automată a postărilor
     Refresh Subscriptions While App Is Closed: "Reîmprospătează abonamentele când aplicația este închisă"
   Distraction Free Settings:
+    Hide Startup Splash: Ascunde ecranul de pornire
     Hide Repeat Stats: Ascunde statisticile de repetare
     Sections:
       Visible While Paused: Vizibile în pauză în fereastră completă / pe ecran complet

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -770,6 +770,7 @@ Settings:
     Posts Auto Refresh Interval: Интервал автообновления публикаций
     Refresh Subscriptions While App Is Closed: "Обновлять подписки, когда приложение закрыто"
   Distraction Free Settings:
+    Hide Startup Splash: Скрыть стартовый экран
     Hide Repeat Stats: Скрыть статистику повторов
     Sections:
       Visible While Paused: Показывать во время паузы в полнооконном и полноэкранном режимах

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -785,6 +785,7 @@ Settings:
     Posts Auto Refresh Interval: Interval automatického obnovenia príspevkov
     Refresh Subscriptions While App Is Closed: "Obnovovať odbery, keď je aplikácia zatvorená"
   Distraction Free Settings:
+    Hide Startup Splash: Skryť úvodnú obrazovku
     Hide Repeat Stats: Skryť štatistiky opakovania
     Sections:
       Visible While Paused: Viditeľné počas pozastavenia v režime celého okna alebo celej obrazovky

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -1019,6 +1019,7 @@ Settings:
     To: Na
     Confirm Before Unsubscribing: Zahtevaj potrditev pred odjavo
   Distraction Free Settings:
+    Hide Startup Splash: Skrij začetni zaslon
     Hide Repeat Stats: Skrij statistiko ponavljanja
     Sections:
       Side Bar: Stranska vrstica

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -808,6 +808,7 @@ Settings:
     Posts Auto Refresh Interval: Интервал аутоматског освежавања објава
     Refresh Subscriptions While App Is Closed: "Освежавај претплате док је апликација затворена"
   Distraction Free Settings:
+    Hide Startup Splash: Сакриј почетни екран
     Hide Repeat Stats: Сакриј статистику понављања
     Sections:
       Visible While Paused: Видљиво током паузе у целом прозору / преко целог екрана

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -787,6 +787,7 @@ Settings:
     Posts Auto Refresh Interval: Intervall för automatisk uppdatering av inlägg
     Refresh Subscriptions While App Is Closed: "Uppdatera prenumerationer medan appen är stängd"
   Distraction Free Settings:
+    Hide Startup Splash: Dölj startskärm
     Hide Repeat Stats: Dölj upprepningsstatistik
     Sections:
       Visible While Paused: Synligt under paus i helfönster eller helskärm

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -797,6 +797,7 @@ Settings:
     Posts Auto Refresh Interval: இடுகைத் தானியக்கப் புதுப்பிப்பு இடைவெளி
     Refresh Subscriptions While App Is Closed: "செயலி மூடியிருக்கும்போது சந்தாக்களைப் புதுப்பி"
   Distraction Free Settings:
+    Hide Startup Splash: தொடக்கத் திரையை மறை
     Hide Repeat Stats: மீளியக்கப் புள்ளிவிவரங்களை மறை
     Sections:
       Visible While Paused: முழுச் சாளரம் / முழுத்திரையில் இடைநிறுத்தியிருக்கும்போது தெரிபவை

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -785,6 +785,7 @@ Settings:
     Posts Auto Refresh Interval: Gönderilerin Otomatik Yenileme Aralığı
     Refresh Subscriptions While App Is Closed: "Uygulama Kapalıyken Abonelikleri Yenile"
   Distraction Free Settings:
+    Hide Startup Splash: Başlangıç Ekranını Gizle
     Hide Repeat Stats: Tekrar istatistiklerini gizle
     Sections:
       Visible While Paused: Tam Pencere / Tam Ekranda Duraklatıldığında Görünür

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -793,6 +793,7 @@ Settings:
     Posts Auto Refresh Interval: Інтервал автоматичного оновлення дописів
     Refresh Subscriptions While App Is Closed: "Оновлювати підписки, коли застосунок закрито"
   Distraction Free Settings:
+    Hide Startup Splash: Приховати початковий екран
     Hide Repeat Stats: Приховати статистику повторів
     Sections:
       Visible While Paused: Видимі під час паузи в режимі на все вікно або на весь екран

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -793,6 +793,7 @@ Settings:
     Posts Auto Refresh Interval: Khoảng tự động làm mới bài đăng
     Refresh Subscriptions While App Is Closed: "Làm mới đăng ký khi ứng dụng đã đóng"
   Distraction Free Settings:
+    Hide Startup Splash: Ẩn màn hình khởi động
     Hide Repeat Stats: Ẩn thống kê lặp lại
     Sections:
       Visible While Paused: Hiện khi tạm dừng ở chế độ toàn cửa sổ / toàn màn hình

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -785,6 +785,7 @@ Settings:
     Posts Auto Refresh Interval: 帖子自动刷新间隔
     Refresh Subscriptions While App Is Closed: "应用关闭时刷新订阅"
   Distraction Free Settings:
+    Hide Startup Splash: 隐藏启动画面
     Hide Repeat Stats: 隐藏循环统计
     Sections:
       Visible While Paused: 全窗口或全屏暂停时显示

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -785,6 +785,7 @@ Settings:
     Posts Auto Refresh Interval: 貼文自動重新整理間隔
     Refresh Subscriptions While App Is Closed: "應用程式關閉時重新整理訂閱"
   Distraction Free Settings:
+    Hide Startup Splash: 隱藏啟動畫面
     Hide Repeat Stats: 隱藏循環統計
     Sections:
       Visible While Paused: 在全視窗／全螢幕模式暫停播放時顯示

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -1073,6 +1073,7 @@ Settings:
     Import search history formats: 'Unterstützte Formate: OpenTubeX / FreeTube (.db), YouTube Takeout (.json)'
     Setting object has insufficient data, skipping item: Das Objekt enthält unzureichende Daten, Element wird übersprungen
   Distraction Free Settings:
+    Hide Startup Splash: Startbildschirm ausblenden
     Hide Repeat Stats: Wiederholungsstatistik ausblenden
     Hide Live Chat: Live-Chat ausblenden
     Hide Popular Videos: Beliebte Videos ausblenden

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1315,6 +1315,7 @@ Settings:
     To: To
     Confirm Before Unsubscribing: Confirm Before Unsubscribing
   Distraction Free Settings:
+    Hide Startup Splash: Hide Startup Splash
     Hide Repeat Stats: Hide Repeat Stats
     Distraction Free Settings: Distraction Free
     Sections:

--- a/tests/unit/settings-search-config.test.mjs
+++ b/tests/unit/settings-search-config.test.mjs
@@ -354,3 +354,16 @@ test('voice-over settings are searchable on Android and Electron, but not the we
     assert.equal(entries.some(({ label }) => label === locale.Settings['Player Settings']['Voice-over Translation'].Enable), usingElectron || isCapacitor)
   }
 })
+
+test('startup splash setting is searchable only on Electron', () => {
+  for (const [usingElectron, isCapacitor] of [[true, false], [false, true], [false, false]]) {
+    const entries = createSettingsSearchIndex({
+      sections: [{ type: 'focus', title: 'Focus', description: '' }],
+      tm: path => getAtPath(locale, path),
+      store: { getters: { getChannelsHiddenParsed: [], getForbiddenTitlesParsed: [] } },
+      usingElectron,
+      isCapacitor,
+    }).get('focus')
+    assert.equal(entries.some(({ label }) => label === 'Hide Startup Splash'), usingElectron)
+  }
+})

--- a/tests/unit/startup-splash.test.mjs
+++ b/tests/unit/startup-splash.test.mjs
@@ -52,3 +52,31 @@ test('the initial splash uses native appearance and cached plain-text localizati
   context.localStorage.getItem = () => { throw new Error('Storage unavailable') }
   assert.doesNotThrow(() => vm.runInNewContext(script, context))
 })
+
+for (const hideSplash of [true, false, undefined]) {
+  test(`early startup honors hideSplash=${hideSplash} before loading the renderer`, async () => {
+    const script = await readFile(new URL('../../src/renderer/startup/boot.js', import.meta.url), 'utf8')
+    let removed = false
+    let inert = true
+    let presented = false
+    const label = { textContent: 'OpenTubeX' }
+    vm.runInNewContext(script, {
+      window: { ftElectron: {
+        startupAppearance: { hideSplash },
+        startupSplashReady: () => { presented = true }
+      } },
+      document: {
+        documentElement: {},
+        getElementById: id => id === 'startup-splash'
+          ? { remove: () => { removed = true } }
+          : { removeAttribute: name => { if (name === 'inert') inert = false } },
+        querySelector: () => removed ? null : label
+      },
+      localStorage: { getItem: () => 'Loading…' },
+      requestAnimationFrame: callback => callback()
+    })
+    assert.equal(removed, hideSplash === true)
+    assert.equal(inert, hideSplash !== true)
+    assert.equal(presented, true, 'the native window still becomes visible')
+  })
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #1268

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The startup splash and curtain reveal could not be disabled. Adds a compact Hide Startup Splash switch under Distraction Free → General. The saved preference takes effect on the next launch or new window, before the renderer loads. The splash stays enabled by default.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Hide the startup splash and curtain reveal with a new switch in Distraction Free settings.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/365390e6-3348-4ca1-8a48-20e93aa8f0c0">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/788f3e38-dc70-43de-adf7-6b06b1cb512a">
  <img alt="Hide Startup Splash in Distraction Free settings" src="https://github.com/user-attachments/assets/365390e6-3348-4ca1-8a48-20e93aa8f0c0">
</picture>
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Settings → Distraction Free → General and enable Hide Startup Splash.
2. Open a new window or restart the app. The splash and curtain reveal should be absent, and the app should remain usable.
3. Turn the switch off and open another window. The splash and curtain reveal should return.

## Additional context
<!-- Add any other context about the pull request here. -->

Implemented with GPT-6 in Codex. Local validation passed: unit tests, 14 startup Electron E2E tests, JavaScript/Vue/style lint, and YAML lint. Standards and spec reviews found no actionable issues.

