### PR TITLE
fix(images): retry missing channel pictures and card thumbnails

### DIFF
--- a/e2e/tests/offline/video-result-avatars.spec.mjs
+++ b/e2e/tests/offline/video-result-avatars.spec.mjs
@@ -66,6 +66,38 @@ test.describe('Invidious search video avatars', () => {
     }
   })
 
+  test('retries failed video and playlist thumbnails without reloading the results', async ({ page }) => {
+    await page.route(`${instanceUrl}/api/v1/search/**`, route => route.fulfill({
+      json: [invidiousVideo('avatar-search-1', 'Retry thumbnail result'), invidiousPlaylist()]
+    }))
+    await page.route(`${instanceUrl}/api/v1/channels/${CHANNEL_ID}?**`, route => route.fulfill({
+      json: { author: 'Channel A', authorThumbnails: [{ url: avatarUrl }], tabs: [] }
+    }))
+    await page.route(avatarUrl, route => fulfillVisualFixture(route, 'avatar'))
+    const failedRequests = []
+    const serveThumbnail = route => {
+      const url = new URL(route.request().url())
+      if (!url.searchParams.has('opentubex_retry')) {
+        failedRequests.push(url.toString())
+        return route.abort('failed')
+      }
+      return fulfillVisualFixture(route, 'video-thumbnail')
+    }
+    await page.route(`${instanceUrl}/vi/**`, serveThumbnail)
+    await page.route('https://i.ytimg.com/**', serveThumbnail)
+
+    await page.locator(sel.searchInput).fill('retry thumbnails')
+    await page.locator(sel.searchInput).press('Enter')
+
+    const thumbnails = page.locator('.ft-list-video .thumbnailImage')
+    await expect(thumbnails).toHaveCount(2)
+    await expectImagesLoaded(thumbnails)
+    expect(failedRequests.length).toBeGreaterThan(0)
+    for (const thumbnail of await thumbnails.all()) {
+      await expect(thumbnail).toHaveAttribute('src', /[?&]opentubex_retry=/)
+    }
+  })
+
   test('loads shared avatars and lays out result metadata responsively', async ({ page }) => {
     let channelRequests = 0
 

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -367,14 +367,14 @@
               draggable="false"
               @error="handleTabSwitcherPreviewError(tab)"
             >
-            <img
+            <FtRetryImage
               v-else-if="!tabSwitcherPreviewPending[tab.id] && getUsableTabSwitcherAvatarUrl(tab)"
               :src="getUsableTabSwitcherAvatarUrl(tab)"
               :alt="`${formatTabTitle(tab.title)} preview`"
               class="tabSwitcherPreviewAvatar"
               draggable="false"
               @error="handleTabSwitcherAvatarError(tab)"
-            >
+            />
             <span
               v-else-if="!tabSwitcherPreviewPending[tab.id]"
               class="tabSwitcherPreviewFallback"
@@ -387,14 +387,14 @@
             </span>
           </span>
           <span class="tabSwitcherTitle">
-            <img
+            <FtRetryImage
               v-if="showTabIcons && getUsableTabSwitcherAvatarUrl(tab)"
               :src="getUsableTabSwitcherAvatarUrl(tab)"
               class="tabSwitcherTitleAvatar"
               alt=""
               draggable="false"
               @error="handleTabSwitcherAvatarError(tab)"
-            >
+            />
             <FtIcon
               v-else-if="showTabIcons && getTabPageIcon(tab)"
               :icon="getTabPageIcon(tab)"
@@ -413,6 +413,7 @@
 </template>
 
 <script setup>
+import FtRetryImage from './components/FtRetryImage.vue'
 import { initializeAndroidYtDlp, ytDlp } from './helpers/ytDlp'
 import { parseAutomaticDownloadRules } from './helpers/automaticDownloadRules'
 import { isAppHidden, setAndroidAppVisible } from './helpers/appVisibility.js'

--- a/src/renderer/components/AutomaticDownloadSettings/AutomaticDownloadSettings.vue
+++ b/src/renderer/components/AutomaticDownloadSettings/AutomaticDownloadSettings.vue
@@ -51,12 +51,12 @@
             class="channelRule"
           >
             <div class="channelRuleHeader">
-              <img
+              <FtRetryImage
                 v-if="channel.thumbnail"
                 class="channelThumbnail"
                 :src="channel.thumbnail"
                 alt=""
-              >
+              />
               <span
                 v-else
                 class="channelThumbnail channelThumbnailPlaceholder"
@@ -181,6 +181,7 @@
 </template>
 
 <script setup>
+import FtRetryImage from '../FtRetryImage.vue'
 import { FtIcon } from '@opentubex/icons'
 import { computed, nextTick, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'

--- a/src/renderer/components/ChannelDetails/ChannelDetails.vue
+++ b/src/renderer/components/ChannelDetails/ChannelDetails.vue
@@ -18,13 +18,13 @@
         <div
           class="thumbnailContainer"
         >
-          <img
+          <FtRetryImage
             v-if="thumbnailUrl && !thumbnailLoadFailed"
             class="thumbnail"
             :src="thumbnailUrl"
             alt=""
             @error="handleThumbnailError"
-          >
+          />
           <FtIcon
             v-else
             class="thumbnail"
@@ -285,6 +285,7 @@
 </template>
 
 <script setup>
+import FtRetryImage from '../FtRetryImage.vue'
 import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue'
 
 import { FtIcon } from '@opentubex/icons'

--- a/src/renderer/components/ChannelSettings/ChannelSettings.vue
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.vue
@@ -106,12 +106,12 @@
                   :to="disableChannelLinks ? undefined : `/channel/${channel.id}`"
                   @click="handleChannelLinkClick"
                 >
-                  <img
+                  <FtRetryImage
                     v-if="channel.thumbnail"
                     class="channelThumbnail"
                     :src="channel.thumbnail"
                     alt=""
-                  >
+                  />
                   <span
                     v-else
                     class="channelThumbnail channelThumbnailPlaceholder"
@@ -259,12 +259,12 @@
                   :disabled="addingSubscribedChannel"
                   @click="addSubscribedChannel(channel.id)"
                 >
-                  <img
+                  <FtRetryImage
                     v-if="channel.thumbnail"
                     class="channelThumbnail"
                     :src="channel.thumbnail"
                     alt=""
-                  >
+                  />
                   <span
                     v-else
                     class="channelThumbnail channelThumbnailPlaceholder"
@@ -303,6 +303,7 @@
 </template>
 
 <script setup>
+import FtRetryImage from '../FtRetryImage.vue'
 import { FtIcon } from '@opentubex/icons'
 import { computed, nextTick, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'

--- a/src/renderer/components/CommentSection/CommentReply.vue
+++ b/src/renderer/components/CommentSection/CommentReply.vue
@@ -159,13 +159,13 @@
           v-if="reply.isHearted"
           class="commentHeartBadge"
         >
-          <img
+          <FtRetryImage
             :src="channelThumbnail"
             :title="$t('Comments.Hearted')"
             :aria-label="$t('Comments.Hearted')"
             class="commentHeartBadgeImg"
             alt=""
-          >
+          />
           <FtIcon
             :icon="['fas', 'heart']"
             class="commentHeartBadgeWhite"

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -363,13 +363,13 @@
               v-if="comment.isHearted"
               class="commentHeartBadge"
             >
-              <img
+              <FtRetryImage
                 :src="channelThumbnail"
                 :title="$t('Comments.Hearted')"
                 :aria-label="$t('Comments.Hearted')"
                 class="commentHeartBadgeImg"
                 alt=""
-              >
+              />
               <FtIcon
                 :icon="['fas', 'heart']"
                 class="commentHeartBadgeWhite"

--- a/src/renderer/components/FtChannelAvatar/FtChannelAvatar.vue
+++ b/src/renderer/components/FtChannelAvatar/FtChannelAvatar.vue
@@ -3,7 +3,7 @@
     class="channelAvatar"
     aria-hidden="true"
   >
-    <img
+    <FtRetryImage
       v-if="thumbnail && !thumbnailLoadFailed"
       class="channelAvatarImage"
       :src="thumbnail"
@@ -13,7 +13,7 @@
       loading="lazy"
       decoding="async"
       @error="thumbnailLoadFailed = true"
-    >
+    />
     <FtIcon
       v-else
       class="channelAvatarFallback"
@@ -23,6 +23,7 @@
 </template>
 
 <script setup>
+import FtRetryImage from '../FtRetryImage.vue'
 import { FtIcon } from '@opentubex/icons'
 import { ref, watch } from 'vue'
 

--- a/src/renderer/components/FtChannelBubble/FtChannelBubble.vue
+++ b/src/renderer/components/FtChannelBubble/FtChannelBubble.vue
@@ -6,13 +6,13 @@
     :to="`/channel/${channelId}`"
     :data-tab-title="channelName"
   >
-    <img
+    <FtRetryImage
       v-if="channelThumbnail != null && !thumbnailLoadFailed"
       class="bubble"
       :src="channelThumbnail"
       alt=""
       @error="handleThumbnailError"
-    >
+    />
     <FtIcon
       v-else
       :icon="['fas', 'circle-user']"
@@ -36,13 +36,13 @@
     @click="handleClick"
     @keydown.space.enter.prevent="handleClick"
   >
-    <img
+    <FtRetryImage
       v-if="channelThumbnail != null && !thumbnailLoadFailed"
       class="bubble"
       :src="channelThumbnail"
       alt=""
       @error="handleThumbnailError"
-    >
+    />
     <FtIcon
       v-else
       :icon="['fas', 'circle-user']"
@@ -68,6 +68,7 @@
 </template>
 
 <script setup>
+import FtRetryImage from '../FtRetryImage.vue'
 import { FtIcon } from '@opentubex/icons'
 import { ref, useId, watch } from 'vue'
 

--- a/src/renderer/components/FtCollaboratorsPrompt/FtCollaboratorsPrompt.vue
+++ b/src/renderer/components/FtCollaboratorsPrompt/FtCollaboratorsPrompt.vue
@@ -27,11 +27,11 @@
           :data-tab-title="collaborator.name"
           @click="emit('close')"
         >
-          <img
+          <FtRetryImage
             :src="collaborator.thumbnail"
             class="collaboratorModalThumbnail"
             alt=""
-          >
+          />
           <span class="collaboratorText">
             <span
               class="collaboratorName"
@@ -61,6 +61,7 @@
 </template>
 
 <script setup>
+import FtRetryImage from '../FtRetryImage.vue'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 

--- a/src/renderer/components/FtCommandPalette/FtCommandPalette.vue
+++ b/src/renderer/components/FtCommandPalette/FtCommandPalette.vue
@@ -102,14 +102,14 @@
                     :fallback="command.profileFallback"
                     aria-hidden="true"
                   />
-                  <img
+                  <FtRetryImage
                     v-else-if="hasUsableIconUrl(command)"
                     class="commandPaletteOptionIconImage"
                     :src="command.iconUrl"
                     alt=""
                     draggable="false"
                     @error="handleIconError(command.iconUrl)"
-                  >
+                  />
                   <FtIcon
                     v-else-if="command.icon"
                     class="commandPaletteOptionIcon"
@@ -167,6 +167,7 @@
 </template>
 
 <script setup>
+import FtRetryImage from '../FtRetryImage.vue'
 import { FtIcon } from '@opentubex/icons'
 import { computed, nextTick, onBeforeMount, onBeforeUnmount, onMounted, ref, useId, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'

--- a/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
+++ b/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
@@ -18,18 +18,18 @@
           tabindex="-1"
           aria-hidden="true"
         >
-          <img
+          <FtRetryImage
             :src="authorThumbnail"
             class="communityThumbnail"
             alt=""
-          >
+          />
         </component>
-        <img
+        <FtRetryImage
           v-else
           :src="authorThumbnail"
           class="communityThumbnail"
           alt=""
-        >
+        />
       </template>
       <p
         class="authorName"
@@ -177,6 +177,7 @@
 </template>
 
 <script setup>
+import FtRetryImage from '../FtRetryImage.vue'
 import { FtIcon } from '@opentubex/icons'
 import autolinker from 'autolinker'
 import { computed, onActivated, onMounted, useTemplateRef } from 'vue'

--- a/src/renderer/components/FtInputTags/FtInputTags.vue
+++ b/src/renderer/components/FtInputTags/FtInputTags.vue
@@ -52,14 +52,14 @@
               :to="tag.iconHref ?? ''"
               class="tag-icon-link"
             >
-              <img
+              <FtRetryImage
                 :src="tag.icon"
                 alt=""
                 class="tag-icon"
                 height="24"
                 width="24"
                 loading="lazy"
-              >
+              />
             </RouterLink>
             <bdi
               class="name"
@@ -91,6 +91,7 @@
 </template>
 
 <script setup>
+import FtRetryImage from '../FtRetryImage.vue'
 import { FtIcon } from '@opentubex/icons'
 import { useId, useTemplateRef, ref } from 'vue'
 import { useI18n } from 'vue-i18n'

--- a/src/renderer/components/FtListChannel/FtListChannel.vue
+++ b/src/renderer/components/FtListChannel/FtListChannel.vue
@@ -15,11 +15,11 @@
         tabindex="-1"
         aria-hidden="true"
       >
-        <img
+        <FtRetryImage
           :src="thumbnail"
           :class="!isGame ? 'channelImage' : 'gameImage'"
           alt=""
-        >
+        />
       </component>
     </div>
     <div class="infoAndSubscribe">
@@ -80,6 +80,7 @@
 </template>
 
 <script setup>
+import FtRetryImage from '../FtRetryImage.vue'
 import { computed } from 'vue'
 
 import FtSubscribeButton from '../FtSubscribeButton/FtSubscribeButton.vue'

--- a/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
+++ b/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
@@ -16,12 +16,12 @@
         tabindex="-1"
         aria-hidden="true"
       >
-        <img
+        <FtRetryImage
           alt=""
           :src="thumbnailForDisplay"
           class="thumbnailImage"
           :class="{ blur: blurThumbnails }"
-        >
+        />
       </RouterLink>
       <div
         class="videoCountContainer"
@@ -124,6 +124,7 @@
 </template>
 
 <script setup>
+import FtRetryImage from '../FtRetryImage.vue'
 import { supportsYtDlp } from '../../helpers/ytDlpCapabilities'
 import { FtIcon } from '@opentubex/icons'
 import { computed, ref, toRef, watch } from 'vue'

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -40,12 +40,12 @@
         @pointerenter="startThumbnailPreview"
         @pointerleave="stopThumbnailPreview"
       >
-        <img
+        <FtRetryImage
           :src="thumbnail"
           class="thumbnailImage"
           :class="{ blur: blurThumbnails }"
           alt=""
-        >
+        />
         <img
           v-if="thumbnailPreviewActive && thumbnailPreviewLoaded"
           :src="thumbnailPreviewUrl"
@@ -384,6 +384,7 @@
 </template>
 
 <script setup>
+import FtRetryImage from '../FtRetryImage.vue'
 import { supportsYtDlp } from '../../helpers/ytDlpCapabilities'
 import { FtIcon } from '@opentubex/icons'
 import { computed, onBeforeUnmount, onMounted, ref, toRef, watch } from 'vue'

--- a/src/renderer/components/FtRetryImage.vue
+++ b/src/renderer/components/FtRetryImage.vue
@@ -18,8 +18,11 @@ const props = defineProps({
   }
 })
 
+const emit = defineEmits(['error'])
+
 const imageUrl = ref(props.src)
 let hasRetried = false
+let retryPending = false
 let retryTimeoutId
 let sourceVersion = 0
 
@@ -28,6 +31,7 @@ watch(() => props.src, (src) => {
   retryTimeoutId = undefined
   sourceVersion++
   hasRetried = false
+  retryPending = false
   imageUrl.value = src
 })
 
@@ -42,12 +46,14 @@ function addRetryParameter(src) {
   }
 }
 
-async function retryImageLoad() {
+async function retryImageLoad(event) {
   if (hasRetried) {
+    if (!retryPending) emit('error', event)
     return
   }
 
   hasRetried = true
+  retryPending = true
   const failedSourceVersion = sourceVersion
 
   if (process.env.IS_CAPACITOR) {
@@ -56,6 +62,7 @@ async function retryImageLoad() {
 
     if (failedSourceVersion !== sourceVersion) return
     if (dataUrl !== null) {
+      retryPending = false
       imageUrl.value = dataUrl
       return
     }
@@ -63,6 +70,7 @@ async function retryImageLoad() {
 
   retryTimeoutId = setTimeout(() => {
     retryTimeoutId = undefined
+    retryPending = false
     imageUrl.value = addRetryParameter(props.src)
   }, RETRY_DELAY_MS)
 }

--- a/src/renderer/components/FtRetryImage.vue
+++ b/src/renderer/components/FtRetryImage.vue
@@ -57,8 +57,13 @@ async function retryImageLoad(event) {
   const failedSourceVersion = sourceVersion
 
   if (process.env.IS_CAPACITOR) {
-    const { fetchCapacitorAvatarDataUrl } = await import('../helpers/api/capacitor-http')
-    const dataUrl = await fetchCapacitorAvatarDataUrl(props.src)
+    let dataUrl = null
+    try {
+      const { fetchCapacitorAvatarDataUrl } = await import('../helpers/api/capacitor-http')
+      dataUrl = await fetchCapacitorAvatarDataUrl(props.src)
+    } catch {
+      // Native recovery is optional; unexpected failures still get a delayed retry.
+    }
 
     if (failedSourceVersion !== sourceVersion) return
     if (dataUrl !== null) {

--- a/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
+++ b/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
@@ -126,12 +126,12 @@
         class="playlistChannel"
         :to="`/channel/${channelId}`"
       >
-        <img
+        <FtRetryImage
           v-if="channelThumbnail"
           class="channelThumbnail"
           :src="channelThumbnail"
           alt=""
-        >
+        />
         <h3
           class="channelName"
           dir="auto"
@@ -326,6 +326,7 @@
 </template>
 
 <script setup>
+import FtRetryImage from '../FtRetryImage.vue'
 import { supportsYtDlp } from '../../helpers/ytDlpCapabilities'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -62,7 +62,7 @@
           <div
             class="thumbnailContainer"
           >
-            <img
+            <FtRetryImage
               v-if="channel.thumbnail != null"
               class="channelThumbnail"
               height="35"
@@ -70,7 +70,7 @@
               loading="lazy"
               :src="channel.thumbnail"
               :alt="isOpen ? '' : channel.name"
-            >
+            />
             <FtIcon
               v-else
               class="channelThumbnail noThumbnail"
@@ -100,6 +100,7 @@
 </template>
 
 <script setup>
+import FtRetryImage from '../FtRetryImage.vue'
 import { FtIcon } from '@opentubex/icons'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'

--- a/src/renderer/components/SubscriptionChannelSettings/SubscriptionChannelSettings.vue
+++ b/src/renderer/components/SubscriptionChannelSettings/SubscriptionChannelSettings.vue
@@ -185,12 +185,12 @@
                   aria-hidden="true"
                 />
               </button>
-              <img
+              <FtRetryImage
                 v-if="channel.thumbnail"
                 class="channelThumbnail"
                 :src="channel.thumbnail"
                 alt=""
-              >
+              />
               <span
                 v-else
                 class="channelThumbnail channelThumbnailPlaceholder"
@@ -290,6 +290,7 @@
 </template>
 
 <script setup>
+import FtRetryImage from '../FtRetryImage.vue'
 import { FtIcon } from '@opentubex/icons'
 import { computed, nextTick, onBeforeUnmount, ref, shallowRef, useId, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'

--- a/src/renderer/components/TabBar/SortableTab.vue
+++ b/src/renderer/components/TabBar/SortableTab.vue
@@ -50,14 +50,14 @@
             class="playingIcon"
             aria-hidden="true"
           />
-          <img
+          <FtRetryImage
             v-else-if="showIcon && usableTabAvatarUrl"
             :src="tabAvatarUrl"
             class="tabAvatar"
             alt=""
             draggable="false"
             @error="handleAvatarError"
-          >
+          />
           <FtIcon
             v-else-if="showIcon && tabPageIcon"
             :icon="tabPageIcon"
@@ -84,6 +84,7 @@
 </template>
 
 <script setup>
+import FtRetryImage from '../FtRetryImage.vue'
 import { FtIcon } from '@opentubex/icons'
 import { computed, ref, watch } from 'vue'
 import { getTabAccentColor } from '../../constants/tabColors'

--- a/src/renderer/components/TabBar/TabTooltipPreview.vue
+++ b/src/renderer/components/TabBar/TabTooltipPreview.vue
@@ -7,14 +7,14 @@
       draggable="false"
       @error="previewUrl = null"
     >
-    <img
+    <FtRetryImage
       v-else-if="avatarUrl && avatarUrl !== failedAvatarUrl"
       :src="avatarUrl"
       alt=""
       class="tabTooltipPreviewAvatar"
       draggable="false"
       @error="failedAvatarUrl = avatarUrl"
-    >
+    />
     <div
       v-else
       class="tabTooltipPreviewFallback"
@@ -30,14 +30,14 @@
     v-if="showTitle"
     class="tabTooltipGridTitle"
   >
-    <img
+    <FtRetryImage
       v-if="showIcon && avatarUrl && avatarUrl !== failedAvatarUrl"
       :src="avatarUrl"
       class="tabTooltipGridTitleAvatar"
       alt=""
       draggable="false"
       @error="failedAvatarUrl = avatarUrl"
-    >
+    />
     <FtIcon
       v-else-if="showIcon && pageIcon"
       :icon="pageIcon"
@@ -49,6 +49,7 @@
 </template>
 
 <script setup>
+import FtRetryImage from '../FtRetryImage.vue'
 import { FtIcon } from '@opentubex/icons'
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import { getTabAvatarUrl, getTabPageIcon, getTabPreviewFallbackUrl } from '../../tabs/tabPreview'

--- a/src/renderer/components/TabOrganizer/TabOrganizer.vue
+++ b/src/renderer/components/TabOrganizer/TabOrganizer.vue
@@ -378,13 +378,13 @@
                     @update:model-value="toggleTabSelection(tab.id, $event.includes(tab.id))"
                   />
                   <span class="tabIcon">
-                    <img
+                    <FtRetryImage
                       v-if="usableTabAvatarUrl(tab)"
                       :src="usableTabAvatarUrl(tab)"
                       alt=""
                       draggable="false"
                       @error="handleTabAvatarError(tab)"
-                    >
+                    />
                     <FtIcon
                       v-else
                       :icon="getTabPageIcon(tab) || ['fas', 'display']"
@@ -520,12 +520,12 @@
                         @click="openOtherDeviceSession({ ...activeOtherDeviceSession, tabs: [tab] })"
                       >
                         <span class="tabIcon">
-                          <img
+                          <FtRetryImage
                             v-if="usableTabAvatarUrl(syncedTabPreview(tab))"
                             :src="usableTabAvatarUrl(syncedTabPreview(tab))"
                             alt=""
                             @error="handleTabAvatarError(syncedTabPreview(tab))"
-                          >
+                          />
                           <FtIcon
                             v-else
                             :icon="getTabPageIcon(syncedTabPreview(tab)) || ['fas', 'display']"
@@ -628,6 +628,7 @@
 </template>
 
 <script setup>
+import FtRetryImage from '../FtRetryImage.vue'
 import { FtIcon } from '@opentubex/icons'
 import { computed, nextTick, onBeforeMount, onBeforeUnmount, onMounted, ref, useId, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'

--- a/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
+++ b/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
@@ -108,13 +108,13 @@
           @click="showCollaboratorsPrompt = true"
         >
           <span class="collaboratorSummaryThumbnails">
-            <img
+            <FtRetryImage
               v-for="collaborator in channelCollaborators"
               :key="collaborator.id"
               :src="collaborator.thumbnail"
               class="channelThumbnail collaboratorThumbnail"
               alt=""
-            >
+            />
           </span>
           <span
             class="channelName collaboratorSummaryName"
@@ -133,12 +133,12 @@
               @click="handleChannelLinkClick"
               @auxclick="handleChannelLinkClick"
             >
-              <img
+              <FtRetryImage
                 :src="channelThumbnail"
                 :class="enableChannelLinks ? '' : 'initialCursor'"
                 class="channelThumbnail"
                 alt=""
-              >
+              />
             </component>
           </div>
           <div>
@@ -313,6 +313,7 @@
 </template>
 
 <script setup>
+import FtRetryImage from '../FtRetryImage.vue'
 import { ytDlp } from '../../helpers/ytDlp'
 import { supportsYtDlp } from '../../helpers/ytDlpCapabilities'
 import { FtIcon } from '@opentubex/icons'

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
@@ -43,13 +43,13 @@
               class="thumbnailContainer"
               :to="`/channel/${channel.id}`"
             >
-              <img
+              <FtRetryImage
                 v-if="hasUsableThumbnail(channel.thumbnail)"
                 class="channelThumbnail"
                 :src="thumbnailURL(channel.thumbnail)"
                 alt=""
                 @error.once="handleThumbnailError(channel)"
-              >
+              />
               <ft-icon
                 v-else
                 class="channelThumbnail"
@@ -99,6 +99,7 @@
 </template>
 
 <script setup>
+import FtRetryImage from '../../components/FtRetryImage.vue'
 import { FtIcon } from '@opentubex/icons'
 import { computed, onMounted, onBeforeUnmount, ref, watch, useTemplateRef } from 'vue'
 import { isNavigationFailure, NavigationFailureType, useRoute, useRouter } from 'vue-router'

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -21,6 +21,7 @@ import WatchVideoQueue from '../../components/WatchVideoQueue/WatchVideoQueue.vu
 import WatchVideoRecommendations from '../../components/WatchVideoRecommendations/WatchVideoRecommendations.vue'
 import FtAgeRestricted from '../../components/FtAgeRestricted/FtAgeRestricted.vue'
 import { hasConfiguredRestrictedPlaybackAuthentication } from '../../helpers/restricted-playback'
+import FtRetryImage from '../../components/FtRetryImage.vue'
 import FtSubscribeButton from '../../components/FtSubscribeButton/FtSubscribeButton.vue'
 import FtShareButton from '../../components/FtShareButton/FtShareButton.vue'
 import FtIconButton from '../../components/FtIconButton/FtIconButton.vue'
@@ -156,6 +157,7 @@ const UNAVAILABLE_VIDEO_THUMBNAILS = {
 export default defineComponent({
   name: 'Watch',
   components: {
+    FtRetryImage,
     'ft-shaka-video-player': FtShakaVideoPlayer,
     'watch-video-info': WatchVideoInfo,
     'watch-video-description': WatchVideoDescription,

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -213,12 +213,12 @@
                   @click="openShortsChannel"
                   @auxclick="openShortsChannel"
                 >
-                  <img
+                  <FtRetryImage
                     v-if="channelThumbnail"
                     :src="channelThumbnail"
                     class="shortsFullscreenChannelThumbnail"
                     alt=""
-                  >
+                  />
                   <span dir="auto">{{ channelName }}</span>
                 </component>
                 <FtSubscribeButton
@@ -380,12 +380,12 @@
                 @click="openShortsChannel"
                 @auxclick="openShortsChannel"
               >
-                <img
+                <FtRetryImage
                   v-if="channelThumbnail"
                   :src="channelThumbnail"
                   class="shortsExternalChannelThumbnail"
                   alt=""
-                >
+                />
                 <span dir="auto">{{ channelName }}</span>
               </component>
               <FtSubscribeButton
@@ -559,10 +559,10 @@
             @click="openShortsChannel"
             @auxclick="openShortsChannel"
           >
-            <img
+            <FtRetryImage
               :src="channelThumbnail"
               alt=""
-            >
+            />
           </component>
         </div>
         <button

--- a/tests/unit/channel-avatar-retry.test.mjs
+++ b/tests/unit/channel-avatar-retry.test.mjs
@@ -19,7 +19,7 @@ async function mountAvatar(t, nativeResult, componentPath = 'FtChannelAvatar/FtC
   const requests = []
   const timers = new Map()
   const RetryImage = await compileComponent('FtRetryImage.vue', {
-    loadNativeHttp: async () => ({ fetchCapacitorAvatarDataUrl: async src => { requests.push(src); return nativeResult } }),
+    loadNativeHttp: async () => ({ fetchCapacitorAvatarDataUrl: async src => { requests.push(src); return typeof nativeResult === 'function' ? nativeResult() : nativeResult } }),
     setTimeout: callback => { const id = {}; timers.set(id, callback); return id },
     clearTimeout: id => timers.delete(id)
   })
@@ -106,4 +106,18 @@ test('tab preview channel avatars recover before hiding the failed URL', async t
   await fail(f.find('img'))
   assert.deepEqual(f.requests, ['https://yt3.ggpht.com/avatar'])
   assert.equal(f.find('img')?.props.src, 'data:image/png;base64,AA==')
+})
+
+test('unexpected native recovery errors still allow the delayed retry and terminal fallback', async t => {
+  const f = await mountAvatar(t, () => { throw new TypeError('Invalid response headers') })
+  await fail(f.find('img'))
+  assert.ok(f.find('img'))
+  assert.equal(f.timers.size, 1)
+  await fail(f.find('img'))
+  assert.ok(f.find('img'), 'ignore duplicate errors while the retry is pending')
+  for (const callback of f.timers.values()) callback()
+  await Vue.nextTick()
+  assert.match(f.find('img').props.src, /opentubex_retry=/)
+  await fail(f.find('img'))
+  assert.ok(f.find('fallback'))
 })

--- a/tests/unit/channel-avatar-retry.test.mjs
+++ b/tests/unit/channel-avatar-retry.test.mjs
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import { runInNewContext } from 'node:vm'
+import * as Vue from 'vue'
+import { compileScript, parse } from 'vue/compiler-sfc'
+
+async function compileComponent(path, bindings = {}) {
+  const { descriptor } = parse(await readFile(new URL(`../../src/renderer/components/${path}`, import.meta.url), 'utf8'))
+  const source = compileScript(descriptor, { id: path, inlineTemplate: true }).content
+    .replace(/import \{([^}]+)\} from ["']vue["'];?/g, (_, imports) => `const {${imports.replace(/ as /g, ': ')}} = Vue`)
+    .replace(/^import .* from .*\n/gm, '')
+    .replace("import('../helpers/api/capacitor-http')", 'loadNativeHttp()')
+    .replace('export default', 'const component =')
+  return runInNewContext(`${source}; component`, { Vue, process: { env: { IS_CAPACITOR: true } }, URL, Date, ...bindings })
+}
+
+async function mountAvatar(t, nativeResult, componentPath = 'FtChannelAvatar/FtChannelAvatar.vue') {
+  const requests = []
+  const timers = new Map()
+  const RetryImage = await compileComponent('FtRetryImage.vue', {
+    loadNativeHttp: async () => ({ fetchCapacitorAvatarDataUrl: async src => { requests.push(src); return nativeResult } }),
+    setTimeout: callback => { const id = {}; timers.set(id, callback); return id },
+    clearTimeout: id => timers.delete(id)
+  })
+  const Avatar = await compileComponent(componentPath, {
+    FtRetryImage: RetryImage, FtIcon: { render: () => Vue.h('fallback') },
+    getTabAvatarUrl: tab => tab.avatarUrl, getTabPreviewFallbackUrl: () => null,
+    getTabPageIcon: () => null, formatTabTitle: title => title
+  })
+  const renderer = Vue.createRenderer({
+    createElement: tag => ({ tag, props: {}, children: [] }),
+    createComment: () => ({ tag: 'comment' }),
+    createText: text => ({ tag: 'text', text }),
+    setElementText() {}, setText() {},
+    patchProp: (node, key, previous, value) => { node.props[key] = value },
+    insert(node, parent, anchor) {
+      node.parent = parent
+      const index = anchor ? parent.children.indexOf(anchor) : -1
+      if (index < 0) parent.children.push(node)
+      else parent.children.splice(index, 0, node)
+    },
+    remove(node) { node.parent.children.splice(node.parent.children.indexOf(node), 1) },
+    parentNode: node => node.parent,
+    nextSibling: node => node.parent.children[node.parent.children.indexOf(node) + 1] ?? null
+  })
+  const thumbnail = Vue.ref('https://yt3.ggpht.com/avatar')
+  const root = { children: [] }
+  const app = renderer.createApp({ render: () => Vue.h(Avatar, componentPath.startsWith('TabBar/')
+    ? { tab: { id: 'channel-tab', avatarUrl: thumbnail.value, title: 'Channel' } }
+    : { thumbnail: thumbnail.value }) })
+  app.mount(root)
+  t.after(() => app.unmount())
+  const find = (tag, node = root) => node.tag === tag ? node : node.children?.map(child => find(tag, child)).find(Boolean)
+  return { requests, timers, thumbnail, find }
+}
+
+async function fail(image) {
+  for (const handler of [image.props.onError].flat()) await handler({ type: 'error' })
+  await Vue.nextTick()
+}
+
+test('channel avatars recover through native HTTP before showing a fallback', async t => {
+  const f = await mountAvatar(t, 'data:image/png;base64,AA==')
+  await fail(f.find('img'))
+  assert.deepEqual(f.requests, ['https://yt3.ggpht.com/avatar'])
+  assert.equal(f.find('img')?.props.src, 'data:image/png;base64,AA==')
+  assert.equal(f.find('fallback'), undefined)
+})
+
+test('channel avatars show a fallback only after the delayed retry fails and reset for a new URL', async t => {
+  const f = await mountAvatar(t, null)
+  await fail(f.find('img'))
+  assert.ok(f.find('img'), 'keep the image mounted while retrying')
+  assert.equal(f.timers.size, 1)
+  for (const callback of f.timers.values()) callback()
+  await Vue.nextTick()
+  assert.match(f.find('img').props.src, /opentubex_retry=/)
+  await fail(f.find('img'))
+  assert.ok(f.find('fallback'))
+  f.thumbnail.value = 'https://yt3.ggpht.com/other-avatar'
+  await Vue.nextTick()
+  assert.equal(f.find('img').props.src, f.thumbnail.value)
+})
+
+test('duplicate errors during the retry delay do not remove the avatar or start another request', async t => {
+  const f = await mountAvatar(t, null)
+  await fail(f.find('img'))
+  await fail(f.find('img'))
+  assert.ok(f.find('img'))
+  assert.equal(f.requests.length, 1)
+  assert.equal(f.timers.size, 1)
+})
+
+test('an undecodable native image falls back without retrying indefinitely', async t => {
+  const f = await mountAvatar(t, 'data:image/png;base64,AA==')
+  await fail(f.find('img'))
+  await fail(f.find('img'))
+  assert.ok(f.find('fallback'))
+  assert.equal(f.requests.length, 1)
+  assert.equal(f.timers.size, 0)
+})
+
+test('tab preview channel avatars recover before hiding the failed URL', async t => {
+  const f = await mountAvatar(t, 'data:image/png;base64,AA==', 'TabBar/TabTooltipPreview.vue')
+  await fail(f.find('img'))
+  assert.deepEqual(f.requests, ['https://yt3.ggpht.com/avatar'])
+  assert.equal(f.find('img')?.props.src, 'data:image/png;base64,AA==')
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

Reported directly in the task; no linked issue.
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
YouTube channel pictures and video thumbnails sometimes remain missing in the Android app after an image request fails. Reuse `FtRetryImage` for channel avatars throughout the app and for video and playlist card thumbnails, including Home recommendations, feeds, and search results. Thumbnails retry after three seconds; supported channel avatars also receive the existing native Android fallback. Emit the terminal error only after recovery is exhausted, keeping placeholder handlers from removing the image during a retry.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Channel pictures and video and playlist card thumbnails now retry failed loads automatically.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing

1. In the Android app, open Home recommendations, subscriptions, search results, a channel, a video with comments, and the tab organizer. Confirm thumbnails and channel pictures load, including creator-heart badges.
2. With remote DevTools attached, select a channel image and run `$0.dispatchEvent(new Event('error'))`. Confirm the image recovers through native HTTP instead of immediately becoming a placeholder.
3. Block the image request and its native fallback, then trigger the error again on a fresh image. Confirm an existing placeholder appears only after the retry fails. Navigate to another channel and confirm its picture can load normally.
4. Select a video or playlist card thumbnail in DevTools and run `$0.dispatchEvent(new Event('error'))`. Confirm it retries after about three seconds without reloading the page.
5. On desktop, repeat the failed-image check in channel results and tab previews. Confirm the image URL gets a retry parameter after about three seconds and the normal image layout remains intact.
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

## Additional context

Validation: the regression tests reproduced immediate placeholder suppression before the fix and pass afterward. The full unit suite, lint, and focused Electron avatar/tab tests were run. An additional Electron regression test rejects initial video and playlist thumbnail requests and verifies that both images load on retry without reloading the results. Android native HTTP is covered with mocks. A separate investigation in an existing Android 15 emulator installation with WebView 124 reproduced ORB for controlled HTML/mislabeled-image responses, while six real YouTube avatar requests succeeded in both WebView and native HTTP. This confirms platform behavior, but does not establish ORB as the cause of the reported failures. No physical-device test was performed.

Media omitted because a still image would not demonstrate failed-request recovery.

Implemented with GPT-6 in the Codex desktop harness.
<!-- Add any other context about the pull request here. -->
