### PR TITLE
fix(downloads): allow offline playback on desktop and Android

### DIFF
--- a/e2e/tests/offline/offline-downloads.spec.mjs
+++ b/e2e/tests/offline/offline-downloads.spec.mjs
@@ -1,0 +1,47 @@
+import path from 'node:path'
+
+import { test, expect, goTo, repoRoot, waitForAppReady } from '../../helpers/app.mjs'
+
+const mediaPath = path.join(repoRoot, 'e2e/fixtures/media/demo.webm')
+test.use({
+  seed: {
+    settings: { landingPage: 'history', enableDownloads: true },
+    downloads: [{
+      id: 1,
+      videoId: 'offline0001',
+      title: 'Offline download',
+      status: 'completed',
+      mode: 'video',
+      percent: 100,
+      destination: mediaPath,
+      destinations: [mediaPath],
+      files: [{ videoId: 'offline0001', path: mediaPath, extension: 'webm' }],
+    }],
+  },
+})
+
+for (const restart of [false, true]) {
+  test(`plays downloads offline ${restart ? 'after restarting the renderer' : 'after losing connectivity'}`, async ({ page }) => {
+    await page.context().route(/^https?:/, route => route.abort('internetdisconnected'))
+    const disconnect = () => {
+      Object.defineProperty(navigator, 'onLine', { configurable: true, get: () => false })
+      window.dispatchEvent(new Event('offline'))
+    }
+    await page.context().addInitScript(disconnect)
+    await page.evaluate(disconnect)
+    if (restart) {
+      await page.reload()
+      await waitForAppReady(page)
+    }
+    await expect(page.locator('.connectionStatus')).toContainText('Connection lost')
+    await goTo(page, 'downloads')
+    await expect(page.locator('.downloadRow')).toContainText('Offline download')
+    await page.getByRole('button', { name: 'Play download', exact: true }).click()
+    const video = page.locator('video').first()
+    await expect(video).toBeVisible()
+    await expect.poll(() => video.evaluate(element => element.readyState)).toBeGreaterThanOrEqual(2)
+    await video.evaluate(element => element.play())
+    await expect.poll(() => video.evaluate(element => element.currentTime)).toBeGreaterThan(0)
+    await expect(page.locator('.videoPlayerPlaceholder.ft-shimmer')).toHaveCount(0)
+  })
+}

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1,4 +1,4 @@
-import { Capacitor } from '@capacitor/core'
+import { connectionEvents, getConnectionState } from '../../helpers/networkRecovery'
 import { ytDlp } from '../../helpers/ytDlp'
 import { supportsYtDlp } from '../../helpers/ytDlpCapabilities'
 import { isAppHidden } from '../../helpers/appVisibility.js'
@@ -1240,6 +1240,7 @@ export default defineComponent({
     this.initializeVideoQuality()
   },
   mounted: function () {
+    connectionEvents.addEventListener('change', this.handleDownloadConnectionChange)
     document.addEventListener('keydown', this.handleShortsNavigationKeydown, true)
     document.addEventListener('visibilitychange', this.updateAndroidBackgroundPlaybackFormat)
     window.addEventListener('resize', this.updateShortsViewportHeight)
@@ -1264,6 +1265,7 @@ export default defineComponent({
     this.onMountedDependOnLocalStateLoading()
   },
   beforeUnmount: function () {
+    connectionEvents.removeEventListener('change', this.handleDownloadConnectionChange)
     document.removeEventListener('keydown', this.handleShortsNavigationKeydown, true)
     document.removeEventListener('visibilitychange', this.updateAndroidBackgroundPlaybackFormat)
     window.removeEventListener('resize', this.updateShortsViewportHeight)
@@ -1291,6 +1293,13 @@ export default defineComponent({
     }
   },
   methods: {
+    handleDownloadConnectionChange({ detail }) {
+      if (detail !== 'offline' || !this.isLoading || this.localFilePlayback) return
+      if (this.finishDownloadedPlaybackWithoutMetadata()) {
+        // Ignore metadata responses that arrive after switching to the local file.
+        this.videoLoadGeneration++
+      }
+    },
     updateAndroidBackgroundPlaybackFormat() {
       if (!process.env.IS_CAPACITOR || this.$refs.player?.isNativePlayback?.()) return
 
@@ -1353,6 +1362,7 @@ export default defineComponent({
         !this.enableVideoMetadataCache ||
         this.isLoading ||
         !this.hasResolvedVideoTitle ||
+        (this.localFilePlayback && !this.channelId) ||
         typeof window.ftElectron?.videoMetadataCache?.update !== 'function'
       ) {
         return
@@ -2085,7 +2095,8 @@ export default defineComponent({
 
       this.cacheOnlinePlaybackSource()
       this.sabrData = null
-      const url = process.env.IS_CAPACITOR ? Capacitor.convertFileSrc(file.path) : `downloadmedia://file/${downloadId}/${this.videoId}`
+      // Android uses the native player, which reads content URIs directly.
+      const url = process.env.IS_CAPACITOR ? file.path : `downloadmedia://file/${downloadId}/${this.videoId}`
       if (download.mode === 'audio') {
         this.manifestSrc = url
         this.manifestMimeType = mimeType
@@ -2735,6 +2746,9 @@ export default defineComponent({
     },
 
     getVideoInformationLocal: async function (loadGeneration = ++this.videoLoadGeneration) {
+      // Keep online metadata when available, but never wait for reconnection to play a download.
+      if (getConnectionState() === 'offline' && this.finishDownloadedPlaybackWithoutMetadata()) return
+
       if (this.firstLoad) {
         this.isLoading = true
       }
@@ -3075,11 +3089,13 @@ export default defineComponent({
               result.streaming_data.adaptive_formats[0]?.cipher
             ) {
               try {
-                this.manifestSrc = await this.createLocalDashManifest(result, true)
+                const manifestSrc = await this.createLocalDashManifest(result, true)
                 if (!this.isCurrentVideoLoad(loadGeneration, videoId)) { return }
+                this.manifestSrc = manifestSrc
                 this.manifestMimeType = MANIFEST_TYPE_DASH
                 useRemoteManifest = false
               } catch (error) {
+                if (!this.isCurrentVideoLoad(loadGeneration, videoId)) { return }
                 console.error(`Failed to generate DASH manifest for this Post Live DVR video ${this.videoId}, falling back to using YouTube's provided one...`, error)
               }
             }
@@ -3279,8 +3295,9 @@ export default defineComponent({
               result.streaming_data.adaptive_formats[0]?.signature_cipher ||
               result.streaming_data.adaptive_formats[0]?.cipher
             ) {
-              this.manifestSrc = await this.createLocalDashManifest(result)
+              const manifestSrc = await this.createLocalDashManifest(result)
               if (!this.isCurrentVideoLoad(loadGeneration, videoId)) { return }
+              this.manifestSrc = manifestSrc
               this.manifestMimeType = MANIFEST_TYPE_DASH
             } else {
               // Neither a SABR streaming URL nor playable adaptive format URLs,
@@ -3341,6 +3358,7 @@ export default defineComponent({
           this.getVideoInformationInvidious(loadGeneration)
         } else {
           const didReload = await this.runIpBlockRecoveryScriptAndReload()
+          if (!this.isCurrentVideoLoad(loadGeneration, videoId)) { return }
           if (didReload) {
             return
           }
@@ -3358,6 +3376,9 @@ export default defineComponent({
     },
 
     getVideoInformationInvidious: function (loadGeneration = ++this.videoLoadGeneration) {
+      // Keep online metadata when available, but never wait for reconnection to play a download.
+      if (getConnectionState() === 'offline' && this.finishDownloadedPlaybackWithoutMetadata()) return
+
       if (this.firstLoad) {
         this.isLoading = true
       }
@@ -3541,8 +3562,9 @@ export default defineComponent({
               })
               ?.projectionType ?? null
 
-            this.manifestSrc = await this.createInvidiousDashManifest(result)
+            const manifestSrc = await this.createInvidiousDashManifest(result)
             if (!this.isCurrentVideoLoad(loadGeneration, videoId)) { return }
+            this.manifestSrc = manifestSrc
             this.manifestMimeType = MANIFEST_TYPE_DASH
           }
 
@@ -3588,6 +3610,7 @@ export default defineComponent({
             }
 
             const didReload = await this.runIpBlockRecoveryScriptAndReload()
+            if (!this.isCurrentVideoLoad(loadGeneration, videoId)) { return }
             if (didReload) {
               return
             }
@@ -3622,6 +3645,8 @@ export default defineComponent({
         return false
       }
 
+      const loadGeneration = this.videoLoadGeneration
+      const videoId = this.videoId
       this.ipBlockRecoveryAttemptedForCurrentVideo = true
       const longToastDurationMs = 10000
       const startedRecovery = await window.ftElectron.startIpBlockRecoveryScript(scriptPath)
@@ -3645,6 +3670,8 @@ export default defineComponent({
           showToastOnAllTabs(this.t('Settings.Proxy Settings.IP block recovery script failed', { exitCode: 'unknown' }), longToastDurationMs, ['fas', 'circle-exclamation'])
         }
       }
+
+      if (!this.isCurrentVideoLoad(loadGeneration, videoId)) return false
 
       // The reload only affects this tab's video, so keep it scoped.
       this.showTabToast({
@@ -3903,15 +3930,21 @@ export default defineComponent({
 
     addToHistory: function (watchProgress, isWatched = isHistoryEntryWatched(this.historyEntry)) {
       const now = Date.now()
+      // Local playback can start before channel metadata is available.
+      const metadata = this.localFilePlayback && !this.channelId && this.historyEntry
+        ? this.historyEntry
+        : {
+            title: this.videoTitle,
+            author: this.channelName,
+            authorId: this.channelId,
+            published: this.videoPublished,
+            description: this.videoDescription,
+            viewCount: this.videoViewCount,
+          }
       const videoData = {
         ...this.historyEntry,
+        ...metadata,
         videoId: this.videoId,
-        title: this.videoTitle,
-        author: this.channelName,
-        authorId: this.channelId,
-        published: this.videoPublished,
-        description: this.videoDescription,
-        viewCount: this.videoViewCount,
         lengthSeconds: this.videoLengthSeconds,
         watchProgress: watchProgress,
         isWatched,

--- a/tests/unit/offline-download-history.test.mjs
+++ b/tests/unit/offline-download-history.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import { runInNewContext } from 'node:vm'
+
+const source = await readFile(new URL('../../src/renderer/views/Watch/Watch.js', import.meta.url), 'utf8')
+const { addToHistory } = runInNewContext(`({
+  ${source.slice(source.indexOf('    addToHistory:'), source.indexOf('    keepHistoryEntryAlive('))}
+})`)
+
+test('offline download playback preserves existing history metadata while updating progress', () => {
+  const historyEntry = {
+    videoId: 'downloaded1', title: 'Saved title', author: 'Saved channel', authorId: 'channel1',
+    published: 1234, description: 'Saved description', viewCount: 123, lengthSeconds: 40,
+    watchProgress: 5, isWatched: false, timeWatched: 1,
+  }
+  let saved
+  addToHistory.call({
+    historyEntry,
+    localFilePlayback: true,
+    videoId: 'downloaded1', videoTitle: 'downloaded-file', channelName: '', channelId: '',
+    videoPublished: 0, videoDescription: '', videoViewCount: 0, videoLengthSeconds: 42,
+    isLive: false, isUpcoming: false,
+    updateHistory(value) { saved = value },
+  }, 20, true)
+
+  for (const key of ['title', 'author', 'authorId', 'published', 'description', 'viewCount']) {
+    assert.equal(saved[key], historyEntry[key], `${key} must survive offline playback`)
+  }
+  assert.equal(saved.watchProgress, 20)
+  assert.equal(saved.lengthSeconds, 42)
+  assert.equal(saved.isWatched, true)
+  assert.ok(saved.timeWatched > historyEntry.timeWatched)
+})
+
+test('download playback with resolved online metadata refreshes history', () => {
+  let saved
+  addToHistory.call({
+    historyEntry: { title: 'Old title', author: 'Old channel' },
+    localFilePlayback: true,
+    videoId: 'downloaded1', videoTitle: 'New title', channelName: 'New channel', channelId: 'channel1',
+    videoPublished: 1234, videoDescription: 'New description', videoViewCount: 123, videoLengthSeconds: 42,
+    isLive: false, isUpcoming: false,
+    updateHistory(value) { saved = value },
+  }, 20, false)
+
+  assert.equal(saved.title, 'New title')
+  assert.equal(saved.author, 'New channel')
+  assert.equal(saved.authorId, 'channel1')
+  assert.equal(saved.description, 'New description')
+})
+
+test('offline download metadata does not create a false metadata cache observation', async () => {
+  let updates = 0
+  const { updateVideoMetadataCache } = runInNewContext(`({
+    ${source.slice(source.indexOf('    async updateVideoMetadataCache()'), source.indexOf('    clearLiveReminderStartTimer()'))}
+  })`, {
+    window: { ftElectron: { videoMetadataCache: { update: async () => { updates++ } } } },
+  })
+  await updateVideoMetadataCache.call({
+    enableVideoMetadataCache: true, isLoading: false, hasResolvedVideoTitle: true,
+    localFilePlayback: true, channelId: '', videoId: 'downloaded1', videoTitle: 'downloaded-file',
+    videoDescription: '', thumbnail: '', videoLoadGeneration: 1,
+    isCurrentVideoLoad: () => true,
+  })
+  assert.equal(updates, 0, 'missing online metadata must not be recorded as a changed description')
+})

--- a/tests/unit/offline-download-manifest.test.mjs
+++ b/tests/unit/offline-download-manifest.test.mjs
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import { runInNewContext } from 'node:vm'
+
+const source = await readFile(new URL('../../src/renderer/views/Watch/Watch.js', import.meta.url), 'utf8')
+const connectionHandler = source.slice(source.indexOf('    handleDownloadConnectionChange('), source.indexOf('    updateAndroidBackgroundPlaybackFormat()'))
+
+for (const expression of ['createLocalDashManifest(result, true)', 'createLocalDashManifest(result)', 'createInvidiousDashManifest(result)']) {
+  test(`late ${expression} does not replace downloaded audio after connection loss`, async () => {
+    const awaitIndex = source.indexOf(`await this.${expression}`)
+    assert.notEqual(awaitIndex, -1)
+    const start = source.lastIndexOf('\n', awaitIndex) + 1
+    const end = source.indexOf('this.manifestMimeType = MANIFEST_TYPE_DASH', awaitIndex) + 'this.manifestMimeType = MANIFEST_TYPE_DASH'.length
+    const { load, handleDownloadConnectionChange } = runInNewContext(`({
+      ${connectionHandler}
+      async load(loadGeneration, videoId) {
+        ${source.slice(start, end)}
+      }
+    })`, { result: {}, MANIFEST_TYPE_DASH: 'application/dash+xml' })
+    let resolveManifest
+    const createManifest = () => new Promise(resolve => { resolveManifest = resolve })
+    const watch = {
+      load,
+      handleDownloadConnectionChange,
+      videoLoadGeneration: 1,
+      isLoading: true,
+      localFilePlayback: false,
+      createLocalDashManifest: createManifest,
+      createInvidiousDashManifest: createManifest,
+      isCurrentVideoLoad(generation) { return generation === this.videoLoadGeneration },
+      finishDownloadedPlaybackWithoutMetadata() {
+        this.manifestSrc = 'content://downloads/document/audio'
+        this.manifestMimeType = 'audio/mp4'
+        this.localFilePlayback = true
+        this.isLoading = false
+        return true
+      },
+    }
+    const pendingLoad = watch.load(1, 'downloaded1')
+    watch.handleDownloadConnectionChange({ detail: 'offline' })
+    resolveManifest('data:application/dash+xml,online-manifest')
+    await pendingLoad
+    assert.equal(watch.manifestSrc, 'content://downloads/document/audio')
+    assert.equal(watch.manifestMimeType, 'audio/mp4')
+  })
+}
+
+test('a stale failed DVR manifest does not fall back to an online source', async () => {
+  const awaitIndex = source.indexOf('await this.createLocalDashManifest(result, true)')
+  const start = source.lastIndexOf('try {', awaitIndex)
+  const end = source.indexOf('          if (useRemoteManifest)', awaitIndex)
+  const { load } = runInNewContext(`({
+    async load(loadGeneration, videoId) {
+      let useRemoteManifest = true
+      ${source.slice(start, end).replace(/\s*}\s*}\s*$/, '')}
+      return useRemoteManifest
+    }
+  })`, { result: {}, MANIFEST_TYPE_DASH: 'application/dash+xml', console: { error() {} } })
+  let rejectManifest
+  const watch = {
+    load,
+    videoLoadGeneration: 1,
+    createLocalDashManifest: () => new Promise((resolve, reject) => { rejectManifest = reject }),
+    isCurrentVideoLoad(generation) { return generation === this.videoLoadGeneration },
+  }
+  const pendingLoad = watch.load(1, 'downloaded1')
+  watch.videoLoadGeneration++
+  rejectManifest(new Error('offline'))
+  assert.equal(await pendingLoad, undefined, 'a superseded load must return before selecting a remote fallback')
+})
+
+for (const backend of ['Local', 'Invidious']) {
+  test(`late ${backend} recovery completion does not restart downloaded playback`, async () => {
+    const loaderStart = source.indexOf(`    getVideoInformation${backend}:`)
+    const loaderEnd = source.indexOf(backend === 'Local' ? '    getVideoInformationInvidious:' : '    async runIpBlockRecoveryScriptAndReload()', loaderStart)
+    const loader = source.slice(loaderStart, loaderEnd)
+    const start = loader.lastIndexOf('const didReload = await this.runIpBlockRecoveryScriptAndReload()')
+    const end = loader.indexOf('if (this.finishDownloadedPlaybackWithoutMetadata()) return', start) + 'if (this.finishDownloadedPlaybackWithoutMetadata()) return'.length
+    const { recover, handleDownloadConnectionChange } = runInNewContext(`({
+      ${connectionHandler}
+      async recover(loadGeneration, videoId) {
+        ${loader.slice(start, end)}
+      }
+    })`)
+    let resolveRecovery
+    let localLoads = 0
+    const watch = {
+      recover,
+      handleDownloadConnectionChange,
+      videoLoadGeneration: 1,
+      isLoading: true,
+      localFilePlayback: false,
+      runIpBlockRecoveryScriptAndReload: () => new Promise(resolve => { resolveRecovery = resolve }),
+      isCurrentVideoLoad(generation) { return generation === this.videoLoadGeneration },
+      finishDownloadedPlaybackWithoutMetadata() {
+        localLoads++
+        this.localFilePlayback = true
+        this.isLoading = false
+        return true
+      },
+    }
+    const pendingRecovery = watch.recover(1, 'downloaded1')
+    watch.handleDownloadConnectionChange({ detail: 'offline' })
+    resolveRecovery(false)
+    await pendingRecovery
+    assert.equal(localLoads, 1)
+  })
+}
+
+test('finishing an IP recovery script cannot reload a superseded offline download', async () => {
+  let resolveScript
+  let reloads = 0
+  const { runIpBlockRecoveryScriptAndReload } = runInNewContext(`({
+    ${source.slice(source.indexOf('    async runIpBlockRecoveryScriptAndReload()'), source.indexOf('    extractExpiryDateFromStreamingUrl:'))}
+  })`, {
+    process: { env: { IS_ELECTRON: true } },
+    window: { ftElectron: {
+      startIpBlockRecoveryScript: async () => true,
+      executeIpBlockRecoveryScript: () => new Promise(resolve => { resolveScript = resolve }),
+    } },
+    showToastOnAllTabs() {},
+  })
+  const watch = {
+    ipBlockDetectedInCurrentChain: true,
+    ipBlockRecoveryAttemptedForCurrentVideo: false,
+    videoIpBlockScriptPath: '/recovery-script',
+    videoLoadGeneration: 1,
+    videoId: 'downloaded1',
+    isCurrentVideoLoad(generation) { return generation === this.videoLoadGeneration },
+    t: key => key,
+    showTabToast() {},
+    async reloadView() { reloads++ },
+  }
+  const pending = runIpBlockRecoveryScriptAndReload.call(watch)
+  for (let i = 0; i < 5; i++) await Promise.resolve()
+  watch.videoLoadGeneration++
+  resolveScript({ exitCode: 0 })
+  assert.equal(await pending, false)
+  assert.equal(reloads, 0)
+})

--- a/tests/unit/offline-download-playback.test.mjs
+++ b/tests/unit/offline-download-playback.test.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import { runInNewContext } from 'node:vm'
+
+const source = await readFile(new URL('../../src/renderer/views/Watch/Watch.js', import.meta.url), 'utf8')
+function method(name, next) {
+  return source.slice(source.indexOf(`    ${name}:`), source.indexOf(`    ${next}`))
+}
+
+for (const android of [false, true]) {
+  for (const backend of ['Local', 'Invidious']) {
+    for (const mode of ['video', 'audio']) {
+      test(`${android ? 'Android' : 'Electron'} ${backend} plays downloaded ${mode} without waiting for metadata`, async () => {
+        let requests = 0
+        const pendingMetadata = () => { requests++; return new Promise(() => {}) }
+        const methods = runInNewContext(`({
+          ${method('applyDownloadedPlaybackSource', 'cacheOnlinePlaybackSource')}
+          ${method('finishDownloadedPlaybackWithoutMetadata', 'onMountedDependOnLocalStateLoading()')}
+          ${method('getVideoInformationLocal', 'getVideoInformationInvidious')}
+          ${method('getVideoInformationInvidious', 'async runIpBlockRecoveryScriptAndReload()')}
+        })`, {
+          process: { env: { IS_CAPACITOR: android } },
+          Capacitor: { convertFileSrc: path => `https://localhost/_capacitor_file_${path}` },
+          DOWNLOADED_MEDIA_MIME_TYPES: { mp4: 'video/mp4' },
+          getConnectionState: () => 'offline',
+          getLocalVideoInfo: pendingMetadata,
+          invidiousGetVideoInformation: pendingMetadata,
+        })
+        const watch = {
+          ...methods,
+          firstLoad: true,
+          isLoading: true,
+          videoLoadGeneration: 0,
+          videoId: 'downloaded1',
+          tabRoute: { params: { id: 'downloaded1' }, query: { downloadId: '1' } },
+          $store: { getters: { getYtDlpDownloads: { 1: {
+            id: 1, videoId: 'downloaded1', title: 'Offline video', status: 'completed', mode,
+            files: [{ path: android ? 'content://downloads/document/1' : '/downloads/video.mp4', videoId: 'downloaded1', extension: 'mp4', duration: 42 }],
+          } } } },
+          playbackSourceKey: 0,
+          cacheOnlinePlaybackSource() {},
+          updateTitle() {},
+          t: key => key,
+        }
+        watch[`getVideoInformation${backend}`]()
+        await Promise.resolve()
+        assert.equal(watch.isLoading, false, 'local playback must not wait for a metadata request that stays queued offline')
+        assert.equal(watch.localFilePlayback, true)
+        assert.equal(watch.videoTitle, 'Offline video')
+        assert.equal(watch.videoLengthSeconds, 42)
+        const url = mode === 'audio' ? watch.manifestSrc : watch.legacyFormats[0].url
+        assert.equal(url, android ? 'content://downloads/document/1' : 'downloadmedia://file/1/downloaded1')
+        assert.equal(requests, 0)
+      })
+    }
+  }
+}
+
+for (const backend of ['Local', 'Invidious']) {
+  test(`${backend} keeps online metadata and switches to the download if the connection fails`, async () => {
+    let resolveMetadata
+    let requests = 0
+    const pendingMetadata = () => { requests++; return new Promise(resolve => { resolveMetadata = resolve }) }
+    const methods = runInNewContext(`({
+      ${method('getVideoInformationLocal', 'getVideoInformationInvidious')}
+      ${method('getVideoInformationInvidious', 'async runIpBlockRecoveryScriptAndReload()')}
+      ${source.slice(source.indexOf('    handleDownloadConnectionChange('), source.indexOf('    updateAndroidBackgroundPlaybackFormat()'))}
+    })`, {
+      getConnectionState: () => 'online',
+      getLocalVideoInfo: pendingMetadata,
+      invidiousGetVideoInformation: pendingMetadata,
+    })
+    let localLoads = 0
+    const watch = {
+      ...methods,
+      firstLoad: true,
+      isLoading: true,
+      videoLoadGeneration: 0,
+      tabRoute: { params: { id: 'downloaded1' } },
+      finishDownloadedPlaybackWithoutMetadata() { localLoads++; this.isLoading = false; this.localFilePlayback = true; return true },
+      isCurrentVideoLoad(generation) { return generation === this.videoLoadGeneration },
+    }
+    watch[`getVideoInformation${backend}`]()
+    await Promise.resolve()
+    assert.equal(requests, 1, 'online downloads retain their normal metadata request')
+    assert.equal(localLoads, 0)
+    watch.handleDownloadConnectionChange({ detail: 'offline' })
+    assert.equal(localLoads, 1)
+    assert.equal(watch.isLoading, false)
+    assert.equal(watch.localFilePlayback, true)
+    assert.equal(watch.videoLoadGeneration, 2, 'the pending metadata load can no longer replace local playback')
+    resolveMetadata({})
+    for (let i = 0; i < 5; i++) await Promise.resolve()
+    assert.equal(localLoads, 1)
+    watch.handleDownloadConnectionChange({ detail: 'offline' })
+    assert.equal(localLoads, 1, 'connection updates do not restart an already playing file')
+  })
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

Closes #1266
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description

Downloaded videos and audio could get stuck waiting for a connection, and Android passed local files to the native player as WebView-only localhost URLs. Selected downloads now load from local storage when offline or when connectivity fails during metadata loading. Android receives the original content URI.

Online playback keeps its metadata, and offline playback preserves existing history metadata. Late metadata responses cannot replace the local source.
<!-- Please write a clear and concise description of what the pull request does. -->

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Play downloaded videos and audio without an internet connection, including on Android.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing

1. Download a video or audio file, then disconnect from the internet. On Android, enable airplane mode and turn Wi-Fi off.
2. Open Downloads and play the completed file. Playback should start even while the connection banner is visible.
3. Restart the app offline and repeat. Confirm that playback also continues when connectivity is lost while the app is open.
4. Reconnect and open a download again. Online metadata should still appear. Previously saved history details should survive offline playback.
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

## Additional context

Validation: unit tests and lint; isolated Electron offline startup and playback tests; Android 15 emulator playback with airplane mode enabled and Wi-Fi off. The emulator test reproduced the localhost URL failure before the Android fix.

Implemented with GPT-6 in Codex.
<!-- Add any other context about the pull request here. -->
