### PR TITLE
fix: match premiere text colors to normal videos

### DIFF
--- a/e2e/tests/offline/playlists.spec.mjs
+++ b/e2e/tests/offline/playlists.spec.mjs
@@ -331,7 +331,7 @@ test.describe('seeded playlists', () => {
     await expect(page.getByTestId('progress-toast')).toHaveCount(0)
   })
 
-  test('restores running premiere styling when the scheduled time arrives', async ({ page }) => {
+  test('keeps normal title styling when a premiere reaches its scheduled time', async ({ page }) => {
     await goTo(page, 'userplaylists')
     await page.clock.install({ time: seededPremiereStart - 86_400_000 })
     await page.getByText('My seeded playlist').click()
@@ -346,7 +346,7 @@ test.describe('seeded playlists', () => {
 
     await page.clock.fastForward(86_400_001)
 
-    await expect(title).toHaveCSS('color', 'rgb(101, 67, 33)')
+    await expect(title).toHaveCSS('color', 'rgb(18, 52, 86)')
   })
 
   test('playlist artwork keeps its native aspect ratio', async ({ page }) => {

--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -89,6 +89,26 @@ const seed = {
 
 test.use({ seed })
 
+for (const theme of ['openTubeXLight', 'openTubeXDark']) {
+  test.describe(`${theme} premiere colors`, () => {
+    test.use({ seed: { ...seed, settings: { ...seed.settings, baseTheme: theme } } })
+
+    test('running premieres use normal video text colors', async ({ page }) => {
+      await goTo(page, 'subscriptions')
+      const premiere = page.locator('.ft-list-video').filter({ hasText: 'Running premiere video' })
+      const video = page.locator('.ft-list-video').filter({ hasText: 'Video A older' })
+      await expect(premiere).toBeVisible()
+      await expect(video).toBeVisible()
+      await expect(premiere.locator('.videoDuration')).toHaveText('Premiere')
+
+      for (const selector of ['.title', '.infoLine', '.channelName']) {
+        const color = await video.locator(selector).evaluate(element => getComputedStyle(element).color)
+        await expect(premiere.locator(selector)).toHaveCSS('color', color)
+      }
+    })
+  })
+}
+
 test.describe('subscriptions feed from cache', () => {
   test('does not animate cards while calculating the initial grid size', async ({ page }) => {
     await page.evaluate(() => {
@@ -275,7 +295,6 @@ test.describe('subscriptions feed from cache', () => {
     await page.clock.runFor(200)
     await expect(premiere.locator('.videoDuration')).toHaveText('11:42')
     await expect(premiere.locator('.viewCount')).toContainText('9k views')
-    await expect(premiere).not.toHaveClass(/premiereVideo/)
 
     const completedRequestCount = requests.length
     await page.clock.fastForward(121_000)

--- a/src/renderer/components/FtListVideo/FtListVideo.scss
+++ b/src/renderer/components/FtListVideo/FtListVideo.scss
@@ -24,12 +24,6 @@
   opacity: 0.3;
 }
 
-.ft-list-item.premiereVideo .info .title,
-.ft-list-item.premiereVideo .info .infoLine,
-.ft-list-item.premiereVideo .info .infoLine .channelName {
-  color: var(--tertiary-text-color);
-}
-
 .draggable:not(.draggable:only-child):focus .grabBar,
 .draggable:not(.draggable:only-child):hover .grabBar {
   display: revert;

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -5,8 +5,7 @@
       list: effectiveListTypeIsList,
       grid: !effectiveListTypeIsList,
       [appearance]: true,
-      watched: addWatchedStyle,
-      premiereVideo: isPremiere && !isUpcomingForCurrentTime
+      watched: addWatchedStyle
     }"
   >
     <div
@@ -619,10 +618,6 @@ const isWatched = computed(() => isHistoryEntryWatched(historyEntry.value))
 
 const premiereTimestamp = computed(() => getUpcomingPremiereTimestamp(props.data))
 const premiereNow = ref(Date.now())
-const isUpcomingForCurrentTime = computed(() => (
-  isUpcoming.value &&
-  (premiereTimestamp.value == null || premiereTimestamp.value > premiereNow.value)
-))
 const MAX_TIMEOUT_DELAY = 2_147_483_647
 let premiereStartTimer = null
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description

Running premiere cards used muted text colors, making their titles differ from ordinary videos in the same feed. Remove the premiere-only color override so titles, channel names, and metadata follow the normal video styling in every theme. The Premiere badge and watched-video styling remain available.
<!-- Please write a clear and concise description of what the pull request does. -->

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Premiere titles and metadata now use the same theme colors as other videos.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/dad54409-9421-402f-8c7a-2d7946bfd2b5">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/0e3152f1-a831-45e1-8255-8575bcad311b">
  <img alt="Premiere and ordinary video titles use matching theme colors" src="https://github.com/user-attachments/assets/dad54409-9421-402f-8c7a-2d7946bfd2b5">
</picture>
<!-- release-note-image:end -->

## Testing

1. Open a feed containing a running premiere and an ordinary unwatched video. Switch between OpenTubeX Light and Dark, then a custom theme with distinct Main Text and Subtle Text colors.
2. Confirm the titles match each other, the channel names and metadata match their ordinary-video counterparts, and the premiere still displays its Premiere badge.
3. Keep an upcoming premiere visible until its scheduled start. Confirm its title retains the normal text color.
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

## Additional context
<!-- Add any other context about the pull request here. -->

Implemented with GPT-6 in the Codex desktop app.

