### PR TITLE
fix(settings): combine matching FFmpeg tool versions

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -493,6 +493,9 @@ test.describe('settings', () => {
     await expect(ytDlpTool.getByPlaceholder('yt-dlp Executable Path')).toBeVisible()
     await expect(ffmpegTool.getByRole('combobox', { name: 'FFmpeg Source' })).toBeVisible()
     await expect(ffmpegTool.getByPlaceholder('FFmpeg Executable Path')).toBeVisible()
+    await expect(ffmpegTool.locator('.externalSoftwareToolStatus')).toHaveText(
+      'Detected FFmpeg/FFprobe version: 8.0'
+    )
 
     const ytDlpSource = ytDlpTool.locator('.select').filter({ hasText: 'yt-dlp Source' })
     const ffmpegSource = ffmpegTool.locator('.select').filter({ hasText: 'FFmpeg Source' })
@@ -540,6 +543,30 @@ test.describe('settings', () => {
     await expect(ffmpegTool.getByPlaceholder('FFmpeg Executable Path')).toHaveCount(0)
     await expect(ffmpegTool.getByRole('button', { name: 'Update FFmpeg and FFprobe' })).toBeVisible()
     await expect(externalSoftware.getByRole('combobox', { name: 'Managed Tool Updates' })).toBeVisible()
+  })
+
+  test('shows separate FFmpeg and FFprobe statuses when their versions differ', async ({ app, page }) => {
+    await app.electronApp.evaluate(({ ipcMain }) => {
+      ipcMain.removeHandler('yt-dlp-get-info')
+      ipcMain.handle('yt-dlp-get-info', (_event, options) => ({
+        ytDlp: {
+          source: options.ytDlpSource,
+          available: true,
+          version: '2026.08.19',
+          supportedBrowsers: []
+        },
+        ffmpeg: { source: options.ffmpegSource, available: true, version: '8.0' },
+        ffprobe: { source: options.ffmpegSource, available: true, version: '8.1' }
+      }))
+    })
+
+    const advanced = await goToSettingsSection(page, 'advanced')
+    const ffmpegStatus = advanced.locator('.externalSoftwareTool').nth(1).locator('.externalSoftwareToolStatus')
+
+    await expect(ffmpegStatus.locator('p')).toHaveText([
+      'Detected FFmpeg version: 8.0',
+      'Detected FFprobe version: 8.1'
+    ])
   })
 
   test.describe('external software at 95% UI scale', () => {

--- a/src/renderer/components/ExternalSoftwareSettings.vue
+++ b/src/renderer/components/ExternalSoftwareSettings.vue
@@ -144,19 +144,25 @@
               : t('Settings.External Software Settings.System FFmpeg Missing Warning') }}
           </p>
           <p
+            v-else-if="ffmpegVersionsMatch"
+            class="ytDlpStatus"
+          >
+            {{ t('Settings.External Software Settings.Detected FFmpeg and FFprobe Version Template', { version: ffmpegInfo.version }) }}
+          </p>
+          <p
             v-else
             class="ytDlpStatus"
           >
             {{ t('Settings.External Software Settings.Detected FFmpeg Version Template', { version: ffmpegInfo.version }) }}
           </p>
           <p
-            v-if="ffprobeInfo === null"
+            v-if="!ffmpegVersionsMatch && ffprobeInfo === null"
             class="ytDlpStatus"
           >
             {{ t('Settings.External Software Settings.Checking FFprobe') }}
           </p>
           <p
-            v-else-if="!ffprobeInfo.available"
+            v-else-if="!ffmpegVersionsMatch && !ffprobeInfo.available"
             class="ytDlpStatus ytDlpWarning"
           >
             <FtIcon :icon="['fas', 'circle-exclamation']" />
@@ -165,7 +171,7 @@
               : t('Settings.External Software Settings.System FFprobe Missing Warning') }}
           </p>
           <p
-            v-else
+            v-else-if="!ffmpegVersionsMatch"
             class="ytDlpStatus"
           >
             {{ t('Settings.External Software Settings.Detected FFprobe Version Template', { version: ffprobeInfo.version }) }}
@@ -449,6 +455,7 @@ const ffprobeInfo = computed(() => ytDlpFfmpegSource.value === 'managed'
     : null)
 
 const ffmpegToolsAvailable = computed(() => ffmpegInfo.value?.available === true && ffprobeInfo.value?.available === true)
+const ffmpegVersionsMatch = computed(() => ffmpegToolsAvailable.value && ffmpegInfo.value.version === ffprobeInfo.value.version)
 
 const ytDlpBinaryDownloadInProgress = ref(false)
 const ffmpegBinaryDownloadInProgress = ref(false)

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -675,6 +675,7 @@ Settings:
     yt-dlp Download Error Template: 'فشل تنزيل yt-dlp: {error}'
     FFmpeg Source: مصدر إف إف إم بي إي جي
     Detected FFmpeg Version Template: 'تم اكتشاف إصدار FFmpeg: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'تم اكتشاف إصدار FFmpeg/FFprobe: {version}'
     FFmpeg Managed Not Downloaded: لم يتم تنزيل FFmpeg بعد. انقر على الزر أدناه لتنزيله.
     System FFmpeg Missing Warning: لم يتم العثور على FFmpeg على نظامك. مطلوب لدمج الفيديو والصوت وتحويل الصوت. قم بتثبيته، أو قم بتعيين مسار مخصص أدناه، أو قم بتبديل المصدر إلى "Managed by OpenTubeX".
     Download FFmpeg: تحميل برنامج FFmpeg

--- a/static/locales/ai/az.yaml
+++ b/static/locales/ai/az.yaml
@@ -669,6 +669,7 @@ Settings:
     yt-dlp Download Error Template: 'yt-dlp endirmək alınmadı: {error}'
     FFmpeg Source: FFmpeg mənbəyi
     Detected FFmpeg Version Template: 'Aşkarlanan FFmpeg versiyası: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Aşkarlanan FFmpeg/FFprobe versiyası: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg hələ endirilməyib. Endirmək üçün aşağıdakı düyməni klikləyin.
     System FFmpeg Missing Warning: Sisteminizdə FFmpeg tapılmadı. O, video və səsi birləşdirmək və səsi çevirmək üçün lazımdır. Onu quraşdırın, aşağıda fərdi yol təyin edin və ya mənbəni “OpenTubeX tərəfindən idarə olunur” seçiminə dəyişin.
     Download FFmpeg: FFmpeg endir

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -696,6 +696,7 @@ Settings:
     yt-dlp Download Error Template: 'Не ўдалося спампаваць yt-dlp: {error}'
     FFmpeg Source: Крыніца FFmpeg
     Detected FFmpeg Version Template: 'Выяўленая версія FFmpeg: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Выяўленая версія FFmpeg/FFprobe: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg яшчэ не спампаваны. Каб спампаваць яго, націсніце кнопку ніжэй.
     System FFmpeg Missing Warning: FFmpeg не знойдзены ў сістэме. Ён патрэбны для аб’яднання відэа і гуку, а таксама для пераўтварэння гуку. Усталюйце яго, задайце карыстальніцкі шлях ніжэй або выберыце крыніцу «Пад кіраваннем OpenTubeX».
     Download FFmpeg: Спампаваць FFmpeg

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -669,6 +669,7 @@ Settings:
     yt-dlp Download Error Template: 'Изтеглянето на yt-dlp беше неуспешно: {error}'
     FFmpeg Source: Източник на FFmpeg
     Detected FFmpeg Version Template: 'Открита версия на FFmpeg: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Открита версия на FFmpeg/FFprobe: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg все още не е изтеглен. Натиснете бутона по-долу, за да го изтеглите.
     System FFmpeg Missing Warning: FFmpeg не е намерен в системата. Той е необходим за обединяване на видео и аудио и за преобразуване на аудио. Инсталирайте го, задайте друг път по-долу или сменете източника на „Управляван от OpenTubeX“.
     Download FFmpeg: Изтегляне на FFmpeg

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -667,6 +667,7 @@ Settings:
     yt-dlp Download Error Template: "C'hwitet eo pellgargañ yt-dlp: {error}"
     FFmpeg Source: "Tarzh FFmpeg"
     Detected FFmpeg Version Template: "Stumm FFmpeg dinoet: {version}"
+    Detected FFmpeg and FFprobe Version Template: "Stumm FFmpeg/FFprobe dinoet: {version}"
     FFmpeg Managed Not Downloaded: "N'eo ket bet pellgarget FFmpeg c'hoazh. Klikit war ar bouton amañ dindan evit e bellgargañ."
     System FFmpeg Missing Warning: "N'eo ket bet kavet FFmpeg war ho reizhiad. Rekis eo evit kendeuziñ ar video hag ar son hag evit amdreiñ ar son. Staliit anezhañ, lakait un hent personelaet amañ dindan pe dibabit «Meret gant OpenTubeX» evel tarzh."
     Download FFmpeg: "Pellgargañ FFmpeg"

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -917,6 +917,7 @@ Settings:
     yt-dlp Download Error Template: 'Ha fallat la baixada de yt-dlp: {error}'
     FFmpeg Source: Origen de FFmpeg
     Detected FFmpeg Version Template: 'Versió de FFmpeg detectada: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Versió de FFmpeg/FFprobe detectada: {version}'
     FFmpeg Managed Not Downloaded: Encara no s'ha baixat FFmpeg. Feu clic al botó de sota per baixar-lo.
     System FFmpeg Missing Warning: No s'ha trobat FFmpeg al sistema. És necessari per combinar vídeo i àudio i per convertir àudio. Instal·leu-lo, definiu un camí personalitzat a sota o canvieu l'origen a "Gestionat per l'OpenTubeX".
     Download FFmpeg: Baixa FFmpeg

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -667,6 +667,7 @@ Settings:
     yt-dlp Download Error Template: 'Stažení yt-dlp se nezdařilo: {error}'
     FFmpeg Source: Zdroj FFmpeg
     Detected FFmpeg Version Template: 'Zjištěná verze FFmpeg: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Zjištěná verze FFmpeg/FFprobe: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg zatím není stažený. Stáhnete jej kliknutím na tlačítko níže.
     System FFmpeg Missing Warning: FFmpeg nebyl v systému nalezen. Je nutný ke slučování obrazu se zvukem a k převodu zvuku. Nainstalujte jej, nastavte níže vlastní cestu nebo změňte zdroj na „Spravováno aplikací OpenTubeX“.
     Download FFmpeg: Stáhnout FFmpeg

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -669,6 +669,7 @@ Settings:
     yt-dlp Download Error Template: 'Methodd lawrlwytho yt-dlp: {error}'
     FFmpeg Source: Ffynhonnell FFmpeg
     Detected FFmpeg Version Template: 'Fersiwn FFmpeg a ganfuwyd: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Fersiwn FFmpeg/FFprobe a ganfuwyd: {version}'
     FFmpeg Managed Not Downloaded: Nid yw FFmpeg wedi'i lawrlwytho eto. Cliciwch y botwm isod i'w lawrlwytho.
     System FFmpeg Missing Warning: Ni chanfuwyd FFmpeg ar eich system. Mae ei angen i uno fideo a sain ac i drosi sain. Gosodwch ef, gosodwch lwybr personol isod, neu newidiwch y ffynhonnell i "Rheolir gan OpenTubeX".
     Download FFmpeg: Lawrlwytho FFmpeg

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -691,6 +691,7 @@ Settings:
     yt-dlp Download Error Template: 'Download af yt-dlp mislykkedes: {error}'
     FFmpeg Source: Kilde til FFmpeg
     Detected FFmpeg Version Template: 'Registreret FFmpeg-version: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Registreret FFmpeg/FFprobe-version: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg er ikke downloadet endnu. Klik på knappen nedenfor for at downloade det.
     System FFmpeg Missing Warning: FFmpeg blev ikke fundet på dit system. Det kræves for at flette video og lyd og konvertere lyd. Installer det, angiv en brugerdefineret sti nedenfor, eller skift kilden til "Administreret af OpenTubeX".
     Download FFmpeg: Download FFmpeg

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -680,6 +680,7 @@ Settings:
     yt-dlp Download Error Template: 'Η λήψη του yt-dlp απέτυχε: {error}'
     FFmpeg Source: Προέλευση FFmpeg
     Detected FFmpeg Version Template: 'Εντοπίστηκε έκδοση FFmpeg: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Εντοπίστηκε έκδοση FFmpeg/FFprobe: {version}'
     FFmpeg Managed Not Downloaded: Δεν έχει γίνει ακόμη λήψη του FFmpeg. Κάντε κλικ στο παρακάτω κουμπί για να το κατεβάσετε.
     System FFmpeg Missing Warning: Το FFmpeg δεν βρέθηκε στο σύστημά σας. Απαιτείται για τη συγχώνευση βίντεο και ήχου, καθώς και για τη μετατροπή ήχου. Εγκαταστήστε το, ορίστε παρακάτω μια προσαρμοσμένη διαδρομή ή αλλάξτε την προέλευση σε «Διαχείριση από το OpenTubeX».
     Download FFmpeg: Λήψη FFmpeg

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -654,6 +654,7 @@ Settings:
     yt-dlp Download Error Template: 'Downloading yt-dlp failed: {error}'
     FFmpeg Source: FFmpeg Source
     Detected FFmpeg Version Template: 'Detected FFmpeg version: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Detected FFmpeg/FFprobe version: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg has not been downloaded yet. Click the button below to download it.
     System FFmpeg Missing Warning: FFmpeg was not found on your system. It is required for merging video and audio and for audio conversion. Install it, set a custom path below, or switch the source to "Managed by OpenTubeX".
     Download FFmpeg: Download FFmpeg

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -750,6 +750,7 @@ Settings:
     yt-dlp Download Error Template: 'No se pudo descargar yt-dlp: {error}'
     FFmpeg Source: Fuente de FFmpeg
     Detected FFmpeg Version Template: 'Versión de FFmpeg detectada: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Versión de FFmpeg/FFprobe detectada: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg aún no se ha descargado. Hacé clic en el botón de abajo para descargarlo.
     System FFmpeg Missing Warning: No se encontró FFmpeg en el sistema. Es necesario para combinar video y audio y para convertir audio. Instalalo, definí una ruta personalizada abajo o cambiá la fuente a «Gestionada por OpenTubeX».
     Download FFmpeg: Descargar FFmpeg

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -784,6 +784,7 @@ Settings:
     yt-dlp Download Error Template: 'No se pudo descargar yt-dlp: {error}'
     FFmpeg Source: Fuente de FFmpeg
     Detected FFmpeg Version Template: 'Versión de FFmpeg detectada: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Versión de FFmpeg/FFprobe detectada: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg aún no se ha descargado. Haz clic en el botón de abajo para descargarlo.
     System FFmpeg Missing Warning: No se encontró FFmpeg en el sistema. Es necesario para combinar video y audio y para convertir audio. Instálalo, define una ruta personalizada abajo o cambia la fuente a «Gestionada por OpenTubeX».
     Download FFmpeg: Descargar FFmpeg

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -673,6 +673,7 @@ Settings:
     yt-dlp Download Error Template: 'No se pudo descargar yt-dlp: {error}'
     FFmpeg Source: Fuente de FFmpeg
     Detected FFmpeg Version Template: 'Versión de FFmpeg detectada: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Versión de FFmpeg/FFprobe detectada: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg aún no se ha descargado. Haz clic en el botón de abajo para descargarlo.
     System FFmpeg Missing Warning: No se encontró FFmpeg en el sistema. Es necesario para combinar vídeo y audio y para convertir audio. Instálalo, define una ruta personalizada abajo o cambia la fuente a «Gestionada por OpenTubeX».
     Download FFmpeg: Descargar FFmpeg

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -667,6 +667,7 @@ Settings:
     yt-dlp Download Error Template: 'yt-dlp allalaadimine nurjus: {error}'
     FFmpeg Source: FFmpegi allikas
     Detected FFmpeg Version Template: 'Tuvastatud FFmpegi versioon: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Tuvastatud FFmpegi/FFprobei versioon: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg pole veel alla laaditud. Allalaadimiseks klõpsa allolevat nuppu.
     System FFmpeg Missing Warning: Sinu süsteemist ei leitud FFmpegi. Seda on vaja video ja heli ühendamiseks ning heli teisendamiseks. Paigalda see, määra allpool kohandatud asukoht või vali allikaks "OpenTubeXi hallatav".
     Download FFmpeg: Laadi FFmpeg alla

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -669,6 +669,7 @@ Settings:
     yt-dlp Download Error Template: 'Ezin izan da yt-dlp deskargatu: {error}'
     FFmpeg Source: FFmpeg-en jatorria
     Detected FFmpeg Version Template: 'Hautemandako FFmpeg bertsioa: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Hautemandako FFmpeg/FFprobe bertsioa: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg ez da deskargatu oraindik. Egin klik beheko botoian deskargatzeko.
     System FFmpeg Missing Warning: Ez da FFmpeg aurkitu sisteman. Beharrezkoa da bideoa eta audioa bateratzeko eta audioa bihurtzeko. Instalatu, ezarri bide-izen pertsonalizatu bat behean edo aldatu jatorria "OpenTubeX aplikazioak kudeatua" aukerara.
     Download FFmpeg: Deskargatu FFmpeg

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -696,6 +696,7 @@ Settings:
     yt-dlp Download Error Template: 'بارگیری yt-dlp ناموفق بود: {error}'
     FFmpeg Source: منبع FFmpeg
     Detected FFmpeg Version Template: 'نسخهٔ شناسایی‌شدهٔ FFmpeg: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'نسخهٔ شناسایی‌شدهٔ FFmpeg/FFprobe: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg هنوز بارگیری نشده است. برای بارگیری، روی دکمهٔ زیر کلیک کنید.
     System FFmpeg Missing Warning: FFmpeg در سیستم شما پیدا نشد. برای ادغام ویدیو و صدا و تبدیل صدا لازم است. آن را نصب کنید، در پایین مسیر سفارشی تعیین کنید یا منبع را به «تحت مدیریت OpenTubeX» تغییر دهید.
     Download FFmpeg: بارگیری FFmpeg

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -680,6 +680,7 @@ Settings:
     yt-dlp Download Error Template: 'yt-dlp:n lataus epäonnistui: {error}'
     FFmpeg Source: FFmpeg-lähde
     Detected FFmpeg Version Template: 'Havaittu FFmpeg-versio: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Havaittu FFmpeg-/FFprobe-versio: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg-ohjelmaa ei ole vielä ladattu. Lataa se napsauttamalla alla olevaa painiketta.
     System FFmpeg Missing Warning: FFmpeg-ohjelmaa ei löytynyt järjestelmästä. Sitä tarvitaan videon ja äänen yhdistämiseen sekä äänen muuntamiseen. Asenna se, määritä mukautettu polku alla tai vaihda lähteeksi "OpenTubeX:n hallitsema".
     Download FFmpeg: Lataa FFmpeg

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -667,6 +667,7 @@ Settings:
     yt-dlp Download Error Template: 'Échec du téléchargement de yt-dlp : {error}'
     FFmpeg Source: Source de FFmpeg
     Detected FFmpeg Version Template: 'Version de FFmpeg détectée : {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Version de FFmpeg/FFprobe détectée : {version}'
     FFmpeg Managed Not Downloaded: FFmpeg n’a pas encore été téléchargé. Cliquez sur le bouton ci-dessous pour le télécharger.
     System FFmpeg Missing Warning: FFmpeg est introuvable sur votre système. Il est nécessaire pour fusionner la vidéo et le son, ainsi que pour convertir le son. Installez-le, indiquez un chemin personnalisé ci-dessous ou choisissez la source « Géré par OpenTubeX ».
     Download FFmpeg: Télécharger FFmpeg

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -675,6 +675,7 @@ Settings:
     yt-dlp Download Error Template: 'Produciuse un erro ao descargar yt-dlp: {error}'
     FFmpeg Source: Orixe de FFmpeg
     Detected FFmpeg Version Template: 'Versión de FFmpeg detectada: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Versión de FFmpeg/FFprobe detectada: {version}'
     FFmpeg Managed Not Downloaded: Aínda non se descargou FFmpeg. Preme o botón inferior para descargalo.
     System FFmpeg Missing Warning: Non se atopou FFmpeg no sistema. É necesario para combinar vídeo e son e para converter son. Instálao, indica unha ruta personalizada embaixo ou cambia a orixe a «Xestionado por OpenTubeX».
     Download FFmpeg: Descargar FFmpeg

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -680,6 +680,7 @@ Settings:
     yt-dlp Download Error Template: 'הורדת yt-dlp נכשלה: {error}'
     FFmpeg Source: מקור FFmpeg
     Detected FFmpeg Version Template: 'גרסת FFmpeg שזוהתה: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'גרסת FFmpeg/FFprobe שזוהתה: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg עדיין לא הורד. לחצו על הכפתור למטה כדי להוריד אותו.
     System FFmpeg Missing Warning: FFmpeg לא נמצא במערכת. הוא דרוש למיזוג וידאו ושמע ולהמרת שמע. התקינו אותו, הגדירו נתיב מותאם אישית למטה או החליפו את המקור ל"מנוהל בידי OpenTubeX".
     Download FFmpeg: הורדת FFmpeg

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -669,6 +669,7 @@ Settings:
     yt-dlp Download Error Template: 'Preuzimanje alata yt-dlp nije uspjelo: {error}'
     FFmpeg Source: Izvor za FFmpeg
     Detected FFmpeg Version Template: 'Otkrivena verzija alata FFmpeg: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Otkrivena verzija alata FFmpeg/FFprobe: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg još nije preuzet. Kliknite gumb u nastavku da biste ga preuzeli.
     System FFmpeg Missing Warning: FFmpeg nije pronađen na sustavu. Potreban je za spajanje videozapisa i zvuka te za pretvorbu zvuka. Instalirajte ga, u nastavku postavite prilagođenu putanju ili promijenite izvor na "Upravlja OpenTubeX".
     Download FFmpeg: Preuzmi FFmpeg

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -667,6 +667,7 @@ Settings:
     yt-dlp Download Error Template: 'Nem sikerült letölteni az yt-dlp programot: {error}'
     FFmpeg Source: FFmpeg forrása
     Detected FFmpeg Version Template: 'Észlelt FFmpeg-verzió: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Észlelt FFmpeg/FFprobe-verzió: {version}'
     FFmpeg Managed Not Downloaded: Az FFmpeg még nincs letöltve. A letöltéshez kattintson az alábbi gombra.
     System FFmpeg Missing Warning: Az FFmpeg nem található a rendszeren. A videó és a hang egyesítéséhez, valamint a hang átalakításához szükséges. Telepítse, adjon meg alább egy egyéni elérési utat, vagy váltson „Az OpenTubeX felügyeletével” forrásra.
     Download FFmpeg: FFmpeg letöltése

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -675,6 +675,7 @@ Settings:
     yt-dlp Download Error Template: 'Gagal mengunduh yt-dlp: {error}'
     FFmpeg Source: Sumber FFmpeg
     Detected FFmpeg Version Template: 'Versi FFmpeg yang terdeteksi: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Versi FFmpeg/FFprobe yang terdeteksi: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg belum diunduh. Klik tombol di bawah untuk mengunduhnya.
     System FFmpeg Missing Warning: FFmpeg tidak ditemukan di sistem Anda. FFmpeg diperlukan untuk menggabungkan video dan audio serta mengonversi audio. Pasang FFmpeg, tentukan jalur khusus di bawah, atau ubah sumber ke "Dikelola oleh OpenTubeX".
     Download FFmpeg: Unduh FFmpeg

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -675,6 +675,7 @@ Settings:
     yt-dlp Download Error Template: 'Ekki tókst að hlaða niður yt-dlp: {error}'
     FFmpeg Source: Uppruni FFmpeg
     Detected FFmpeg Version Template: 'Útgáfa FFmpeg fannst: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Útgáfa FFmpeg/FFprobe fannst: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg hefur ekki verið hlaðið niður enn. Smelltu á hnappinn fyrir neðan til að hlaða því niður.
     System FFmpeg Missing Warning: FFmpeg fannst ekki í kerfinu. Það er nauðsynlegt til að sameina mynd og hljóð og til að umbreyta hljóði. Settu það upp, tilgreindu sérsniðna slóð fyrir neðan eða veldu "Umsjón OpenTubeX" sem uppruna.
     Download FFmpeg: Hlaða niður FFmpeg

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -667,6 +667,7 @@ Settings:
     yt-dlp Download Error Template: 'Download di yt-dlp non riuscito: {error}'
     FFmpeg Source: Origine di FFmpeg
     Detected FFmpeg Version Template: 'Versione di FFmpeg rilevata: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Versione di FFmpeg/FFprobe rilevata: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg non è ancora stato scaricato. Fai clic sul pulsante qui sotto per scaricarlo.
     System FFmpeg Missing Warning: FFmpeg non è stato trovato nel sistema. È necessario per unire video e audio e per convertire l'audio. Installalo, imposta un percorso personalizzato qui sotto oppure seleziona l'origine "Gestito da OpenTubeX".
     Download FFmpeg: Scarica FFmpeg

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -667,6 +667,7 @@ Settings:
     yt-dlp Download Error Template: 'yt-dlpのダウンロードに失敗しました: {error}'
     FFmpeg Source: FFmpegの入手元
     Detected FFmpeg Version Template: '検出したFFmpegのバージョン: {version}'
+    Detected FFmpeg and FFprobe Version Template: '検出したFFmpeg/FFprobeのバージョン: {version}'
     FFmpeg Managed Not Downloaded: FFmpegはまだダウンロードされていません。下のボタンをクリックしてダウンロードしてください。
     System FFmpeg Missing Warning: システムにFFmpegが見つかりません。動画と音声の結合や音声変換に必要です。インストールするか、下でカスタムパスを指定するか、入手元を「OpenTubeXで管理」に変更してください。
     Download FFmpeg: FFmpegをダウンロード

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -843,6 +843,7 @@ Settings:
     yt-dlp Download Error Template: 'yt-dlp 다운로드 실패: {error}'
     FFmpeg Source: FFmpeg 소스
     Detected FFmpeg Version Template: '감지된 FFmpeg 버전: {version}'
+    Detected FFmpeg and FFprobe Version Template: '감지된 FFmpeg/FFprobe 버전: {version}'
     FFmpeg Managed Not Downloaded: 아직 FFmpeg를 다운로드하지 않았습니다. 아래 버튼을 클릭하여 다운로드하세요.
     System FFmpeg Missing Warning: 시스템에서 FFmpeg를 찾을 수 없습니다. 동영상과 오디오 병합 및 오디오 변환에 필요합니다. 설치하거나 아래에서 사용자 지정 경로를 설정하거나 소스를 "OpenTubeX에서 관리"로 변경하세요.
     Download FFmpeg: FFmpeg 다운로드

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -868,6 +868,7 @@ Settings:
     yt-dlp Download Error Template: 'Nepavyko atsisiųsti yt-dlp: {error}'
     FFmpeg Source: FFmpeg šaltinis
     Detected FFmpeg Version Template: 'Aptikta FFmpeg versija: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Aptikta FFmpeg/FFprobe versija: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg dar neatsisiųsta. Norėdami atsisiųsti, spustelėkite toliau esantį mygtuką.
     System FFmpeg Missing Warning: Sistemoje nerasta FFmpeg. Ji būtina vaizdo ir garso failams sujungti bei garsui konvertuoti. Įdiekite ją, toliau nurodykite pasirinktinį kelią arba kaip šaltinį pasirinkite „Valdo OpenTubeX“.
     Download FFmpeg: Atsisiųsti FFmpeg

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -667,6 +667,7 @@ Settings:
     yt-dlp Download Error Template: 'Kunne ikke laste ned yt-dlp: {error}'
     FFmpeg Source: Kilde for FFmpeg
     Detected FFmpeg Version Template: 'Oppdaget FFmpeg-versjon: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Oppdaget FFmpeg/FFprobe-versjon: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg er ikke lastet ned ennå. Klikk på knappen nedenfor for å laste det ned.
     System FFmpeg Missing Warning: Fant ikke FFmpeg på systemet. Det kreves for å slå sammen video og lyd og for å konvertere lyd. Installer det, angi en egendefinert bane nedenfor eller bytt kilde til «Administrert av OpenTubeX».
     Download FFmpeg: Last ned FFmpeg

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -680,6 +680,7 @@ Settings:
     yt-dlp Download Error Template: 'Downloaden van yt-dlp mislukt: {error}'
     FFmpeg Source: FFmpeg-bron
     Detected FFmpeg Version Template: 'Gedetecteerde FFmpeg-versie: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Gedetecteerde FFmpeg/FFprobe-versie: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg is nog niet gedownload. Klik op de knop hieronder om het te downloaden.
     System FFmpeg Missing Warning: FFmpeg is niet op je systeem gevonden. Het is vereist om video en audio samen te voegen en audio te converteren. Installeer het, stel hieronder een aangepast pad in of wijzig de bron in "Beheerd door OpenTubeX".
     Download FFmpeg: FFmpeg downloaden

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -810,6 +810,7 @@ Settings:
     yt-dlp Download Error Template: 'Klarte ikkje å laste ned yt-dlp: {error}'
     FFmpeg Source: FFmpeg-kjelde
     Detected FFmpeg Version Template: 'Oppdaga FFmpeg-versjon: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Oppdaga FFmpeg/FFprobe-versjon: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg er ikkje lasta ned enno. Trykk på knappen nedanfor for å laste det ned.
     System FFmpeg Missing Warning: Fann ikkje FFmpeg på systemet. Det trengst for å slå saman video og lyd og for å konvertere lyd. Installer det, vel ein tilpassa stig nedanfor eller byt kjelde til "Forvalta av OpenTubeX".
     Download FFmpeg: Last ned FFmpeg

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -249,6 +249,7 @@ Settings:
     Concurrent Downloads: Jednoczesne pobieranie
     Bandwidth Limit: Limit przepustowości (KiB/s, 0 oznacza brak limitu)
   External Software Settings:
+    Detected FFmpeg and FFprobe Version Template: 'Wykryta wersja FFmpeg/FFprobe: {version}'
     Download FFmpeg and FFprobe: Pobierz FFmpeg i FFprobe
     Update FFmpeg and FFprobe: Zaktualizuj FFmpeg i FFprobe
     Downloading FFmpeg and FFprobe: Pobieranie FFmpeg i FFprobe…

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -667,6 +667,7 @@ Settings:
     yt-dlp Download Error Template: 'Falha ao baixar o yt-dlp: {error}'
     FFmpeg Source: Origem do FFmpeg
     Detected FFmpeg Version Template: 'Versão do FFmpeg detectada: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Versão do FFmpeg/FFprobe detectada: {version}'
     FFmpeg Managed Not Downloaded: O FFmpeg ainda não foi baixado. Clique no botão abaixo para o baixar.
     System FFmpeg Missing Warning: O FFmpeg não foi encontrado no sistema. Ele é necessário para combinar vídeo e áudio e para converter áudio. Instale-o, defina um caminho personalizado abaixo ou altere a origem para «Gerenciado pelo OpenTubeX».
     Download FFmpeg: Transferir FFmpeg

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -675,6 +675,7 @@ Settings:
     yt-dlp Download Error Template: 'Falha ao transferir o yt-dlp: {error}'
     FFmpeg Source: Origem do FFmpeg
     Detected FFmpeg Version Template: 'Versão do FFmpeg detetada: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Versão do FFmpeg/FFprobe detetada: {version}'
     FFmpeg Managed Not Downloaded: O FFmpeg ainda não foi transferido. Clique no botão abaixo para o transferir.
     System FFmpeg Missing Warning: O FFmpeg não foi encontrado no sistema. É necessário para combinar vídeo e áudio e para converter áudio. Instale-o, defina um caminho personalizado abaixo ou altere a origem para «Gerido pelo OpenTubeX».
     Download FFmpeg: Transferir FFmpeg

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -682,6 +682,7 @@ Settings:
     yt-dlp Download Error Template: 'Falha ao transferir o yt-dlp: {error}'
     FFmpeg Source: Origem do FFmpeg
     Detected FFmpeg Version Template: 'Versão do FFmpeg detetada: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Versão do FFmpeg/FFprobe detetada: {version}'
     FFmpeg Managed Not Downloaded: O FFmpeg ainda não foi transferido. Clique no botão abaixo para o transferir.
     System FFmpeg Missing Warning: O FFmpeg não foi encontrado no sistema. É necessário para combinar vídeo e áudio e para converter áudio. Instale-o, defina um caminho personalizado abaixo ou altere a origem para «Gerido pelo OpenTubeX».
     Download FFmpeg: Transferir FFmpeg

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -671,6 +671,7 @@ Settings:
     yt-dlp Download Error Template: 'Descărcarea yt-dlp a eșuat: {error}'
     FFmpeg Source: Sursa FFmpeg
     Detected FFmpeg Version Template: 'Versiune FFmpeg detectată: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Versiune FFmpeg/FFprobe detectată: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg nu a fost descărcat încă. Apăsați butonul de mai jos pentru a-l descărca.
     System FFmpeg Missing Warning: FFmpeg nu a fost găsit în sistem. Este necesar pentru îmbinarea imaginii cu sunetul și pentru conversia audio. Instalați-l, setați mai jos o cale personalizată sau schimbați sursa la „Gestionată de OpenTubeX”.
     Download FFmpeg: Descarcă FFmpeg

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -652,6 +652,7 @@ Settings:
     yt-dlp Download Error Template: 'Не удалось загрузить yt-dlp: {error}'
     FFmpeg Source: Источник FFmpeg
     Detected FFmpeg Version Template: 'Обнаружена версия FFmpeg: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Обнаружена версия FFmpeg/FFprobe: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg ещё не загружен. Нажмите кнопку ниже, чтобы загрузить его.
     System FFmpeg Missing Warning: FFmpeg не найден в системе. Он необходим для объединения видео и звука, а также для преобразования звука. Установите его, укажите пользовательский путь ниже или выберите источник «Управляется OpenTubeX».
     Download FFmpeg: Загрузить FFmpeg

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -667,6 +667,7 @@ Settings:
     yt-dlp Download Error Template: 'yt-dlp sa nepodarilo stiahnuť: {error}'
     FFmpeg Source: Zdroj FFmpeg
     Detected FFmpeg Version Template: 'Zistená verzia FFmpeg: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Zistená verzia FFmpeg/FFprobe: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg ešte nebol stiahnutý. Stiahnite ho tlačidlom nižšie.
     System FFmpeg Missing Warning: FFmpeg sa v systéme nenašiel. Je potrebný na spájanie obrazu so zvukom a na prevod zvuku. Nainštalujte ho, nastavte vlastnú cestu nižšie alebo zmeňte zdroj na „Spravované aplikáciou OpenTubeX“.
     Download FFmpeg: Stiahnuť FFmpeg

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -884,6 +884,7 @@ Settings:
     yt-dlp Download Error Template: 'Prenos yt-dlp ni uspel: {error}'
     FFmpeg Source: Vir za FFmpeg
     Detected FFmpeg Version Template: 'Zaznana različica FFmpeg: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Zaznana različica FFmpeg/FFprobe: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg še ni prenesen. Za prenos kliknite spodnji gumb.
     System FFmpeg Missing Warning: Orodja FFmpeg ni bilo mogoče najti v sistemu. Potrebno je za združevanje slike in zvoka ter pretvorbo zvoka. Namestite ga, spodaj nastavite pot po meri ali kot vir izberite »Upravlja OpenTubeX«.
     Download FFmpeg: Prenesi FFmpeg

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -689,6 +689,7 @@ Settings:
     yt-dlp Download Error Template: 'Преузимање програма yt-dlp није успело: {error}'
     FFmpeg Source: Извор за FFmpeg
     Detected FFmpeg Version Template: 'Откривена верзија програма FFmpeg: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Откривена верзија програма FFmpeg/FFprobe: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg још није преузет. Кликни на дугме испод да га преузмеш.
     System FFmpeg Missing Warning: FFmpeg није пронађен на систему. Неопходан је за спајање видео-снимка и звука, као и за претварање звука. Инсталирај га, подеси прилагођену путању испод или пребаци извор на „Управља OpenTubeX“.
     Download FFmpeg: Преузми FFmpeg

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -669,6 +669,7 @@ Settings:
     yt-dlp Download Error Template: 'Det gick inte att ladda ned yt-dlp: {error}'
     FFmpeg Source: Källa för FFmpeg
     Detected FFmpeg Version Template: 'Identifierad FFmpeg-version: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Identifierad FFmpeg/FFprobe-version: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg har inte laddats ned ännu. Klicka på knappen nedan för att ladda ned det.
     System FFmpeg Missing Warning: FFmpeg hittades inte på systemet. Det krävs för att sammanfoga video och ljud samt för ljudkonvertering. Installera det, ange en egen sökväg nedan eller byt källa till "Hanteras av OpenTubeX".
     Download FFmpeg: Ladda ned FFmpeg

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -679,6 +679,7 @@ Settings:
     yt-dlp Download Error Template: 'yt-dlp பதிவிறக்கம் தோல்வியடைந்தது: {error}'
     FFmpeg Source: FFmpeg மூலம்
     Detected FFmpeg Version Template: 'கண்டறிந்த FFmpeg பதிப்பு: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'கண்டறிந்த FFmpeg/FFprobe பதிப்பு: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg இன்னும் பதிவிறக்கப்படவில்லை. அதைப் பதிவிறக்கக் கீழுள்ள பொத்தானைக் கிளிக் செய்யவும்.
     System FFmpeg Missing Warning: உங்கள் கணினியில் FFmpeg கிடைக்கவில்லை. காணொளியையும் ஒலியையும் ஒன்றிணைக்கவும் ஒலியை மாற்றவும் இது தேவை. அதை நிறுவவும், கீழே தனிப்பயன் பாதையை அமைக்கவும் அல்லது மூலத்தை "OpenTubeX நிர்வகிப்பது" என மாற்றவும்.
     Download FFmpeg: FFmpeg-ஐப் பதிவிறக்கு

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -667,6 +667,7 @@ Settings:
     yt-dlp Download Error Template: 'yt-dlp indirilemedi: {error}'
     FFmpeg Source: FFmpeg Kaynağı
     Detected FFmpeg Version Template: 'Algılanan FFmpeg sürümü: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Algılanan FFmpeg/FFprobe sürümü: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg henüz indirilmedi. İndirmek için aşağıdaki düğmeye tıklayın.
     System FFmpeg Missing Warning: FFmpeg sisteminizde bulunamadı. Video ve sesi birleştirmenin yanı sıra ses dönüştürme için de gereklidir. Yükleyin, aşağıda özel bir yol ayarlayın veya kaynağı "OpenTubeX tarafından yönetilen" olarak değiştirin.
     Download FFmpeg: FFmpeg'i İndir

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -675,6 +675,7 @@ Settings:
     yt-dlp Download Error Template: 'Не вдалося завантажити yt-dlp: {error}'
     FFmpeg Source: Джерело FFmpeg
     Detected FFmpeg Version Template: 'Виявлена версія FFmpeg: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Виявлена версія FFmpeg/FFprobe: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg ще не завантажено. Натисніть кнопку нижче, щоб завантажити його.
     System FFmpeg Missing Warning: У системі не знайдено FFmpeg. Він потрібен для об’єднання відео й аудіо та перетворення аудіо. Встановіть його, укажіть власний шлях нижче або виберіть джерело «Керується OpenTubeX».
     Download FFmpeg: Завантажити FFmpeg

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -675,6 +675,7 @@ Settings:
     yt-dlp Download Error Template: 'Không tải được yt-dlp: {error}'
     FFmpeg Source: Nguồn FFmpeg
     Detected FFmpeg Version Template: 'Phiên bản FFmpeg đã phát hiện: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Phiên bản FFmpeg/FFprobe đã phát hiện: {version}'
     FFmpeg Managed Not Downloaded: Chưa tải FFmpeg. Nhấp vào nút bên dưới để tải.
     System FFmpeg Missing Warning: Không tìm thấy FFmpeg trên hệ thống. Công cụ này cần thiết để ghép video với âm thanh và chuyển đổi âm thanh. Hãy cài đặt, đặt đường dẫn tùy chỉnh bên dưới hoặc chuyển nguồn sang "Do OpenTubeX quản lý".
     Download FFmpeg: Tải FFmpeg

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -667,6 +667,7 @@ Settings:
     yt-dlp Download Error Template: '下载 yt-dlp 失败：{error}'
     FFmpeg Source: FFmpeg 来源
     Detected FFmpeg Version Template: '检测到的 FFmpeg 版本：{version}'
+    Detected FFmpeg and FFprobe Version Template: '检测到的 FFmpeg/FFprobe 版本：{version}'
     FFmpeg Managed Not Downloaded: 尚未下载 FFmpeg。点击下方按钮进行下载。
     System FFmpeg Missing Warning: 系统中未找到 FFmpeg。合并视频和音频以及转换音频时需要该工具。请安装该工具，在下方设置自定义路径，或将来源切换为“由 OpenTubeX 管理”。
     Download FFmpeg: 下载 FFmpeg

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -667,6 +667,7 @@ Settings:
     yt-dlp Download Error Template: '下載 yt-dlp 失敗：{error}'
     FFmpeg Source: FFmpeg 來源
     Detected FFmpeg Version Template: '偵測到的 FFmpeg 版本：{version}'
+    Detected FFmpeg and FFprobe Version Template: '偵測到的 FFmpeg/FFprobe 版本：{version}'
     FFmpeg Managed Not Downloaded: 尚未下載 FFmpeg。請按下方按鈕下載。
     System FFmpeg Missing Warning: 系統中找不到 FFmpeg。合併影片與音訊及轉換音訊時需要使用 FFmpeg。請安裝 FFmpeg、在下方設定自訂路徑，或將來源切換為「由 OpenTubeX 管理」。
     Download FFmpeg: 下載 FFmpeg

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -1296,6 +1296,7 @@ Settings:
     yt-dlp Download Error Template: 'Herunterladen von yt-dlp fehlgeschlagen: {error}'
     FFmpeg Source: FFmpeg-Quelle
     Detected FFmpeg Version Template: 'Erkannte FFmpeg-Version: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Erkannte FFmpeg-/FFprobe-Version: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg wurde noch nicht heruntergeladen. Klicke auf die Schaltfläche unten, um es herunterzuladen.
     System FFmpeg Missing Warning: FFmpeg wurde auf deinem System nicht gefunden. Es wird zum Zusammenführen von Video und Audio sowie zur Audiokonvertierung benötigt. Installiere es, lege unten einen benutzerdefinierten Pfad fest oder wechsle die Quelle auf „Von OpenTubeX verwaltet“.
     Download FFmpeg: FFmpeg herunterladen

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1164,6 +1164,7 @@ Settings:
     yt-dlp Download Error Template: 'Downloading yt-dlp failed: {error}'
     FFmpeg Source: FFmpeg Source
     Detected FFmpeg Version Template: 'Detected FFmpeg version: {version}'
+    Detected FFmpeg and FFprobe Version Template: 'Detected FFmpeg/FFprobe version: {version}'
     FFmpeg Managed Not Downloaded: FFmpeg has not been downloaded yet. Click the button below to download it.
     System FFmpeg Missing Warning: FFmpeg was not found on your system. It is required for merging video and audio and for audio conversion. Install it, set a custom path below, or switch the source to "Managed by OpenTubeX".
     Download FFmpeg: Download FFmpeg


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The External Software settings repeated the same version on separate FFmpeg and FFprobe status lines when both tools reported an identical version.

This combines matching versions into one localized `FFmpeg/FFprobe` status. Different versions and missing-tool states remain separate.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Matching FFmpeg and FFprobe versions now appear on a single line in External Software settings.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
Open Settings, select Advanced, and inspect External Software. When FFmpeg and FFprobe report the same version, one `FFmpeg/FFprobe` version line should appear. When their versions differ, each tool should retain its own version line.

## Additional context
<!-- Add any other context about the pull request here. -->
Created with GPT-5 using the Codex desktop app.
