### PR TITLE
feat: start on the landing page with previous tabs unloaded

### DIFF
--- a/e2e/tests/offline/session-restore.spec.mjs
+++ b/e2e/tests/offline/session-restore.spec.mjs
@@ -378,3 +378,36 @@ test.describe('restored watch tab startup priority', () => {
     await expect(backgroundWatchTab).not.toHaveClass(/unloaded/)
   })
 })
+
+for (const existingLanding of [false, true]) {
+  test.describe(`landing-page startup ${existingLanding ? 'reuses' : 'creates'} a tab`, () => {
+    test.use({
+      seed: {
+        settings: { startupBehavior: 'loadLandingPage', landingPage: 'history' },
+        tabSessions: [{
+          _id: 'e2e-window-session',
+          value: {
+            tabs: [
+              { id: WATCH_TAB_ID, url: 'app://bundle/index.html#/watch/jNQXAC9IVRw', title: 'Saved video', isUnloaded: false },
+              ...(existingLanding ? [{ id: HISTORY_TAB_ID, url: 'app://bundle/index.html#/history', title: 'History', isUnloaded: true }] : [])
+            ],
+            activeTabId: WATCH_TAB_ID
+          }
+        }]
+      }
+    })
+
+    test('loads only the landing page and keeps the previous tabs', async ({ page }) => {
+      await expect(page).toHaveURL(/#\/history$/)
+      await expect.poll(async () => page.evaluate(async () => {
+        const state = await window.ftElectron.tabs.getState()
+        return state.tabs.map(tab => ({ id: tab.id, isUnloaded: tab.isUnloaded, active: tab.id === state.activeTabId }))
+      })).toEqual([
+        { id: WATCH_TAB_ID, isUnloaded: true, active: false },
+        { id: existingLanding ? HISTORY_TAB_ID : expect.any(String), isUnloaded: false, active: true }
+      ])
+      await expect(page.locator('.tabContent[aria-hidden="false"]')).toHaveCount(1)
+      await expect(page.locator('.videoPlayerPlaceholder')).toHaveCount(0)
+    })
+  })
+}

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -363,6 +363,7 @@ function runApp() {
     'loadAllTabs',
     'restoreTabLoadState',
     'loadLastActiveTab',
+    'loadLandingPage',
     'emptySession'
   ])
   const closeConfirmedWindowIds = new Set()
@@ -2445,7 +2446,8 @@ function runApp() {
       firstWindow = await createWindow({
         sessionData: savedSessions[0],
         loadInactiveTabsOnRestore: startupBehavior === 'loadAllTabs',
-        restoreTabLoadStateOnRestore: startupBehavior === 'restoreTabLoadState'
+        restoreTabLoadStateOnRestore: startupBehavior === 'restoreTabLoadState',
+        loadLandingPageOnRestore: startupBehavior === 'loadLandingPage'
       })
       for (let i = 1; i < savedSessions.length; i++) {
         await createWindow({
@@ -2453,7 +2455,8 @@ function runApp() {
           showWindowNow: true,
           sessionData: savedSessions[i],
           loadInactiveTabsOnRestore: startupBehavior === 'loadAllTabs',
-          restoreTabLoadStateOnRestore: startupBehavior === 'restoreTabLoadState'
+          restoreTabLoadStateOnRestore: startupBehavior === 'restoreTabLoadState',
+          loadLandingPageOnRestore: startupBehavior === 'loadLandingPage'
         })
       }
     }
@@ -2628,7 +2631,8 @@ function runApp() {
       searchQueryText = null,
       sessionData = null,
       loadInactiveTabsOnRestore = false,
-      restoreTabLoadStateOnRestore = false
+      restoreTabLoadStateOnRestore = false,
+      loadLandingPageOnRestore = false
     } = { }) {
     // Syncing new window background to theme choice.
     const windowBackground = await baseHandlers.settings._findOne('baseTheme').then(async (setting) => {
@@ -2916,7 +2920,8 @@ function runApp() {
       if (!windowStartupUrl) {
         sessionRestored = await tabManager.restoreFromData(sessionData, {
           loadInactiveTabs: loadInactiveTabsOnRestore,
-          restoreTabLoadState: restoreTabLoadStateOnRestore
+          restoreTabLoadState: restoreTabLoadStateOnRestore,
+          loadLandingPage: loadLandingPageOnRestore
         })
       }
 

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -3401,10 +3401,10 @@ export class TabManager {
 
   /**
    * @param {{ tabs?: Array<{id?: string, url: string, title?: string, avatarFileName?: string | null, isPinned?: boolean, color?: string | null, skipSilence?: boolean, isUnloaded?: boolean, previewFileName?: string | null, previewCapturedAt?: number, placementOpenerTabId?: string | null, history?: object[], historyIndex?: number}>, activeTabId?: string }} sessionData
-   * @param {{ loadInactiveTabs?: boolean, restoreTabLoadState?: boolean }} [options]
+   * @param {{ loadInactiveTabs?: boolean, restoreTabLoadState?: boolean, loadLandingPage?: boolean }} [options]
    * @returns {Promise<boolean>}
    */
-  async restoreFromData(sessionData, { loadInactiveTabs = false, restoreTabLoadState = false } = {}) {
+  async restoreFromData(sessionData, { loadInactiveTabs = false, restoreTabLoadState = false, loadLandingPage = false } = {}) {
     if (!sessionData || !Array.isArray(sessionData.tabs) || sessionData.tabs.length === 0) {
       return false
     }
@@ -3420,7 +3420,10 @@ export class TabManager {
     try {
       const restoreNavigationHistory = await TabManager.getStoredRememberTabNavigationHistory()
       this._restoreTabGroups(sessionData.groups)
-      const activeTabData = sessionData.tabs.find(tab => tab.id === sessionData.activeTabId)
+      const landingRoute = loadLandingPage ? await TabManager.getStoredLandingRoute() : null
+      const activeTabData = loadLandingPage
+        ? sessionData.tabs.find(tab => TabManager.getRouteFromUrl(tab.url).path === landingRoute)
+        : sessionData.tabs.find(tab => tab.id === sessionData.activeTabId)
       const prioritizeActiveWatchTab = activeTabData != null &&
         TabManager.getRouteFromUrl(activeTabData.url).path.startsWith('/watch/')
       const deferredStartupWatchTabIds = new Set()
@@ -3437,17 +3440,17 @@ export class TabManager {
 
       await this.runBatched(() => {
         for (const tabData of sessionData.tabs) {
-          const makeActive = tabData.id === sessionData.activeTabId
+          const makeActive = tabData === activeTabData
           const hasSavedTitle = typeof tabData.title === 'string' && tabData.title.trim().length > 0
           const previewFileName = normalizeTabPreviewFileName(tabData.previewFileName)
           const avatarFileName = normalizeTabPreviewFileName(tabData.avatarFileName)
           const avatarDataUrl = avatars.get(avatarFileName) ?? null
-          const loadInBackground = loadInactiveTabs || (restoreTabLoadState && tabData.isUnloaded === false)
+          const loadInBackground = !loadLandingPage && (loadInactiveTabs || (restoreTabLoadState && tabData.isUnloaded === false))
           const deferForActiveWatchTab = prioritizeActiveWatchTab &&
             !makeActive &&
             loadInBackground &&
             TabManager.getRouteFromUrl(tabData.url).path.startsWith('/watch/')
-          const restoreAsUnloaded = deferForActiveWatchTab || (!loadInactiveTabs && !makeActive && (
+          const restoreAsUnloaded = (loadLandingPage && !makeActive) || deferForActiveWatchTab || (!loadInactiveTabs && !makeActive && (
             (restoreTabLoadState && tabData.isUnloaded === true) ||
             (!loadInBackground && hasSavedTitle)
           ))
@@ -3496,6 +3499,10 @@ export class TabManager {
         }
 
         restoreTabPlacementOpeners(this.tabs, sessionData.tabs)
+
+        if (loadLandingPage && !activeTabData) {
+          this.createTab({ route: landingRoute, makeActive: true, openPosition: 'end' })
+        }
 
         if (!this.activeTabId) {
           const firstTabId = this.tabs.keys().next().value

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -624,20 +624,21 @@ function updateTabCloseFocus(value) {
   store.dispatch('updateTabCloseFocus', value)
 }
 
-const STARTUP_BEHAVIOR_VALUES = ['loadAllTabs', 'restoreTabLoadState', 'loadLastActiveTab', 'emptySession']
+const STARTUP_BEHAVIOR_VALUES = ['loadAllTabs', 'restoreTabLoadState', 'loadLastActiveTab', 'loadLandingPage', 'emptySession']
 
 const startupBehaviorNames = computed(() => [
   t('Settings.General Settings.Startup Behavior.Load all tabs'),
   t('Settings.General Settings.Startup Behavior.Load previously loaded tabs'),
   t('Settings.General Settings.Startup Behavior.Load last active tab'),
+  t('Settings.General Settings.Startup Behavior.Load landing page, keep other tabs unloaded'),
   t('Settings.General Settings.Startup Behavior.Start with an empty session')
 ])
 
-/** @type {import('vue').ComputedRef<'loadAllTabs' | 'restoreTabLoadState' | 'loadLastActiveTab' | 'emptySession'>} */
+/** @type {import('vue').ComputedRef<'loadAllTabs' | 'restoreTabLoadState' | 'loadLastActiveTab' | 'loadLandingPage' | 'emptySession'>} */
 const startupBehavior = computed(() => store.getters.getStartupBehavior)
 
 /**
- * @param {'loadAllTabs' | 'restoreTabLoadState' | 'loadLastActiveTab' | 'emptySession'} value
+ * @param {'loadAllTabs' | 'restoreTabLoadState' | 'loadLastActiveTab' | 'loadLandingPage' | 'emptySession'} value
  */
 function updateStartupBehavior(value) {
   store.dispatch('updateStartupBehavior', value)

--- a/src/renderer/tabs/CapacitorTabService.js
+++ b/src/renderer/tabs/CapacitorTabService.js
@@ -67,6 +67,13 @@ export class CapacitorTabService {
       undefined,
       this.store.getters.getRememberTabNavigationHistory === true
     )
+    if (startupBehavior === 'loadLandingPage') {
+      const landingRoute = this.router.resolve(`/${this.store.getters.getLandingPage}`)
+      const landingTab = session.tabs.find(tab => tab.route.path === landingRoute.path)
+      session = landingTab
+        ? activateCapacitorTab(session, landingTab.id)
+        : addCapacitorTab(session, createCapacitorTab(landingRoute))
+    }
     for (const tab of session.tabs) {
       if (tab.id === session.activeTabId || startupBehavior === 'loadAllTabs') {
         session = loadCapacitorTab(session, tab.id)

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -284,7 +284,7 @@ Settings:
       Load previously loaded tabs: تحميل علامات التبويب المحملة مسبقًا
       Load last active tab: تحميل آخر علامة تبويب نشطة
       Start with an empty session: ابدأ بجلسة فارغة
-      Load landing page, keep other tabs unloaded: تحميل الصفحة الرئيسية وإبقاء علامات التبويب الأخرى دون تحميل
+      Load landing page, keep other tabs unloaded: تحميل الصفحة المقصودة وإبقاء علامات التبويب الأخرى دون تحميل
     Use AI Translation Completions: أكمل الترجمات المفقودة بأخرى مولّدة بالذكاء الاصطناعي
     Reduced Motion:
       Reduced Motion: تقليل الحركة

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -284,6 +284,7 @@ Settings:
       Load previously loaded tabs: تحميل علامات التبويب المحملة مسبقًا
       Load last active tab: تحميل آخر علامة تبويب نشطة
       Start with an empty session: ابدأ بجلسة فارغة
+      Load landing page, keep other tabs unloaded: تحميل الصفحة الرئيسية وإبقاء علامات التبويب الأخرى دون تحميل
     Use AI Translation Completions: أكمل الترجمات المفقودة بأخرى مولّدة بالذكاء الاصطناعي
     Reduced Motion:
       Reduced Motion: تقليل الحركة

--- a/static/locales/ai/az.yaml
+++ b/static/locales/ai/az.yaml
@@ -284,6 +284,7 @@ Settings:
       Load previously loaded tabs: Əvvəllər yüklənmiş vərəqləri yüklə
       Load last active tab: Son aktiv vərəqi yüklə
       Start with an empty session: Boş sessiya ilə başla
+      Load landing page, keep other tabs unloaded: Başlanğıc səhifəsini yüklə, digər vərəqləri yüklənməmiş saxla
     Date Format: Tarix formatı
     Time Format: Vaxt formatı
     Language Default: Dilin ilkin formatı

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -297,6 +297,7 @@ Settings:
       Load previously loaded tabs: Загрузіць раней загружаныя ўкладкі
       Load last active tab: Загрузіць апошнюю актыўную ўкладку
       Start with an empty session: Пачаць з пустога сеанса
+      Load landing page, keep other tabs unloaded: Загрузіць пачатковую старонку, астатнія ўкладкі пакінуць незагружанымі
     Use AI Translation Completions: Запаўняць адсутныя пераклады перакладамі, створанымі ШІ
     Reduced Motion:
       Reduced Motion: Менш анімацыі

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -282,6 +282,7 @@ Settings:
       Load previously loaded tabs: Зареди по-рано заредените раздели
       Load last active tab: Зареди последния активен раздел
       Start with an empty session: Започни с празна сесия
+      Load landing page, keep other tabs unloaded: Зареждане на началната страница, другите раздели остават незаредени
     Use AI Translation Completions: Попълвай липсващите преводи с преводи, генерирани от ИИ
     Reduced Motion:
       Reduced Motion: Намалено движение

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -280,6 +280,7 @@ Settings:
       Load previously loaded tabs: "Kargañ an ivinelloù a oa karget a-raok"
       Load last active tab: "Kargañ an ivinell oberiant diwezhañ"
       Start with an empty session: "Loc'hañ gant un estez goullo"
+      Load landing page, keep other tabs unloaded: Kargañ ar bajenn degemer, lezel an ivinelloù all hep bezañ karget
     Use AI Translation Completions: "Leuniañ an troidigezhioù a vank gant reoù savet gant an IA"
     Reduced Motion:
       Reduced Motion: "Fiñvoù digresket"

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -415,6 +415,7 @@ Settings:
       Load previously loaded tabs: Carrega les pestanyes carregades anteriorment
       Load last active tab: Carrega la darrera pestanya activa
       Start with an empty session: Inicia una sessió buida
+      Load landing page, keep other tabs unloaded: Carrega la pàgina inicial i mantén les altres pestanyes sense carregar
     Use AI Translation Completions: Completa les traduccions que falten amb altres de generades per IA
     Reduced Motion:
       Reduced Motion: Moviment reduït

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -280,6 +280,7 @@ Settings:
       Load previously loaded tabs: Načíst dříve načtené karty
       Load last active tab: Načíst naposledy aktivní kartu
       Start with an empty session: Začít s prázdnou relací
+      Load landing page, keep other tabs unloaded: Načíst úvodní stránku, ostatní karty ponechat nenačtené
     Use AI Translation Completions: Doplnit chybějící překlady těmi vytvořenými umělou inteligencí
     Reduced Motion:
       Reduced Motion: Omezení pohybu

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -282,6 +282,7 @@ Settings:
       Load previously loaded tabs: Llwytho tabiau a lwythwyd o'r blaen
       Load last active tab: Llwytho'r tab a oedd yn weithredol ddiwethaf
       Start with an empty session: Cychwyn â sesiwn wag
+      Load landing page, keep other tabs unloaded: Llwytho’r dudalen gychwyn, cadw’r tabiau eraill heb eu llwytho
     Use AI Translation Completions: Llenwi cyfieithiadau coll â rhai a gynhyrchwyd gan AI
     Reduced Motion:
       Reduced Motion: Llai o symudiad

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -292,6 +292,7 @@ Settings:
       Load previously loaded tabs: Indlæs tidligere indlæste faner
       Load last active tab: Indlæs den senest aktive fane
       Start with an empty session: Start med en tom session
+      Load landing page, keep other tabs unloaded: Indlæs startsiden, og lad andre faner forblive uindlæste
     Use AI Translation Completions: Udfyld manglende oversættelser med AI-genererede oversættelser
     Reduced Motion:
       Reduced Motion: Reduceret bevægelse

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -284,6 +284,7 @@ Settings:
       Load previously loaded tabs: Φόρτωση των καρτελών που ήταν ήδη φορτωμένες
       Load last active tab: Φόρτωση της τελευταίας ενεργής καρτέλας
       Start with an empty session: Έναρξη με κενή συνεδρία
+      Load landing page, keep other tabs unloaded: Φόρτωση αρχικής σελίδας, διατήρηση των άλλων καρτελών χωρίς φόρτωση
     Use AI Translation Completions: Συμπλήρωση μεταφράσεων που λείπουν με μεταφράσεις παραγόμενες από AI
     Reduced Motion:
       Reduced Motion: Μειωμένη κίνηση

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -280,6 +280,7 @@ Settings:
       Load previously loaded tabs: Load previously loaded tabs
       Load last active tab: Load last active tab
       Start with an empty session: Start with an empty session
+      Load landing page, keep other tabs unloaded: Load landing page, keep other tabs unloaded
     Comment Translation:
       Title: Comment translations
       Enable: Enable comment translations

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -301,6 +301,7 @@ Settings:
       Load previously loaded tabs: Cargar las pestañas que estaban cargadas
       Load last active tab: Cargar la última pestaña activa
       Start with an empty session: Iniciar con una sesión vacía
+      Load landing page, keep other tabs unloaded: Cargar la página de inicio y mantener las demás pestañas sin cargar
     Use AI Translation Completions: Completar las traducciones que faltan con otras generadas por IA
     Reduced Motion:
       Reduced Motion: Movimiento reducido

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -309,6 +309,7 @@ Settings:
       Load previously loaded tabs: Cargar las pestañas que estaban cargadas
       Load last active tab: Cargar la última pestaña activa
       Start with an empty session: Iniciar con una sesión vacía
+      Load landing page, keep other tabs unloaded: Cargar la página de inicio y mantener las demás pestañas sin cargar
     Use AI Translation Completions: Completar las traducciones que faltan con otras generadas por IA
     Reduced Motion:
       Reduced Motion: Movimiento reducido

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -282,6 +282,7 @@ Settings:
       Load previously loaded tabs: Cargar las pestañas que estaban cargadas
       Load last active tab: Cargar la última pestaña activa
       Start with an empty session: Iniciar con una sesión vacía
+      Load landing page, keep other tabs unloaded: Cargar la página de inicio y mantener las demás pestañas sin cargar
     Use AI Translation Completions: Completar las traducciones que faltan con otras generadas por IA
     Reduced Motion:
       Reduced Motion: Movimiento reducido

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -280,6 +280,7 @@ Settings:
       Load previously loaded tabs: Laadi varem laaditud vahekaardid
       Load last active tab: Laadi viimati aktiivne vahekaart
       Start with an empty session: Alusta tühja seansiga
+      Load landing page, keep other tabs unloaded: Laadi avaleht, jäta teised kaardid laadimata
     Use AI Translation Completions: Täida puuduvad tõlked tehisaru loodud tõlgetega
     Reduced Motion:
       Reduced Motion: Vähendatud liikumine

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -280,7 +280,7 @@ Settings:
       Load previously loaded tabs: Laadi varem laaditud vahekaardid
       Load last active tab: Laadi viimati aktiivne vahekaart
       Start with an empty session: Alusta tühja seansiga
-      Load landing page, keep other tabs unloaded: Laadi avaleht, jäta teised kaardid laadimata
+      Load landing page, keep other tabs unloaded: Laadi avaleht, jäta teised vahekaardid laadimata
     Use AI Translation Completions: Täida puuduvad tõlked tehisaru loodud tõlgetega
     Reduced Motion:
       Reduced Motion: Vähendatud liikumine

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -282,6 +282,7 @@ Settings:
       Load previously loaded tabs: Kargatu aurretik kargatutako fitxak
       Load last active tab: Kargatu aktibo egon den azken fitxa
       Start with an empty session: Hasi saio huts batekin
+      Load landing page, keep other tabs unloaded: Kargatu hasierako orria eta mantendu beste fitxak kargatu gabe
     Use AI Translation Completions: Bete falta diren itzulpenak adimen artifizialak sortutakoekin
     Reduced Motion:
       Reduced Motion: Mugimendu murriztua

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -297,6 +297,7 @@ Settings:
       Load previously loaded tabs: بارگذاری زبانه‌های قبلاً بارگذاری‌شده
       Load last active tab: بارگذاری آخرین زبانه فعال
       Start with an empty session: شروع با نشست خالی
+      Load landing page, keep other tabs unloaded: بارگذاری صفحهٔ آغازین و باز نگه داشتن سایر زبانه‌ها بدون بارگذاری
     Use AI Translation Completions: ترجمه‌های جاافتاده را با موارد تولیدشده توسط هوش مصنوعی تکمیل کنید
     Reduced Motion:
       Reduced Motion: کاهش حرکت

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -284,6 +284,7 @@ Settings:
       Load previously loaded tabs: Lataa aiemmin ladatut välilehdet
       Load last active tab: Lataa viimeksi aktiivinen välilehti
       Start with an empty session: Aloita tyhjällä istunnolla
+      Load landing page, keep other tabs unloaded: Lataa aloitussivu, jätä muut välilehdet lataamatta
     Use AI Translation Completions: Täydennä puuttuvat käännökset tekoälyn tuottamilla käännöksillä
     Reduced Motion:
       Reduced Motion: Vähennetty liike

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -280,6 +280,7 @@ Settings:
       Load previously loaded tabs: Charger les onglets précédemment chargés
       Load last active tab: Charger le dernier onglet actif
       Start with an empty session: Démarrer avec une session vide
+      Load landing page, keep other tabs unloaded: Charger la page d’accueil et garder les autres onglets non chargés
     Use AI Translation Completions: Compléter les traductions manquantes par celles générées par l’IA
     Reduced Motion:
       Reduced Motion: Réduction des animations

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -284,6 +284,7 @@ Settings:
       Load previously loaded tabs: Cargar as lapelas que xa estaban cargadas
       Load last active tab: Cargar a última lapela activa
       Start with an empty session: Comezar cunha sesión baleira
+      Load landing page, keep other tabs unloaded: Cargar a páxina de inicio e manter as outras lapelas sen cargar
     Use AI Translation Completions: Completar as traducións que faltan con outras xeradas por IA
     Reduced Motion:
       Reduced Motion: Movemento reducido

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -284,6 +284,7 @@ Settings:
       Load previously loaded tabs: טעינת הכרטיסיות שנטענו קודם
       Load last active tab: טעינת הכרטיסייה הפעילה האחרונה
       Start with an empty session: התחלה בהפעלה ריקה
+      Load landing page, keep other tabs unloaded: טעינת דף הפתיחה והשארת שאר הלשוניות ללא טעינה
     Use AI Translation Completions: השלמת תרגומים חסרים באמצעות תרגומים שנוצרו בבינה מלאכותית
     Reduced Motion:
       Reduced Motion: הפחתת תנועה

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -282,6 +282,7 @@ Settings:
       Load previously loaded tabs: Učitaj prethodno učitane kartice
       Load last active tab: Učitaj posljednju aktivnu karticu
       Start with an empty session: Pokreni s praznom sesijom
+      Load landing page, keep other tabs unloaded: Učitaj početnu stranicu, ostale kartice ostavi neučitanima
     Use AI Translation Completions: Dopuni prijevode koji nedostaju onima koje je generirala umjetna inteligencija
     Reduced Motion:
       Reduced Motion: Smanjeno kretanje

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -280,6 +280,7 @@ Settings:
       Load previously loaded tabs: Korábban betöltött lapok betöltése
       Load last active tab: Legutóbb aktív lap betöltése
       Start with an empty session: Indítás üres munkamenettel
+      Load landing page, keep other tabs unloaded: Kezdőlap betöltése, a többi lap maradjon betöltetlen
     Use AI Translation Completions: Hiányzó fordítások kiegészítése MI által készítettekkel
     Reduced Motion:
       Reduced Motion: Csökkentett mozgás

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -284,7 +284,7 @@ Settings:
       Load previously loaded tabs: Muat tab yang sebelumnya dimuat
       Load last active tab: Muat tab yang terakhir aktif
       Start with an empty session: Mulai dengan sesi kosong
-      Load landing page, keep other tabs unloaded: Muat halaman awal, biarkan tab lain tidak dimuat
+      Load landing page, keep other tabs unloaded: Muat halaman awal, biarkan tab lain dibongkar dari memori
     Use AI Translation Completions: Isi terjemahan yang hilang dengan terjemahan buatan AI
     Reduced Motion:
       Reduced Motion: Kurangi Gerakan

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -284,6 +284,7 @@ Settings:
       Load previously loaded tabs: Muat tab yang sebelumnya dimuat
       Load last active tab: Muat tab yang terakhir aktif
       Start with an empty session: Mulai dengan sesi kosong
+      Load landing page, keep other tabs unloaded: Muat halaman awal, biarkan tab lain tidak dimuat
     Use AI Translation Completions: Isi terjemahan yang hilang dengan terjemahan buatan AI
     Reduced Motion:
       Reduced Motion: Kurangi Gerakan

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -284,7 +284,7 @@ Settings:
       Load previously loaded tabs: Hlaða inn flipum sem voru áður hlaðnir inn
       Load last active tab: Hlaða inn síðasta virka flipa
       Start with an empty session: Hefja tóma setu
-      Load landing page, keep other tabs unloaded: Hlaða upphafssíðu, halda öðrum flipum óhlöðnum
+      Load landing page, keep other tabs unloaded: Hlaða upphafssíðu, halda öðrum flipum opnum en ekki í minni
     Use AI Translation Completions: Fylla inn þýðingar sem vantar með þýðingum sem gervigreind hefur búið til
     Reduced Motion:
       Reduced Motion: Minni hreyfing

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -284,6 +284,7 @@ Settings:
       Load previously loaded tabs: Hlaða inn flipum sem voru áður hlaðnir inn
       Load last active tab: Hlaða inn síðasta virka flipa
       Start with an empty session: Hefja tóma setu
+      Load landing page, keep other tabs unloaded: Hlaða upphafssíðu, halda öðrum flipum óhlöðnum
     Use AI Translation Completions: Fylla inn þýðingar sem vantar með þýðingum sem gervigreind hefur búið til
     Reduced Motion:
       Reduced Motion: Minni hreyfing

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -280,6 +280,7 @@ Settings:
       Load previously loaded tabs: Carica le schede già caricate in precedenza
       Load last active tab: Carica l'ultima scheda attiva
       Start with an empty session: Avvia con una sessione vuota
+      Load landing page, keep other tabs unloaded: Carica la pagina iniziale e lascia le altre schede non caricate
     Use AI Translation Completions: Completa le traduzioni mancanti con quelle generate dall'IA
     Reduced Motion:
       Reduced Motion: Movimento ridotto

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -280,7 +280,7 @@ Settings:
       Load previously loaded tabs: Carica le schede già caricate in precedenza
       Load last active tab: Carica l'ultima scheda attiva
       Start with an empty session: Avvia con una sessione vuota
-      Load landing page, keep other tabs unloaded: Carica la pagina iniziale e lascia le altre schede non caricate
+      Load landing page, keep other tabs unloaded: Carica la pagina iniziale e lascia le altre schede scaricate dalla memoria
     Use AI Translation Completions: Completa le traduzioni mancanti con quelle generate dall'IA
     Reduced Motion:
       Reduced Motion: Movimento ridotto

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -280,6 +280,7 @@ Settings:
       Load previously loaded tabs: 前回読み込まれていたタブを読み込む
       Load last active tab: 最後に使用したタブを読み込む
       Start with an empty session: 空のセッションで開始
+      Load landing page, keep other tabs unloaded: 起動ページを読み込み、他のタブは未読み込みのまま保持
     Use AI Translation Completions: 未翻訳部分をAI生成の翻訳で補完
     Reduced Motion:
       Reduced Motion: 視覚効果を減らす

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -373,6 +373,7 @@ Settings:
       Load previously loaded tabs: 이전에 불러온 탭 불러오기
       Load last active tab: 마지막 활성 탭 불러오기
       Start with an empty session: 빈 세션으로 시작
+      Load landing page, keep other tabs unloaded: 시작 페이지를 로드하고 다른 탭은 로드하지 않은 상태로 유지
     Use AI Translation Completions: 누락된 번역을 AI 생성 번역으로 채우기
     Reduced Motion:
       Reduced Motion: 모션 줄이기

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -398,6 +398,7 @@ Settings:
       Load previously loaded tabs: Įkelti anksčiau įkeltus skirtukus
       Load last active tab: Įkelti paskutinį aktyvų skirtuką
       Start with an empty session: Pradėti tuščią seansą
+      Load landing page, keep other tabs unloaded: Įkelti pradinį puslapį, kitus skirtukus palikti neįkeltus
     Use AI Translation Completions: Trūkstamus vertimus užpildyti DI sugeneruotais vertimais
     Reduced Motion:
       Reduced Motion: Mažiau animacijos

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -280,6 +280,7 @@ Settings:
       Load previously loaded tabs: Last inn faner som var lastet inn tidligere
       Load last active tab: Last inn fanen som sist var aktiv
       Start with an empty session: Start med en tom økt
+      Load landing page, keep other tabs unloaded: Last inn startsiden, la andre faner forbli ulastet
     Use AI Translation Completions: Fyll inn manglende oversettelser med KI-genererte oversettelser
     Reduced Motion:
       Reduced Motion: Redusert bevegelse

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -284,6 +284,7 @@ Settings:
       Load previously loaded tabs: Eerder geladen tabbladen laden
       Load last active tab: Laatst actieve tabblad laden
       Start with an empty session: Met een lege sessie beginnen
+      Load landing page, keep other tabs unloaded: Startpagina laden, andere tabbladen ongeladen houden
     Use AI Translation Completions: Ontbrekende vertalingen aanvullen met door AI gegenereerde vertalingen
     Reduced Motion:
       Reduced Motion: Minder beweging

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -340,6 +340,7 @@ Settings:
       Load previously loaded tabs: Last inn tidlegare innlasta faner
       Load last active tab: Last inn den sist aktive fana
       Start with an empty session: Start med ei tom økt
+      Load landing page, keep other tabs unloaded: Last inn startsida, lat andre faner vere ulasta
     Use AI Translation Completions: Fyll inn manglande omsetjingar med KI-genererte omsetjingar
     Reduced Motion:
       Reduced Motion: Redusert rørsle

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -124,6 +124,8 @@ Settings:
       Automatic: 'Automatycznie'
       Phone: 'Telefon'
       Tablet: 'Tablet'
+    Startup Behavior:
+      Load landing page, keep other tabs unloaded: Wczytaj stronę startową, pozostaw inne karty niewczytane
   Theme Settings:
     Main Color Theme:
       Catppuccin Macchiato Rosewater: "Catppuccin Macchiato Woda Różana"

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -280,6 +280,7 @@ Settings:
       Load previously loaded tabs: Carregar as guias carregadas anteriormente
       Load last active tab: Carregar a última guia ativa
       Start with an empty session: Iniciar com uma sessão vazia
+      Load landing page, keep other tabs unloaded: Carregar a página inicial e manter as outras abas sem carregar
     Use AI Translation Completions: Preencher traduções ausentes com outras geradas por IA
     Reduced Motion:
       Reduced Motion: Movimento reduzido

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -284,6 +284,7 @@ Settings:
       Load previously loaded tabs: Carregar os separadores anteriormente carregados
       Load last active tab: Carregar o último separador ativo
       Start with an empty session: Iniciar com uma sessão vazia
+      Load landing page, keep other tabs unloaded: Carregar a página inicial e manter os outros separadores por carregar
     Use AI Translation Completions: Preencher traduções em falta com outras geradas por IA
     Reduced Motion:
       Reduced Motion: Movimento reduzido

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -284,6 +284,7 @@ Settings:
       Load previously loaded tabs: Carregar os separadores anteriormente carregados
       Load last active tab: Carregar o último separador ativo
       Start with an empty session: Iniciar com uma sessão vazia
+      Load landing page, keep other tabs unloaded: Carregar a página inicial e manter os outros separadores por carregar
     Use AI Translation Completions: Preencher traduções em falta com outras geradas por IA
     Reduced Motion:
       Reduced Motion: Movimento reduzido

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -282,6 +282,7 @@ Settings:
       Load previously loaded tabs: Încarcă filele încărcate anterior
       Load last active tab: Încarcă ultima filă activă
       Start with an empty session: Pornește cu o sesiune goală
+      Load landing page, keep other tabs unloaded: Încarcă pagina de pornire, păstrează celelalte file neîncărcate
     Use AI Translation Completions: Completează traducerile lipsă cu unele generate de IA
     Reduced Motion:
       Reduced Motion: Mișcare redusă

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -259,6 +259,7 @@ Settings:
       Load previously loaded tabs: Загружать ранее загруженные вкладки
       Load last active tab: Загружать последнюю активную вкладку
       Start with an empty session: Начинать с пустого сеанса
+      Load landing page, keep other tabs unloaded: Загрузить начальную страницу, остальные вкладки оставить незагруженными
     Use AI Translation Completions: Заполнять пропущенные переводы переводами, созданными ИИ
     Reduced Motion:
       Reduced Motion: Уменьшение движения

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -280,6 +280,7 @@ Settings:
       Load previously loaded tabs: Načítať predtým načítané karty
       Load last active tab: Načítať naposledy aktívnu kartu
       Start with an empty session: Začať s prázdnou reláciou
+      Load landing page, keep other tabs unloaded: Načítať úvodnú stránku, ostatné karty ponechať nenačítané
     Use AI Translation Completions: Doplniť chýbajúce preklady prekladmi vytvorenými umelou inteligenciou
     Reduced Motion:
       Reduced Motion: Obmedzenie pohybu

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -407,6 +407,7 @@ Settings:
       Load previously loaded tabs: Naloži prej naložene zavihke
       Load last active tab: Naloži zadnji dejavni zavihek
       Start with an empty session: Začni s prazno sejo
+      Load landing page, keep other tabs unloaded: Naloži začetno stran, druge zavihke pusti nenaložene
     Use AI Translation Completions: Dopolni manjkajoče prevode s prevodi, ustvarjenimi z umetno inteligenco
     Reduced Motion:
       Reduced Motion: Zmanjšano gibanje

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -290,6 +290,7 @@ Settings:
       Load previously loaded tabs: Учитај претходно учитане картице
       Load last active tab: Учитај последњу активну картицу
       Start with an empty session: Покрени празну сесију
+      Load landing page, keep other tabs unloaded: Учитај почетну страницу, остале картице остави неучитане
     Use AI Translation Completions: Попуни преводе који недостају преводима које је генерисала ВИ
     Reduced Motion:
       Reduced Motion: Смањено кретање

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -282,6 +282,7 @@ Settings:
       Load previously loaded tabs: Läs in tidigare inlästa flikar
       Load last active tab: Läs in senast aktiva fliken
       Start with an empty session: Starta med en tom session
+      Load landing page, keep other tabs unloaded: Läs in startsidan, behåll andra flikar oladdade
     Use AI Translation Completions: Fyll i saknade översättningar med AI-genererade översättningar
     Reduced Motion:
       Reduced Motion: Minskade rörelser

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -285,7 +285,7 @@ Settings:
       Load previously loaded tabs: முன்பு ஏற்றிய தாவல்களை ஏற்று
       Load last active tab: கடைசியாகச் செயலிலிருந்த தாவலை ஏற்று
       Start with an empty session: காலியான அமர்வுடன் தொடங்கு
-      Load landing page, keep other tabs unloaded: தொடக்கப் பக்கத்தை ஏற்றி, மற்ற கீற்றுகளை ஏற்றாமல் வைத்திரு
+      Load landing page, keep other tabs unloaded: தொடக்கப் பக்கத்தை ஏற்றி, மற்ற தாவல்களை ஏற்றாமல் வைத்திரு
     Use AI Translation Completions: விடுபட்ட மொழிபெயர்ப்புகளை AI உருவாக்கிய மொழிபெயர்ப்புகளால் நிரப்பு
     Reduced Motion:
       Reduced Motion: குறைந்த அசைவு

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -285,6 +285,7 @@ Settings:
       Load previously loaded tabs: முன்பு ஏற்றிய தாவல்களை ஏற்று
       Load last active tab: கடைசியாகச் செயலிலிருந்த தாவலை ஏற்று
       Start with an empty session: காலியான அமர்வுடன் தொடங்கு
+      Load landing page, keep other tabs unloaded: தொடக்கப் பக்கத்தை ஏற்றி, மற்ற கீற்றுகளை ஏற்றாமல் வைத்திரு
     Use AI Translation Completions: விடுபட்ட மொழிபெயர்ப்புகளை AI உருவாக்கிய மொழிபெயர்ப்புகளால் நிரப்பு
     Reduced Motion:
       Reduced Motion: குறைந்த அசைவு

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -280,6 +280,7 @@ Settings:
       Load previously loaded tabs: Daha önce yüklenen sekmeleri yükle
       Load last active tab: Son etkin sekmeyi yükle
       Start with an empty session: Boş bir oturumla başla
+      Load landing page, keep other tabs unloaded: Başlangıç sayfasını yükle, diğer sekmeleri yüklenmemiş tut
     Use AI Translation Completions: Eksik çevirileri yapay zekâ tarafından oluşturulan çevirilerle tamamla
     Reduced Motion:
       Reduced Motion: Azaltılmış Hareket

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -284,6 +284,7 @@ Settings:
       Load previously loaded tabs: Завантажувати раніше завантажені вкладки
       Load last active tab: Завантажувати останню активну вкладку
       Start with an empty session: Починати з порожнього сеансу
+      Load landing page, keep other tabs unloaded: Завантажити початкову сторінку, інші вкладки залишити незавантаженими
     Use AI Translation Completions: Заповнювати пропущені переклади перекладами, створеними ШІ
     Reduced Motion:
       Reduced Motion: Зменшення руху

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -284,6 +284,7 @@ Settings:
       Load previously loaded tabs: Tải các thẻ đã tải trước đó
       Load last active tab: Tải thẻ hoạt động gần nhất
       Start with an empty session: Bắt đầu với phiên trống
+      Load landing page, keep other tabs unloaded: Tải trang khởi đầu, giữ các thẻ khác chưa tải
     Use AI Translation Completions: Điền các bản dịch còn thiếu bằng những bản dịch do AI tạo
     Reduced Motion:
       Reduced Motion: Giảm chuyển động

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -280,6 +280,7 @@ Settings:
       Load previously loaded tabs: 加载之前已加载的标签页
       Load last active tab: 加载最后使用的标签页
       Start with an empty session: 启动空会话
+      Load landing page, keep other tabs unloaded: 加载起始页，保持其他标签页未加载
     Use AI Translation Completions: 用 AI 生成的翻译补全缺失部分
     Reduced Motion:
       Reduced Motion: 减少动态效果

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -280,6 +280,7 @@ Settings:
       Load previously loaded tabs: 載入先前已載入的分頁
       Load last active tab: 載入上次使用的分頁
       Start with an empty session: 以空白工作階段啟動
+      Load landing page, keep other tabs unloaded: 載入起始頁，保持其他分頁未載入
     Use AI Translation Completions: 使用 AI 產生的翻譯補上缺少的部分
     Reduced Motion:
       Reduced Motion: 減少動態效果

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -356,6 +356,7 @@ Settings:
       Start with an empty session: Mit leerer Sitzung starten
 
       Load previously loaded tabs: Zuvor geladene Tabs laden
+      Load landing page, keep other tabs unloaded: Startseite laden, andere Tabs ungeladen lassen
     Locale Preference: Sprache
     Date Format: Datumsformat
     Time Format: Zeitformat

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -558,6 +558,7 @@ Settings:
       Load previously loaded tabs: Load previously loaded tabs
       Load last active tab: Load last active tab
       Start with an empty session: Start with an empty session
+      Load landing page, keep other tabs unloaded: Load landing page, keep other tabs unloaded
     Locale Preference: Locale Preference
     Date Format: Date Format
     Time Format: Time Format

--- a/tests/unit/capacitor-tab-service.test.mjs
+++ b/tests/unit/capacitor-tab-service.test.mjs
@@ -458,3 +458,35 @@ for (const rememberHistory of [true, false, undefined]) {
     }
   })
 }
+
+for (const existingLanding of [false, true]) {
+  test(`mobile landing-page startup ${existingLanding ? 'reuses' : 'adds'} the landing tab and unloads the previous active tab`, async () => {
+    const session = createThreeTabSession()
+    const persisted = {
+      ...session,
+      tabs: session.tabs.map(tab => ({ ...tab, isUnloaded: false })),
+    }
+    const previousStorage = globalThis.localStorage
+    globalThis.localStorage = { getItem: () => JSON.stringify(persisted), setItem() {} }
+    const store = createStore(createLoadedSession())
+    store.getters.getStartupBehavior = 'loadLandingPage'
+    store.getters.getLandingPage = existingLanding ? 'home' : 'subscriptions'
+    const router = createRouter()
+    router.afterEach = () => () => {}
+    const navigation = createNavigation(store, true)
+    navigation.projectRoute = async route => { router.currentRoute.value = route }
+    navigation.restoreScroll = () => {}
+    const service = new CapacitorTabService(router, store, navigation)
+    try {
+      await service.initialize({ path: '/', fullPath: '/' })
+      assert.equal(store.getters.getTabs.length, existingLanding ? 3 : 4)
+      assert.equal(store.getters.getActiveTab.route.path, existingLanding ? '/home' : '/subscriptions')
+      assert.equal(store.getters.getActiveTab.loadState, 'mounting')
+      if (existingLanding) assert.equal(store.getters.getActiveTabId, 'tab-a')
+      assert.ok(store.getters.getTabs.filter(tab => tab.id !== store.getters.getActiveTabId).every(tab => tab.loadState === 'unloaded'))
+    } finally {
+      service.dispose()
+      globalThis.localStorage = previousStorage
+    }
+  })
+}

--- a/tests/unit/tab-startup.test.mjs
+++ b/tests/unit/tab-startup.test.mjs
@@ -255,3 +255,40 @@ test('closing the window cancels pending background mounts', async t => {
   assert.equal(manager.tabs.get('tab-0').mountDeferred, true)
   assert.equal(manager._pendingTabMountWaiters.size, 0)
 })
+
+for (const existingLanding of [false, true]) {
+  test(`landing-page startup ${existingLanding ? 'reuses an existing tab' : 'adds a tab'} and unloads every other tab`, async t => {
+    const manager = createManager(t)
+    t.mock.method(TabManager, 'getStoredLandingRoute', async () => '/subscriptions')
+    const saved = session(3)
+    saved.tabs[0].title = ''
+    if (existingLanding) {
+      saved.tabs[1].url = 'app://bundle/index.html#/subscriptions'
+      saved.tabs[1].isUnloaded = true
+      saved.tabs[1].isPinned = true
+    }
+    await manager.restoreFromData(saved, { loadLandingPage: true })
+    const tabs = [...manager.tabs.values()]
+    assert.equal(tabs.length, existingLanding ? 3 : 4)
+    const active = manager.tabs.get(manager.activeTabId)
+    assert.equal(TabManager.getRouteFromUrl(active.url).path, '/subscriptions')
+    assert.equal(active.loadState, 'mounting')
+    if (existingLanding) {
+      assert.equal(active.id, 'tab-1')
+      assert.equal(active.isPinned, true)
+    }
+    assert.ok(tabs.filter(tab => tab !== active).every(tab => tab.loadState === 'unloaded'))
+    presentActive(manager)
+    assert.equal(manager._startupMountQueue.size, 0)
+    assert.deepEqual(saved.tabs.map(tab => tab.id), ['tab-0', 'tab-1', 'tab-2'])
+  })
+}
+
+test('landing-page startup selects only the first matching tab', async t => {
+  const manager = createManager(t)
+  t.mock.method(TabManager, 'getStoredLandingRoute', async () => '/history')
+  await manager.restoreFromData(session(3), { loadLandingPage: true })
+  assert.equal(manager.activeTabId, 'tab-0')
+  assert.equal(manager.tabs.size, 3)
+  assert.deepEqual([...manager.tabs.values()].map(tab => tab.loadState), ['mounting', 'unloaded', 'unloaded'])
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Restoring the previous session currently starts on its last active tab. Add an On Startup option that opens the configured landing page while retaining the previous tabs unloaded in the background.

Reuse and activate the first existing landing-page tab, or append a new one if missing. Apply this on desktop and Android, including each restored desktop window. Add English, German, and AI locale translations.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Add a startup option to open your landing page while keeping previous tabs unloaded in the background.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. In General Settings, choose a landing page and set On Startup to “Load landing page, keep other tabs unloaded”.
2. Open several tabs, including a video, and quit with the video tab active. Restart with no landing-page tab saved. A new landing-page tab should be active and all previous tabs should remain unloaded.
3. Restart with a landing-page tab already open. That tab should load and become active without creating a duplicate. Repeat with that tab pinned or unloaded.
4. Select a background tab and confirm it loads normally. Check the same flow on Android and with multiple desktop windows.

## Additional context
<!-- Add any other context about the pull request here. -->
Validation: full unit suite passed with 1,610 tests and two skips; both focused Electron startup tests passed. JavaScript, style, and YAML lint passed, with one existing i18n warning. Independent standards and spec reviews found no issues.

Implemented with GPT-6 in Codex.
