### PR TITLE
fix(android): smooth player motion and enlarge resize touch targets

### DIFF
--- a/android/app/src/androidTest/java/org/opentubex/app/NativePlaybackScreenTest.java
+++ b/android/app/src/androidTest/java/org/opentubex/app/NativePlaybackScreenTest.java
@@ -129,7 +129,8 @@ public class NativePlaybackScreenTest {
             screen.setControlsVisible(true);
             screen.setFollowsPageScroll(true);
             screen.layoutVideo(0, 180, 400, 225, 1000);
-            screen.layoutControls(0, 180, 400, 225, 1000);
+            // Keep both countdown positions inside the controller after scrolling.
+            screen.layoutControls(0, 180, 400, 400, 1000);
             controls.setBackgroundColor(android.graphics.Color.MAGENTA);
             screen.setMenuBounds(new android.graphics.RectF[] { new android.graphics.RectF(0, 0, 1000, 100) });
             screen.setScrollingMenuBounds(new android.graphics.RectF[] { new android.graphics.RectF(200, 300, 280, 380) });
@@ -259,8 +260,78 @@ public class NativePlaybackScreenTest {
         });
     }
 
+    @Test public void draggingAndResizingKeepVideoAboveThePageUntilTheFinalClipDraws() {
+        ViewGroup[] frame = new ViewGroup[1];
+        withScreen((screen, controls, web, engine) -> {
+            screen.setFullscreen(false);
+            screen.setInlineVisible(true);
+            screen.setMiniPlayer(true, 12);
+            screen.layoutVideo(200, 200, 400, 225, 1000);
+            frame[0] = (ViewGroup) screen.getChildAt(0);
+            frame[0].setBackgroundColor(android.graphics.Color.MAGENTA);
+            frame[0].getChildAt(0).setVisibility(View.INVISIBLE);
+            web.setBackgroundColor(android.graphics.Color.RED);
+            web.holdVisualState = true;
+            screen.setGestureActive(true);
+            int textureWidth = frame[0].getLayoutParams().width;
+            screen.layoutVideo(140.125, 170.25, 400, 225, 1000);
+            assertEquals("Dragging must move the native video with the handle", 140.125 * screen.getWidth() / 1000, frame[0].getTranslationX(), 1);
+            screen.layoutVideo(100.125, 150.25, 600.5, 337.78125, 1000);
+            assertEquals("Live resizing must keep the decoder buffer size stable", textureWidth, frame[0].getLayoutParams().width);
+            assertEquals(100.125 * screen.getWidth() / 1000, frame[0].getTranslationX(), 1);
+            assertTrue(screen.indexOfChild(frame[0]) > screen.indexOfChild((View) web.getParent()));
+            android.graphics.Bitmap image = android.graphics.Bitmap.createBitmap(screen.getWidth(), screen.getHeight(), android.graphics.Bitmap.Config.ARGB_8888);
+            screen.draw(new android.graphics.Canvas(image));
+            assertEquals("The resized video must cover page content outside its old cutout", android.graphics.Color.MAGENTA,
+                image.getPixel((int) (150 * screen.getWidth() / 1000f), (int) (250 * screen.getWidth() / 1000f)));
+            image.recycle();
+            screen.setGestureActive(false);
+            assertNotNull(web.heldVisualState);
+            web.heldVisualState.onComplete(web.heldVisualStateId);
+            // A second resize can start before the previous handoff draws.
+            screen.setGestureActive(true);
+            image = android.graphics.Bitmap.createBitmap(screen.getWidth(), screen.getHeight(), android.graphics.Bitmap.Config.ARGB_8888);
+            screen.draw(new android.graphics.Canvas(image));
+            image.recycle();
+        }, (screen, controls, web, engine) -> {
+            assertTrue("An obsolete handoff cannot lower the video during another resize", screen.indexOfChild(frame[0]) > screen.indexOfChild((View) web.getParent()));
+            screen.layoutVideo(250, 200, 300, 168.75, 1000);
+            screen.setGestureActive(false);
+            web.heldVisualState.onComplete(web.heldVisualStateId);
+            assertTrue("A ready callback alone must not lower the video", screen.indexOfChild(frame[0]) > screen.indexOfChild((View) web.getParent()));
+            android.graphics.Bitmap image = android.graphics.Bitmap.createBitmap(screen.getWidth(), screen.getHeight(), android.graphics.Bitmap.Config.ARGB_8888);
+            screen.draw(new android.graphics.Canvas(image));
+            image.recycle();
+        }, (screen, controls, web, engine) -> {
+            assertTrue("Releasing the resize must restore shared controls after the final draw", screen.indexOfChild((View) web.getParent()) > screen.indexOfChild(frame[0]));
+            assertEquals(250 * screen.getWidth() / 1000f, frame[0].getTranslationX(), 1);
+        });
+    }
+
+    @Test public void anAnimationCanTakeOverALiveGestureAndReturnBelowThePage() {
+        View[] frame = new View[1];
+        withScreen((screen, controls, web, engine) -> {
+            screen.setFullscreen(false);
+            screen.setInlineVisible(true);
+            screen.setMiniPlayer(true, 12);
+            screen.layoutVideo(200, 200, 400, 225, 1000);
+            frame[0] = screen.getChildAt(0);
+            web.holdVisualState = true;
+            screen.setGestureActive(true);
+            screen.animateVideo(new double[] { 200, 200, 400, 225 }, new double[] { 100, 200, 400, 225, 1000 }, 0, 12, screen::finishVideoTransition);
+        }, (screen, controls, web, engine) -> {
+            assertNotNull("The finished animation must release the previous gesture", web.heldVisualState);
+            web.heldVisualState.onComplete(web.heldVisualStateId);
+            android.graphics.Bitmap image = android.graphics.Bitmap.createBitmap(screen.getWidth(), screen.getHeight(), android.graphics.Bitmap.Config.ARGB_8888);
+            screen.draw(new android.graphics.Canvas(image));
+            image.recycle();
+        }, (screen, controls, web, engine) -> {
+            assertTrue(screen.indexOfChild((View) web.getParent()) > screen.indexOfChild(frame[0]));
+        });
+    }
+
     @Test public void pictureInPictureDuringMotionUsesTheWholeVideoWindow() {
-        for (String mode : new String[] { "scroll", "handoff", "animation" }) withScreen((screen, controls, web, engine) -> {
+        for (String mode : new String[] { "scroll", "handoff", "animation", "resize" }) withScreen((screen, controls, web, engine) -> {
             screen.setFullscreen(false);
             screen.setInlineVisible(true);
             screen.layoutVideo(200, 200, 400, 225, 1000);
@@ -268,7 +339,9 @@ public class NativePlaybackScreenTest {
             ViewGroup frame = (ViewGroup) screen.getChildAt(0);
             frame.setBackgroundColor(android.graphics.Color.MAGENTA);
             frame.getChildAt(0).setVisibility(View.INVISIBLE);
-            if (mode.equals("animation")) {
+            if (mode.equals("resize")) {
+                screen.setGestureActive(true);
+            } else if (mode.equals("animation")) {
                 screen.animateVideo(new double[] { 200, 200, 400, 225 }, new double[] { 100, 100, 600, 337.5, 1000 }, 1200, 12, () -> {});
             } else {
                 swipePage(screen);

--- a/android/app/src/main/java/org/opentubex/app/AndroidPlaybackPlugin.java
+++ b/android/app/src/main/java/org/opentubex/app/AndroidPlaybackPlugin.java
@@ -158,6 +158,7 @@ public class AndroidPlaybackPlugin extends Plugin {
                         screen.layoutControls(controlsX, controlsY, controlsWidth, controlsHeight, viewportWidth);
                     }
                 }
+                screen.setGestureActive(call.getBoolean("gestureActive", false));
             }
             call.resolve();
         });

--- a/android/app/src/main/java/org/opentubex/app/NativePlaybackScreen.java
+++ b/android/app/src/main/java/org/opentubex/app/NativePlaybackScreen.java
@@ -57,6 +57,7 @@ final class NativePlaybackScreen extends FrameLayout implements TextureView.Surf
     private boolean miniPlayer;
     private float miniRadius;
     private boolean scrollingPage;
+    private boolean gestureActive;
     private boolean scrollEndRequested;
     private boolean pageTouchDown;
     private float pageTouchY;
@@ -308,6 +309,7 @@ final class NativePlaybackScreen extends FrameLayout implements TextureView.Surf
 
     void setFullscreen(boolean enabled) {
         fullscreen = enabled;
+        if (enabled) setGestureActive(false);
         controls.updateIsFullscreen(enabled);
         // Inline phone players reserve their center row for play and seeking.
         updateQueueButtons();
@@ -384,6 +386,7 @@ final class NativePlaybackScreen extends FrameLayout implements TextureView.Surf
     void setMiniPlayer(boolean enabled, float radius) {
         miniPlayer = enabled;
         miniRadius = radius;
+        if (!enabled) setGestureActive(false);
         if (!enabled && scrollingPage) {
             scrollingPage = false;
             pageTouchDown = false;
@@ -391,6 +394,25 @@ final class NativePlaybackScreen extends FrameLayout implements TextureView.Surf
             action.accept("scroll-end");
             finishVideoTransition();
         }
+    }
+
+    void setGestureActive(boolean enabled) {
+        enabled = enabled && miniPlayer && !fullscreen && !pictureInPicture && inlineVisible && videoBounds != null;
+        if (gestureActive == enabled) return;
+        gestureActive = enabled;
+        if (!enabled) {
+            finishVideoTransition();
+            return;
+        }
+        // Live gestures move the existing texture above the WebView so Chromium
+        // only needs to paint the page opening at the end of the gesture.
+        transitionSequence++;
+        if (videoAnimation != null) videoAnimation.cancel();
+        transitioning = true;
+        updateScrollBounds();
+        refreshVideoLayout();
+        videoFrame.bringToFront();
+        updatePresentation();
     }
 
     private void onPageScroll() {
@@ -448,14 +470,15 @@ final class NativePlaybackScreen extends FrameLayout implements TextureView.Surf
     void setInlineVisible(boolean visible) {
         if (inlineVisible == visible) return;
         inlineVisible = visible;
+        if (!visible) setGestureActive(false);
         updatePresentation();
     }
 
     void layoutVideo(double x, double y, double width, double height, double viewportWidth) {
         videoBounds = new double[] { x, y, width, height, viewportWidth };
-        if (transitioning && !pictureInPicture && !(scrollingPage && videoAnimation == null)) return;
+        if (transitioning && !pictureInPicture && !((scrollingPage || gestureActive) && videoAnimation == null)) return;
         positionVideo(x, y + pageScrollDelta(viewportWidth), width, height, viewportWidth);
-        if (scrollingPage && videoAnimation == null) updateScrollBounds();
+        if ((scrollingPage || gestureActive) && videoAnimation == null) updateScrollBounds();
     }
 
     private void positionVideo(double x, double y, double width, double height, double viewportWidth) {
@@ -491,6 +514,7 @@ final class NativePlaybackScreen extends FrameLayout implements TextureView.Surf
 
     void animateVideo(double[] from, double[] to, long duration, float radius, Runnable finished) {
         followsPageScroll = false;
+        gestureActive = false;
         double scale = getWidth() / to[4];
         // A reversal starts where the native frame is actually being drawn,
         // even though the shared DOM already has the previous destination.
@@ -529,7 +553,7 @@ final class NativePlaybackScreen extends FrameLayout implements TextureView.Surf
     }
 
     void finishVideoTransition() {
-        if (scrollingPage) return;
+        if (scrollingPage || gestureActive) return;
         long sequence = ++transitionSequence;
         if (videoAnimation != null) videoAnimation.cancel();
         // Wait for the WebView's destination clip and controls to be committed
@@ -554,6 +578,7 @@ final class NativePlaybackScreen extends FrameLayout implements TextureView.Surf
 
     void setPictureInPicture(boolean enabled) {
         pictureInPicture = enabled;
+        if (enabled) setGestureActive(false);
         updatePresentation();
         if (webOverlayHost != null) webOverlayHost.setAlpha(enabled ? 0 : 1);
         refreshVideoLayout();

--- a/e2e/tests/offline/android-native-screen.spec.mjs
+++ b/e2e/tests/offline/android-native-screen.spec.mjs
@@ -445,6 +445,62 @@ test('closing an inactive player cannot remove the active inline surface window'
   await page.evaluate(() => window.nativeScreenTest.destroy())
 })
 
+for (const differentPage of [false, true]) {
+  test(`transferring native ownership cleans page clips (${differentPage ? 'different pages' : 'same page'})`, async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await openMockedVideo(page)
+    await openNativeScreen(page, false)
+    await page.locator('.ftVideoPlayer').evaluate(element => document.querySelector('#cross-tab-mini-player-layer').append(element))
+    await expect(page.locator('[data-native-player-backdrop]')).toBeAttached()
+    const result = await page.evaluate(async differentPage => {
+      const previousPage = document.querySelector('[data-native-player-backdrop]')
+      const host = document.createElement('div')
+      host.className = 'app'
+      const nextPage = differentPage ? document.createElement('div') : previousPage
+      if (differentPage) {
+        nextPage.className = 'flexBox'
+        host.append(nextPage)
+        document.body.prepend(host)
+      }
+      const container = document.createElement('div')
+      const element = document.createElement('video')
+      Object.assign(container.style, { position: 'fixed', left: '20px', top: '80px', width: '180px', height: '100px' })
+      container.append(element)
+      document.querySelector('#cross-tab-mini-player-layer').append(container)
+      const second = window.createNativeScreenTest({
+        element,
+        container,
+        getController: () => ({ async show() {}, async layout() {} }),
+        getLocale: () => 'en-US',
+        onError: error => { throw error }
+      })
+      // Commit the handoff synchronously so the retiring screen's queued layout
+      // cannot obscure whether cleanup happens before ownership changes.
+      window.holdNativeLayout = true
+      try {
+        await second.attach()
+        second.action('scroll-end')
+        const previousCleared = !previousPage.hasAttribute('data-native-player-backdrop') && previousPage.style.clipPath === ''
+        const nextClip = nextPage.style.clipPath
+        window.nativeScreenTest.destroy()
+        const preserved = nextPage.hasAttribute('data-native-player-backdrop') && nextPage.style.clipPath === nextClip && nextClip !== ''
+        second.reset()
+        const released = !nextPage.hasAttribute('data-native-player-backdrop') && nextPage.style.clipPath === ''
+        return { previousCleared, preserved, released }
+      } finally {
+        window.nativeScreenTest.destroy()
+        second.destroy()
+        container.remove()
+        host.remove()
+        window.holdNativeLayout = false
+      }
+    }, differentPage)
+    if (differentPage) expect(result.previousCleared).toBe(true)
+    expect(result.preserved).toBe(true)
+    expect(result.released).toBe(true)
+  })
+}
+
 test('global Quick Settings clips native controls wherever its menu overlaps inline video', async ({ app, page }) => {
   await mockPlayableWatchPage(app, page)
   const video = await openMockedVideo(page)

--- a/e2e/tests/offline/android-native-screen.spec.mjs
+++ b/e2e/tests/offline/android-native-screen.spec.mjs
@@ -398,7 +398,7 @@ for (const uiScale of [100, 125]) {
           canvas.getContext('2d').fillRect(0, 0, canvas.width, canvas.height)
         }
       })
-      await expect.poll(() => page.evaluate(() => getComputedStyle(document.body, '::before').clipPath)).toContain('path(')
+      await expect.poll(() => page.evaluate(() => getComputedStyle(document.querySelector('.nativeInlineBackdrop')).clipPath)).toContain('path(')
       const bounds = await player.boundingBox()
       const screenshot = await page.screenshot({ omitBackground: true })
       const pixels = await page.evaluate(async ({ imageData, bounds }) => {
@@ -431,7 +431,7 @@ test('closing an inactive player cannot remove the active inline surface window'
   await openMockedVideo(page)
   await openNativeScreen(page, false)
   await expect(page.locator('html')).toHaveClass(/nativePlaybackInline/)
-  const clip = await page.evaluate(() => document.documentElement.style.getPropertyValue('--native-inline-background-clip'))
+  const clip = await page.evaluate(() => document.querySelector('.nativeInlineBackdrop').style.clipPath)
   await page.evaluate(() => {
     const container = document.createElement('div')
     const element = document.createElement('video')
@@ -441,7 +441,7 @@ test('closing an inactive player cannot remove the active inline surface window'
     inactive.destroy()
   })
   await expect(page.locator('html')).toHaveClass(/nativePlaybackInline/)
-  expect(await page.evaluate(() => document.documentElement.style.getPropertyValue('--native-inline-background-clip'))).toBe(clip)
+  expect(await page.evaluate(() => document.querySelector('.nativeInlineBackdrop').style.clipPath)).toBe(clip)
   await page.evaluate(() => window.nativeScreenTest.destroy())
 })
 
@@ -1289,3 +1289,250 @@ test('desktop playback does not load Android document compositing styles', async
   ))
   expect(nativeStyles).toBe(false)
 })
+
+for (const uiScale of [100, 125]) {
+  test.describe(`native scroll work at ${uiScale}%`, () => {
+    test.use({ seed: { settings: { videoPlaybackEngine: 'built-in', ytDlpPlaybackEngineDefaultMigration: true, uiScale, ambientMode: false } } })
+    test('scrolling avoids whole-page searches and hit tests', async ({ app, page }) => {
+      await mockPlayableWatchPage(app, page)
+      const video = await openMockedVideo(page)
+      await setWindowSize(app, page, { width: 480, height: 850 })
+      await video.evaluate(element => element.pause())
+      await openNativeScreen(page, false)
+      const work = await page.evaluate(async () => {
+        const nextFrame = () => new Promise(resolve => requestAnimationFrame(resolve))
+        await nextFrame()
+        await nextFrame()
+        const query = document.querySelectorAll
+        const hitTest = document.elementFromPoint
+        let searches = 0
+        let hitTests = 0
+        document.querySelectorAll = function (selector) {
+          if (selector.includes('[role="dialog"]') || selector.includes('.topNav')) searches++
+          return query.call(this, selector)
+        }
+        document.elementFromPoint = function (...args) {
+          hitTests++
+          return hitTest.apply(this, args)
+        }
+        try {
+          for (let i = 0; i < 40; i++) {
+            window.scrollTo(0, i * 2)
+            await nextFrame()
+          }
+          return { searches, hitTests, scrollY: window.scrollY, pageScroll: window.nativeLayoutTest.pageScroll }
+        } finally {
+          document.querySelectorAll = query
+          document.elementFromPoint = hitTest
+        }
+      })
+      expect(work.scrollY).toBeGreaterThan(50)
+      expect(work.pageScroll).toBe(true)
+      // Allow occasional Shaka DOM updates, but no document search per frame.
+      expect(work.searches).toBeLessThan(20)
+      expect(work.hitTests).toBe(0)
+      await page.evaluate(() => window.nativeScreenTest.destroy())
+    })
+  })
+}
+
+test('cached global overlays follow insertion, roles, styles, classes and removal', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  await openMockedVideo(page)
+  await openNativeScreen(page, false)
+  await page.evaluate(() => {
+    const overlay = document.createElement('div')
+    overlay.id = 'native-menu-test'
+    Object.assign(overlay.style, { position: 'fixed', left: '110px', top: '120px', width: '80px', height: '70px' })
+    document.body.append(overlay)
+  })
+  const overlay = page.locator('#native-menu-test')
+  const hasClip = () => page.evaluate(() => window.nativeLayoutTest.menus.some(menu => menu.x === 110 && menu.width === 80))
+  for (const attribute of ['role', 'aria-modal', 'class']) {
+    const value = { role: 'dialog', 'aria-modal': 'true', class: 'sideNav' }[attribute]
+    await overlay.evaluate((element, { attribute, value }) => element.setAttribute(attribute, value), { attribute, value })
+    await expect.poll(hasClip).toBe(true)
+    await overlay.evaluate(element => { element.style.top = '130px' })
+    await expect.poll(() => page.evaluate(() => window.nativeLayoutTest.menus.some(menu => menu.x === 110 && menu.y === 130))).toBe(true)
+    await overlay.evaluate((element, attribute) => element.removeAttribute(attribute), attribute)
+    await expect.poll(hasClip).toBe(false)
+    await overlay.evaluate(element => { element.style.top = '120px' })
+  }
+  await overlay.evaluate(element => element.setAttribute('role', 'menu'))
+  await expect.poll(hasClip).toBe(true)
+  await overlay.evaluate(element => element.remove())
+  await expect.poll(hasClip).toBe(false)
+  await page.evaluate(() => window.nativeScreenTest.destroy())
+})
+
+for (const uiScale of [100, 125]) {
+  for (const gesture of ['resize', 'drag']) {
+    test.describe(`native mini-player ${gesture} at ${uiScale}%`, () => {
+      test.use({ seed: { settings: { videoPlaybackEngine: 'built-in', ytDlpPlaybackEngineDefaultMigration: true, uiScale, ambientMode: false } } })
+      test('motion keeps cutout styles out of unrelated page content', async ({ app, page }) => {
+        await mockPlayableWatchPage(app, page)
+        await openMockedVideo(page)
+        await openNativeScreen(page, false)
+        const player = page.locator('.ftVideoPlayer')
+        await player.evaluate(element => window.scrollTo(0, scrollY + element.getBoundingClientRect().bottom + 200))
+        await expect(player).toHaveClass(/scrollMiniPlayer/)
+        await expect(player).not.toHaveClass(/scrollMiniPlayerAnimating/)
+        await player.evaluate(element => document.querySelector('#cross-tab-mini-player-layer').append(element))
+        await expect(page.locator('[data-native-player-backdrop]')).toBeAttached()
+        const result = await page.evaluate(async gesture => {
+          const player = document.querySelector('.scrollMiniPlayer')
+          const handle = player.querySelector(gesture === 'resize' ? '.scrollMiniResizeHandle' : '.scrollMiniDragHandle')
+          const bounds = handle.getBoundingClientRect()
+          const x = bounds.x + bounds.width / 2
+          const y = bounds.y + bounds.height / 2
+          const pageStyles = () => {
+            const style = getComputedStyle(document.querySelector('.watchVideoInfo'))
+            return JSON.stringify([...style].filter(name => name.startsWith('--')).map(name => [name, style.getPropertyValue(name)]))
+          }
+          const before = pageStyles()
+          const widths = []
+          let changedPageStyles = 0
+          const cutouts = new Set()
+          handle.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1, clientX: x, clientY: y }))
+          for (let i = 0; i < 40; i++) {
+            const delta = Math.sin(i * Math.PI / 20) * 80
+            window.dispatchEvent(new PointerEvent('pointermove', { pointerId: 1, clientX: x + delta, clientY: y + delta * 9 / 16 }))
+            await new Promise(requestAnimationFrame)
+            widths.push(player.getBoundingClientRect()[gesture === 'resize' ? 'width' : 'x'])
+            if (i > 2) cutouts.add(document.querySelector('[data-native-player-backdrop]').style.clipPath)
+            if (pageStyles() !== before) changedPageStyles++
+          }
+          const bouncePositions = []
+          const bounceCutouts = new Set()
+          if (gesture === 'drag') {
+            window.dispatchEvent(new PointerEvent('pointermove', { pointerId: 1, clientX: x - 80, clientY: y }))
+            await new Promise(requestAnimationFrame)
+          }
+          window.dispatchEvent(new PointerEvent('pointerup', { pointerId: 1, clientX: gesture === 'drag' ? x - 80 : x, clientY: y }))
+          if (gesture === 'drag') {
+            for (let i = 0; i < 45; i++) {
+              await new Promise(requestAnimationFrame)
+              bouncePositions.push(player.getBoundingClientRect().x)
+              bounceCutouts.add(document.querySelector('[data-native-player-backdrop]').style.clipPath)
+            }
+          }
+          return {
+            changedPageStyles,
+            cutouts: cutouts.size,
+            range: Math.max(...widths) - Math.min(...widths),
+            bounceRange: Math.max(...bouncePositions) - Math.min(...bouncePositions),
+            bounceCutouts: bounceCutouts.size
+          }
+        }, gesture)
+        expect(result.range).toBeGreaterThan(50)
+        expect(result.changedPageStyles).toBe(0)
+        expect(result.cutouts).toBe(1)
+        if (gesture === 'drag') {
+          expect(result.bounceRange).toBeGreaterThan(30)
+          expect(result.bounceCutouts).toBeLessThanOrEqual(2)
+        }
+        await expect.poll(() => page.evaluate(() => window.nativeLayoutTest.gestureActive)).toBe(false)
+        await expect.poll(() => page.evaluate(() => document.querySelector('[data-native-player-backdrop]').style.clipPath.match(/M /g)?.length)).toBe(2)
+        // Touch cancellation must restore the cutout and release native ownership.
+        await player.locator(gesture === 'resize' ? '.scrollMiniResizeHandle' : '.scrollMiniDragHandle').dispatchEvent('pointerdown', { pointerId: 2, clientX: 300, clientY: 300 })
+        await expect.poll(() => page.evaluate(() => window.nativeLayoutTest.gestureActive)).toBe(true)
+        await page.evaluate(() => window.dispatchEvent(new PointerEvent('pointercancel', { pointerId: 2 })))
+        await expect.poll(() => page.evaluate(() => window.nativeLayoutTest.gestureActive)).toBe(false)
+        await expect.poll(() => page.evaluate(() => document.querySelector('[data-native-player-backdrop]').style.clipPath.match(/M /g)?.length)).toBe(2)
+        await expect.poll(async () => Math.abs((await player.boundingBox()).width - await page.evaluate(() => window.nativeLayoutTest.width))).toBeLessThan(1)
+        await page.evaluate(() => window.nativeScreenTest.destroy())
+      })
+    })
+  }
+}
+
+for (const uiScale of [100, 125]) {
+  test.describe(`mini-player touch target at ${uiScale}%`, () => {
+    test.use({ seed: { settings: { videoPlaybackEngine: 'built-in', ytDlpPlaybackEngineDefaultMigration: true, uiScale, ambientMode: false } } })
+    test('touch resizing has a larger target without jumping at the grab point', async ({ app, page }) => {
+      await mockPlayableWatchPage(app, page)
+      await openMockedVideo(page)
+      await openNativeScreen(page, false)
+      const player = page.locator('.ftVideoPlayer')
+      await player.evaluate(element => window.scrollTo(0, scrollY + element.getBoundingClientRect().bottom + 200))
+      await expect(player).toHaveClass(/scrollMiniPlayer/)
+      await expect(player).not.toHaveClass(/scrollMiniPlayerAnimating/)
+      await page.evaluate(() => window.nativeScreenTest.destroy())
+      await setWindowSize(app, page, { width: 480, height: 800 })
+      const cdp = await page.context().newCDPSession(page)
+      await cdp.send('Emulation.setTouchEmulationEnabled', { enabled: true, maxTouchPoints: 1 })
+      await expect.poll(() => page.evaluate(() => matchMedia('(pointer: coarse)').matches)).toBe(true)
+      const handle = player.locator('.scrollMiniResizeHandle')
+      await expect.poll(() => handle.evaluate(element => [getComputedStyle(element).width, getComputedStyle(element).height])).toEqual(['48px', '48px'])
+      const result = await player.evaluate(async player => {
+        const handle = player.querySelector('.scrollMiniResizeHandle')
+        const original = handle.className
+        const corners = ['top-left', 'top-right', 'bottom-left', 'bottom-right']
+        const hits = corners.map(corner => {
+          handle.className = `scrollMiniResizeHandle scrollMiniResizeHandle-${corner}`
+          const r = handle.getBoundingClientRect()
+          // Stay beside the volume button, which keeps priority where targets overlap.
+          const x = corner.endsWith('left') ? r.left + 8 : r.right - 8
+          const y = corner.startsWith('top') ? r.top + 40 : r.bottom - 40
+          return document.elementFromPoint(x, y) === handle
+        })
+        const volume = player.querySelector('.scrollMiniVolume')
+        const v = volume.getBoundingClientRect()
+        handle.className = 'scrollMiniResizeHandle scrollMiniResizeHandle-bottom-left'
+        const volumeAccessible = volume.contains(document.elementFromPoint(v.x + v.width / 2, v.y + v.height / 2))
+        handle.className = original
+        const corner = corners.find(c => handle.classList.contains(`scrollMiniResizeHandle-${c}`))
+        const outward = corner.endsWith('left') ? -1 : 1
+        // Grow first so minimum-size clamping cannot hide an initial jump.
+        const r = player.getBoundingClientRect()
+        const x = corner.endsWith('left') ? r.left : r.right
+        const y = corner.startsWith('top') ? r.top : r.bottom
+        handle.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientX: x, clientY: y, pointerId: 1 }))
+        window.dispatchEvent(new PointerEvent('pointermove', { clientX: x + outward * 60, clientY: y, pointerId: 1 }))
+        await new Promise(requestAnimationFrame)
+        window.dispatchEvent(new PointerEvent('pointerup', { clientX: x + outward * 60, clientY: y, pointerId: 1 }))
+        await new Promise(requestAnimationFrame)
+        const h = handle.getBoundingClientRect()
+        const grabX = corner.endsWith('left') ? h.left + 38 : h.right - 38
+        const grabY = corner.startsWith('top') ? h.top + 38 : h.bottom - 38
+        const before = player.getBoundingClientRect().width
+        document.elementFromPoint(grabX, grabY).dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientX: grabX, clientY: grabY, pointerId: 2 }))
+        window.dispatchEvent(new PointerEvent('pointermove', { clientX: grabX, clientY: grabY, pointerId: 2 }))
+        await new Promise(requestAnimationFrame)
+        const stationary = player.getBoundingClientRect().width
+        window.dispatchEvent(new PointerEvent('pointermove', { clientX: grabX - outward * 10, clientY: grabY, pointerId: 2 }))
+        await new Promise(requestAnimationFrame)
+        const moved = player.getBoundingClientRect().width
+        window.dispatchEvent(new PointerEvent('pointerup', { clientX: grabX - outward * 10, clientY: grabY, pointerId: 2 }))
+        return { hits, volumeAccessible, before, stationary, moved, backgroundSize: getComputedStyle(handle).backgroundSize }
+      })
+      expect(result.hits).toEqual([true, true, true, true])
+      expect(result.volumeAccessible).toBe(true)
+      expect(result.backgroundSize).toBe('18px 18px')
+      expect(Math.abs(result.stationary - result.before)).toBeLessThan(1)
+      expect(result.before - result.moved).toBeCloseTo(10, 0)
+      await cdp.send('Emulation.setTouchEmulationEnabled', { enabled: false })
+      await expect.poll(() => handle.evaluate(element => getComputedStyle(element).width)).toBe('18px')
+    })
+  })
+}
+
+for (const gesture of ['drag', 'resize']) {
+  test(`leaving mini-player mode releases an unfinished ${gesture} with reduced motion`, async ({ app, page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    await mockPlayableWatchPage(app, page)
+    await openMockedVideo(page)
+    await openNativeScreen(page, false)
+    const player = page.locator('.ftVideoPlayer')
+    await player.evaluate(element => window.scrollTo(0, scrollY + element.getBoundingClientRect().bottom + 200))
+    await expect(player).toHaveClass(/scrollMiniPlayer/)
+    await player.locator(gesture === 'drag' ? '.scrollMiniDragHandle' : '.scrollMiniResizeHandle').dispatchEvent('pointerdown', { clientX: 300, clientY: 300, pointerId: 1 })
+    await expect.poll(() => page.evaluate(() => window.nativeLayoutTest.gestureActive)).toBe(true)
+    await page.evaluate(() => window.scrollTo(0, 0))
+    await expect(player).not.toHaveClass(/scrollMiniPlayer/)
+    await expect.poll(() => page.evaluate(() => window.nativeLayoutTest.gestureActive)).toBe(false)
+    await expect(player).not.toHaveAttribute('data-native-player-gesture')
+    await expect(page.locator('body')).not.toHaveClass(/scroll-mini-player-grabbing/)
+    await page.evaluate(() => window.nativeScreenTest.destroy())
+  })
+}

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -4415,6 +4415,7 @@ html[data-reduced-motion='reduce'] .musicVisualizerCanvas {
     var(--scroll-mini-resize-handle-color) calc(50% + 1px),
     transparent calc(50% + 1px)
   );
+  background-position: bottom left;
 }
 
 .scrollMiniResizeHandle-bottom-right {
@@ -4428,6 +4429,7 @@ html[data-reduced-motion='reduce'] .musicVisualizerCanvas {
     var(--scroll-mini-resize-handle-color) calc(50% + 1px),
     transparent calc(50% + 1px)
   );
+  background-position: bottom right;
 }
 
 .scrollMiniResizeHandle-top-left {
@@ -4441,6 +4443,7 @@ html[data-reduced-motion='reduce'] .musicVisualizerCanvas {
     var(--scroll-mini-resize-handle-color) calc(50% + 1px),
     transparent calc(50% + 1px)
   );
+  background-position: top left;
 }
 
 .scrollMiniResizeHandle-top-right {
@@ -4454,6 +4457,21 @@ html[data-reduced-motion='reduce'] .musicVisualizerCanvas {
     var(--scroll-mini-resize-handle-color) calc(50% + 1px),
     transparent calc(50% + 1px)
   );
+  background-position: top right;
+}
+
+/* Enlarge the touch area without enlarging the visible corner grip. */
+@media (pointer: coarse) {
+  .scrollMiniResizeHandle {
+    width: 48px;
+    height: 48px;
+    background-size: 18px 18px;
+    background-repeat: no-repeat;
+  }
+
+  .scrollMiniVolume {
+    z-index: 4;
+  }
 }
 
 :global(body.scroll-mini-player-grabbing),

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
@@ -462,11 +462,17 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     )
   }
 
+  function syncNativeMiniPlayerGesture() {
+    const active = ['drag', 'resize'].includes(scrollMiniPointerSession?.type) || scrollMiniBounceCancel !== null
+    container.value?.dispatchEvent(new CustomEvent('native-player-gesture', { detail: active }))
+  }
+
   function cancelScrollMiniPlayerBounce() {
     if (!scrollMiniBounceCancel) return
 
     scrollMiniBounceCancel()
     scrollMiniBounceCancel = null
+    syncNativeMiniPlayerGesture()
   }
 
   function cancelScrollMiniPlayerLayoutAnimation(replacingNative = false) {
@@ -734,6 +740,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     scrollMiniVolumeExpanded.value = false
 
     cancelScrollMiniPlayerBounce()
+    endScrollMiniPointerSession()
 
     if (previousRect) {
       animateScrollMiniPlayerLayout(previousRect, false, animationSequence)
@@ -956,6 +963,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
 
   function endScrollMiniPointerSession() {
     scrollMiniPointerSession = null
+    syncNativeMiniPlayerGesture()
     document.body.classList.remove('scroll-mini-player-grabbing')
     window.removeEventListener('pointermove', handleScrollMiniPointerMoveWindow)
     window.removeEventListener('pointerup', handleScrollMiniPointerUpWindow)
@@ -979,10 +987,13 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
         top: startRect.top + dy,
       }, scrollMiniVideoAspectRatio.value))
     } else if (scrollMiniPointerSession.type === 'resize' && scrollMiniPointerSession.corner) {
+      const { startRect, startX, corner } = scrollMiniPointerSession
+      const edgeX = startRect.left + (corner.endsWith('right') ? startRect.width : 0)
+      // Preserve the grab offset, including presses inside the larger touch target.
       applyScrollMiniPlayerRect(resizeScrollMiniPlayerFromCorner(
-        scrollMiniPointerSession.startRect,
-        /** @type {'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'} */ (scrollMiniPointerSession.corner),
-        event.clientX,
+        startRect,
+        /** @type {'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'} */ (corner),
+        edgeX + event.clientX - startX,
         event.clientY,
         insets,
         scrollMiniVideoAspectRatio.value
@@ -1044,6 +1055,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
           () => {
             applyScrollMiniPlayerRect(clampScrollMiniPlayerRect(targetRect, scrollMiniVideoAspectRatio.value), true)
             scrollMiniBounceCancel = null
+            syncNativeMiniPlayerGesture()
           }
         )
       } else {
@@ -1086,6 +1098,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
       startRect: { ...scrollMiniPlayerRect.value },
     }
 
+    syncNativeMiniPlayerGesture()
     document.body.classList.add('scroll-mini-player-grabbing')
     window.addEventListener('pointermove', handleScrollMiniPointerMoveWindow)
     window.addEventListener('pointerup', handleScrollMiniPointerUpWindow)
@@ -1108,6 +1121,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
       startRect: { ...scrollMiniPlayerRect.value },
     }
 
+    syncNativeMiniPlayerGesture()
     document.body.classList.add('scroll-mini-player-grabbing')
     window.addEventListener('pointermove', handleScrollMiniPointerMoveWindow)
     window.addEventListener('pointerup', handleScrollMiniPointerUpWindow)

--- a/src/renderer/helpers/player/androidNativeScreen.css
+++ b/src/renderer/helpers/player/androidNativeScreen.css
@@ -7,26 +7,19 @@
   background: transparent !important;
 }
 
-.nativePlaybackInline body::before {
-  content: '';
+.nativePlaybackInline .nativeInlineBackdrop {
   position: fixed;
   inset: 0;
   z-index: -1;
   pointer-events: none;
   background: var(--bg-color);
-  clip-path: var(--native-inline-background-clip, inset(0));
 }
 
 /* Inline video follows document scrolling. Its opening must share the page's
    scroll transform instead of waiting for JS to move a fixed clipping path. */
-.nativePlaybackPageScroll body::before {
+.nativePlaybackPageScroll .nativeInlineBackdrop {
   position: absolute;
   inset-block-end: auto;
-  block-size: var(--native-inline-page-height, 100vh);
-}
-
-.nativePlaybackInline [data-native-player-backdrop] {
-  clip-path: var(--native-player-content-clip);
 }
 
 .nativePlaybackScreen {
@@ -82,12 +75,14 @@
 /* Android moves the live texture above the page during mini-player motion.
    Shared controls resume at the destination after the native animation. */
 [data-native-player-transition],
-[data-native-player-scrolling] {
+[data-native-player-scrolling],
+[data-native-player-gesture] {
   box-shadow: none !important;
 }
 
 [data-native-player-transition] > *,
-[data-native-player-scrolling] > * {
+[data-native-player-scrolling] > *,
+[data-native-player-gesture] > * {
   visibility: hidden !important;
 }
 

--- a/src/renderer/helpers/player/androidNativeScreen.js
+++ b/src/renderer/helpers/player/androidNativeScreen.js
@@ -18,7 +18,7 @@ export function createAndroidNativeScreen({ element, container, getController, g
   let attachmentSequence = 0
   let lastInlineClip = ''
   let clippedPage = null
-  const inlineOwner = {}
+  const inlineOwner = { clearPageClip }
   let transitionSequence = 0
   let transitioning = false
   let pageScrolling = false
@@ -114,7 +114,10 @@ export function createAndroidNativeScreen({ element, container, getController, g
 
   function syncInlineBackground(visible) {
     if (!attached || open) return
-    if (inlineScreenOwner !== inlineOwner) lastInlineClip = ''
+    if (inlineScreenOwner !== inlineOwner) {
+      inlineScreenOwner?.clearPageClip()
+      lastInlineClip = ''
+    }
     inlineScreenOwner = inlineOwner
     if (!inlineBackdrop) {
       inlineBackdrop = document.createElement('div')

--- a/src/renderer/helpers/player/androidNativeScreen.js
+++ b/src/renderer/helpers/player/androidNativeScreen.js
@@ -1,6 +1,7 @@
 import { overrideShakaMethods } from './overrideShakaMethods'
 
 let inlineScreenOwner = null
+let inlineBackdrop = null
 
 /** Shares the existing feature panels with the native video and basic controls. */
 export function createAndroidNativeScreen({ element, container, getController, getLocale, hasVideoCanvas, isFullscreenOnRotationEnabled = () => false, onError }) {
@@ -21,6 +22,11 @@ export function createAndroidNativeScreen({ element, container, getController, g
   let transitionSequence = 0
   let transitioning = false
   let pageScrolling = false
+  let gestureActive = false
+  let appChromeElements = []
+  let globalMenuElements = []
+  let globalElementsDirty = true
+  const appChromeSelector = '.topNav, .sideNav, .tabBar, .capacitorTabletTabBar'
 
   function endTransition() {
     if (!transitioning) return
@@ -39,6 +45,7 @@ export function createAndroidNativeScreen({ element, container, getController, g
     }
     if (!attached || open || hasVideoCanvas?.()) return
     event.preventDefault()
+    endGesture()
     const sequence = ++transitionSequence
     const { from, to, duration } = event.detail
     transitioning = true
@@ -57,11 +64,31 @@ export function createAndroidNativeScreen({ element, container, getController, g
   }
   container.addEventListener('native-player-transition', handleTransition)
 
+  function handleGesture(event) {
+    if (!attached || open || hasVideoCanvas?.()) return
+    gestureActive = event.detail === true
+    container.toggleAttribute('data-native-player-gesture', gestureActive)
+    // Pointer handlers update Vue geometry in the same turn. Send the final
+    // rectangle and reopen the cutout together after that update has rendered.
+    scheduleLayout()
+  }
+  container.addEventListener('native-player-gesture', handleGesture)
+
+  function endGesture() {
+    if (!gestureActive) return
+    gestureActive = false
+    container.toggleAttribute('data-native-player-gesture', false)
+    syncLayout()
+  }
+
   function inlineClip(bounds, visible, origin = { x: 0, y: 0 }) {
     const style = getComputedStyle(container)
     const radius = Math.max(0, Math.min(parseFloat(style.borderTopLeftRadius) || 0, bounds.width / 2, bounds.height / 2))
-    const left = bounds.x - origin.x
-    const top = bounds.y - origin.y
+    // Float32 viewport bounds plus fractional WebView scroll offsets can vary
+    // by millionths of a CSS pixel. Do not invalidate the whole page's backdrop
+    // for that noise; retain the same subpixel precision as native geometry.
+    const left = Math.round((bounds.x - origin.x) * 1000) / 1000
+    const top = Math.round((bounds.y - origin.y) * 1000) / 1000
     const right = left + bounds.width
     const bottom = top + bounds.height
     // Preserve the page background everywhere except the native video's window.
@@ -76,7 +103,7 @@ export function createAndroidNativeScreen({ element, container, getController, g
     if (clippedPage) resize.unobserve(clippedPage)
     if (inlineScreenOwner === inlineOwner) {
       clippedPage?.removeAttribute('data-native-player-backdrop')
-      clippedPage?.style.removeProperty('--native-player-content-clip')
+      clippedPage?.style.removeProperty('clip-path')
     }
     clippedPage = null
   }
@@ -87,26 +114,38 @@ export function createAndroidNativeScreen({ element, container, getController, g
 
   function syncInlineBackground(visible) {
     if (!attached || open) return
+    if (inlineScreenOwner !== inlineOwner) lastInlineClip = ''
     inlineScreenOwner = inlineOwner
-    document.documentElement.classList.toggle('nativePlaybackInline', true)
+    if (!inlineBackdrop) {
+      inlineBackdrop = document.createElement('div')
+      inlineBackdrop.className = 'nativeInlineBackdrop'
+      inlineBackdrop.setAttribute('aria-hidden', 'true')
+      document.body.append(inlineBackdrop)
+    }
     const bounds = container.getBoundingClientRect()
     const scrolling = followsPageScroll()
-    document.documentElement.classList.toggle('nativePlaybackPageScroll', scrolling)
     const origin = scrolling ? { x: -window.scrollX, y: -window.scrollY } : undefined
     const clip = inlineClip(bounds, visible, origin)
-    const pageHeight = `${Math.max(window.innerHeight, document.body.getBoundingClientRect().height)}px`
-    if (document.documentElement.style.getPropertyValue('--native-inline-page-height') !== pageHeight) {
-      document.documentElement.style.setProperty('--native-inline-page-height', pageHeight)
+    const pageHeight = scrolling ? `${Math.max(window.innerHeight, document.body.getBoundingClientRect().height)}px` : ''
+    // Read both openings before changing either clip, so a resize does not
+    // force another style/layout pass midway through measuring the page.
+    const page = container.closest?.('#cross-tab-mini-player-layer')
+      ? document.querySelector('.app > .flexBox')
+      : null
+    const pageClip = page ? inlineClip(bounds, visible, page.getBoundingClientRect()) : ''
+    document.documentElement.classList.toggle('nativePlaybackInline', true)
+    document.documentElement.classList.toggle('nativePlaybackPageScroll', scrolling)
+    if (inlineBackdrop.style.getPropertyValue('block-size') !== pageHeight) {
+      inlineBackdrop.style.setProperty('block-size', pageHeight)
     }
     if (clip !== lastInlineClip) {
-      document.documentElement.style.setProperty('--native-inline-background-clip', clip)
+      // Keep changing geometry local. Inherited custom properties make every
+      // descendant recalculate styles while dragging or resizing the mini player.
+      inlineBackdrop.style.setProperty('clip-path', clip)
       lastInlineClip = clip
     }
     // Floating native video sits below the WebView. Cut the route's content
     // out too, while its teleported controls stay in the separate overlay layer.
-    const page = container.closest?.('#cross-tab-mini-player-layer')
-      ? document.querySelector('.app > .flexBox')
-      : null
     if (page !== clippedPage) {
       clearPageClip()
       clippedPage = page
@@ -114,10 +153,8 @@ export function createAndroidNativeScreen({ element, container, getController, g
       if (page) resize.observe(page)
     }
     if (page) {
-      const origin = page.getBoundingClientRect()
-      const pageClip = inlineClip(bounds, visible, origin)
-      if (page.style.getPropertyValue('--native-player-content-clip') !== pageClip) {
-        page.style.setProperty('--native-player-content-clip', pageClip)
+      if (page.style.getPropertyValue('clip-path') !== pageClip) {
+        page.style.setProperty('clip-path', pageClip)
       }
     }
   }
@@ -127,8 +164,8 @@ export function createAndroidNativeScreen({ element, container, getController, g
     if (inlineScreenOwner === inlineOwner) {
       document.documentElement.classList.toggle('nativePlaybackInline', false)
       document.documentElement.classList.toggle('nativePlaybackPageScroll', false)
-      document.documentElement.style.removeProperty('--native-inline-page-height')
-      document.documentElement.style.removeProperty('--native-inline-background-clip')
+      inlineBackdrop?.remove()
+      inlineBackdrop = null
       inlineScreenOwner = null
     }
     lastInlineClip = ''
@@ -174,26 +211,25 @@ export function createAndroidNativeScreen({ element, container, getController, g
     frame = null
     if ((!open && !attached) || transitioning) return
     const bounds = element.getBoundingClientRect()
-    syncAmbientClip(bounds)
     const sharedControls = container.querySelector('.shaka-controls-container')
     const controlBounds = sharedControls?.getBoundingClientRect() ?? bounds
     const visible = !document.hidden && bounds.width > 0 && bounds.height > 0 &&
       bounds.y + bounds.height > 0 && bounds.y < window.innerHeight &&
       container.checkVisibility?.({ checkOpacity: true, checkVisibilityCSS: true }) !== false
-    syncInlineBackground(visible && !pageScrolling)
-    const centerElement = !open && document.elementFromPoint(
-      Math.max(0, Math.min(window.innerWidth - 1, controlBounds.x + controlBounds.width / 2)),
-      Math.max(0, Math.min(window.innerHeight - 1, controlBounds.y + controlBounds.height / 2)))
     // Notices need the same native clipping and touch priority as menus.
     const playerMenus = [...container.querySelectorAll('.shaka-overflow-menu:not(.shaka-hidden), .shaka-settings-menu:not(.shaka-hidden), .shaka-sub-menu:not(.shaka-hidden), .shaka-context-menu:not(.shaka-hidden), .skippedSegmentsWrapper')]
     const countdowns = [...container.querySelectorAll('.countdownProgress')]
     // Global dialogs such as Quick Settings can cover only one native button.
     // Keep their whole rectangle above native controls, not just the center hit.
-    const appChrome = open ? [] : [...document.querySelectorAll('.topNav, .sideNav, .tabBar, .capacitorTabletTabBar')]
-    const globalMenus = open
-      ? []
-      : [...document.querySelectorAll('[role="dialog"], [role="menu"], [aria-modal="true"]')]
-          .filter(menu => !container.contains(menu))
+    // Scroll and scrollbar style updates change geometry, not membership.
+    // Avoid searching the whole Watch page again on every scrolling frame.
+    if (!open && globalElementsDirty) {
+      appChromeElements = [...document.querySelectorAll(appChromeSelector)]
+      globalMenuElements = [...document.querySelectorAll('[role="dialog"], [role="menu"], [aria-modal="true"]')]
+      globalElementsDirty = false
+    }
+    const appChrome = open ? [] : appChromeElements
+    const globalMenus = open ? [] : globalMenuElements.filter(menu => !container.contains(menu))
     const menuElements = [...playerMenus, ...countdowns, ...globalMenus, ...appChrome]
     const pageScroll = followsPageScroll()
     const nativeY = y => pageScroll ? Math.round((y + window.scrollY) * 1000) / 1000 : y
@@ -213,6 +249,7 @@ export function createAndroidNativeScreen({ element, container, getController, g
       viewportWidth: window.innerWidth,
       pageScroll,
       miniPlayer: container.classList.contains('scrollMiniPlayer'),
+      gestureActive,
       radius: parseFloat(getComputedStyle(container).borderTopLeftRadius) || 0,
       controlsX: controlBounds.x,
       controlsY: nativeY(controlBounds.y),
@@ -221,8 +258,9 @@ export function createAndroidNativeScreen({ element, container, getController, g
       videoVisible: visible,
       controlsVisible: visible && controlBounds.width > 0 && controlBounds.height > 0 &&
         !container.querySelector('.endedScreen') &&
-        !container.classList.contains('scrollMiniPlayer') && sharedControls?.hasAttribute('shown') === true &&
-        (!centerElement || container.contains(centerElement)),
+        !container.classList.contains('scrollMiniPlayer') && sharedControls?.hasAttribute('shown') === true,
+      // Android clips and routes touches around these rectangles. A browser
+      // hit test at the controls' center duplicates that work on every scroll.
       menus: menus.map(({ x, y, width, height, pageScroll = false }) => ({ x, y: pageScroll ? nativeY(y) : y, width, height, pageScroll })),
       overlayActive: panelOpen || [...playerMenus, ...globalMenus].some(menu => {
         const bounds = menu.getBoundingClientRect()
@@ -233,6 +271,8 @@ export function createAndroidNativeScreen({ element, container, getController, g
     // Transforms do not trigger ResizeObserver. Follow zoom transitions until
     // their final frame so native video matches the shared gesture geometry.
     if ([container, element, ...menuElements].some(target => target.getAnimations().some(animation => animation.playState === 'running'))) scheduleLayout()
+    syncAmbientClip(bounds)
+    syncInlineBackground(visible && !pageScrolling && !gestureActive)
     if (signature === lastLayout) return
     lastLayout = signature
     getController()?.layout(layout).catch(onError)
@@ -241,12 +281,20 @@ export function createAndroidNativeScreen({ element, container, getController, g
     if ((open || attached) && frame === null) frame = requestAnimationFrame(syncLayout)
   }
   const resize = new ResizeObserver(scheduleLayout)
-  const mutations = new MutationObserver(scheduleLayout)
+  const mutations = new MutationObserver(records => {
+    if (records.some(record => record.type === 'childList'
+      ? [...record.addedNodes, ...record.removedNodes].some(node => node.nodeType === 1)
+      : ['role', 'aria-modal'].includes(record.attributeName) ||
+        (record.attributeName === 'class' && (appChromeElements.includes(record.target) || record.target.matches(appChromeSelector))))) {
+      globalElementsDirty = true
+    }
+    scheduleLayout()
+  })
   resize.observe(document.body)
   resize.observe(container)
   resize.observe(element)
   // Popups outside the player must invalidate clipping even during paused video.
-  mutations.observe(document.body, { subtree: true, attributes: true, attributeFilter: ['class', 'style', 'shown', 'hidden', 'inert'], childList: true })
+  mutations.observe(document.body, { subtree: true, attributes: true, attributeFilter: ['class', 'style', 'shown', 'hidden', 'inert', 'role', 'aria-modal'], childList: true })
   mutations.observe(document.documentElement, { attributes: true, attributeFilter: ['class', 'style'] })
   window.addEventListener('resize', scheduleLayout)
   window.addEventListener('scroll', scheduleLayout, true)
@@ -254,6 +302,7 @@ export function createAndroidNativeScreen({ element, container, getController, g
 
   function setOpen(value) {
     if (open === value) return
+    endGesture()
     endTransition()
     open = value
     presentationSequence++
@@ -369,6 +418,7 @@ export function createAndroidNativeScreen({ element, container, getController, g
     },
     reset() {
       attachmentSequence++
+      endGesture()
       endTransition()
       attached = false
       pageScrolling = false
@@ -380,6 +430,7 @@ export function createAndroidNativeScreen({ element, container, getController, g
     },
     destroy() {
       attachmentSequence++
+      endGesture()
       endTransition()
       attached = false
       pageScrolling = false
@@ -396,6 +447,7 @@ export function createAndroidNativeScreen({ element, container, getController, g
       document.removeEventListener('visibilitychange', scheduleLayout)
       container.removeEventListener('click', handleFullscreenClick, true)
       container.removeEventListener('native-player-transition', handleTransition)
+      container.removeEventListener('native-player-gesture', handleGesture)
       if (frame !== null) cancelAnimationFrame(frame)
       restoreControls?.()
     },

--- a/tests/unit/android-native-screen.test.mjs
+++ b/tests/unit/android-native-screen.test.mjs
@@ -15,6 +15,8 @@ async function fixture({ fullscreen = true, chrome = [], deferTransitions = fals
   const completeFullscreen = []
   const fullscreenEvents = []
   const observers = []
+  const styleWrites = []
+  const window = Object.assign(new EventTarget(), { innerWidth: 1000, innerHeight: 700, scrollX: 0, scrollY: 0 })
   let shown = true
   let menu = false
   let panel = false
@@ -39,7 +41,7 @@ async function fixture({ fullscreen = true, chrome = [], deferTransitions = fals
   const element = Object.assign(new EventTarget(), {
     getBoundingClientRect: () => bounds, getAnimations: () => [],
   })
-  const document = Object.assign(new EventTarget(), { body: { getBoundingClientRect: () => ({ height: 2000 }) }, elementFromPoint: () => null, querySelectorAll: selector => selector.includes('.topNav') ? chrome : [], documentElement: { classList: { toggle() {} }, style: { getPropertyValue() { return '' }, setProperty() {}, removeProperty() {} } } })
+  const document = Object.assign(new EventTarget(), { body: { append() {}, getBoundingClientRect: () => ({ height: 2000 }) }, createElement: () => ({ setAttribute() {}, remove() {}, style: { getPropertyValue() { return '' }, setProperty(name, value) { styleWrites.push({ name, value }) } } }), elementFromPoint: () => null, querySelectorAll: selector => selector.includes('.topNav') ? chrome : [], documentElement: { classList: { toggle() {} }, style: { getPropertyValue() { return '' }, setProperty(name, value) { styleWrites.push({ name, value }) }, removeProperty() {} } } })
   document.addEventListener('fullscreenchange', () => fullscreenEvents.push(presentations.length))
   class Observer {
     constructor(callback) { this.callback = callback; observers.push(this) }
@@ -47,7 +49,7 @@ async function fixture({ fullscreen = true, chrome = [], deferTransitions = fals
     disconnect() {}
   }
   const create = vm.runInNewContext(`${source}\ncreateAndroidNativeScreen`, {
-    document, window: Object.assign(new EventTarget(), { innerWidth: 1000, innerHeight: 700, scrollX: 0, scrollY: 0 }), Event,
+    document, window, Event,
     ResizeObserver: Observer, MutationObserver: Observer, overrideShakaMethods,
     getComputedStyle: () => ({ borderTopLeftRadius: '12px' }),
     requestAnimationFrame(callback) { frames.set(++id, callback); return id },
@@ -69,13 +71,71 @@ async function fixture({ fullscreen = true, chrome = [], deferTransitions = fals
   if (fullscreen) await screen.show()
   else await screen.attach()
   await flush()
-  return { screen, container, layouts, presentations, completeTransitions, completeFullscreen, fullscreenEvents, bounds, observers, flush, change({ visible = shown, menuOpen = menu, panelOpen = panel, containerAnimating = animating, endedRecommendations = recommendations }) {
+  return { screen, container, layouts, presentations, completeTransitions, completeFullscreen, fullscreenEvents, bounds, observers, window, styleWrites, flush, change({ visible = shown, menuOpen = menu, panelOpen = panel, containerAnimating = animating, endedRecommendations = recommendations }) {
     shown = visible; menu = menuOpen; panel = panelOpen
     recommendations = endedRecommendations
     animating = containerAnimating
-    for (const observer of observers) observer.callback()
+    for (const observer of observers) observer.callback([{ type: 'attributes', attributeName: 'style', target: container }])
   } }
 }
+
+test('fractional Android scrolling does not repaint an unchanged document cutout', async () => {
+  const f = await fixture({ fullscreen: false })
+  f.bounds.y = 111
+  f.bounds.width = 460.79998779296875
+  f.bounds.height = 259.20001220703125
+  f.change({})
+  await f.flush()
+  f.styleWrites.length = 0
+  for (let i = 1; i <= 40; i++) {
+    // WebView returns float32 viewport bounds and fractional CSS scroll offsets.
+    // Adding them back produces small errors even with an unchanged document Y.
+    f.window.scrollY = Math.fround(i * 3.2)
+    f.bounds.y = Math.fround(111 - f.window.scrollY)
+    f.window.dispatchEvent(new Event('scroll'))
+    await f.flush()
+  }
+  assert.equal(f.styleWrites.filter(write => write.name === 'clip-path').length, 0)
+  // Preserve real subpixel layout changes, including fractional UI scaling.
+  f.bounds.y += 0.125
+  f.change({})
+  await f.flush()
+  const clips = f.styleWrites.filter(write => write.name === 'clip-path')
+  assert.equal(clips.length, 1)
+  assert.ok(clips[0].value.includes('111.125'))
+  f.screen.destroy()
+})
+
+test('live dragging and resizing keeps the page cutout fixed and restores its final fractional geometry', async () => {
+  const f = await fixture({ fullscreen: false })
+  const gesture = active => {
+    const event = new Event('native-player-gesture')
+    event.detail = active
+    f.container.dispatchEvent(event)
+  }
+  gesture(true)
+  await f.flush()
+  assert.equal(f.layouts.at(-1).gestureActive, true)
+  f.styleWrites.length = 0
+  for (let i = 0; i < 20; i++) {
+    f.bounds.width += 0.125
+    f.bounds.x += 0.375
+    f.change({})
+    await f.flush()
+  }
+  assert.equal(f.styleWrites.filter(write => write.name === 'clip-path').length, 0)
+  assert.equal(f.layouts.at(-1).width, f.bounds.width)
+  gesture(false)
+  await f.flush()
+  assert.equal(f.layouts.at(-1).gestureActive, false)
+  assert.equal(f.styleWrites.filter(write => write.name === 'clip-path').length, 1)
+  // Replacing the player during a gesture must release native ownership too.
+  gesture(true)
+  await f.flush()
+  f.screen.reset()
+  assert.equal(f.layouts.at(-1).gestureActive, false)
+  f.screen.destroy()
+})
 
 test('mini-player motion is sent as one native animation instead of separate browser frames', async () => {
   const f = await fixture({ fullscreen: false })
@@ -89,6 +149,21 @@ test('mini-player motion is sent as one native animation instead of separate bro
   assert.equal(transitions[0].transition.duration, 300)
   assert.equal(transitions[0].x, 300)
   assert.ok(f.layouts.some(layout => layout.endTransition), 'Return below shared controls only after the final page clip is ready')
+  f.screen.destroy()
+})
+
+test('an edge animation takes over a live gesture without retaining gesture ownership', async () => {
+  const f = await fixture({ fullscreen: false })
+  const gesture = new Event('native-player-gesture')
+  gesture.detail = true
+  f.container.dispatchEvent(gesture)
+  await f.flush()
+  const motion = new Event('native-player-transition', { cancelable: true })
+  motion.detail = { from: f.bounds, to: { ...f.bounds, x: -200 }, duration: 300 }
+  f.container.dispatchEvent(motion)
+  await motion.detail.finished
+  assert.equal(f.layouts.filter(layout => 'gestureActive' in layout).at(-1).gestureActive, false)
+  assert.equal(f.layouts.at(-1).endTransition, true)
   f.screen.destroy()
 })
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Android watch pages became sluggish after switching to native playback, particularly when scrolling, dragging, or resizing the mini player. Phone resizing was also difficult to start because the handle had an 18-pixel touch target.

Cache global overlay membership, avoid redundant hit tests and cutout writes while scrolling, and keep changing cutout styles local. During mini-player gestures and edge settling, Android moves the video above the page and restores the final cutout after it has drawn. Touch resize targets are now 48 × 48 pixels with the same visible grip; preserving the grab offset prevents an initial size jump. Leaving mini-player mode also releases unfinished gestures, including with reduced motion enabled.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Smoother scrolling and mini-player dragging/resizing with Android native playback, plus larger touch resize targets that keep the initial grab position.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. On Android, open a watch page with native playback and scroll while playing and paused. The video should stay aligned and scrolling should remain smooth.
2. Scroll below the player. Drag and resize the mini player, release it between edges, and tuck/restore it. The video should follow smoothly and the controls should return when movement finishes.
3. Start resizing from the enlarged invisible area beside the corner grip. The first movement should preserve the grab offset, and nearby volume/close controls should still work. Mouse handles should retain their original size.
4. Repeat at a non-default UI scale. With reduced motion enabled, return to inline mode during a gesture; the video and controls should remain visible.

## Additional context
<!-- Add any other context about the pull request here. -->
Validated on a Pixel 8 Pro running Android 16. In the same scripted drag range, 95th-percentile frame time fell from 58.3 ms to 8.4 ms and frames over 25 ms fell from 100 to 2 out of 119. The resize investigation measured 75 ms to 16.7 ms and 40 to 2 slow frames. Real touch gestures while playing also measured around 17 ms at the 95th percentile.

Regression coverage includes fractional scrolling, overlay-cache invalidation, active-player ownership, drag/resize and edge settling, interrupted native handoffs, PiP, touch hit testing at all corners, grab offsets, and deactivation during unfinished gestures. JavaScript unit and lint checks, targeted Electron tests at 100%/125% UI scale, Android debug builds, and 26 native instrumentation tests passed during validation.

No media attached: the visible grip is unchanged and static screenshots cannot demonstrate frame pacing or the invisible touch target.

Implemented and reviewed with OpenAI GPT-6 in Codex.
