### PR TITLE
fix: keep connection status accurate and group subscription errors

### DIFF
--- a/e2e/tests/offline/connection-status.spec.mjs
+++ b/e2e/tests/offline/connection-status.spec.mjs
@@ -40,3 +40,29 @@ for (const scale of [1, 1.25]) {
     await expect(banner).toBeHidden({ timeout: 5000 })
   })
 }
+
+test('an unavailable service retries quietly while another service remains usable', async ({ page }) => {
+  let failedRequests = 0
+  await page.route('https://unavailable.example/**', route => {
+    failedRequests++
+    return route.abort('connectionrefused')
+  })
+  await page.route('https://connection.example/**', route => route.fulfill({ status: 200, body: 'working' }))
+  await page.evaluate(() => {
+    window.connectionTestController = new AbortController()
+    window.connectionTestPending = fetch('https://unavailable.example/status', {
+      signal: window.connectionTestController.signal
+    }).catch(error => error.name)
+  })
+  try {
+    await expect.poll(() => failedRequests).toBeGreaterThanOrEqual(2)
+    expect(await page.evaluate(() => fetch('https://connection.example/status').then(response => response.text()))).toBe('working')
+    await expect(page.locator('.connectionStatus')).toBeHidden()
+    await expect(page.locator('.toast-slot:not(.persistent-slot)')).toHaveCount(0)
+  } finally {
+    await page.evaluate(async () => {
+      window.connectionTestController.abort()
+      await window.connectionTestPending
+    })
+  }
+})

--- a/e2e/tests/offline/subscription-errors.spec.mjs
+++ b/e2e/tests/offline/subscription-errors.spec.mjs
@@ -1,0 +1,80 @@
+import { test, expect, goTo } from '../../helpers/app.mjs'
+
+for (const count of [2, 20]) {
+  test.describe(`${count} unavailable channels`, () => {
+    const channels = Array.from({ length: count }, (_, index) => ({
+      id: `UC${String(index).padStart(22, '0')}`,
+      name: `Unavailable channel ${index + 1}`,
+      thumbnail: ''
+    }))
+    test.use({
+      seed: {
+        settings: {
+          backendPreference: 'invidious',
+          backendFallback: false,
+          defaultInvidiousInstance: 'https://feeds.example',
+          fetchSubscriptionsAutomatically: false,
+          useRssFeeds: true,
+          hideSubscriptionsVideos: true,
+          hideSubscriptionsLive: true,
+          hideSubscriptionsCommunity: true
+        },
+        profiles: [{
+          _id: 'allChannels',
+          name: 'All Channels',
+          bgColor: '#000000',
+          textColor: '#FFFFFF',
+          subscriptions: channels
+        }]
+      }
+    })
+
+    test('shows a compact summary and copies details for every channel', async ({ page, app }) => {
+      await page.setViewportSize({ width: 480, height: 800 })
+      await page.evaluate(() => window.ftElectron.setZoomFactor(1.25))
+      await page.route('https://feeds.example/**', route => route.fulfill({ status: 404, body: 'Not found' }))
+      await goTo(page, 'subscriptions')
+      await page.locator('[data-subscription-feed-tab="shorts"]').click()
+      await page.getByRole('button', { name: /Refresh Shorts/ }).click()
+      const toast = page.locator('.toast', { hasText: 'Channels that could not be refreshed:' })
+      await expect(toast).toHaveText(`Channels that could not be refreshed: ${count}. Click to copy details.`)
+      await expect(page.locator('.toast')).toHaveCount(1)
+      await expect(page.locator('.connectionStatus')).toBeHidden()
+      const bounds = await toast.boundingBox()
+      expect(bounds.height).toBeLessThan(160)
+      expect(bounds.width).toBeLessThanOrEqual(480)
+      await toast.click()
+      await expect.poll(() => app.electronApp.evaluate(({ clipboard }) => clipboard.readText())).toContain(channels.at(-1).id)
+      const details = await app.electronApp.evaluate(({ clipboard }) => clipboard.readText())
+      for (const channel of channels) expect(details).toContain(`${channel.name} (${channel.id})`)
+      expect(details).toContain('HTTP 404')
+    })
+
+    if (count === 2) {
+      test('copying an ongoing summary keeps later failures accessible', async ({ page, app }) => {
+        let releaseSecond
+        const secondReady = new Promise(resolve => { releaseSecond = resolve })
+        await page.route('https://feeds.example/**', async route => {
+          if (route.request().url().includes(channels[1].id.slice(2))) await secondReady
+          return route.fulfill({ status: 404, body: 'Not found' })
+        })
+        try {
+          await goTo(page, 'subscriptions')
+          await page.locator('[data-subscription-feed-tab="shorts"]').click()
+          await page.getByRole('button', { name: /Refresh Shorts/ }).click()
+          const toast = page.locator('.toast', { hasText: 'Channels that could not be refreshed:' })
+          await expect(toast).toContainText('refreshed: 1.')
+          await toast.click()
+          await expect.poll(() => app.electronApp.evaluate(({ clipboard }) => clipboard.readText())).toContain(channels[0].id)
+          releaseSecond()
+          await expect(toast).toContainText('refreshed: 2.')
+          await expect(toast).toHaveCount(1)
+          await toast.click()
+          await expect.poll(() => app.electronApp.evaluate(({ clipboard }) => clipboard.readText())).toContain(channels[1].id)
+        } finally {
+          releaseSecond()
+        }
+      })
+    }
+  })
+}

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -76,6 +76,7 @@ const { t } = useI18n()
  * @typedef ToastState the live state handed to {@link FtToastItem}
  * @property {string} message
  * @property {Function | null} action
+ * @property {boolean} dismissOnAction whether the main action closes the toast
  * @property {{ label: string, action?: Function, primary?: boolean, icon?: [string, string] }[]} buttons
  * @property {boolean} verticalButtons whether buttons should be stacked vertically
  * @property {boolean} dismissible whether Escape and swipe gestures can dismiss the toast
@@ -407,9 +408,9 @@ function stopProgressToastPointerTracking() {
 }
 
 /**
- * @param {CustomEvent<{ message: string | (({elapsedMs: number, remainingMs: number}) => string), time: number | null, action: Function | null, abortSignal: AbortSignal | null, image: string | null, icon: [string, string] | null, buttons: { label: string, action?: Function, primary?: boolean, icon?: [string, string] }[], buttonAction: 'open-sync-settings' | null, verticalButtons: boolean, dismissible: boolean }>} event
+ * @param {CustomEvent<{ message: string | (({elapsedMs: number, remainingMs: number}) => string), time: number | null, action: Function | null, abortSignal: AbortSignal | null, image: string | null, icon: [string, string] | null, buttons: { label: string, action?: Function, primary?: boolean, icon?: [string, string] }[], buttonAction: 'open-sync-settings' | null, verticalButtons: boolean, dismissible: boolean, dismissOnAction?: boolean }>} event
  */
-function open({ detail: { message, time, action, abortSignal, image, icon, buttons, buttonAction, verticalButtons, dismissible } }) {
+function open({ detail: { message, time, action, abortSignal, image, icon, buttons, buttonAction, verticalButtons, dismissible, dismissOnAction } }) {
   if (buttonAction === 'open-sync-settings') {
     buttons = [{
       label: t('Settings.Sync Settings.Sync Settings'),
@@ -429,6 +430,7 @@ function open({ detail: { message, time, action, abortSignal, image, icon, butto
   const state = reactive({
     message: typeof message === 'function' ? message({ elapsedMs: 0, remainingMs: time }) : message,
     action: action ?? null,
+    dismissOnAction: dismissOnAction ?? true,
     buttons: buttons ?? [],
     verticalButtons: verticalButtons ?? false,
     dismissible: dismissible ?? true,

--- a/src/renderer/components/FtToast/FtToastItem.vue
+++ b/src/renderer/components/FtToast/FtToastItem.vue
@@ -161,7 +161,7 @@ function performAction() {
   if (!props.toast.action) { return }
 
   props.toast.action()
-  close()
+  if (props.toast.dismissOnAction !== false) close()
 }
 
 /**

--- a/src/renderer/helpers/networkRecovery.js
+++ b/src/renderer/helpers/networkRecovery.js
@@ -27,7 +27,9 @@ export function createNetworkRecovery({ eventTarget, isOnline, onChange = () => 
   }
 
   function update() {
-    if (!online || [...origins.values()].some(entry => entry.failed)) publish('offline')
+    // A failed origin or subscription refresh is not a device-wide outage.
+    // Keep request recovery independent from the global connection banner.
+    if (!online) publish('offline')
     else if (state === 'offline') publish('restored')
     else if (!state) publish('online')
   }
@@ -95,19 +97,16 @@ export function createNetworkRecovery({ eventTarget, isOnline, onChange = () => 
               try {
                 const result = await task(signal)
                 origin.failed = false
-                update()
                 return result
               } catch (error) {
                 if (signal.aborted) throw createAbortError()
                 const networkError = await isNetworkError(error)
                 if (!networkError) {
                   origin.failed = false
-                  update()
                   throw error
                 }
                 if (!retry) throw error
                 origin.failed = true
-                update()
                 delay = Math.min(delay * 2, 60000)
               }
             }
@@ -117,21 +116,16 @@ export function createNetworkRecovery({ eventTarget, isOnline, onChange = () => 
           }
         }
         try {
-          const result = await task(signal)
-          update()
-          return result
+          return await task(signal)
         } catch (error) {
           if (signal.aborted || !retry || !await isNetworkError(error)) throw error
           origin.failed = true
-          update()
         }
       }
     } finally {
       origin.users--
       if (origin.users === 0) {
         origins.delete(originKey)
-        // Cancellation is not evidence of restored connectivity.
-        if (state === 'offline' && online && ![...origins.values()].some(entry => entry.failed)) publish('online')
       }
     }
   }

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -15,6 +15,7 @@ import {
   parseLocalPlaylistVideos
 } from './api/local'
 import {
+  copyToClipboard,
   getChannelPlaylistId,
   showApiErrorToast,
   showToast,
@@ -58,7 +59,7 @@ let electronRefreshOwnerTabId = null
 
 /**
  * Cancellation state of the refresh this renderer is running, if any.
- * @type {{ cancelled: boolean, tab: string, profileId: string, refreshId: number, controller: AbortController, errorShown: boolean, networkRecovery: ReturnType<typeof createSubscriptionNetworkRecovery> | null } | null}
+ * @type {{ cancelled: boolean, tab: string, profileId: string, refreshId: number, controller: AbortController, errors: Map<string, Set<string>>, errorSummary: ReturnType<typeof createSubscriptionErrorSummary>, networkRecovery: ReturnType<typeof createSubscriptionNetworkRecovery> | null } | null}
  */
 let activeRefresh = null
 let nextRefreshId = 0
@@ -188,20 +189,20 @@ function isRefreshCancelled() {
  * @param {() => Promise<T>} refresh
  * @returns {Promise<T | null>}
  */
-async function withSubscriptionRefreshLock(tab, profileId, refresh) {
+async function withSubscriptionRefreshLock(tab, profileId, refresh, t) {
   if (rendererRefreshReserved || store.getters.getSubscriptionFeedRefreshInProgress) {
     return null
   }
 
   rendererRefreshReserved = true
   try {
-    return await runWithSubscriptionRefreshLock(tab, profileId, refresh)
+    return await runWithSubscriptionRefreshLock(tab, profileId, refresh, t)
   } finally {
     rendererRefreshReserved = false
   }
 }
 
-async function runWithSubscriptionRefreshLock(tab, profileId, refresh) {
+async function runWithSubscriptionRefreshLock(tab, profileId, refresh, t) {
   if (process.env.IS_CAPACITOR && await isAndroidSubscriptionRefreshActive()) {
     return null
   }
@@ -212,7 +213,8 @@ async function runWithSubscriptionRefreshLock(tab, profileId, refresh) {
     const controller = new AbortController()
     activeRefresh = {
       cancelled: false,
-      errorShown: false,
+      errors: new Map(),
+      errorSummary: createSubscriptionErrorSummary(t),
       controller,
       tab,
       profileId,
@@ -234,6 +236,7 @@ async function runWithSubscriptionRefreshLock(tab, profileId, refresh) {
       return await refresh()
     } finally {
       activeRefresh.networkRecovery?.cancel()
+      activeRefresh.errorSummary.finish()
       activeRefresh = null
       window.dispatchEvent(new CustomEvent(SUBSCRIPTION_REFRESH_FINISHED_EVENT, {
         detail: { tab, profileId, refreshId }
@@ -303,6 +306,33 @@ function notifySubscriptionChannelRefreshed(tab) {
   }))
 }
 
+/** Keep confirmed channel failures visible even when another channel keeps retrying. */
+function createSubscriptionErrorSummary(t) {
+  const errors = new Map()
+  const controller = new AbortController()
+  let shown = false
+  return {
+    add(channelId, messages) {
+      if (!messages?.size) return
+      errors.set(channelId, messages)
+      if (shown) return
+      shown = true
+      showToast({
+        message: () => t('Subscriptions.Refresh Errors', { count: errors.size }),
+        time: Infinity,
+        dismissOnAction: false,
+        abortSignal: controller.signal,
+        action: () => copyToClipboard([...errors.values()].flatMap(messages => [...messages]).join('\n')),
+        icon: ['fas', 'circle-exclamation']
+      })
+    },
+    finish() {
+      // Keep the final details available briefly after completion or cancellation.
+      if (shown) setTimeout(() => controller.abort(), 10000)
+    }
+  }
+}
+
 async function fetchSubscriptionsConcurrently(channels, fetchChannel) {
   await mapConcurrently(
     channels,
@@ -330,6 +360,10 @@ async function fetchSubscriptionsConcurrently(channels, fetchChannel) {
         }
       } catch (error) {
         if (!isRefreshCancelled()) throw error
+      }
+
+      if (!isRefreshCancelled()) {
+        activeRefresh.errorSummary.add(channel.id, activeRefresh.errors.get(channel.id))
       }
 
       // Let input and navigation tasks run between parsing/cache updates.
@@ -378,8 +412,10 @@ function handleSubscriptionFetchError(channel, error, title, context) {
   const message = `${channelLabel}: ${diagnostic}`
 
   console.error(`Failed to fetch subscription channel ${channelLabel}: ${diagnostic}`)
-  if (!activeRefresh?.errorShown) {
-    if (activeRefresh) activeRefresh.errorShown = true
+  if (activeRefresh) {
+    if (!activeRefresh.errors.has(channel.id)) activeRefresh.errors.set(channel.id, new Set())
+    activeRefresh.errors.get(channel.id).add(message)
+  } else {
     showApiErrorToast(title, message)
   }
 }
@@ -737,7 +773,8 @@ export function refreshSubscriptionVideosFromRemote(options) {
   return withSubscriptionRefreshLock(
     'videos',
     activeProfile._id,
-    () => refreshSubscriptionVideosFromRemoteUnlocked(options, activeProfile)
+    () => refreshSubscriptionVideosFromRemoteUnlocked(options, activeProfile),
+    options.t
   )
 }
 
@@ -786,6 +823,7 @@ async function refreshSubscriptionVideosFromRemoteUnlocked({
       setSubscriptionRefreshProgress((channelCount / subscriptionList.length) * 100)
 
       if (videos != null) {
+        activeRefresh.errors.delete(channel.id)
         const previousCache = store.getters.getVideoCache[channel.id]
         videos = reconcileFetchedSubscriptionEntries(
           videos,
@@ -843,7 +881,8 @@ export function refreshSubscriptionShortsFromRemote(options) {
   return withSubscriptionRefreshLock(
     'shorts',
     activeProfile._id,
-    () => refreshSubscriptionShortsFromRemoteUnlocked(options, activeProfile)
+    () => refreshSubscriptionShortsFromRemoteUnlocked(options, activeProfile),
+    options.t
   )
 }
 
@@ -883,6 +922,7 @@ async function refreshSubscriptionShortsFromRemoteUnlocked({
       setSubscriptionRefreshProgress((channelCount / subscriptionList.length) * 100)
 
       if (videos != null) {
+        activeRefresh.errors.delete(channel.id)
         const previousCache = store.getters.getShortsCache[channel.id]
         videos = reconcileFetchedSubscriptionEntries(
           videos,
@@ -933,7 +973,8 @@ export function refreshSubscriptionLiveFromRemote(options) {
   return withSubscriptionRefreshLock(
     'live',
     activeProfile._id,
-    () => refreshSubscriptionLiveFromRemoteUnlocked(options, activeProfile)
+    () => refreshSubscriptionLiveFromRemoteUnlocked(options, activeProfile),
+    options.t
   )
 }
 
@@ -982,6 +1023,7 @@ async function refreshSubscriptionLiveFromRemoteUnlocked({
       setSubscriptionRefreshProgress((channelCount / subscriptionList.length) * 100)
 
       if (videos != null) {
+        activeRefresh.errors.delete(channel.id)
         const previousCache = store.getters.getLiveCache[channel.id]
         videos = reconcileFetchedSubscriptionEntries(
           videos,
@@ -1039,7 +1081,8 @@ export function refreshSubscriptionPostsFromRemote(options) {
   return withSubscriptionRefreshLock(
     'posts',
     activeProfile._id,
-    () => refreshSubscriptionPostsFromRemoteUnlocked(options, activeProfile)
+    () => refreshSubscriptionPostsFromRemoteUnlocked(options, activeProfile),
+    options.t
   )
 }
 
@@ -1077,6 +1120,8 @@ async function refreshSubscriptionPostsFromRemoteUnlocked({
       channelCount++
       setSubscriptionRefreshProgress((channelCount / activeSubscriptionList.length) * 100)
 
+      if (posts === null) return
+      activeRefresh.errors.delete(channel.id)
       const previousCache = store.getters.getPostsCache[channel.id]
       posts = reconcileFetchedSubscriptionEntries(
         posts,
@@ -1130,7 +1175,11 @@ async function getChannelPostsLocal(channel, t, errorChannels) {
 
     if (posts === null) {
       errorChannels.push(channel)
-      return []
+      handleSubscriptionFetchError(channel, new Error('Channel unavailable'), t('Local API Error (Click to copy)'), {
+        category: 'subscription posts',
+        backend: 'local API'
+      })
+      return null
     }
 
     return posts
@@ -1145,7 +1194,7 @@ async function getChannelPostsLocal(channel, t, errorChannels) {
       return await getChannelPostsInvidious(channel, t, errorChannels)
     }
 
-    return []
+    return null
   }
 }
 
@@ -1169,7 +1218,7 @@ async function getChannelPostsInvidious(channel, t, errorChannels) {
       return await getChannelPostsLocal(channel, t, errorChannels)
     }
 
-    return []
+    return null
   }
 }
 
@@ -1179,6 +1228,10 @@ async function getChannelVideosLocalScraper(channel, t, errorChannels, failedAtt
 
     if (result === null) {
       errorChannels.push(channel)
+      handleSubscriptionFetchError(channel, new Error('Channel unavailable'), t('Local API Error (Click to copy)'), {
+        category: 'subscription videos',
+        backend: 'local API'
+      })
       return { videos: null }
     }
 
@@ -1211,6 +1264,15 @@ async function getChannelVideosLocalScraper(channel, t, errorChannels, failedAtt
   }
 }
 
+/** Reject HTTP failures before trying to parse an error page as RSS. */
+function checkSubscriptionFeedResponse(response) {
+  if (response.status >= 400) {
+    const error = new Error(`Subscription feed returned HTTP ${response.status}`)
+    error.status = response.status
+    throw error
+  }
+}
+
 async function getChannelVideosLocalRSS(channel, t, errorChannels, failedAttempts = 0) {
   const playlistId = getChannelPlaylistId(channel.id, 'videos', 'newest')
   const feedUrl = `https://www.youtube.com/feeds/videos.xml?playlist_id=${playlistId}`
@@ -1218,16 +1280,13 @@ async function getChannelVideosLocalRSS(channel, t, errorChannels, failedAttempt
   try {
     const response = await localApiFetch(feedUrl, { signal: activeRefresh?.controller.signal })
 
-    if (response.status === 403) {
-      return { videos: null }
-    }
-
     if (response.status === 404) {
       // RSS can return 404 for channels that still exist. Verify through
       // the API instead of treating a second RSS response as channel removal.
       return await getChannelVideosLocalScraper(channel, t, errorChannels, 3)
     }
 
+    checkSubscriptionFeedResponse(response)
     return await parseYouTubeRSSFeed(await response.text(), channel.id)
   } catch (error) {
     handleSubscriptionFetchError(channel, error, t('Local API Error (Click to copy)'), {
@@ -1303,12 +1362,18 @@ async function getChannelVideosInvidiousRSS(channel, t, errorChannels, failedAtt
 
       if (response2.status === 404) {
         errorChannels.push(channel)
+        handleSubscriptionFetchError(channel, Object.assign(new Error('Subscription feed returned HTTP 404'), { status: 404 }), t('Invidious API Error (Click to copy)'), {
+          category: 'subscription videos',
+          backend: 'Invidious RSS'
+        })
         return { videos: null }
       }
 
+      checkSubscriptionFeedResponse(response2)
       return { videos: [] }
     }
 
+    checkSubscriptionFeedResponse(response)
     return await parseYouTubeRSSFeed(await response.text(), channel.id)
   } catch (error) {
     handleSubscriptionFetchError(channel, error, t('Invidious API Error (Click to copy)'), {
@@ -1340,14 +1405,14 @@ async function getChannelShortsLocal(channel, t, errorChannels, failedAttempts =
   try {
     const response = await localApiFetch(feedUrl, { signal: activeRefresh?.controller.signal })
 
-    if (response.status === 403) {
-      return { videos: null }
-    }
-
     if (response.status === 404) {
       const channelPage = await getLocalChannel(channel.id, activeRefresh?.controller.signal)
       if (channelPage.alert) {
         errorChannels.push(channel)
+        handleSubscriptionFetchError(channel, new Error(String(channelPage.alert)), t('Local API Error (Click to copy)'), {
+          category: 'subscription Shorts',
+          backend: 'local API'
+        })
         return { videos: null }
       }
       if (!channelPage.has_shorts) return { videos: [] }
@@ -1357,6 +1422,7 @@ async function getChannelShortsLocal(channel, t, errorChannels, failedAttempts =
       return { videos }
     }
 
+    checkSubscriptionFeedResponse(response)
     const [result, thumbnailEntries] = await Promise.all([
       parseYouTubeRSSFeed(await response.text(), channel.id),
       getLocalShortThumbnailEntries(playlistId)
@@ -1404,12 +1470,18 @@ async function getChannelShortsInvidious(channel, t, errorChannels, failedAttemp
 
       if (response2.status === 404) {
         errorChannels.push(channel)
+        handleSubscriptionFetchError(channel, Object.assign(new Error('Subscription feed returned HTTP 404'), { status: 404 }), t('Invidious API Error (Click to copy)'), {
+          category: 'subscription Shorts',
+          backend: 'Invidious RSS'
+        })
         return { videos: null }
       }
 
+      checkSubscriptionFeedResponse(response2)
       return { videos: [] }
     }
 
+    checkSubscriptionFeedResponse(response)
     const result = await parseYouTubeRSSFeed(await response.text(), channel.id)
     result.videos.forEach(video => { video.isShort = true })
     return result
@@ -1434,6 +1506,10 @@ async function getChannelLiveLocal(channel, t, errorChannels, failedAttempts = 0
 
     if (result === null) {
       errorChannels.push(channel)
+      handleSubscriptionFetchError(channel, new Error('Channel unavailable'), t('Local API Error (Click to copy)'), {
+        category: 'subscription live streams',
+        backend: 'local API'
+      })
       return { videos: null }
     }
 
@@ -1468,14 +1544,11 @@ async function getChannelLiveLocalRSS(channel, t, errorChannels, failedAttempts 
   try {
     const response = await localApiFetch(feedUrl, { signal: activeRefresh?.controller.signal })
 
-    if (response.status === 403) {
-      return { videos: null }
-    }
-
     if (response.status === 404) {
       return await getChannelLiveLocal(channel, t, errorChannels, 3)
     }
 
+    checkSubscriptionFeedResponse(response)
     return await parseYouTubeRSSFeed(await response.text(), channel.id)
   } catch (error) {
     handleSubscriptionFetchError(channel, error, t('Local API Error (Click to copy)'), {
@@ -1551,12 +1624,18 @@ async function getChannelLiveInvidiousRSS(channel, t, errorChannels, failedAttem
 
       if (response2.status === 404) {
         errorChannels.push(channel)
+        handleSubscriptionFetchError(channel, Object.assign(new Error('Subscription feed returned HTTP 404'), { status: 404 }), t('Invidious API Error (Click to copy)'), {
+          category: 'subscription live streams',
+          backend: 'Invidious RSS'
+        })
         return { videos: null }
       }
 
+      checkSubscriptionFeedResponse(response2)
       return { videos: [] }
     }
 
+    checkSubscriptionFeedResponse(response)
     return await parseYouTubeRSSFeed(await response.text(), channel.id)
   } catch (error) {
     handleSubscriptionFetchError(channel, error, t('Invidious API Error (Click to copy)'), {

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -269,6 +269,7 @@ const ERROR_TOAST_ICON = ['fas', 'circle-exclamation']
  * @property {string | (({elapsedMs: number, remainingMs: number}) => string)} message
  * @property {number} [time]
  * @property {Function} [action]
+ * @property {boolean} [dismissOnAction] close the toast after its main action, defaults to true
  * @property {{ label: string, action?: Function, primary?: boolean, icon?: [string, string] }[]} [buttons]
  * @property {'open-sync-settings' | null} [buttonAction] predefined action for cross-window notifications
  * @property {boolean} [verticalButtons] whether buttons should be stacked vertically
@@ -293,11 +294,12 @@ export function showToast(message, time = null, action = null, abortSignal = nul
   let buttonAction = null
   let verticalButtons = false
   let dismissible = true
+  let dismissOnAction = true
 
   // Allow calling with a single options object while staying backwards compatible
   // with the positional (message, time, action, abortSignal) signature
   if (message !== null && typeof message === 'object') {
-    ({ message, time = null, action = null, abortSignal = null, image = null, icon = null, buttons = [], buttonAction = null, verticalButtons = false, dismissible = true } = message)
+    ({ message, time = null, action = null, abortSignal = null, image = null, icon = null, buttons = [], buttonAction = null, verticalButtons = false, dismissible = true, dismissOnAction = true } = message)
   }
 
   // Sometimes caller just pass user setting based value in and it can be zero
@@ -318,6 +320,7 @@ export function showToast(message, time = null, action = null, abortSignal = nul
       buttonAction,
       verticalButtons,
       dismissible,
+      dismissOnAction,
     }
   }))
 }

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: جميع الأقسام مخفية
   All sections hidden description: خصّص الصفحة الرئيسية لإظهار قسم من جديد.
 Subscriptions:
+  Refresh Errors: "القنوات التي تعذر تحديثها: {count}. انقر لنسخ التفاصيل."
   Never show {type} from this channel in feeds again: عدم عرض {type} من هذه القناة في الخلاصات مجددًا
   Refreshing Subscription Videos: تحديث مقاطع الفيديو الخاصة بالاشتراك
   Refreshing Subscription Shorts: 'تحديث الفيديوهات القصيرة للاشتراكات'

--- a/static/locales/ai/az.yaml
+++ b/static/locales/ai/az.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Bütün bölmələr gizlədilib
   All sections hidden description: Bölməni yenidən göstərmək üçün ana səhifəni fərdiləşdirin.
 Subscriptions:
+  Refresh Errors: "Yenilənə bilməyən kanallar: {count}. Təfərrüatları kopyalamaq üçün klikləyin."
   Never show {type} from this channel in feeds again: Bu kanaldan {type} məzmununu lentlərdə bir daha göstərmə
   Refreshing Subscription Videos: Abunəlik videoları yenilənir
   Refreshing Subscription Shorts: Abunəlik qısa videoları yenilənir

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -148,6 +148,7 @@ Home Page:
   All sections hidden: Усе раздзелы схаваны
   All sections hidden description: Наладзьце галоўную, каб зноў паказаць раздзел.
 Subscriptions:
+  Refresh Errors: "Каналы, якія не ўдалося абнавіць: {count}. Націсніце, каб скапіяваць падрабязнасці."
   Never show {type} from this channel in feeds again: Больш не паказваць {type} з гэтага канала ў стужках
   Refreshing Subscription Videos: Абнаўляюцца відэа з падпісак
   Refreshing Subscription Shorts: Абнаўляюцца кароткія відэа з падпісак

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Всички раздели са скрити
   All sections hidden description: Персонализирайте началната страница, за да покажете отново раздел.
 Subscriptions:
+  Refresh Errors: "Канали, които не можаха да се обновят: {count}. Натиснете, за да копирате подробностите."
   Never show {type} from this channel in feeds again: Никога повече да не се показват {type} от този канал в емисиите
   Refreshing Subscription Videos: Обновяват се видеоклиповете от абонаментите
   Refreshing Subscription Shorts: Обновяват се кратките видеоклипове от абонаментите

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Kuzhet eo an holl rannoù
   All sections hidden description: Personelait ar bajenn degemer evit diskouez ur rann en-dro.
 Subscriptions:
+  Refresh Errors: "Kanolioù n'int ket bet hizivaet: {count}. Klikit evit eilañ ar munudoù."
   Never show {type} from this channel in feeds again: Na ziskouez biken {type} eus ar chadenn-mañ er gwazhioù en-dro
   Refreshing Subscription Videos: "Oc'h adkargañ videoioù ar c'houmanantoù"
   Refreshing Subscription Shorts: "Oc'h adkargañ videoioù berr (Shorts) ar c'houmanantoù"

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -172,6 +172,7 @@ Home Page:
   All sections hidden: Totes les seccions estan ocultes
   All sections hidden description: Personalitzeu l'inici per tornar a mostrar una secció.
 Subscriptions:
+  Refresh Errors: "Canals que no s'han pogut actualitzar: {count}. Feu clic per copiar els detalls."
   Never show {type} from this channel in feeds again: No tornis a mostrar {type} d’aquest canal als canals de contingut
   Disabled Automatic Fetching: Heu desactivat l'obtenció automàtica de subscripcions. Actualitzeu-les per veure-les aquí.
   Empty Channels: Els canals als quals us heu subscrit no tenen cap vídeo ara mateix.

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Všechny sekce jsou skryté
   All sections hidden description: Přizpůsobte domovskou stránku a některou sekci znovu zobrazte.
 Subscriptions:
+  Refresh Errors: "Kanály, které se nepodařilo obnovit: {count}. Kliknutím zkopírujete podrobnosti."
   Never show {type} from this channel in feeds again: Už nikdy nezobrazovat {type} z tohoto kanálu ve feedech
   Refreshing Subscription Videos: Obnovování videí z odběrů
   Refreshing Subscription Shorts: Obnovování krátkých videí z odběrů

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Mae pob adran wedi'i chuddio
   All sections hidden description: Addaswch yr hafan i ddangos adran eto.
 Subscriptions:
+  Refresh Errors: "Sianeli na ellid eu hadnewyddu: {count}. Cliciwch i gopïo'r manylion."
   Never show {type} from this channel in feeds again: Peidio byth â dangos {type} o’r sianel hon mewn ffrydiau eto
   Refreshing Subscription Videos: Wrthi'n adnewyddu fideos tanysgrifiadau
   Refreshing Subscription Shorts: Wrthi'n adnewyddu Byrion tanysgrifiadau

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -144,6 +144,7 @@ Home Page:
   All sections hidden: Alle sektioner er skjult
   All sections hidden description: Tilpas startsiden for at vise en sektion igen.
 Subscriptions:
+  Refresh Errors: "Kanaler, der ikke kunne opdateres: {count}. Klik for at kopiere detaljer."
   Never show {type} from this channel in feeds again: Vis aldrig {type} fra denne kanal i feeds igen
   Refreshing Subscription Videos: Opdaterer videoer fra abonnementer
   Refreshing Subscription Shorts: Opdaterer Shorts fra abonnementer

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Όλες οι ενότητες είναι κρυφές
   All sections hidden description: Προσαρμόστε την αρχική για να εμφανίσετε ξανά μια ενότητα.
 Subscriptions:
+  Refresh Errors: "Κανάλια που δεν ήταν δυνατό να ανανεωθούν: {count}. Κάντε κλικ για αντιγραφή λεπτομερειών."
   Never show {type} from this channel in feeds again: Να μην εμφανίζεται ξανά περιεχόμενο τύπου {type} από αυτό το κανάλι στις ροές
   Refreshing Subscription Videos: Ανανέωση βίντεο συνδρομών
   Refreshing Subscription Shorts: Ανανέωση σύντομων βίντεο συνδρομών

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -141,6 +141,7 @@ Home Page:
   All sections hidden: All sections are hidden
   All sections hidden description: Customise Home to show a section again.
 Subscriptions:
+  Refresh Errors: "Channels that could not be refreshed: {count}. Click to copy details."
   Never show {type} from this channel in feeds again: Never show {type} from this channel in feeds again
   Refreshing Subscription Videos: Refreshing subscription videos
   Refreshing Subscription Shorts: Refreshing subscription shorts

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -150,6 +150,7 @@ Home Page:
   All sections hidden: Todas las secciones están ocultas
   All sections hidden description: Personalizá Inicio para volver a mostrar una sección.
 Subscriptions:
+  Refresh Errors: "Canales que no se pudieron actualizar: {count}. Hacé clic para copiar los detalles."
   Never show {type} from this channel in feeds again: No volver a mostrar {type} de este canal en los feeds
   Refreshing Subscription Videos: Actualizando videos de las suscripciones
   Refreshing Subscription Shorts: Actualizando Shorts de las suscripciones

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -148,6 +148,7 @@ Home Page:
   All sections hidden: Todas las secciones están ocultas
   All sections hidden description: Personaliza Inicio para volver a mostrar una sección.
 Subscriptions:
+  Refresh Errors: "Canales que no se pudieron actualizar: {count}. Haz clic para copiar los detalles."
   Never show {type} from this channel in feeds again: No volver a mostrar {type} de este canal en los feeds
   Refreshing Subscription Videos: Actualizando videos de las suscripciones
   Refreshing Subscription Shorts: Actualizando Shorts de las suscripciones

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Todas las secciones están ocultas
   All sections hidden description: Personaliza Inicio para volver a mostrar una sección.
 Subscriptions:
+  Refresh Errors: "Canales que no se pudieron actualizar: {count}. Haz clic para copiar los detalles."
   Never show {type} from this channel in feeds again: No volver a mostrar {type} de este canal en los feeds
   Refreshing Subscription Videos: Actualizando vídeos de las suscripciones
   Refreshing Subscription Shorts: Actualizando Shorts de las suscripciones

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Kõik jaotised on peidetud
   All sections hidden description: Kohanda avalehte, et mõni jaotis uuesti kuvada.
 Subscriptions:
+  Refresh Errors: "Kanalid, mida ei saanud värskendada: {count}. Klõpsa üksikasjade kopeerimiseks."
   Never show {type} from this channel in feeds again: Ära enam näita selle kanali sisu tüübiga {type} voogudes
   Refreshing Subscription Videos: Tellimuste videote värskendamine
   Refreshing Subscription Shorts: Tellimuste Shorts-videote värskendamine

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Atal guztiak ezkutatuta daude
   All sections hidden description: Pertsonalizatu hasiera atal bat berriro erakusteko.
 Subscriptions:
+  Refresh Errors: "Eguneratu ezin izan diren kanalak: {count}. Egin klik xehetasunak kopiatzeko."
   Never show {type} from this channel in feeds again: Ez erakutsi berriro kanal honetako {type} jarioetan
   Refreshing Subscription Videos: Harpidetzetako bideoak freskatzen
   Refreshing Subscription Shorts: Harpidetzetako bideo laburrak freskatzen

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -152,6 +152,7 @@ Home Page:
   All sections hidden: همهٔ بخش‌ها پنهان هستند
   All sections hidden description: صفحهٔ اصلی را سفارشی کنید تا بخشی دوباره نمایش داده شود.
 Subscriptions:
+  Refresh Errors: "کانال‌هایی که به‌روزرسانی نشدند: {count}. برای کپی جزئیات کلیک کنید."
   Never show {type} from this channel in feeds again: دیگر هرگز {type} این کانال را در خوراک‌ها نشان نده
   Refreshing Subscription Videos: در حال تازه‌سازی ویدیوهای اشتراک‌ها
   Refreshing Subscription Shorts: در حال تازه‌سازی ویدیوهای کوتاه اشتراک‌ها

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Kaikki osiot on piilotettu
   All sections hidden description: Mukauta etusivua, jotta voit näyttää osion uudelleen.
 Subscriptions:
+  Refresh Errors: "Kanavat, joita ei voitu päivittää: {count}. Kopioi tiedot napsauttamalla."
   Never show {type} from this channel in feeds again: Älä enää näytä tämän kanavan sisältöä tyypillä {type} syötteissä
   Refreshing Subscription Videos: Päivitetään tilausten videoita
   Refreshing Subscription Shorts: Päivitetään tilausten Shorts-videoita

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Toutes les sections sont masquées
   All sections hidden description: Personnalisez l’accueil pour afficher à nouveau une section.
 Subscriptions:
+  Refresh Errors: "Chaînes qui n'ont pas pu être actualisées : {count}. Cliquez pour copier les détails."
   Never show {type} from this channel in feeds again: Ne plus jamais afficher les contenus de type {type} de cette chaîne dans les flux
   Refreshing Subscription Videos: Actualisation des vidéos des abonnements
   Refreshing Subscription Shorts: Actualisation des Shorts des abonnements

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Todas as seccións están ocultas
   All sections hidden description: Personaliza o inicio para volver amosar unha sección.
 Subscriptions:
+  Refresh Errors: "Canles que non se puideron actualizar: {count}. Preme para copiar os detalles."
   Never show {type} from this channel in feeds again: Non volver mostrar {type} desta canle nos fluxos
   Refreshing Subscription Videos: Actualizando os vídeos das subscricións
   Refreshing Subscription Shorts: Actualizando os vídeos curtos das subscricións

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: כל המקטעים מוסתרים
   All sections hidden description: התאימו אישית את דף הבית כדי להציג שוב מקטע.
 Subscriptions:
+  Refresh Errors: "ערוצים שלא ניתן היה לרענן: {count}. יש ללחוץ להעתקת הפרטים."
   Never show {type} from this channel in feeds again: לא להציג שוב תוכן מסוג {type} מהערוץ הזה בפידים
   Refreshing Subscription Videos: סרטוני המינויים מתרעננים
   Refreshing Subscription Shorts: הסרטונים הקצרים מהמינויים מתרעננים

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Svi su odjeljci skriveni
   All sections hidden description: Prilagodite početnu stranicu kako biste ponovno prikazali odjeljak.
 Subscriptions:
+  Refresh Errors: "Kanali koji se nisu mogli osvježiti: {count}. Kliknite za kopiranje pojedinosti."
   Never show {type} from this channel in feeds again: Nikad više ne prikazuj {type} s ovog kanala u sažecima sadržaja
   Refreshing Subscription Videos: Osvježavanje videozapisa iz pretplata
   Refreshing Subscription Shorts: Osvježavanje sadržaja Shorts iz pretplata

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Minden szakasz el van rejtve
   All sections hidden description: Szabja testre a kezdőlapot egy szakasz újbóli megjelenítéséhez.
 Subscriptions:
+  Refresh Errors: "Nem frissíthető csatornák: {count}. Kattintson a részletek másolásához."
   Never show {type} from this channel in feeds again: Soha többé ne jelenjen meg {type} típusú tartalom ettől a csatornától a hírcsatornákban
   Refreshing Subscription Videos: Feliratkozások videóinak frissítése
   Refreshing Subscription Shorts: Feliratkozások rövid videóinak frissítése

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Semua bagian disembunyikan
   All sections hidden description: Sesuaikan Beranda untuk menampilkan kembali bagian.
 Subscriptions:
+  Refresh Errors: "Channel yang tidak dapat diperbarui: {count}. Klik untuk menyalin detail."
   Never show {type} from this channel in feeds again: Jangan pernah tampilkan {type} dari channel ini di feed lagi
   Refreshing Subscription Videos: Memperbarui video langganan
   Refreshing Subscription Shorts: Memperbarui Shorts langganan

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Allir hlutar eru faldir
   All sections hidden description: Sérsníddu heimasíðuna til að sýna hluta aftur.
 Subscriptions:
+  Refresh Errors: "Rásir sem ekki tókst að uppfæra: {count}. Smelltu til að afrita upplýsingar."
   Never show {type} from this channel in feeds again: Aldrei sýna aftur efni af gerðinni {type} frá þessari rás í straumum
   Refreshing Subscription Videos: Endurnýja myndbönd úr áskriftum
   Refreshing Subscription Shorts: Endurnýja Shorts-myndbönd úr áskriftum

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Tutte le sezioni sono nascoste
   All sections hidden description: Personalizza Home per mostrare di nuovo una sezione.
 Subscriptions:
+  Refresh Errors: "Canali che non è stato possibile aggiornare: {count}. Fai clic per copiare i dettagli."
   Never show {type} from this channel in feeds again: Non mostrare più contenuti di tipo {type} di questo canale nei feed
   Refreshing Subscription Videos: Aggiornamento dei video delle iscrizioni
   Refreshing Subscription Shorts: Aggiornamento degli Shorts delle iscrizioni

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: すべてのセクションが非表示です
   All sections hidden description: ホームをカスタマイズして、セクションを再表示してください。
 Subscriptions:
+  Refresh Errors: "更新できなかったチャンネル数: {count}。クリックして詳細をコピーします。"
   Never show {type} from this channel in feeds again: このチャンネルの「{type}」をフィードに今後表示しない
   Refreshing Subscription Videos: 登録チャンネルの動画を更新中
   Refreshing Subscription Shorts: 登録チャンネルのショート動画を更新中

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -149,6 +149,7 @@ Home Page:
   All sections hidden: 모든 섹션이 숨겨져 있습니다
   All sections hidden description: 홈을 맞춤 설정하여 섹션을 다시 표시하세요.
 Subscriptions:
+  Refresh Errors: "새로고침하지 못한 채널: {count}. 클릭하여 세부 정보를 복사하세요."
   Never show {type} from this channel in feeds again: 이 채널의 {type} 콘텐츠를 피드에 다시 표시하지 않기
   Refreshing Subscription Videos: 구독 동영상 새로 고치는 중
   Refreshing Subscription Shorts: 구독 Shorts 새로 고치는 중

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -164,6 +164,7 @@ Home Page:
   All sections hidden: Visi skyriai paslėpti
   All sections hidden description: Tinkinkite pradžios puslapį, kad vėl būtų rodomas skyrius.
 Subscriptions:
+  Refresh Errors: "Kanalai, kurių nepavyko atnaujinti: {count}. Spustelėkite, kad nukopijuotumėte išsamią informaciją."
   Never show {type} from this channel in feeds again: Daugiau niekada nerodyti šio kanalo {type} turinio srautuose
   Load More Posts: Įkelti daugiau įrašų
   Subscriptions Tabs: Prenumeratų kortelės

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Alle deler er skjult
   All sections hidden description: Tilpass startsiden for å vise en del igjen.
 Subscriptions:
+  Refresh Errors: "Kanaler som ikke kunne oppdateres: {count}. Klikk for å kopiere detaljer."
   Never show {type} from this channel in feeds again: Vis aldri {type} fra denne kanalen i strømmer igjen
   Refreshing Subscription Videos: Oppdaterer abonnementsvideoer
   Refreshing Subscription Shorts: Oppdaterer Shorts fra abonnementer

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Alle secties zijn verborgen
   All sections hidden description: Pas de startpagina aan om weer een sectie te tonen.
 Subscriptions:
+  Refresh Errors: "Kanalen die niet konden worden vernieuwd: {count}. Klik om details te kopiëren."
   Never show {type} from this channel in feeds again: Nooit meer {type} van dit kanaal in feeds tonen
   Refreshing Subscription Videos: Abonnementsvideo's vernieuwen
   Refreshing Subscription Shorts: Shorts van abonnementen vernieuwen

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -148,6 +148,7 @@ Home Page:
   All sections hidden: Alle delar er gøymde
   All sections hidden description: Tilpass heimesida for å vise ein del igjen.
 Subscriptions:
+  Refresh Errors: "Kanalar som ikkje kunne oppdaterast: {count}. Klikk for å kopiere detaljar."
   Never show {type} from this channel in feeds again: Vis aldri {type} frå denne kanalen i straumar igjen
   Subscriptions Tabs: Abonnementsfaner
   All Subscription Tabs Hidden: Alle abonnementsfanene er gøymde. Vis nokre faner i delen "{subsection}" under "{settingsSection}" for å sjå innhald her.

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -55,6 +55,7 @@ Home Page:
   All sections hidden: Wszystkie sekcje są ukryte
   All sections hidden description: Dostosuj stronę główną, aby ponownie wyświetlić sekcję.
 Subscriptions:
+  Refresh Errors: "Kanały, których nie udało się odświeżyć: {count}. Kliknij, aby skopiować szczegóły."
   Never show {type} from this channel in feeds again: Nigdy więcej nie pokazuj treści typu {type} z tego kanału w strumieniach
   New Content Tabs: Karty nowych treści
   Show Tabbed View: Pokaż widok kart

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Todas as seções estão ocultas
   All sections hidden description: Personalize a página inicial para mostrar uma seção novamente.
 Subscriptions:
+  Refresh Errors: "Canais que não puderam ser atualizados: {count}. Clique para copiar os detalhes."
   Never show {type} from this channel in feeds again: Nunca mais mostrar {type} deste canal nos feeds
   Refreshing Subscription Videos: Atualizando os vídeos das inscrições
   Refreshing Subscription Shorts: Atualizando os Shorts das inscrições

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Todas as secções estão ocultas
   All sections hidden description: Personalize a página inicial para voltar a mostrar uma secção.
 Subscriptions:
+  Refresh Errors: "Canais que não foi possível atualizar: {count}. Clique para copiar os detalhes."
   Never show {type} from this channel in feeds again: Nunca mais mostrar {type} deste canal nos feeds
   Refreshing Subscription Videos: A atualizar os vídeos das subscrições
   Refreshing Subscription Shorts: A atualizar os Shorts das subscrições

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Todas as secções estão ocultas
   All sections hidden description: Personalize a página inicial para voltar a mostrar uma secção.
 Subscriptions:
+  Refresh Errors: "Canais que não foi possível atualizar: {count}. Clique para copiar os detalhes."
   Never show {type} from this channel in feeds again: Nunca mais mostrar {type} deste canal nos feeds
   Refreshing Subscription Videos: A atualizar os vídeos das subscrições
   Refreshing Subscription Shorts: A atualizar os Shorts das subscrições

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Toate secțiunile sunt ascunse
   All sections hidden description: Personalizează pagina principală pentru a afișa din nou o secțiune.
 Subscriptions:
+  Refresh Errors: "Canale care nu au putut fi actualizate: {count}. Faceți clic pentru a copia detaliile."
   Never show {type} from this channel in feeds again: Nu mai afișa niciodată conținut de tip {type} de pe acest canal în fluxuri
   Refreshing Subscription Videos: Se reîmprospătează videoclipurile din abonamente
   Refreshing Subscription Shorts: Se reîmprospătează videoclipurile Shorts din abonamente

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -117,6 +117,7 @@ Home Page:
   All sections hidden: Все разделы скрыты
   All sections hidden description: Настройте главную, чтобы снова показать раздел.
 Subscriptions:
+  Refresh Errors: "Каналы, которые не удалось обновить: {count}. Нажмите, чтобы скопировать подробности."
   Never show {type} from this channel in feeds again: Больше никогда не показывать {type} с этого канала в лентах
   Refreshing Subscription Videos: Обновление видео из подписок
   Refreshing Subscription Shorts: Обновление Shorts из подписок

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Všetky sekcie sú skryté
   All sections hidden description: Prispôsobte domovskú stránku a znova zobrazte sekciu.
 Subscriptions:
+  Refresh Errors: "Kanály, ktoré sa nepodarilo obnoviť: {count}. Kliknutím skopírujete podrobnosti."
   Never show {type} from this channel in feeds again: Už nikdy nezobrazovať {type} z tohto kanála v kanáloch odberov
   Refreshing Subscription Videos: Obnovujú sa videá z odberov
   Refreshing Subscription Shorts: Obnovujú sa krátke videá z odberov

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -171,6 +171,7 @@ Home Page:
   All sections hidden: Vsi razdelki so skriti
   All sections hidden description: Prilagodite domačo stran, da znova prikažete razdelek.
 Subscriptions:
+  Refresh Errors: "Kanali, ki jih ni bilo mogoče osvežiti: {count}. Kliknite za kopiranje podrobnosti."
   Never show {type} from this channel in feeds again: Nikoli več ne prikazuj vsebine vrste {type} s tega kanala v virih
   Empty Posts: Kanali, na katere ste naročeni, trenutno nimajo objav.
   Load More Posts: Naloži več objav

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -144,6 +144,7 @@ Home Page:
   All sections hidden: Сви одељци су сакривени
   All sections hidden description: Прилагодите почетну страницу да бисте поново приказали одељак.
 Subscriptions:
+  Refresh Errors: "Канали које није било могуће освежити: {count}. Кликните да копирате детаље."
   Never show {type} from this channel in feeds again: Никада више не приказуј {type} са овог канала у фидовима
   Refreshing Subscription Videos: Освежавају се видео-снимци из претплата
   Refreshing Subscription Shorts: Освежавају се кратки видео-снимци из претплата

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Alla avsnitt är dolda
   All sections hidden description: Anpassa startsidan för att visa ett avsnitt igen.
 Subscriptions:
+  Refresh Errors: "Kanaler som inte kunde uppdateras: {count}. Klicka för att kopiera detaljer."
   Never show {type} from this channel in feeds again: Visa aldrig {type} från den här kanalen i flöden igen
   Refreshing Subscription Videos: Uppdaterar prenumerationsvideor
   Refreshing Subscription Shorts: Uppdaterar Shorts från prenumerationer

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -145,6 +145,7 @@ Home Page:
   All sections hidden: அனைத்துப் பிரிவுகளும் மறைக்கப்பட்டுள்ளன
   All sections hidden description: ஒரு பிரிவை மீண்டும் காட்ட முகப்பைத் தனிப்பயனாக்கவும்.
 Subscriptions:
+  Refresh Errors: "புதுப்பிக்க முடியாத சேனல்கள்: {count}. விவரங்களை நகலெடுக்க கிளிக் செய்யவும்."
   Never show {type} from this channel in feeds again: இந்தச் சேனலின் {type} உள்ளடக்கத்தை ஊட்டங்களில் இனி ஒருபோதும் காட்டாதே
   Refreshing Subscription Videos: சந்தாக்களின் காணொளிகள் புதுப்பிக்கப்படுகின்றன
   Refreshing Subscription Shorts: சந்தாக்களின் Shorts புதுப்பிக்கப்படுகின்றன

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Tüm bölümler gizli
   All sections hidden description: Bir bölümü yeniden göstermek için Ana Sayfayı özelleştirin.
 Subscriptions:
+  Refresh Errors: "Yenilenemeyen kanallar: {count}. Ayrıntıları kopyalamak için tıklayın."
   Never show {type} from this channel in feeds again: Bu kanalın {type} içeriklerini akışlarda bir daha gösterme
   Refreshing Subscription Videos: Abonelik videoları yenileniyor
   Refreshing Subscription Shorts: Abonelik kısa videoları yenileniyor

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Усі розділи приховано
   All sections hidden description: Налаштуйте головну, щоб знову показати розділ.
 Subscriptions:
+  Refresh Errors: "Канали, які не вдалося оновити: {count}. Натисніть, щоб скопіювати подробиці."
   Never show {type} from this channel in feeds again: Більше ніколи не показувати {type} із цього каналу в стрічках
   Refreshing Subscription Videos: Оновлення відео з підписок
   Refreshing Subscription Shorts: Оновлення коротких відео з підписок

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: Tất cả các mục đều bị ẩn
   All sections hidden description: Tùy chỉnh Trang chủ để hiển thị lại một mục.
 Subscriptions:
+  Refresh Errors: "Các kênh không thể làm mới: {count}. Nhấp để sao chép chi tiết."
   Never show {type} from this channel in feeds again: Không bao giờ hiển thị {type} từ kênh này trong bảng tin nữa
   Refreshing Subscription Videos: Đang làm mới video từ kênh đăng ký
   Refreshing Subscription Shorts: Đang làm mới video ngắn từ kênh đăng ký

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: 所有版块均已隐藏
   All sections hidden description: 自定义首页以重新显示版块。
 Subscriptions:
+  Refresh Errors: "无法刷新的频道数：{count}。点击复制详情。"
   Never show {type} from this channel in feeds again: 不再在动态中显示此频道的{type}
   Refreshing Subscription Videos: 正在刷新订阅视频
   Refreshing Subscription Shorts: 正在刷新订阅短视频

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -142,6 +142,7 @@ Home Page:
   All sections hidden: 所有區塊均已隱藏
   All sections hidden description: 自訂首頁以重新顯示區塊。
 Subscriptions:
+  Refresh Errors: "無法重新整理的頻道數：{count}。點擊複製詳細資訊。"
   Never show {type} from this channel in feeds again: 不再於動態中顯示此頻道的{type}
   Refreshing Subscription Videos: 正在重新整理訂閱影片
   Refreshing Subscription Shorts: 正在重新整理訂閱的 Shorts 短片

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -141,6 +141,7 @@ Home Page:
   All sections hidden description: Passe die Startseite an, um wieder einen Bereich anzuzeigen.
 
 Subscriptions:
+  Refresh Errors: "Nicht aktualisierte Kanäle: {count}. Klicken, um Details zu kopieren."
   Never show {type} from this channel in feeds again: Nie wieder {type} von diesem Kanal in Feeds anzeigen
     # On Subscriptions Page
   Subscriptions: Abos

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -259,6 +259,7 @@ Home Page:
   All sections hidden description: Customize Home to show a section again.
 
 Subscriptions:
+  Refresh Errors: "Channels that could not be refreshed: {count}. Click to copy details."
   Never show {type} from this channel in feeds again: Never show {type} from this channel in feeds again
     # On Subscriptions Page
   Subscriptions: Subscriptions

--- a/tests/unit/network-recovery.test.mjs
+++ b/tests/unit/network-recovery.test.mjs
@@ -36,7 +36,7 @@ test('a stalled route pauses concurrent requests, probes with backoff, and resum
   const second = recovery.run('https://www.youtube.com', task)
   await flush()
   assert.equal(calls, 1)
-  assert.equal(states.at(-1), 'offline')
+  assert.equal(states.at(-1), 'online')
   t.mock.timers.tick(5000)
   await flush()
   assert.equal(calls, 2)
@@ -44,7 +44,7 @@ test('a stalled route pauses concurrent requests, probes with backoff, and resum
   t.mock.timers.tick(10000)
   await flush()
   assert.deepEqual(await Promise.all([first, second]), [42, 42])
-  assert.equal(states.at(-1), 'restored')
+  assert.equal(states.at(-1), 'online')
 })
 
 test('an unavailable optional host does not block other services or mistake their responses for its recovery', async t => {
@@ -54,7 +54,7 @@ test('an unavailable optional host does not block other services or mistake thei
   const rejected = assert.rejects(failed, { name: 'AbortError' })
   await flush()
   assert.equal(await recovery.run('https://www.youtube.com', async () => 'ok'), 'ok')
-  assert.equal(states.at(-1), 'offline')
+  assert.equal(states.at(-1), 'online')
   controller.abort()
   await rejected
 })
@@ -93,7 +93,7 @@ test('non-idempotent operations wait offline but are never automatically replaye
   t.mock.timers.tick(60000)
   await flush()
   assert.equal(calls, 1)
-  assert.equal(states.includes('restored'), false, 'a failed write is not proof of recovery')
+  assert.equal(states.includes('restored'), true, 'the online event restores the device status independently of a failed write')
 })
 
 async function loadAppNetwork(t, fetch, nativeRequest, options = {}) {
@@ -135,14 +135,14 @@ test('native API and WebView requests share recovery, including an unreported ro
   const web = app.window.fetch('https://www.youtube.com/oembed')
   await flush()
   assert.equal(webCalls, 0)
-  assert.equal(app.recovery.state, 'offline')
+  assert.equal(app.recovery.state, 'online')
   fail = false
   t.mock.timers.tick(5000)
   await flush()
   assert.equal(await (await native).text(), 'native')
   assert.equal(await (await web).text(), 'web')
   assert.equal(nativeCalls, 2)
-  assert.equal(app.recovery.state, 'restored')
+  assert.equal(app.recovery.state, 'online')
 })
 
 test('a browser CORS failure does not enter endless recovery when native HTTP reaches the server', async t => {
@@ -172,11 +172,11 @@ test('Electron route failures recover while the OS still reports online', async 
   }, undefined, { corsDisabled: true, verifyConnection: undefined })
   const pending = app.window.fetch('https://www.youtube.com/feeds/videos.xml')
   await flush()
-  assert.equal(app.recovery.state, 'offline')
+  assert.equal(app.recovery.state, 'online')
   fail = false
   t.mock.timers.tick(5000)
   assert.equal(await (await pending).text(), 'recovered')
-  assert.equal(app.recovery.state, 'restored')
+  assert.equal(app.recovery.state, 'online')
 })
 
 test('delegated subscription transport retains browser CORS classification', async t => {
@@ -202,3 +202,29 @@ for (const transport of ['native', 'browser']) {
     await assert.rejects(pending, { name: 'TypeError' })
   })
 }
+
+test('device reconnection clears the banner while an optional service keeps retrying', async t => {
+  const { recovery, states, connect } = setup(t)
+  const controller = new AbortController()
+  let calls = 0
+  const pending = recovery.run('https://optional.example', async () => {
+    calls++
+    throw new TypeError('Failed to fetch')
+  }, { signal: controller.signal })
+  const rejected = assert.rejects(pending, { name: 'AbortError' })
+  await flush()
+  connect(false)
+  assert.equal(recovery.state, 'offline')
+  connect(true)
+  await flush()
+  assert.equal(recovery.state, 'restored')
+  assert.equal(calls, 2)
+  t.mock.timers.tick(3000)
+  assert.equal(recovery.state, 'online')
+  t.mock.timers.tick(7000)
+  await flush()
+  assert.equal(calls, 3, 'the failed service still retries after the banner clears')
+  assert.deepEqual(states, ['online', 'offline', 'restored', 'online'])
+  controller.abort()
+  await rejected
+})

--- a/tests/unit/subscription-network-recovery.test.mjs
+++ b/tests/unit/subscription-network-recovery.test.mjs
@@ -20,10 +20,11 @@ const source = (await readFile(new URL('../../src/renderer/helpers/subscriptions
 
 // Exercise the real refresh, fallback, cache, and notification paths with fake
 // platform APIs. Webpack-only imports are supplied in the isolated context.
-function createRefresh({ online = true, feed = 'Shorts', error = new TypeError('Failed to fetch'), webCors = false, backend = 'local', fallbackWorks = false, rssStatus = 200, channelInfo = { has_shorts: true }, playlistError = null, stallChannelProbe = false } = {}) {
+function createRefresh({ online = true, feed = 'Shorts', error = new TypeError('Failed to fetch'), webCors = false, backend = 'local', fallbackWorks = false, rssStatus = 200, channelInfo = { has_shorts: true }, playlistError = null, stallChannelProbe = false, channelStatus = rssStatus, scraperError = null } = {}) {
   const window = new EventTarget()
   const navigator = { onLine: online }
   const toasts = []
+  const copied = []
   const requests = []
   const fallbackRequests = []
   const writes = []
@@ -45,8 +46,8 @@ function createRefresh({ online = true, feed = 'Shorts', error = new TypeError('
   }
   const fetchChannel = async url => {
     requests.push(url)
-    if (fail) throw error
-    return { videos: [], posts: [], status: rssStatus, text: async () => '<feed/>' }
+    if (fail) throw typeof error === 'function' ? error(url) : error
+    return { videos: [], posts: [], status: url.includes('/feed/channel/') ? channelStatus : rssStatus, text: async () => '<feed/>' }
   }
   const fetchFallback = async url => {
     fallbackRequests.push(url)
@@ -71,12 +72,15 @@ function createRefresh({ online = true, feed = 'Shorts', error = new TypeError('
     startAutomaticDownloadsForChannel: async () => {},
     getChannelPlaylistId: id => id,
     showApiErrorToast: (...args) => toasts.push(args),
+    copyToClipboard: text => copied.push(text),
     showToast: (...args) => toasts.push(args),
     localApiFetch: fetchLocal,
     fetch: webCors ? async () => { throw new TypeError('Failed to fetch') } : fetchChannel,
     invidiousFetch: fetchInvidious,
-    getLocalChannelVideos: fetchLocal,
-    getLocalChannelLiveStreams: fetchLocal,
+    getLocalChannelVideos: async url => { if (scraperError) throw scraperError; return fetchLocal(url) },
+    getLocalChannelLiveStreams: async url => { if (scraperError) throw scraperError; return fetchLocal(url) },
+    getInvidiousChannelVideos: async url => { if (scraperError) throw scraperError; return fetchInvidious(url) },
+    getInvidiousChannelLive: async url => { if (scraperError) throw scraperError; return fetchInvidious(url) },
     getLocalChannelCommunity: async id => (await fetchLocal(id)).posts,
     invidiousGetCommunityPosts: fetchInvidious,
     getLocalChannel: async () => channelInfo,
@@ -103,7 +107,7 @@ function createRefresh({ online = true, feed = 'Shorts', error = new TypeError('
   }
   vm.runInContext(`${source}\nglobalThis.api = { refreshSubscriptionVideosFromRemote, refreshSubscriptionShortsFromRemote, refreshSubscriptionLiveFromRemote, refreshSubscriptionPostsFromRemote, cancelSubscriptionRefresh }`, context)
   return {
-    ...context.api, refresh: context.api[`refreshSubscription${feed}FromRemote`], navigator, requests, fallbackRequests, toasts, writes, events, getters,
+    ...context.api, refresh: context.api[`refreshSubscription${feed}FromRemote`], navigator, requests, fallbackRequests, toasts, copied, writes, events, getters, recovery: sharedRecovery,
     reconnect() {
       fail = false
       navigator.onLine = true
@@ -140,6 +144,7 @@ for (const feed of ['Videos', 'Shorts', 'Live', 'Posts']) {
     try {
       await settle()
       assert.equal(app.requests.length, 8, 'only already-running channel requests may fail')
+      assert.equal(app.recovery.state, 'online', 'a failed refresh is not a device-wide outage')
       assert.equal(app.toasts.length, 0)
       assert.equal(app.writes.length, 0)
       assert.deepEqual(app.events, [])
@@ -177,12 +182,13 @@ for (const online of [false, true]) {
   })
 }
 
-for (const error of [Object.assign(new Error('HTTP 503'), { status: 503 }), new SyntaxError('Invalid JSON')]) {
+for (const error of [404, 500, 503].map(status => Object.assign(new Error(`HTTP ${status}`), { status })).concat(new SyntaxError('Invalid JSON'))) {
   test(`${error.message} keeps the existing error and fallback behavior`, async () => {
     const app = createRefresh({ error })
     await app.refresh({ t: key => key })
     assert.equal(app.requests.length, 40)
-    assert.ok(app.toasts.length > 0)
+    assert.equal(app.toasts.length, 1)
+    assert.equal(app.recovery.state, 'online')
     assert.deepEqual(app.events, ['completed', 'finished'])
   })
 }
@@ -345,3 +351,109 @@ for (const feed of ['Videos', 'Shorts', 'Live']) {
     assert.deepEqual(app.events, ['finished'])
   })
 }
+
+for (const feed of ['Videos', 'Shorts', 'Live']) {
+  for (const backend of ['local', 'invidious']) {
+    for (const status of [403, 500, 503]) {
+      test(`${backend} ${feed} RSS HTTP ${status} produces one error toast without a connection banner`, async () => {
+        const app = createRefresh({ feed, backend, rssStatus: status, scraperError: Object.assign(new Error(`HTTP ${status}`), { status }) })
+        app.reconnect()
+        await app.refresh({ t: key => key, errorChannels: [] })
+        assert.equal(app.toasts.length, 1)
+        app.toasts[0][0].action()
+        assert.match(app.copied[0], new RegExp(`HTTP ${status}`))
+        assert.equal(app.recovery.state, 'online')
+        assert.deepEqual(app.events, ['completed', 'finished'])
+      })
+    }
+  }
+}
+
+for (const feed of ['Videos', 'Shorts', 'Live']) {
+  for (const status of [404, 500]) {
+    test(`${feed} failed Invidious channel verification HTTP ${status} reports one toast`, async () => {
+      const app = createRefresh({ feed, backend: 'invidious', rssStatus: 404, channelStatus: status, scraperError: Object.assign(new Error(`HTTP ${status}`), { status }) })
+      app.getters.getBackendFallback = false
+      app.reconnect()
+      const errorChannels = []
+      await app.refresh({ t: key => key, errorChannels })
+      assert.equal(app.toasts.length, 1)
+      app.toasts[0][0].action()
+      assert.match(app.copied[0], new RegExp(`HTTP ${status}`))
+      assert.equal(app.recovery.state, 'online')
+      assert.equal(errorChannels.length, status === 404 ? 20 : 0)
+    })
+  }
+}
+
+const translateSummary = (key, values) => values ? `${key}: ${values.count}` : key
+
+test('one compact refresh notification retains every failed channel and distinct diagnostic', async () => {
+  const app = createRefresh({ error: Object.assign(new Error('HTTP 500'), { status: 500 }) })
+  await app.refresh({ t: translateSummary })
+  assert.equal(app.toasts.length, 1)
+  const toast = app.toasts[0][0]
+  assert.equal(toast.message(), 'Subscriptions.Refresh Errors: 20')
+  assert.ok(toast.message().length < 100)
+  toast.action()
+  for (let i = 0; i < 20; i++) assert.match(app.copied[0], new RegExp(`UC${i}:`))
+  assert.match(app.copied[0], /HTTP 500/)
+  assert.match(app.copied[0], /backend=YouTube RSS/)
+  assert.match(app.copied[0], /backend=Invidious RSS/)
+  assert.equal(new Set(app.copied[0].split('\n')).size, app.copied[0].split('\n').length)
+})
+
+for (const feed of ['Videos', 'Shorts', 'Live', 'Posts']) {
+  test(`${feed} HTTP failures recovered by fallback do not appear in the summary`, async () => {
+    const app = createRefresh({ feed, error: Object.assign(new Error('HTTP 500'), { status: 500 }), fallbackWorks: true })
+    await app.refresh({ t: translateSummary })
+    assert.equal(app.toasts.length, 0)
+    assert.equal(app.writes.filter(write => write.key.endsWith('CacheByChannel')).length, 20)
+  })
+}
+
+test('two confirmed unavailable channels are both included in the copied summary', async () => {
+  const app = createRefresh({ rssStatus: 404, channelInfo: { alert: 'This channel does not exist.' } })
+  app.getters.getActiveProfile.subscriptions = [{ id: 'UCfirst', name: 'First channel' }, { id: 'UCsecond', name: 'Second channel' }]
+  app.reconnect()
+  await app.refresh({ t: translateSummary })
+  assert.equal(app.toasts.length, 1)
+  assert.equal(app.toasts[0][0].message(), 'Subscriptions.Refresh Errors: 2')
+  app.toasts[0][0].action()
+  assert.match(app.copied[0], /First channel \(UCfirst\)/)
+  assert.match(app.copied[0], /Second channel \(UCsecond\)/)
+})
+
+for (const feed of ['Videos', 'Shorts', 'Live', 'Posts']) {
+  test(`${feed} unrecovered failures preserve cached entries and report all channels`, async () => {
+    const app = createRefresh({ feed, error: Object.assign(new Error('HTTP 500'), { status: 500 }) })
+    await app.refresh({ t: translateSummary })
+    assert.equal(app.writes.filter(write => write.key.endsWith('CacheByChannel')).length, 0)
+    assert.equal(app.toasts.length, 1)
+    assert.equal(app.toasts[0][0].message(), 'Subscriptions.Refresh Errors: 20')
+  })
+}
+
+
+test('confirmed HTTP failures stay accessible while another channel retries and after cancellation', async () => {
+  const app = createRefresh({ error: url => url.includes('UC0')
+    ? Object.assign(new Error('HTTP 500'), { status: 500 })
+    : new TypeError('Failed to fetch') })
+  app.getters.getActiveProfile.subscriptions = [{ id: 'UC0' }, { id: 'UC1' }]
+  const refresh = app.refresh({ t: translateSummary })
+  try {
+    await settle()
+    assert.deepEqual(app.events, [])
+    assert.equal(app.toasts.length, 1, 'the finished HTTP failure must not wait for network recovery')
+    app.toasts[0][0].action()
+    assert.match(app.copied[0], /UC0:/)
+    assert.doesNotMatch(app.copied[0], /UC1:/)
+    app.cancelSubscriptionRefresh()
+    await refresh
+    assert.equal(app.toasts.length, 1)
+    assert.equal(app.toasts[0][0].abortSignal.aborted, false, 'cancellation must retain the confirmed failures')
+  } finally {
+    app.cancelSubscriptionRefresh()
+    await refresh
+  }
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Reported during Pixel testing in this task.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The app could display “Connection lost” while videos still loaded because one failing service kept the global connection state offline. Subscription errors also either filled the screen with notifications or exposed only the first failing channel.

Track the device's reported connectivity separately from quiet request retries. Show one updating, copyable summary of confirmed channel failures after fallback attempts, including while other channels retry or after cancellation. Copying keeps the summary available for later errors. Reject RSS HTTP errors before parsing them and preserve cached posts on failed refreshes.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Connection warnings now follow device connectivity, and subscription failures appear in one compact summary with copyable details for every affected channel.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. With the app running from this branch in dev mode, disconnect and reconnect the device. The connection banner should follow that state; a failed optional service must not show a global outage while videos still load.
2. Refresh subscriptions containing multiple unavailable channels. Expect one compact summary, with every failed channel included when you click to copy details. If other requests are still pending, copying should keep the summary open as the count updates.
3. Verify that connection retries stay quiet, successful fallbacks disappear from the error summary, and a failed refresh preserves cached entries.

## Additional context
<!-- Add any other context about the pull request here. -->

Changes prepared by GPT-6 using the Codex desktop harness.
