### PR TITLE
fix(subscriptions): show failed channels and reasons in a details dialog

### DIFF
--- a/e2e/tests/offline/subscription-errors.spec.mjs
+++ b/e2e/tests/offline/subscription-errors.spec.mjs
@@ -10,6 +10,10 @@ for (const count of [2, 20]) {
     test.use({
       seed: {
         settings: {
+          baseTheme: 'system',
+          themeColorMode: 'standard',
+          mainColor: 'Red',
+          secColor: 'Blue',
           backendPreference: 'invidious',
           backendFallback: false,
           defaultInvidiousInstance: 'https://feeds.example',
@@ -29,29 +33,65 @@ for (const count of [2, 20]) {
       }
     })
 
-    test('shows a compact summary and copies details for every channel', async ({ page, app }) => {
-      await page.setViewportSize({ width: 480, height: 800 })
+    test('shows channel names and opens failure reasons before copying technical details', async ({ page, app }, testInfo) => {
+      await page.setViewportSize({ width: count === 2 ? 375 : 480, height: 800 })
       await page.evaluate(() => window.ftElectron.setZoomFactor(1.25))
       await page.route('https://feeds.example/**', route => route.fulfill({ status: 404, body: 'Not found' }))
       await goTo(page, 'subscriptions')
       await page.locator('[data-subscription-feed-tab="shorts"]').click()
       await page.getByRole('button', { name: /Refresh Shorts/ }).click()
       const toast = page.locator('.toast', { hasText: 'Channels that could not be refreshed:' })
-      await expect(toast).toHaveText(`Channels that could not be refreshed: ${count}. Click to copy details.`)
+      await expect(toast).toContainText(channels[0].name)
       await expect(page.locator('.toast')).toHaveCount(1)
       await expect(page.locator('.connectionStatus')).toBeHidden()
       const bounds = await toast.boundingBox()
       expect(bounds.height).toBeLessThan(160)
       expect(bounds.width).toBeLessThanOrEqual(480)
       await toast.click()
+      const dialog = page.getByRole('dialog', { name: 'Channels with Errors' })
+      await expect(dialog).toBeVisible()
+      await expect(toast).toBeHidden({ timeout: 2000 })
+      for (const channel of channels) await expect(dialog).toContainText(channel.name)
+      await expect(dialog).toContainText('HTTP 404')
+      await expect(dialog).not.toContainText('lifecycle=')
+      for (const colorScheme of ['dark', 'light']) {
+        await page.emulateMedia({ colorScheme })
+        await expect(page.locator('body')).toHaveClass(new RegExp(colorScheme))
+        await expect(page.locator('.prompt')).toHaveCSS('opacity', '1')
+        await expect(dialog).toHaveCSS('opacity', '1')
+        const dialogBounds = await dialog.boundingBox()
+        // Electron reports CSS bounds before UI zoom; screenshot clips use physical pixels.
+        const clip = Object.fromEntries(Object.entries(dialogBounds).map(([key, value]) => [key, value * 1.25]))
+        await testInfo.attach(`subscription refresh failure reasons ${colorScheme}`, {
+          body: await page.screenshot({ clip }),
+          contentType: 'image/png'
+        })
+      }
+      if (count === 20) {
+        const scroller = dialog.locator('.promptContentScroller')
+        await expect(scroller).toHaveAttribute('data-overlayscrollbars-viewport')
+        await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
+        await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+        await expect(dialog.getByRole('heading', { level: 2 })).toBeInViewport()
+        await expect(dialog.getByRole('button', { name: 'Copy technical details' })).toBeInViewport()
+        await page.setViewportSize({ width: 1100, height: 1000 })
+        await expect.poll(() => scroller.evaluate(element => {
+          const content = element.querySelector('.refreshErrors').getBoundingClientRect()
+          return Math.abs(content.bottom - element.getBoundingClientRect().bottom)
+        })).toBeLessThan(2)
+        await expect(scroller.locator(':scope > .os-scrollbar-vertical')).not.toHaveClass(/os-scrollbar-unusable/)
+      }
+      await dialog.getByRole('button', { name: 'Copy technical details' }).click()
       await expect.poll(() => app.electronApp.evaluate(({ clipboard }) => clipboard.readText())).toContain(channels.at(-1).id)
       const details = await app.electronApp.evaluate(({ clipboard }) => clipboard.readText())
       for (const channel of channels) expect(details).toContain(`${channel.name} (${channel.id})`)
       expect(details).toContain('HTTP 404')
+      await page.keyboard.press('Escape')
+      await expect(dialog).toBeHidden()
     })
 
     if (count === 2) {
-      test('copying an ongoing summary keeps later failures accessible', async ({ page, app }) => {
+      test('an open dialog receives later failures', async ({ page, app }) => {
         let releaseSecond
         const secondReady = new Promise(resolve => { releaseSecond = resolve })
         await page.route('https://feeds.example/**', async route => {
@@ -63,13 +103,44 @@ for (const count of [2, 20]) {
           await page.locator('[data-subscription-feed-tab="shorts"]').click()
           await page.getByRole('button', { name: /Refresh Shorts/ }).click()
           const toast = page.locator('.toast', { hasText: 'Channels that could not be refreshed:' })
-          await expect(toast).toContainText('refreshed: 1.')
+          await expect(toast).toContainText(channels[0].name)
           await toast.click()
-          await expect.poll(() => app.electronApp.evaluate(({ clipboard }) => clipboard.readText())).toContain(channels[0].id)
+          const dialog = page.getByRole('dialog', { name: 'Channels with Errors' })
+          await expect(dialog).toContainText(channels[0].name)
           releaseSecond()
-          await expect(toast).toContainText('refreshed: 2.')
-          await expect(toast).toHaveCount(1)
+          await expect(dialog).toContainText(channels[1].name)
+          await expect(toast).toBeHidden()
+          await dialog.getByRole('button', { name: 'Copy technical details' }).click()
+          await expect.poll(() => app.electronApp.evaluate(({ clipboard }) => clipboard.readText())).toContain(channels[1].id)
+        } finally {
+          releaseSecond()
+        }
+      })
+
+      test('later failures notify again after closing the details dialog', async ({ page, app }) => {
+        let releaseSecond
+        const secondReady = new Promise(resolve => { releaseSecond = resolve })
+        await page.route('https://feeds.example/**', async route => {
+          if (route.request().url().includes(channels[1].id.slice(2))) await secondReady
+          return route.fulfill({ status: 404, body: 'Not found' })
+        })
+        try {
+          await goTo(page, 'subscriptions')
+          await page.locator('[data-subscription-feed-tab="shorts"]').click()
+          await page.getByRole('button', { name: /Refresh Shorts/ }).click()
+          const toast = page.locator('.toast', { hasText: 'Channels that could not be refreshed:' })
+          await expect(toast).toContainText(channels[0].name)
           await toast.click()
+          const dialog = page.getByRole('dialog', { name: 'Channels with Errors' })
+          await expect(dialog).toContainText(channels[0].name)
+          await dialog.getByRole('button', { name: 'Close', exact: true }).click()
+          await expect(dialog).toBeHidden()
+          releaseSecond()
+          await expect(toast).toContainText(channels[1].name)
+          await toast.click()
+          await expect(dialog).toContainText(channels[1].name)
+          await expect(toast).toBeHidden()
+          await dialog.getByRole('button', { name: 'Copy technical details' }).click()
           await expect.poll(() => app.electronApp.evaluate(({ clipboard }) => clipboard.readText())).toContain(channels[1].id)
         } finally {
           releaseSecond()

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -105,6 +105,7 @@
       v-if="tabOrganizerOpen"
       @close="closeTabOrganizer"
     />
+    <SubscriptionRefreshErrors />
     <FtPrompt
       v-if="showReleaseNotes"
       theme="readable-width"
@@ -432,6 +433,7 @@ import TabBar from './components/TabBar/TabBar.vue'
 import CapacitorTabletTabBar from './components/TabBar/CapacitorTabletTabBar.vue'
 import TabContent from './components/TabContent/TabContent.vue'
 import FtPrompt from './components/FtPrompt/FtPrompt.vue'
+import SubscriptionRefreshErrors from './components/SubscriptionRefreshErrors.vue'
 import FtButton from './components/FtButton/FtButton.vue'
 import FtToast from './components/FtToast/FtToast.vue'
 import FtConnectionStatus from './components/FtConnectionStatus/FtConnectionStatus.vue'

--- a/src/renderer/components/SubscriptionRefreshErrors.vue
+++ b/src/renderer/components/SubscriptionRefreshErrors.vue
@@ -1,0 +1,72 @@
+<template>
+  <FtPrompt
+    v-if="subscriptionRefreshErrors"
+    :label="t('Subscriptions.Error Channels')"
+    theme="readable-width"
+    fixed-layout
+    @click="subscriptionRefreshErrors = null"
+  >
+    <div class="refreshErrors">
+      <section
+        v-for="channel in subscriptionRefreshErrors.values()"
+        :key="channel.id"
+      >
+        <h3>{{ channel.name }}</h3>
+        <p
+          v-for="reason in channel.reasons"
+          :key="reason"
+        >
+          {{ reason }}
+        </p>
+      </section>
+    </div>
+    <template #footer>
+      <FtFlexBox>
+        <FtButton
+          :label="t('Subscriptions.Copy Error Details')"
+          :icon="['fas', 'copy']"
+          @click="copyDetails"
+        />
+        <FtButton
+          :label="t('Close')"
+          :icon="['fas', 'xmark']"
+          :text-color="null"
+          :background-color="null"
+          @click="subscriptionRefreshErrors = null"
+        />
+      </FtFlexBox>
+    </template>
+  </FtPrompt>
+</template>
+
+<script setup>
+import { useI18n } from 'vue-i18n'
+import FtPrompt from './FtPrompt/FtPrompt.vue'
+import FtButton from './FtButton/FtButton.vue'
+import FtFlexBox from './ft-flex-box/ft-flex-box.vue'
+import { subscriptionRefreshErrors } from '../helpers/subscriptionRefreshErrors'
+import { copyToClipboard } from '../helpers/utils'
+
+const { t } = useI18n()
+
+function copyDetails() {
+  copyToClipboard([...subscriptionRefreshErrors.value.values()].map(channel => channel.trace).join('\n'))
+}
+</script>
+
+<style scoped>
+.refreshErrors {
+  padding-inline: 16px;
+  overflow-wrap: anywhere;
+}
+
+.refreshErrors section + section {
+  border-block-start: 1px solid var(--tertiary-text-color);
+  margin-block-start: 16px;
+  padding-block-start: 8px;
+}
+
+.refreshErrors p {
+  white-space: pre-wrap;
+}
+</style>

--- a/src/renderer/helpers/subscriptionRefreshErrors.js
+++ b/src/renderer/helpers/subscriptionRefreshErrors.js
@@ -1,0 +1,4 @@
+import { shallowRef } from 'vue'
+
+/** @type {import('vue').ShallowRef<Map<string, { id: string, name: string, reasons: string[], trace: string }> | null>} */
+export const subscriptionRefreshErrors = shallowRef(null)

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -1,3 +1,5 @@
+import { shallowReactive } from 'vue'
+import { subscriptionRefreshErrors } from './subscriptionRefreshErrors'
 import store from '../store/index'
 import {
   getInvidiousChannelLive,
@@ -15,7 +17,6 @@ import {
   parseLocalPlaylistVideos
 } from './api/local'
 import {
-  copyToClipboard,
   getChannelPlaylistId,
   showApiErrorToast,
   showToast,
@@ -59,7 +60,7 @@ let electronRefreshOwnerTabId = null
 
 /**
  * Cancellation state of the refresh this renderer is running, if any.
- * @type {{ cancelled: boolean, tab: string, profileId: string, refreshId: number, controller: AbortController, errors: Map<string, Set<string>>, errorSummary: ReturnType<typeof createSubscriptionErrorSummary>, networkRecovery: ReturnType<typeof createSubscriptionNetworkRecovery> | null } | null}
+ * @type {{ cancelled: boolean, tab: string, profileId: string, refreshId: number, controller: AbortController, errors: Map<string, Map<string, string>>, errorSummary: ReturnType<typeof createSubscriptionErrorSummary>, networkRecovery: ReturnType<typeof createSubscriptionNetworkRecovery> | null } | null}
  */
 let activeRefresh = null
 let nextRefreshId = 0
@@ -308,21 +309,31 @@ function notifySubscriptionChannelRefreshed(tab) {
 
 /** Keep confirmed channel failures visible even when another channel keeps retrying. */
 function createSubscriptionErrorSummary(t) {
-  const errors = new Map()
+  const errors = shallowReactive(new Map())
   const controller = new AbortController()
   let shown = false
   return {
-    add(channelId, messages) {
+    add(channel, messages) {
       if (!messages?.size) return
-      errors.set(channelId, messages)
-      if (shown) return
+      errors.set(channel.id, {
+        id: channel.id,
+        name: channel.name || channel.id,
+        reasons: [...new Set(messages.values())],
+        trace: [...messages.keys()].join('\n')
+      })
+      if (shown || subscriptionRefreshErrors.value === errors) return
       shown = true
       showToast({
-        message: () => t('Subscriptions.Refresh Errors', { count: errors.size }),
+        message: () => {
+          const names = [...errors.values()].slice(0, 3).map(channel => channel.name).join(', ')
+          return `${t('Subscriptions.Refresh Errors', { count: errors.size })}\n${names}${errors.size > 3 ? '…' : ''}`
+        },
         time: Infinity,
-        dismissOnAction: false,
         abortSignal: controller.signal,
-        action: () => copyToClipboard([...errors.values()].flatMap(messages => [...messages]).join('\n')),
+        action: () => {
+          shown = false
+          subscriptionRefreshErrors.value = errors
+        },
         icon: ['fas', 'circle-exclamation']
       })
     },
@@ -363,7 +374,7 @@ async function fetchSubscriptionsConcurrently(channels, fetchChannel) {
       }
 
       if (!isRefreshCancelled()) {
-        activeRefresh.errorSummary.add(channel.id, activeRefresh.errors.get(channel.id))
+        activeRefresh.errorSummary.add(channel, activeRefresh.errors.get(channel.id))
       }
 
       // Let input and navigation tasks run between parsing/cache updates.
@@ -408,13 +419,14 @@ function handleSubscriptionFetchError(channel, error, title, context) {
   }
 
   const channelLabel = channel.name ? `${channel.name} (${channel.id})` : channel.id
-  const diagnostic = formatRequestDiagnostic(buildRequestDiagnostic(error, context))
+  const details = buildRequestDiagnostic(error, context)
+  const diagnostic = formatRequestDiagnostic(details)
   const message = `${channelLabel}: ${diagnostic}`
 
   console.error(`Failed to fetch subscription channel ${channelLabel}: ${diagnostic}`)
   if (activeRefresh) {
-    if (!activeRefresh.errors.has(channel.id)) activeRefresh.errors.set(channel.id, new Set())
-    activeRefresh.errors.get(channel.id).add(message)
+    if (!activeRefresh.errors.has(channel.id)) activeRefresh.errors.set(channel.id, new Map())
+    activeRefresh.errors.get(channel.id).set(message, details.message)
   } else {
     showApiErrorToast(title, message)
   }

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: جميع الأقسام مخفية
   All sections hidden description: خصّص الصفحة الرئيسية لإظهار قسم من جديد.
 Subscriptions:
-  Refresh Errors: "القنوات التي تعذر تحديثها: {count}. انقر لنسخ التفاصيل."
+  Copy Error Details: "نسخ التفاصيل التقنية"
+  Refresh Errors: "القنوات التي تعذر تحديثها: {count}. انقر لعرض التفاصيل."
   Never show {type} from this channel in feeds again: عدم عرض {type} من هذه القناة في الخلاصات مجددًا
   Refreshing Subscription Videos: تحديث مقاطع الفيديو الخاصة بالاشتراك
   Refreshing Subscription Shorts: 'تحديث الفيديوهات القصيرة للاشتراكات'

--- a/static/locales/ai/az.yaml
+++ b/static/locales/ai/az.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Bütün bölmələr gizlədilib
   All sections hidden description: Bölməni yenidən göstərmək üçün ana səhifəni fərdiləşdirin.
 Subscriptions:
-  Refresh Errors: "Yenilənə bilməyən kanallar: {count}. Təfərrüatları kopyalamaq üçün klikləyin."
+  Copy Error Details: "Texniki təfərrüatları kopyala"
+  Refresh Errors: "Yenilənə bilməyən kanallar: {count}. Təfərrüatlara baxmaq üçün klikləyin."
   Never show {type} from this channel in feeds again: Bu kanaldan {type} məzmununu lentlərdə bir daha göstərmə
   Refreshing Subscription Videos: Abunəlik videoları yenilənir
   Refreshing Subscription Shorts: Abunəlik qısa videoları yenilənir

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -148,7 +148,8 @@ Home Page:
   All sections hidden: Усе раздзелы схаваны
   All sections hidden description: Наладзьце галоўную, каб зноў паказаць раздзел.
 Subscriptions:
-  Refresh Errors: "Каналы, якія не ўдалося абнавіць: {count}. Націсніце, каб скапіяваць падрабязнасці."
+  Copy Error Details: "Скапіяваць тэхнічныя падрабязнасці"
+  Refresh Errors: "Каналы, якія не ўдалося абнавіць: {count}. Націсніце, каб праглядзець падрабязнасці."
   Never show {type} from this channel in feeds again: Больш не паказваць {type} з гэтага канала ў стужках
   Refreshing Subscription Videos: Абнаўляюцца відэа з падпісак
   Refreshing Subscription Shorts: Абнаўляюцца кароткія відэа з падпісак

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Всички раздели са скрити
   All sections hidden description: Персонализирайте началната страница, за да покажете отново раздел.
 Subscriptions:
-  Refresh Errors: "Канали, които не можаха да се обновят: {count}. Натиснете, за да копирате подробностите."
+  Copy Error Details: "Копиране на техническите подробности"
+  Refresh Errors: "Канали, които не можаха да се обновят: {count}. Натиснете, за да видите подробностите."
   Never show {type} from this channel in feeds again: Никога повече да не се показват {type} от този канал в емисиите
   Refreshing Subscription Videos: Обновяват се видеоклиповете от абонаментите
   Refreshing Subscription Shorts: Обновяват се кратките видеоклипове от абонаментите

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Kuzhet eo an holl rannoù
   All sections hidden description: Personelait ar bajenn degemer evit diskouez ur rann en-dro.
 Subscriptions:
-  Refresh Errors: "Kanolioù n'int ket bet hizivaet: {count}. Klikit evit eilañ ar munudoù."
+  Copy Error Details: "Eilañ ar munudoù teknikel"
+  Refresh Errors: "Kanolioù n'int ket bet hizivaet: {count}. Klikit evit gwelet ar munudoù."
   Never show {type} from this channel in feeds again: Na ziskouez biken {type} eus ar chadenn-mañ er gwazhioù en-dro
   Refreshing Subscription Videos: "Oc'h adkargañ videoioù ar c'houmanantoù"
   Refreshing Subscription Shorts: "Oc'h adkargañ videoioù berr (Shorts) ar c'houmanantoù"

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -172,7 +172,8 @@ Home Page:
   All sections hidden: Totes les seccions estan ocultes
   All sections hidden description: Personalitzeu l'inici per tornar a mostrar una secció.
 Subscriptions:
-  Refresh Errors: "Canals que no s'han pogut actualitzar: {count}. Feu clic per copiar els detalls."
+  Copy Error Details: "Copia els detalls tècnics"
+  Refresh Errors: "Canals que no s'han pogut actualitzar: {count}. Feu clic per veure els detalls."
   Never show {type} from this channel in feeds again: No tornis a mostrar {type} d’aquest canal als canals de contingut
   Disabled Automatic Fetching: Heu desactivat l'obtenció automàtica de subscripcions. Actualitzeu-les per veure-les aquí.
   Empty Channels: Els canals als quals us heu subscrit no tenen cap vídeo ara mateix.

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Všechny sekce jsou skryté
   All sections hidden description: Přizpůsobte domovskou stránku a některou sekci znovu zobrazte.
 Subscriptions:
-  Refresh Errors: "Kanály, které se nepodařilo obnovit: {count}. Kliknutím zkopírujete podrobnosti."
+  Copy Error Details: "Kopírovat technické podrobnosti"
+  Refresh Errors: "Kanály, které se nepodařilo obnovit: {count}. Kliknutím zobrazíte podrobnosti."
   Never show {type} from this channel in feeds again: Už nikdy nezobrazovat {type} z tohoto kanálu ve feedech
   Refreshing Subscription Videos: Obnovování videí z odběrů
   Refreshing Subscription Shorts: Obnovování krátkých videí z odběrů

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Mae pob adran wedi'i chuddio
   All sections hidden description: Addaswch yr hafan i ddangos adran eto.
 Subscriptions:
-  Refresh Errors: "Sianeli na ellid eu hadnewyddu: {count}. Cliciwch i gopïo'r manylion."
+  Copy Error Details: "Copïo manylion technegol"
+  Refresh Errors: "Sianeli na ellid eu hadnewyddu: {count}. Cliciwch i weld y manylion."
   Never show {type} from this channel in feeds again: Peidio byth â dangos {type} o’r sianel hon mewn ffrydiau eto
   Refreshing Subscription Videos: Wrthi'n adnewyddu fideos tanysgrifiadau
   Refreshing Subscription Shorts: Wrthi'n adnewyddu Byrion tanysgrifiadau

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -144,7 +144,8 @@ Home Page:
   All sections hidden: Alle sektioner er skjult
   All sections hidden description: Tilpas startsiden for at vise en sektion igen.
 Subscriptions:
-  Refresh Errors: "Kanaler, der ikke kunne opdateres: {count}. Klik for at kopiere detaljer."
+  Copy Error Details: "Kopiér tekniske detaljer"
+  Refresh Errors: "Kanaler, der ikke kunne opdateres: {count}. Klik for at se detaljer."
   Never show {type} from this channel in feeds again: Vis aldrig {type} fra denne kanal i feeds igen
   Refreshing Subscription Videos: Opdaterer videoer fra abonnementer
   Refreshing Subscription Shorts: Opdaterer Shorts fra abonnementer

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Όλες οι ενότητες είναι κρυφές
   All sections hidden description: Προσαρμόστε την αρχική για να εμφανίσετε ξανά μια ενότητα.
 Subscriptions:
-  Refresh Errors: "Κανάλια που δεν ήταν δυνατό να ανανεωθούν: {count}. Κάντε κλικ για αντιγραφή λεπτομερειών."
+  Copy Error Details: "Αντιγραφή τεχνικών λεπτομερειών"
+  Refresh Errors: "Κανάλια που δεν ήταν δυνατό να ανανεωθούν: {count}. Κάντε κλικ για προβολή λεπτομερειών."
   Never show {type} from this channel in feeds again: Να μην εμφανίζεται ξανά περιεχόμενο τύπου {type} από αυτό το κανάλι στις ροές
   Refreshing Subscription Videos: Ανανέωση βίντεο συνδρομών
   Refreshing Subscription Shorts: Ανανέωση σύντομων βίντεο συνδρομών

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -141,7 +141,8 @@ Home Page:
   All sections hidden: All sections are hidden
   All sections hidden description: Customise Home to show a section again.
 Subscriptions:
-  Refresh Errors: "Channels that could not be refreshed: {count}. Click to copy details."
+  Copy Error Details: "Copy technical details"
+  Refresh Errors: "Channels that could not be refreshed: {count}. Click to view details."
   Never show {type} from this channel in feeds again: Never show {type} from this channel in feeds again
   Refreshing Subscription Videos: Refreshing subscription videos
   Refreshing Subscription Shorts: Refreshing subscription shorts

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -150,7 +150,8 @@ Home Page:
   All sections hidden: Todas las secciones están ocultas
   All sections hidden description: Personalizá Inicio para volver a mostrar una sección.
 Subscriptions:
-  Refresh Errors: "Canales que no se pudieron actualizar: {count}. Hacé clic para copiar los detalles."
+  Copy Error Details: "Copiar detalles técnicos"
+  Refresh Errors: "Canales que no se pudieron actualizar: {count}. Hacé clic para ver los detalles."
   Never show {type} from this channel in feeds again: No volver a mostrar {type} de este canal en los feeds
   Refreshing Subscription Videos: Actualizando videos de las suscripciones
   Refreshing Subscription Shorts: Actualizando Shorts de las suscripciones

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -148,7 +148,8 @@ Home Page:
   All sections hidden: Todas las secciones están ocultas
   All sections hidden description: Personaliza Inicio para volver a mostrar una sección.
 Subscriptions:
-  Refresh Errors: "Canales que no se pudieron actualizar: {count}. Haz clic para copiar los detalles."
+  Copy Error Details: "Copiar detalles técnicos"
+  Refresh Errors: "Canales que no se pudieron actualizar: {count}. Haz clic para ver los detalles."
   Never show {type} from this channel in feeds again: No volver a mostrar {type} de este canal en los feeds
   Refreshing Subscription Videos: Actualizando videos de las suscripciones
   Refreshing Subscription Shorts: Actualizando Shorts de las suscripciones

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Todas las secciones están ocultas
   All sections hidden description: Personaliza Inicio para volver a mostrar una sección.
 Subscriptions:
-  Refresh Errors: "Canales que no se pudieron actualizar: {count}. Haz clic para copiar los detalles."
+  Copy Error Details: "Copiar detalles técnicos"
+  Refresh Errors: "Canales que no se pudieron actualizar: {count}. Haz clic para ver los detalles."
   Never show {type} from this channel in feeds again: No volver a mostrar {type} de este canal en los feeds
   Refreshing Subscription Videos: Actualizando vídeos de las suscripciones
   Refreshing Subscription Shorts: Actualizando Shorts de las suscripciones

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Kõik jaotised on peidetud
   All sections hidden description: Kohanda avalehte, et mõni jaotis uuesti kuvada.
 Subscriptions:
-  Refresh Errors: "Kanalid, mida ei saanud värskendada: {count}. Klõpsa üksikasjade kopeerimiseks."
+  Copy Error Details: "Kopeeri tehnilised üksikasjad"
+  Refresh Errors: "Kanalid, mida ei saanud värskendada: {count}. Klõpsa üksikasjade vaatamiseks."
   Never show {type} from this channel in feeds again: Ära enam näita selle kanali sisu tüübiga {type} voogudes
   Refreshing Subscription Videos: Tellimuste videote värskendamine
   Refreshing Subscription Shorts: Tellimuste Shorts-videote värskendamine

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Atal guztiak ezkutatuta daude
   All sections hidden description: Pertsonalizatu hasiera atal bat berriro erakusteko.
 Subscriptions:
-  Refresh Errors: "Eguneratu ezin izan diren kanalak: {count}. Egin klik xehetasunak kopiatzeko."
+  Copy Error Details: "Kopiatu xehetasun teknikoak"
+  Refresh Errors: "Eguneratu ezin izan diren kanalak: {count}. Egin klik xehetasunak ikusteko."
   Never show {type} from this channel in feeds again: Ez erakutsi berriro kanal honetako {type} jarioetan
   Refreshing Subscription Videos: Harpidetzetako bideoak freskatzen
   Refreshing Subscription Shorts: Harpidetzetako bideo laburrak freskatzen

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -152,7 +152,8 @@ Home Page:
   All sections hidden: همهٔ بخش‌ها پنهان هستند
   All sections hidden description: صفحهٔ اصلی را سفارشی کنید تا بخشی دوباره نمایش داده شود.
 Subscriptions:
-  Refresh Errors: "کانال‌هایی که به‌روزرسانی نشدند: {count}. برای کپی جزئیات کلیک کنید."
+  Copy Error Details: "کپی جزئیات فنی"
+  Refresh Errors: "کانال‌هایی که به‌روزرسانی نشدند: {count}. برای مشاهده جزئیات کلیک کنید."
   Never show {type} from this channel in feeds again: دیگر هرگز {type} این کانال را در خوراک‌ها نشان نده
   Refreshing Subscription Videos: در حال تازه‌سازی ویدیوهای اشتراک‌ها
   Refreshing Subscription Shorts: در حال تازه‌سازی ویدیوهای کوتاه اشتراک‌ها

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Kaikki osiot on piilotettu
   All sections hidden description: Mukauta etusivua, jotta voit näyttää osion uudelleen.
 Subscriptions:
-  Refresh Errors: "Kanavat, joita ei voitu päivittää: {count}. Kopioi tiedot napsauttamalla."
+  Copy Error Details: "Kopioi tekniset tiedot"
+  Refresh Errors: "Kanavat, joita ei voitu päivittää: {count}. Näytä tiedot napsauttamalla."
   Never show {type} from this channel in feeds again: Älä enää näytä tämän kanavan sisältöä tyypillä {type} syötteissä
   Refreshing Subscription Videos: Päivitetään tilausten videoita
   Refreshing Subscription Shorts: Päivitetään tilausten Shorts-videoita

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Toutes les sections sont masquées
   All sections hidden description: Personnalisez l’accueil pour afficher à nouveau une section.
 Subscriptions:
-  Refresh Errors: "Chaînes qui n'ont pas pu être actualisées : {count}. Cliquez pour copier les détails."
+  Copy Error Details: "Copier les détails techniques"
+  Refresh Errors: "Chaînes qui n'ont pas pu être actualisées : {count}. Cliquez pour voir les détails."
   Never show {type} from this channel in feeds again: Ne plus jamais afficher les contenus de type {type} de cette chaîne dans les flux
   Refreshing Subscription Videos: Actualisation des vidéos des abonnements
   Refreshing Subscription Shorts: Actualisation des Shorts des abonnements

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Todas as seccións están ocultas
   All sections hidden description: Personaliza o inicio para volver amosar unha sección.
 Subscriptions:
-  Refresh Errors: "Canles que non se puideron actualizar: {count}. Preme para copiar os detalles."
+  Copy Error Details: "Copiar detalles técnicos"
+  Refresh Errors: "Canles que non se puideron actualizar: {count}. Preme para ver os detalles."
   Never show {type} from this channel in feeds again: Non volver mostrar {type} desta canle nos fluxos
   Refreshing Subscription Videos: Actualizando os vídeos das subscricións
   Refreshing Subscription Shorts: Actualizando os vídeos curtos das subscricións

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: כל המקטעים מוסתרים
   All sections hidden description: התאימו אישית את דף הבית כדי להציג שוב מקטע.
 Subscriptions:
-  Refresh Errors: "ערוצים שלא ניתן היה לרענן: {count}. יש ללחוץ להעתקת הפרטים."
+  Copy Error Details: "העתקת פרטים טכניים"
+  Refresh Errors: "ערוצים שלא ניתן היה לרענן: {count}. יש ללחוץ להצגת הפרטים."
   Never show {type} from this channel in feeds again: לא להציג שוב תוכן מסוג {type} מהערוץ הזה בפידים
   Refreshing Subscription Videos: סרטוני המינויים מתרעננים
   Refreshing Subscription Shorts: הסרטונים הקצרים מהמינויים מתרעננים

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Svi su odjeljci skriveni
   All sections hidden description: Prilagodite početnu stranicu kako biste ponovno prikazali odjeljak.
 Subscriptions:
-  Refresh Errors: "Kanali koji se nisu mogli osvježiti: {count}. Kliknite za kopiranje pojedinosti."
+  Copy Error Details: "Kopiraj tehničke pojedinosti"
+  Refresh Errors: "Kanali koji se nisu mogli osvježiti: {count}. Kliknite za prikaz pojedinosti."
   Never show {type} from this channel in feeds again: Nikad više ne prikazuj {type} s ovog kanala u sažecima sadržaja
   Refreshing Subscription Videos: Osvježavanje videozapisa iz pretplata
   Refreshing Subscription Shorts: Osvježavanje sadržaja Shorts iz pretplata

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Minden szakasz el van rejtve
   All sections hidden description: Szabja testre a kezdőlapot egy szakasz újbóli megjelenítéséhez.
 Subscriptions:
-  Refresh Errors: "Nem frissíthető csatornák: {count}. Kattintson a részletek másolásához."
+  Copy Error Details: "Technikai részletek másolása"
+  Refresh Errors: "Nem frissíthető csatornák: {count}. Kattintson a részletek megtekintéséhez."
   Never show {type} from this channel in feeds again: Soha többé ne jelenjen meg {type} típusú tartalom ettől a csatornától a hírcsatornákban
   Refreshing Subscription Videos: Feliratkozások videóinak frissítése
   Refreshing Subscription Shorts: Feliratkozások rövid videóinak frissítése

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Semua bagian disembunyikan
   All sections hidden description: Sesuaikan Beranda untuk menampilkan kembali bagian.
 Subscriptions:
-  Refresh Errors: "Channel yang tidak dapat diperbarui: {count}. Klik untuk menyalin detail."
+  Copy Error Details: "Salin detail teknis"
+  Refresh Errors: "Channel yang tidak dapat diperbarui: {count}. Klik untuk melihat detail."
   Never show {type} from this channel in feeds again: Jangan pernah tampilkan {type} dari channel ini di feed lagi
   Refreshing Subscription Videos: Memperbarui video langganan
   Refreshing Subscription Shorts: Memperbarui Shorts langganan

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Allir hlutar eru faldir
   All sections hidden description: Sérsníddu heimasíðuna til að sýna hluta aftur.
 Subscriptions:
-  Refresh Errors: "Rásir sem ekki tókst að uppfæra: {count}. Smelltu til að afrita upplýsingar."
+  Copy Error Details: "Afrita tæknilegar upplýsingar"
+  Refresh Errors: "Rásir sem ekki tókst að uppfæra: {count}. Smelltu til að sjá upplýsingar."
   Never show {type} from this channel in feeds again: Aldrei sýna aftur efni af gerðinni {type} frá þessari rás í straumum
   Refreshing Subscription Videos: Endurnýja myndbönd úr áskriftum
   Refreshing Subscription Shorts: Endurnýja Shorts-myndbönd úr áskriftum

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Tutte le sezioni sono nascoste
   All sections hidden description: Personalizza Home per mostrare di nuovo una sezione.
 Subscriptions:
-  Refresh Errors: "Canali che non è stato possibile aggiornare: {count}. Fai clic per copiare i dettagli."
+  Copy Error Details: "Copia dettagli tecnici"
+  Refresh Errors: "Canali che non è stato possibile aggiornare: {count}. Fai clic per vedere i dettagli."
   Never show {type} from this channel in feeds again: Non mostrare più contenuti di tipo {type} di questo canale nei feed
   Refreshing Subscription Videos: Aggiornamento dei video delle iscrizioni
   Refreshing Subscription Shorts: Aggiornamento degli Shorts delle iscrizioni

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: すべてのセクションが非表示です
   All sections hidden description: ホームをカスタマイズして、セクションを再表示してください。
 Subscriptions:
-  Refresh Errors: "更新できなかったチャンネル数: {count}。クリックして詳細をコピーします。"
+  Copy Error Details: "技術的な詳細をコピー"
+  Refresh Errors: "更新できなかったチャンネル数: {count}。クリックして詳細を表示します。"
   Never show {type} from this channel in feeds again: このチャンネルの「{type}」をフィードに今後表示しない
   Refreshing Subscription Videos: 登録チャンネルの動画を更新中
   Refreshing Subscription Shorts: 登録チャンネルのショート動画を更新中

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -149,7 +149,8 @@ Home Page:
   All sections hidden: 모든 섹션이 숨겨져 있습니다
   All sections hidden description: 홈을 맞춤 설정하여 섹션을 다시 표시하세요.
 Subscriptions:
-  Refresh Errors: "새로고침하지 못한 채널: {count}. 클릭하여 세부 정보를 복사하세요."
+  Copy Error Details: "기술 세부 정보 복사"
+  Refresh Errors: "새로고침하지 못한 채널: {count}. 클릭하여 세부 정보를 확인하세요."
   Never show {type} from this channel in feeds again: 이 채널의 {type} 콘텐츠를 피드에 다시 표시하지 않기
   Refreshing Subscription Videos: 구독 동영상 새로 고치는 중
   Refreshing Subscription Shorts: 구독 Shorts 새로 고치는 중

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -164,7 +164,8 @@ Home Page:
   All sections hidden: Visi skyriai paslėpti
   All sections hidden description: Tinkinkite pradžios puslapį, kad vėl būtų rodomas skyrius.
 Subscriptions:
-  Refresh Errors: "Kanalai, kurių nepavyko atnaujinti: {count}. Spustelėkite, kad nukopijuotumėte išsamią informaciją."
+  Copy Error Details: "Kopijuoti techninę informaciją"
+  Refresh Errors: "Kanalai, kurių nepavyko atnaujinti: {count}. Spustelėkite, kad peržiūrėtumėte išsamią informaciją."
   Never show {type} from this channel in feeds again: Daugiau niekada nerodyti šio kanalo {type} turinio srautuose
   Load More Posts: Įkelti daugiau įrašų
   Subscriptions Tabs: Prenumeratų kortelės

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Alle deler er skjult
   All sections hidden description: Tilpass startsiden for å vise en del igjen.
 Subscriptions:
-  Refresh Errors: "Kanaler som ikke kunne oppdateres: {count}. Klikk for å kopiere detaljer."
+  Copy Error Details: "Kopier tekniske detaljer"
+  Refresh Errors: "Kanaler som ikke kunne oppdateres: {count}. Klikk for å se detaljer."
   Never show {type} from this channel in feeds again: Vis aldri {type} fra denne kanalen i strømmer igjen
   Refreshing Subscription Videos: Oppdaterer abonnementsvideoer
   Refreshing Subscription Shorts: Oppdaterer Shorts fra abonnementer

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Alle secties zijn verborgen
   All sections hidden description: Pas de startpagina aan om weer een sectie te tonen.
 Subscriptions:
-  Refresh Errors: "Kanalen die niet konden worden vernieuwd: {count}. Klik om details te kopiëren."
+  Copy Error Details: "Technische details kopiëren"
+  Refresh Errors: "Kanalen die niet konden worden vernieuwd: {count}. Klik om details te bekijken."
   Never show {type} from this channel in feeds again: Nooit meer {type} van dit kanaal in feeds tonen
   Refreshing Subscription Videos: Abonnementsvideo's vernieuwen
   Refreshing Subscription Shorts: Shorts van abonnementen vernieuwen

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -148,7 +148,8 @@ Home Page:
   All sections hidden: Alle delar er gøymde
   All sections hidden description: Tilpass heimesida for å vise ein del igjen.
 Subscriptions:
-  Refresh Errors: "Kanalar som ikkje kunne oppdaterast: {count}. Klikk for å kopiere detaljar."
+  Copy Error Details: "Kopier tekniske detaljar"
+  Refresh Errors: "Kanalar som ikkje kunne oppdaterast: {count}. Klikk for å sjå detaljar."
   Never show {type} from this channel in feeds again: Vis aldri {type} frå denne kanalen i straumar igjen
   Subscriptions Tabs: Abonnementsfaner
   All Subscription Tabs Hidden: Alle abonnementsfanene er gøymde. Vis nokre faner i delen "{subsection}" under "{settingsSection}" for å sjå innhald her.

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -55,7 +55,8 @@ Home Page:
   All sections hidden: Wszystkie sekcje są ukryte
   All sections hidden description: Dostosuj stronę główną, aby ponownie wyświetlić sekcję.
 Subscriptions:
-  Refresh Errors: "Kanały, których nie udało się odświeżyć: {count}. Kliknij, aby skopiować szczegóły."
+  Copy Error Details: "Kopiuj szczegóły techniczne"
+  Refresh Errors: "Kanały, których nie udało się odświeżyć: {count}. Kliknij, aby zobaczyć szczegóły."
   Never show {type} from this channel in feeds again: Nigdy więcej nie pokazuj treści typu {type} z tego kanału w strumieniach
   New Content Tabs: Karty nowych treści
   Show Tabbed View: Pokaż widok kart

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Todas as seções estão ocultas
   All sections hidden description: Personalize a página inicial para mostrar uma seção novamente.
 Subscriptions:
-  Refresh Errors: "Canais que não puderam ser atualizados: {count}. Clique para copiar os detalhes."
+  Copy Error Details: "Copiar detalhes técnicos"
+  Refresh Errors: "Canais que não puderam ser atualizados: {count}. Clique para ver os detalhes."
   Never show {type} from this channel in feeds again: Nunca mais mostrar {type} deste canal nos feeds
   Refreshing Subscription Videos: Atualizando os vídeos das inscrições
   Refreshing Subscription Shorts: Atualizando os Shorts das inscrições

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Todas as secções estão ocultas
   All sections hidden description: Personalize a página inicial para voltar a mostrar uma secção.
 Subscriptions:
-  Refresh Errors: "Canais que não foi possível atualizar: {count}. Clique para copiar os detalhes."
+  Copy Error Details: "Copiar detalhes técnicos"
+  Refresh Errors: "Canais que não foi possível atualizar: {count}. Clique para ver os detalhes."
   Never show {type} from this channel in feeds again: Nunca mais mostrar {type} deste canal nos feeds
   Refreshing Subscription Videos: A atualizar os vídeos das subscrições
   Refreshing Subscription Shorts: A atualizar os Shorts das subscrições

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Todas as secções estão ocultas
   All sections hidden description: Personalize a página inicial para voltar a mostrar uma secção.
 Subscriptions:
-  Refresh Errors: "Canais que não foi possível atualizar: {count}. Clique para copiar os detalhes."
+  Copy Error Details: "Copiar detalhes técnicos"
+  Refresh Errors: "Canais que não foi possível atualizar: {count}. Clique para ver os detalhes."
   Never show {type} from this channel in feeds again: Nunca mais mostrar {type} deste canal nos feeds
   Refreshing Subscription Videos: A atualizar os vídeos das subscrições
   Refreshing Subscription Shorts: A atualizar os Shorts das subscrições

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Toate secțiunile sunt ascunse
   All sections hidden description: Personalizează pagina principală pentru a afișa din nou o secțiune.
 Subscriptions:
-  Refresh Errors: "Canale care nu au putut fi actualizate: {count}. Faceți clic pentru a copia detaliile."
+  Copy Error Details: "Copiază detaliile tehnice"
+  Refresh Errors: "Canale care nu au putut fi actualizate: {count}. Faceți clic pentru a vedea detaliile."
   Never show {type} from this channel in feeds again: Nu mai afișa niciodată conținut de tip {type} de pe acest canal în fluxuri
   Refreshing Subscription Videos: Se reîmprospătează videoclipurile din abonamente
   Refreshing Subscription Shorts: Se reîmprospătează videoclipurile Shorts din abonamente

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -117,7 +117,8 @@ Home Page:
   All sections hidden: Все разделы скрыты
   All sections hidden description: Настройте главную, чтобы снова показать раздел.
 Subscriptions:
-  Refresh Errors: "Каналы, которые не удалось обновить: {count}. Нажмите, чтобы скопировать подробности."
+  Copy Error Details: "Скопировать технические подробности"
+  Refresh Errors: "Каналы, которые не удалось обновить: {count}. Нажмите, чтобы посмотреть подробности."
   Never show {type} from this channel in feeds again: Больше никогда не показывать {type} с этого канала в лентах
   Refreshing Subscription Videos: Обновление видео из подписок
   Refreshing Subscription Shorts: Обновление Shorts из подписок

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Všetky sekcie sú skryté
   All sections hidden description: Prispôsobte domovskú stránku a znova zobrazte sekciu.
 Subscriptions:
-  Refresh Errors: "Kanály, ktoré sa nepodarilo obnoviť: {count}. Kliknutím skopírujete podrobnosti."
+  Copy Error Details: "Kopírovať technické podrobnosti"
+  Refresh Errors: "Kanály, ktoré sa nepodarilo obnoviť: {count}. Kliknutím zobrazíte podrobnosti."
   Never show {type} from this channel in feeds again: Už nikdy nezobrazovať {type} z tohto kanála v kanáloch odberov
   Refreshing Subscription Videos: Obnovujú sa videá z odberov
   Refreshing Subscription Shorts: Obnovujú sa krátke videá z odberov

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -171,7 +171,8 @@ Home Page:
   All sections hidden: Vsi razdelki so skriti
   All sections hidden description: Prilagodite domačo stran, da znova prikažete razdelek.
 Subscriptions:
-  Refresh Errors: "Kanali, ki jih ni bilo mogoče osvežiti: {count}. Kliknite za kopiranje podrobnosti."
+  Copy Error Details: "Kopiraj tehnične podrobnosti"
+  Refresh Errors: "Kanali, ki jih ni bilo mogoče osvežiti: {count}. Kliknite za ogled podrobnosti."
   Never show {type} from this channel in feeds again: Nikoli več ne prikazuj vsebine vrste {type} s tega kanala v virih
   Empty Posts: Kanali, na katere ste naročeni, trenutno nimajo objav.
   Load More Posts: Naloži več objav

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -144,7 +144,8 @@ Home Page:
   All sections hidden: Сви одељци су сакривени
   All sections hidden description: Прилагодите почетну страницу да бисте поново приказали одељак.
 Subscriptions:
-  Refresh Errors: "Канали које није било могуће освежити: {count}. Кликните да копирате детаље."
+  Copy Error Details: "Копирај техничке детаље"
+  Refresh Errors: "Канали које није било могуће освежити: {count}. Кликните да видите детаље."
   Never show {type} from this channel in feeds again: Никада више не приказуј {type} са овог канала у фидовима
   Refreshing Subscription Videos: Освежавају се видео-снимци из претплата
   Refreshing Subscription Shorts: Освежавају се кратки видео-снимци из претплата

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Alla avsnitt är dolda
   All sections hidden description: Anpassa startsidan för att visa ett avsnitt igen.
 Subscriptions:
-  Refresh Errors: "Kanaler som inte kunde uppdateras: {count}. Klicka för att kopiera detaljer."
+  Copy Error Details: "Kopiera tekniska detaljer"
+  Refresh Errors: "Kanaler som inte kunde uppdateras: {count}. Klicka för att visa detaljer."
   Never show {type} from this channel in feeds again: Visa aldrig {type} från den här kanalen i flöden igen
   Refreshing Subscription Videos: Uppdaterar prenumerationsvideor
   Refreshing Subscription Shorts: Uppdaterar Shorts från prenumerationer

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -145,7 +145,8 @@ Home Page:
   All sections hidden: அனைத்துப் பிரிவுகளும் மறைக்கப்பட்டுள்ளன
   All sections hidden description: ஒரு பிரிவை மீண்டும் காட்ட முகப்பைத் தனிப்பயனாக்கவும்.
 Subscriptions:
-  Refresh Errors: "புதுப்பிக்க முடியாத சேனல்கள்: {count}. விவரங்களை நகலெடுக்க கிளிக் செய்யவும்."
+  Copy Error Details: "தொழில்நுட்ப விவரங்களை நகலெடு"
+  Refresh Errors: "புதுப்பிக்க முடியாத சேனல்கள்: {count}. விவரங்களைக் காண கிளிக் செய்யவும்."
   Never show {type} from this channel in feeds again: இந்தச் சேனலின் {type} உள்ளடக்கத்தை ஊட்டங்களில் இனி ஒருபோதும் காட்டாதே
   Refreshing Subscription Videos: சந்தாக்களின் காணொளிகள் புதுப்பிக்கப்படுகின்றன
   Refreshing Subscription Shorts: சந்தாக்களின் Shorts புதுப்பிக்கப்படுகின்றன

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Tüm bölümler gizli
   All sections hidden description: Bir bölümü yeniden göstermek için Ana Sayfayı özelleştirin.
 Subscriptions:
-  Refresh Errors: "Yenilenemeyen kanallar: {count}. Ayrıntıları kopyalamak için tıklayın."
+  Copy Error Details: "Teknik ayrıntıları kopyala"
+  Refresh Errors: "Yenilenemeyen kanallar: {count}. Ayrıntıları görmek için tıklayın."
   Never show {type} from this channel in feeds again: Bu kanalın {type} içeriklerini akışlarda bir daha gösterme
   Refreshing Subscription Videos: Abonelik videoları yenileniyor
   Refreshing Subscription Shorts: Abonelik kısa videoları yenileniyor

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Усі розділи приховано
   All sections hidden description: Налаштуйте головну, щоб знову показати розділ.
 Subscriptions:
-  Refresh Errors: "Канали, які не вдалося оновити: {count}. Натисніть, щоб скопіювати подробиці."
+  Copy Error Details: "Скопіювати технічні подробиці"
+  Refresh Errors: "Канали, які не вдалося оновити: {count}. Натисніть, щоб переглянути подробиці."
   Never show {type} from this channel in feeds again: Більше ніколи не показувати {type} із цього каналу в стрічках
   Refreshing Subscription Videos: Оновлення відео з підписок
   Refreshing Subscription Shorts: Оновлення коротких відео з підписок

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: Tất cả các mục đều bị ẩn
   All sections hidden description: Tùy chỉnh Trang chủ để hiển thị lại một mục.
 Subscriptions:
-  Refresh Errors: "Các kênh không thể làm mới: {count}. Nhấp để sao chép chi tiết."
+  Copy Error Details: "Sao chép chi tiết kỹ thuật"
+  Refresh Errors: "Các kênh không thể làm mới: {count}. Nhấp để xem chi tiết."
   Never show {type} from this channel in feeds again: Không bao giờ hiển thị {type} từ kênh này trong bảng tin nữa
   Refreshing Subscription Videos: Đang làm mới video từ kênh đăng ký
   Refreshing Subscription Shorts: Đang làm mới video ngắn từ kênh đăng ký

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: 所有版块均已隐藏
   All sections hidden description: 自定义首页以重新显示版块。
 Subscriptions:
-  Refresh Errors: "无法刷新的频道数：{count}。点击复制详情。"
+  Copy Error Details: "复制技术详情"
+  Refresh Errors: "无法刷新的频道数：{count}。点击查看详情。"
   Never show {type} from this channel in feeds again: 不再在动态中显示此频道的{type}
   Refreshing Subscription Videos: 正在刷新订阅视频
   Refreshing Subscription Shorts: 正在刷新订阅短视频

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -142,7 +142,8 @@ Home Page:
   All sections hidden: 所有區塊均已隱藏
   All sections hidden description: 自訂首頁以重新顯示區塊。
 Subscriptions:
-  Refresh Errors: "無法重新整理的頻道數：{count}。點擊複製詳細資訊。"
+  Copy Error Details: "複製技術詳細資訊"
+  Refresh Errors: "無法重新整理的頻道數：{count}。點擊查看詳細資訊。"
   Never show {type} from this channel in feeds again: 不再於動態中顯示此頻道的{type}
   Refreshing Subscription Videos: 正在重新整理訂閱影片
   Refreshing Subscription Shorts: 正在重新整理訂閱的 Shorts 短片

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -141,7 +141,8 @@ Home Page:
   All sections hidden description: Passe die Startseite an, um wieder einen Bereich anzuzeigen.
 
 Subscriptions:
-  Refresh Errors: "Nicht aktualisierte Kanäle: {count}. Klicken, um Details zu kopieren."
+  Copy Error Details: "Technische Details kopieren"
+  Refresh Errors: "Nicht aktualisierte Kanäle: {count}. Klicken, um Details anzuzeigen."
   Never show {type} from this channel in feeds again: Nie wieder {type} von diesem Kanal in Feeds anzeigen
     # On Subscriptions Page
   Subscriptions: Abos

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -259,7 +259,8 @@ Home Page:
   All sections hidden description: Customize Home to show a section again.
 
 Subscriptions:
-  Refresh Errors: "Channels that could not be refreshed: {count}. Click to copy details."
+  Copy Error Details: "Copy technical details"
+  Refresh Errors: "Channels that could not be refreshed: {count}. Click to view details."
   Never show {type} from this channel in feeds again: Never show {type} from this channel in feeds again
     # On Subscriptions Page
   Subscriptions: Subscriptions

--- a/tests/unit/subscription-network-recovery.test.mjs
+++ b/tests/unit/subscription-network-recovery.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 import test from 'node:test'
 import vm from 'node:vm'
+import { shallowReactive } from 'vue'
 
 import { createNetworkRecovery } from '../../src/renderer/helpers/networkRecovery.js'
 import { createAbortError } from '../../src/renderer/helpers/api/requestErrors.js'
@@ -25,6 +26,7 @@ function createRefresh({ online = true, feed = 'Shorts', error = new TypeError('
   const navigator = { onLine: online }
   const toasts = []
   const copied = []
+  const subscriptionRefreshErrors = { value: null }
   const requests = []
   const fallbackRequests = []
   const writes = []
@@ -56,7 +58,7 @@ function createRefresh({ online = true, feed = 'Shorts', error = new TypeError('
   const fetchLocal = fallbackWorks && backend === 'invidious' ? fetchFallback : fetchChannel
   const fetchInvidious = fallbackWorks && backend === 'local' ? fetchFallback : fetchChannel
   const context = vm.createContext({
-    window, navigator, CustomEvent, AbortController, AbortSignal, Request, Response, URL, EventTarget, createAbortError,
+    shallowReactive, subscriptionRefreshErrors, window, navigator, CustomEvent, AbortController, AbortSignal, Request, Response, URL, EventTarget, createAbortError,
     location: { href: 'https://localhost/', origin: 'https://localhost' }, setTimeout, clearTimeout, console: { error() {}, warn() {} },
     process: { env: { IS_CAPACITOR: true, SUPPORTS_LOCAL_API: true } },
     store: {
@@ -107,6 +109,7 @@ function createRefresh({ online = true, feed = 'Shorts', error = new TypeError('
   }
   vm.runInContext(`${source}\nglobalThis.api = { refreshSubscriptionVideosFromRemote, refreshSubscriptionShortsFromRemote, refreshSubscriptionLiveFromRemote, refreshSubscriptionPostsFromRemote, cancelSubscriptionRefresh }`, context)
   return {
+    get details() { return [...subscriptionRefreshErrors.value.values()].map(channel => channel.trace).join('\n') },
     ...context.api, refresh: context.api[`refreshSubscription${feed}FromRemote`], navigator, requests, fallbackRequests, toasts, copied, writes, events, getters, recovery: sharedRecovery,
     reconnect() {
       fail = false
@@ -361,7 +364,7 @@ for (const feed of ['Videos', 'Shorts', 'Live']) {
         await app.refresh({ t: key => key, errorChannels: [] })
         assert.equal(app.toasts.length, 1)
         app.toasts[0][0].action()
-        assert.match(app.copied[0], new RegExp(`HTTP ${status}`))
+        assert.match(app.details, new RegExp(`HTTP ${status}`))
         assert.equal(app.recovery.state, 'online')
         assert.deepEqual(app.events, ['completed', 'finished'])
       })
@@ -379,7 +382,7 @@ for (const feed of ['Videos', 'Shorts', 'Live']) {
       await app.refresh({ t: key => key, errorChannels })
       assert.equal(app.toasts.length, 1)
       app.toasts[0][0].action()
-      assert.match(app.copied[0], new RegExp(`HTTP ${status}`))
+      assert.match(app.details, new RegExp(`HTTP ${status}`))
       assert.equal(app.recovery.state, 'online')
       assert.equal(errorChannels.length, status === 404 ? 20 : 0)
     })
@@ -393,14 +396,15 @@ test('one compact refresh notification retains every failed channel and distinct
   await app.refresh({ t: translateSummary })
   assert.equal(app.toasts.length, 1)
   const toast = app.toasts[0][0]
-  assert.equal(toast.message(), 'Subscriptions.Refresh Errors: 20')
+  assert.match(toast.message(), /^Subscriptions.Refresh Errors: 20\nUC0, UC1, UC2…$/)
   assert.ok(toast.message().length < 100)
   toast.action()
-  for (let i = 0; i < 20; i++) assert.match(app.copied[0], new RegExp(`UC${i}:`))
-  assert.match(app.copied[0], /HTTP 500/)
-  assert.match(app.copied[0], /backend=YouTube RSS/)
-  assert.match(app.copied[0], /backend=Invidious RSS/)
-  assert.equal(new Set(app.copied[0].split('\n')).size, app.copied[0].split('\n').length)
+  assert.equal(app.copied.length, 0, 'opening details must not overwrite the clipboard')
+  for (let i = 0; i < 20; i++) assert.match(app.details, new RegExp(`UC${i}:`))
+  assert.match(app.details, /HTTP 500/)
+  assert.match(app.details, /backend=YouTube RSS/)
+  assert.match(app.details, /backend=Invidious RSS/)
+  assert.equal(new Set(app.details.split('\n')).size, app.details.split('\n').length)
 })
 
 for (const feed of ['Videos', 'Shorts', 'Live', 'Posts']) {
@@ -412,16 +416,16 @@ for (const feed of ['Videos', 'Shorts', 'Live', 'Posts']) {
   })
 }
 
-test('two confirmed unavailable channels are both included in the copied summary', async () => {
+test('two confirmed unavailable channels are both named in the notification and details', async () => {
   const app = createRefresh({ rssStatus: 404, channelInfo: { alert: 'This channel does not exist.' } })
   app.getters.getActiveProfile.subscriptions = [{ id: 'UCfirst', name: 'First channel' }, { id: 'UCsecond', name: 'Second channel' }]
   app.reconnect()
   await app.refresh({ t: translateSummary })
   assert.equal(app.toasts.length, 1)
-  assert.equal(app.toasts[0][0].message(), 'Subscriptions.Refresh Errors: 2')
+  assert.match(app.toasts[0][0].message(), /First channel.*Second channel/)
   app.toasts[0][0].action()
-  assert.match(app.copied[0], /First channel \(UCfirst\)/)
-  assert.match(app.copied[0], /Second channel \(UCsecond\)/)
+  assert.match(app.details, /First channel \(UCfirst\)/)
+  assert.match(app.details, /Second channel \(UCsecond\)/)
 })
 
 for (const feed of ['Videos', 'Shorts', 'Live', 'Posts']) {
@@ -430,7 +434,7 @@ for (const feed of ['Videos', 'Shorts', 'Live', 'Posts']) {
     await app.refresh({ t: translateSummary })
     assert.equal(app.writes.filter(write => write.key.endsWith('CacheByChannel')).length, 0)
     assert.equal(app.toasts.length, 1)
-    assert.equal(app.toasts[0][0].message(), 'Subscriptions.Refresh Errors: 20')
+    assert.match(app.toasts[0][0].message(), /^Subscriptions.Refresh Errors: 20\n/)
   })
 }
 
@@ -446,8 +450,8 @@ test('confirmed HTTP failures stay accessible while another channel retries and 
     assert.deepEqual(app.events, [])
     assert.equal(app.toasts.length, 1, 'the finished HTTP failure must not wait for network recovery')
     app.toasts[0][0].action()
-    assert.match(app.copied[0], /UC0:/)
-    assert.doesNotMatch(app.copied[0], /UC1:/)
+    assert.match(app.details, /UC0:/)
+    assert.doesNotMatch(app.details, /UC1:/)
     app.cancelSubscriptionRefresh()
     await refresh
     assert.equal(app.toasts.length, 1)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
Requested directly by Nico in Codex.
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The subscription refresh failure notification showed only a count and required copying diagnostics to find the affected channels. It now previews up to three channel names and opens a dialog listing every failed channel with its error message. A separate button copies the technical diagnostics.

The dialog receives failures as they arrive. If it is closed before another channel fails, a new notification makes those later failures accessible.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/57d8a648-dab8-4e91-9a5b-fefa5827575d">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/6af34f4f-c65d-4e73-94dc-8ea7ccf70b63">
  <img alt="Channel refresh failure reasons with a button to copy technical details" src="https://github.com/user-attachments/assets/57d8a648-dab8-4e91-9a5b-fefa5827575d">
</picture>

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
1. Refresh subscriptions that contain unavailable channels. Check that the notification includes channel names.
2. Open the notification. Confirm the dialog lists the failed channels and their reasons, and that “Copy technical details” copies the diagnostics.
3. Open the dialog during a refresh. Confirm new failures appear there. Close it before another channel fails and confirm a new notification appears.
4. With a long failure list, scroll to the bottom and resize the window at 125% UI scale. The heading and buttons should remain visible, with no blank space below the list.
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

## Additional context
<!-- Add any other context about the pull request here. -->
The count-only notification is not in the latest stable release. The standards review found no issues; the spec review found and resolved the missing notification after closing an early dialog.

Implemented and reviewed with GPT-6 in the Codex harness.

