### PR TITLE
fix(subscriptions): correct dates after premieres finish

### DIFF
--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -1730,7 +1730,7 @@ function updateUploadedTime() {
   uploadedTimeIsRelative.value = false
   published.value = undefined
 
-  if (props.data.premiereDate !== undefined) {
+  if (props.data.premiereDate != null) {
     let premiereDate = props.data.premiereDate
 
     // premiereDate will be a string when the subscriptions are restored from the cache

--- a/src/renderer/helpers/subscription-premieres.js
+++ b/src/renderer/helpers/subscription-premieres.js
@@ -91,7 +91,9 @@ export function getInvidiousSubscriptionPremiereUpdate(video, videoId) {
   if (video?.error || video?.videoId !== videoId || typeof video.liveNow !== 'boolean') return null
   const update = stateUpdate(video.liveNow, video.isUpcoming === true)
   if (!update.liveNow && !update.isUpcoming) {
-    const published = numericCount(video.published) * 1000
+    const published = typeof video.published === 'number' && Number.isFinite(video.published)
+      ? video.published * 1000
+      : undefined
     if (Number.isFinite(published) && published > 0) update.published = published
   }
   const viewCount = numericCount(video.viewCount)

--- a/src/renderer/helpers/subscription-premieres.js
+++ b/src/renderer/helpers/subscription-premieres.js
@@ -55,13 +55,18 @@ export function getLocalSubscriptionPremiereUpdate(html, videoId) {
     if (details?.videoId !== videoId) return null
     const isUpcoming = details.isUpcoming === true
     if (player.playabilityStatus?.status !== 'OK' && !isUpcoming) return null
-    const broadcast = player.microformat?.playerMicroformatRenderer?.liveBroadcastDetails
+    const microformat = player.microformat?.playerMicroformatRenderer
+    const broadcast = microformat?.liveBroadcastDetails
     // Finished premieres can omit isLive entirely once they become VODs.
     const live = broadcast?.isLiveNow ?? details.isLive ??
       (numericCount(details.lengthSeconds) > 0 ? false : undefined)
     if (typeof live !== 'boolean') return null
     const liveNow = live && !isUpcoming
     const update = stateUpdate(liveNow, isUpcoming)
+    if (!liveNow && !isUpcoming && typeof microformat?.publishDate === 'string') {
+      const published = Date.parse(microformat.publishDate)
+      if (Number.isFinite(published) && published > 0) update.published = published
+    }
     if ((liveNow || isUpcoming) && typeof details.isLiveContent === 'boolean') {
       update.isPremiere = !details.isLiveContent
     }
@@ -85,6 +90,10 @@ export function getLocalSubscriptionPremiereUpdate(html, videoId) {
 export function getInvidiousSubscriptionPremiereUpdate(video, videoId) {
   if (video?.error || video?.videoId !== videoId || typeof video.liveNow !== 'boolean') return null
   const update = stateUpdate(video.liveNow, video.isUpcoming === true)
+  if (!update.liveNow && !update.isUpcoming) {
+    const published = numericCount(video.published) * 1000
+    if (Number.isFinite(published) && published > 0) update.published = published
+  }
   const viewCount = numericCount(video.viewCount)
   const lengthSeconds = numericCount(video.lengthSeconds)
   if (viewCount !== undefined) update.viewCount = viewCount

--- a/tests/unit/subscription-premieres.test.mjs
+++ b/tests/unit/subscription-premieres.test.mjs
@@ -6,13 +6,55 @@ import vm from 'node:vm'
 import { getLocalSubscriptionPremiereUpdate, getInvidiousSubscriptionPremiereUpdate, shouldRefreshSubscriptionPremiere } from '../../src/renderer/helpers/subscription-premieres.js'
 import { mapConcurrently } from '../../src/renderer/helpers/concurrent-map.js'
 import { getSubscriptionsForFeed } from '../../src/renderer/helpers/subscription-channels.js'
+import { formatDate, formatDateTime } from '../../src/renderer/helpers/dateFormat.js'
+
+const cardSource = await readFile(new URL('../../src/renderer/components/FtListVideo/FtListVideo.vue', import.meta.url), 'utf8')
+const dateStart = cardSource.indexOf('function updateUploadedTime()')
+const dateSource = cardSource.slice(dateStart, cardSource.indexOf('\nfunction ', dateStart + 1))
+
+for (const backend of ['local', 'invidious']) {
+  test(`${backend} completed premiere displays its publication date instead of January 1970`, () => {
+    const update = backend === 'local'
+      ? getLocalSubscriptionPremiereUpdate(html({ live: false }), videoId)
+      : getInvidiousSubscriptionPremiereUpdate({ videoId, liveNow: false, lengthSeconds: 4540 }, videoId)
+    const published = 1789026626910
+    const context = {
+      props: { data: { published, ...update } },
+      uploadedTime: { value: '' },
+      uploadedTimeIsRelative: { value: false },
+      published: { value: undefined },
+      locale: { value: 'en-US' },
+      dateFormat: { value: 'locale' },
+      timeFormat: { value: 'locale' },
+      isLive: { value: false },
+      isStation: { value: false },
+      inHistory: { value: false },
+      formatDate,
+      formatDateTime,
+      getRelativeTimeFromDate(timestamp) {
+        assert.equal(timestamp, published)
+        return '2 hours ago'
+      }
+    }
+    let error
+    try {
+      vm.runInNewContext(`${dateSource}\nupdateUploadedTime()`, context)
+    } catch (caught) {
+      error = caught
+    }
+    assert.equal(context.uploadedTime.value, '2 hours ago')
+    assert.equal(error, undefined)
+    assert.equal(context.published.value, published)
+    assert.equal(context.uploadedTimeIsRelative.value, true)
+  })
+}
 
 const videoId = 'premiere123'
-function html({ live = true, upcoming = false, watching = '2,500', status = 'OK' } = {}) {
+function html({ live = true, upcoming = false, watching = '2,500', status = 'OK', microformat = {} } = {}) {
   return `<script>var ytInitialPlayerResponse = ${JSON.stringify({
     playabilityStatus: { status },
     videoDetails: { videoId, isLive: live, isLiveContent: false, isUpcoming: upcoming, viewCount: '9000', lengthSeconds: '702' },
-    microformat: { playerMicroformatRenderer: { liveBroadcastDetails: { isLiveNow: live && !upcoming } } }
+    microformat: { playerMicroformatRenderer: { liveBroadcastDetails: { isLiveNow: live && !upcoming }, ...microformat } }
   })}; var ytInitialData = ${JSON.stringify({ contents: { videoViewCountRenderer: {
     viewCount: { runs: [{ text: watching }, { text: ' watching now' }] }, isLive: true
   } } })};</script>`
@@ -128,6 +170,41 @@ function createRefresh(fetch) {
   })
   return { refresh, getters, writes }
 }
+
+for (const backend of ['local', 'invidious']) {
+  test(`${backend} completion replaces the cached live fetch time with the fetched publication date`, async () => {
+    const published = Date.parse('2026-09-10T16:00:00Z')
+    const { refresh, getters, writes } = createRefresh(async () => backend === 'local'
+      ? new Response(html({ live: false, microformat: { publishDate: '2026-09-10T16:00:00Z' } }))
+      : Response.json({ videoId, liveNow: false, published: published / 1000 }))
+    getters.getBackendPreference = backend
+    getters.getVideoCache.channel.videos[0].published = published + 30 * 60 * 1000
+    await refresh(() => true)
+    assert.equal(writes[0].videos[0].published, published)
+    assert.equal(writes[0].videos[0].isPremiere, false)
+    assert.equal(writes[0].timestamp.getTime(), 1000)
+  })
+}
+
+test('completion does not replace cached publication dates with missing or invalid metadata', () => {
+  for (const publishDate of [undefined, null, '', 'invalid', 0, '1970-01-01']) {
+    const update = getLocalSubscriptionPremiereUpdate(html({ live: false, microformat: { publishDate } }), videoId)
+    assert.equal(Object.hasOwn(update, 'published'), false)
+  }
+  for (const published of [undefined, null, '', 'invalid', 0, -1, Infinity]) {
+    const update = getInvidiousSubscriptionPremiereUpdate({ videoId, liveNow: false, published }, videoId)
+    assert.equal(Object.hasOwn(update, 'published'), false)
+  }
+})
+
+test('running and upcoming premieres keep their cached publication date', () => {
+  for (const upcoming of [false, true]) {
+    const local = getLocalSubscriptionPremiereUpdate(html({ upcoming, microformat: { publishDate: '2026-09-10T06:37:06Z' } }), videoId)
+    const invidious = getInvidiousSubscriptionPremiereUpdate({ videoId, liveNow: !upcoming, isUpcoming: upcoming, published: 1789022226 }, videoId)
+    assert.equal(Object.hasOwn(local, 'published'), false)
+    assert.equal(Object.hasOwn(invidious, 'published'), false)
+  }
+})
 
 test('polling preserves seen state and the last full channel refresh timestamp', async () => {
   const { refresh, writes } = createRefresh(async () => new Response(html()))

--- a/tests/unit/subscription-premieres.test.mjs
+++ b/tests/unit/subscription-premieres.test.mjs
@@ -191,7 +191,7 @@ test('completion does not replace cached publication dates with missing or inval
     const update = getLocalSubscriptionPremiereUpdate(html({ live: false, microformat: { publishDate } }), videoId)
     assert.equal(Object.hasOwn(update, 'published'), false)
   }
-  for (const published of [undefined, null, '', 'invalid', 0, -1, Infinity]) {
+  for (const published of [undefined, null, '', 'invalid', '1789026626', true, 0, -1, Infinity]) {
     const update = getInvidiousSubscriptionPremiereUpdate({ videoId, liveNow: false, published }, videoId)
     assert.equal(Object.hasOwn(update, 'published'), false)
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Completed premieres could display January 1, 1970 after auto-refresh cleared their scheduled date. The video card now treats that cleared date as absent, and completion refreshes the publication timestamp from YouTube or Invidious instead of retaining the cached live fetch time. Missing or invalid publication metadata leaves the saved timestamp unchanged.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed incorrect publication dates on videos after their premieres finish.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Subscriptions with a premiere that is running and leave the feed open until it finishes.
2. Confirm its card switches to a normal video, displays a relative publication age, and never shows January 1970.
3. Refresh subscriptions and compare the age. It should remain consistent, allowing for the feed’s rounded relative publication metadata.
4. Repeat with the Invidious backend.

## Additional context
<!-- Add any other context about the pull request here. -->
Regression tests reproduced the 1970 display and stale publication date before the fixes. All 1,611 unit tests passed, with two skips. Lint passed with one existing warning in an unrelated E2E test.

Compared the fixed parser against the reported video and the refreshed production cache. Both displayed “1 hour ago”; the watch response supplies an exact publication timestamp, while a full feed refresh can estimate it from rounded relative text. Already-completed cached entries receive fresh metadata on a normal subscription refresh.

Created with GPT-6 in the Codex harness.
