### PR TITLE
fix(subscriptions): load Shorts when automatic playlists are missing

### DIFF
--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -14,6 +14,7 @@ import {
   getLocalChannelVideos,
   getLocalPlaylist,
   localApiFetch,
+  parseLocalChannelShorts,
   parseLocalPlaylistVideos
 } from './api/local'
 import {
@@ -1431,10 +1432,41 @@ async function getChannelShortsLocal(channel, t, errorChannels, failedAttempts =
         return { videos: null }
       }
       if (!channelPage.has_shorts) return { videos: [] }
-      const playlist = await getLocalPlaylist(playlistId, activeRefresh?.controller.signal)
-      const videos = parseLocalPlaylistVideos(playlist.items)
-      videos.forEach(video => { video.isShort = true })
-      return { videos }
+      try {
+        const playlist = await getLocalPlaylist(playlistId, activeRefresh?.controller.signal)
+        const videos = parseLocalPlaylistVideos(playlist.items)
+        videos.forEach(video => { video.isShort = true })
+        return { videos }
+      } catch (error) {
+        if (error.message !== 'The playlist does not exist.') throw error
+        // Some channels have Shorts even though their automatic playlist is missing.
+        const shortsTab = await channelPage.getShorts()
+        const videos = parseLocalChannelShorts(shortsTab.videos, channel.id, channel.name)
+        const cachedVideos = store.getters.getShortsCache[channel.id]?.videos ?? []
+        // The Shorts tab omits dates, which subscriptions need for sorting and New badges.
+        for (const video of videos) {
+          const cached = cachedVideos.find(entry => entry.videoId === video.videoId)
+          if (Number.isFinite(cached?.published)) {
+            video.published = cached.published
+            continue
+          }
+          const response = await localApiFetch(`https://www.youtube.com/watch?v=${video.videoId}`, {
+            signal: AbortSignal.any([
+              activeRefresh?.controller.signal,
+              AbortSignal.timeout(RSS_ENRICHMENT_TIMEOUT_MS)
+            ].filter(Boolean)),
+            nativeTimeoutMs: RSS_ENRICHMENT_TIMEOUT_MS
+          })
+          checkSubscriptionFeedResponse(response)
+          const player = JSON.parse(extractAssignedJsonObject(await response.text(), 'ytInitialPlayerResponse') ?? 'null')
+          const published = Date.parse(player?.microformat?.playerMicroformatRenderer?.publishDate)
+          if (player?.videoDetails?.videoId !== video.videoId || !Number.isFinite(published)) {
+            throw new Error(`Could not load the publication date for Short ${video.videoId}`, { cause: error })
+          }
+          video.published = published
+        }
+        return { videos }
+      }
     }
 
     checkSubscriptionFeedResponse(response)

--- a/tests/unit/subscription-network-recovery.test.mjs
+++ b/tests/unit/subscription-network-recovery.test.mjs
@@ -5,6 +5,7 @@ import vm from 'node:vm'
 import { shallowReactive } from 'vue'
 import { createI18n } from 'vue-i18n'
 import { load } from 'js-yaml'
+import { YTNodes } from 'youtubei.js'
 
 import { createNetworkRecovery } from '../../src/renderer/helpers/networkRecovery.js'
 import { createAbortError } from '../../src/renderer/helpers/api/requestErrors.js'
@@ -12,7 +13,12 @@ import { createSubscriptionNetworkRecovery, SubscriptionNetworkError } from '../
 import { mapConcurrently } from '../../src/renderer/helpers/concurrent-map.js'
 import { buildRequestDiagnostic, classifyRequestFailure, formatRequestDiagnostic } from '../../src/renderer/helpers/api/requestDiagnostics.js'
 import { getSubscriptionsForFeed } from '../../src/renderer/helpers/subscription-channels.js'
-import { reconcileFetchedSubscriptionEntries } from '../../src/renderer/helpers/subscription-entries.js'
+import { extractAssignedJsonObject } from '../../src/renderer/helpers/assigned-json.js'
+import { getSubscriptionVideoSortTimestamp, updateUpcomingPremiereState, reconcileFetchedSubscriptionEntries } from '../../src/renderer/helpers/subscription-entries.js'
+
+const localSource = await readFile(new URL('../../src/renderer/helpers/api/local.js', import.meta.url), 'utf8')
+const shortsParserSource = localSource.slice(localSource.indexOf('export function parseShort('), localSource.indexOf('export function parseLocalListPlaylist('))
+  .replace(/^export /gm, '')
 
 const networkSource = (await readFile(new URL('../../src/renderer/helpers/networkRecovery.js', import.meta.url), 'utf8'))
   .replace(/^import .* from .*\n/gm, '').replace(/^export /gm, '')
@@ -23,7 +29,7 @@ const source = (await readFile(new URL('../../src/renderer/helpers/subscriptions
 
 // Exercise the real refresh, fallback, cache, and notification paths with fake
 // platform APIs. Webpack-only imports are supplied in the isolated context.
-function createRefresh({ online = true, feed = 'Shorts', error = new TypeError('Failed to fetch'), webCors = false, backend = 'local', fallbackWorks = false, rssStatus = 200, channelInfo = { has_shorts: true }, playlistError = null, stallChannelProbe = false, channelStatus = rssStatus, scraperError = null } = {}) {
+function createRefresh({ online = true, feed = 'Shorts', error = new TypeError('Failed to fetch'), webCors = false, backend = 'local', fallbackWorks = false, rssStatus = 200, channelInfo = { has_shorts: true, getShorts: async () => ({ videos: [] }) }, playlistError = null, stallChannelProbe = false, channelStatus = rssStatus, scraperError = null, shortPublishDate = '2026-09-06T12:00:00Z' } = {}) {
   const window = new EventTarget()
   const navigator = { onLine: online }
   const toasts = []
@@ -51,6 +57,13 @@ function createRefresh({ online = true, feed = 'Shorts', error = new TypeError('
   const fetchChannel = async url => {
     requests.push(url)
     if (fail) throw typeof error === 'function' ? error(url) : error
+    if (url.includes('/watch?v=')) {
+      const videoId = new URL(url).searchParams.get('v')
+      return { ok: true, status: 200, text: async () => `var ytInitialPlayerResponse = ${JSON.stringify({
+        videoDetails: { videoId },
+        microformat: { playerMicroformatRenderer: { publishDate: shortPublishDate } }
+      })};` }
+    }
     return { videos: [], posts: [], status: url.includes('/feed/channel/') ? channelStatus : rssStatus, text: async () => '<feed/>' }
   }
   const fetchFallback = async url => {
@@ -70,7 +83,7 @@ function createRefresh({ online = true, feed = 'Shorts', error = new TypeError('
     },
     createSubscriptionNetworkRecovery, SubscriptionNetworkError,
     mapConcurrently, buildRequestDiagnostic, classifyRequestFailure, formatRequestDiagnostic, getSubscriptionsForFeed,
-    reconcileFetchedSubscriptionEntries,
+    reconcileFetchedSubscriptionEntries, extractAssignedJsonObject, getSubscriptionVideoSortTimestamp, updateUpcomingPremiereState,
     isAndroidSubscriptionRefreshActive: async () => false,
     includeAutomaticDownloadChannels: channels => channels,
     startAutomaticDownloadsForChannel: async () => {},
@@ -97,6 +110,7 @@ function createRefresh({ online = true, feed = 'Shorts', error = new TypeError('
       }
     },
   })
+  vm.runInContext(shortsParserSource, context)
   vm.runInContext(networkSource, context)
   const sharedRecovery = vm.runInContext('initializeNetworkRecovery()', context)
   context.createSubscriptionNetworkRecovery = options => createSubscriptionNetworkRecovery({ ...options, recovery: sharedRecovery })
@@ -109,7 +123,7 @@ function createRefresh({ online = true, feed = 'Shorts', error = new TypeError('
       init?.signal?.addEventListener('abort', () => reject(createAbortError()), { once: true })
     })
   }
-  vm.runInContext(`${source}\nglobalThis.api = { refreshSubscriptionVideosFromRemote, refreshSubscriptionShortsFromRemote, refreshSubscriptionLiveFromRemote, refreshSubscriptionPostsFromRemote, cancelSubscriptionRefresh }`, context)
+  vm.runInContext(`${source}\nglobalThis.api = { refreshSubscriptionVideosFromRemote, refreshSubscriptionShortsFromRemote, refreshSubscriptionLiveFromRemote, refreshSubscriptionPostsFromRemote, cancelSubscriptionRefresh, updateVideoListAfterProcessing }`, context)
   return {
     get details() { return [...subscriptionRefreshErrors.value.values()].map(channel => channel.trace).join('\n') },
     ...context.api, refresh: context.api[`refreshSubscription${feed}FromRemote`], navigator, requests, fallbackRequests, toasts, copied, writes, events, getters, recovery: sharedRecovery,
@@ -329,6 +343,85 @@ for (const feed of ['Videos', 'Shorts', 'Live']) {
     assert.deepEqual(errorChannels, [])
     assert.equal(app.toasts.length, 0)
     assert.equal(app.writes.filter(write => write.key.endsWith('CacheByChannel')).length, 20)
+  })
+}
+
+test('Shorts refresh loads the channel tab when its automatic playlist does not exist', async () => {
+  const channelId = 'UCvNL_YC5NbOcoqSjjJSTzSA'
+  let tabRequests = 0
+  const app = createRefresh({
+    rssStatus: 404,
+    playlistError: new Error('The playlist does not exist.'),
+    channelInfo: {
+      has_shorts: true,
+      async getShorts() {
+        tabRequests++
+        return { videos: [new YTNodes.ReelItem({
+          videoId: 'C9wafAQcub0',
+          headline: { simpleText: 'CAIVA Short' },
+          thumbnail: { thumbnails: [{ url: 'https://i.ytimg.com/vi/C9wafAQcub0/hqdefault.jpg' }] },
+        }), new YTNodes.ReelItem({ videoId: 'cached-short', headline: { simpleText: 'Older Short' }, thumbnail: { thumbnails: [] } })] }
+      }
+    }
+  })
+  app.getters.getActiveProfile.subscriptions = [{ id: channelId, name: 'CAIVA' }]
+  app.getters.getBackendFallback = false
+  const cachedPublished = Date.parse('2026-09-01T12:00:00Z')
+  app.getters.getShortsCache[channelId] = {
+    timestamp: new Date('2026-09-05T12:00:00Z'),
+    videos: [{ videoId: 'cached-short', published: cachedPublished }]
+  }
+  app.reconnect()
+  const errorChannels = []
+  await app.refresh({ t: key => key, errorChannels })
+  assert.equal(app.toasts.length, 0)
+  assert.deepEqual(errorChannels, [])
+  assert.equal(tabRequests, 1)
+  const update = app.writes.find(write => write.key === 'updateSubscriptionShortsCacheByChannel')
+  assert.equal(update?.value.channelId, channelId)
+  assert.equal(update.value.videos.length, 2)
+  assert.equal(update.value.videos[0].videoId, 'C9wafAQcub0')
+  assert.equal(update.value.videos[0].authorId, channelId)
+  assert.equal(update.value.videos[0].author, 'CAIVA')
+  assert.equal(update.value.videos[0].isShort, true)
+  assert.equal(update.value.videos[0].published, Date.parse('2026-09-06T12:00:00Z'))
+  assert.equal(update.value.videos[0].isNewInSubscriptionFeed, true)
+  assert.equal(update.value.videos[1].published, cachedPublished)
+  assert.equal(app.requests.filter(url => url.includes('/watch?v=')).length, 1)
+  const sorted = app.updateVideoListAfterProcessing([
+    { videoId: 'middle', published: Date.parse('2026-09-03T12:00:00Z') },
+    ...update.value.videos
+  ])
+  assert.equal(sorted.map(video => video.videoId).join(','), 'C9wafAQcub0,middle,cached-short')
+})
+
+for (const failure of ['playlist request', 'Shorts tab request', 'publication date']) {
+  test(`Shorts refresh preserves errors from a failed ${failure}`, async () => {
+    let tabRequests = 0
+    const app = createRefresh({
+      rssStatus: 404,
+      shortPublishDate: null,
+      playlistError: new Error(failure === 'playlist request' ? 'Request rejected' : 'The playlist does not exist.'),
+      channelInfo: {
+        has_shorts: true,
+        async getShorts() {
+          tabRequests++
+          if (failure !== 'publication date') throw new Error('Request rejected')
+          return { videos: [new YTNodes.ReelItem({
+            videoId: 'short-without-date', headline: { simpleText: 'Short' }, thumbnail: { thumbnails: [] }
+          })] }
+        }
+      }
+    })
+    app.getters.getActiveProfile.subscriptions = [{ id: 'UC-test' }]
+    app.getters.getBackendFallback = false
+    app.reconnect()
+    await app.refresh({ t: key => key })
+    assert.equal(tabRequests, failure === 'playlist request' ? 0 : 1)
+    assert.equal(app.toasts.length, 1)
+    app.toasts[0][0].action()
+    assert.match(app.details, failure === 'publication date' ? /Could not load the publication date/ : /Request rejected/)
+    assert.equal(app.writes.filter(write => write.key.endsWith('CacheByChannel')).length, 0)
   })
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

Refreshing CAIVA's Shorts reports that a playlist does not exist even though the channel's Shorts tab works. Fall back to that tab when YouTube's automatic Shorts playlist is missing, and supply publication dates so the entries sort and receive New badges correctly.

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Keep the existing playlist path when available. For missing playlists, reuse cached publication dates and fetch actual dates from watch-page metadata for uncached Shorts. Failed metadata requests remain refresh errors rather than replacing the cache with undated entries.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fix Shorts subscription refreshes for channels whose automatic YouTube Shorts playlist is unavailable.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

Subscribe to [CAIVA](https://www.youtube.com/channel/UCvNL_YC5NbOcoqSjjJSTzSA), open Subscriptions, select Shorts, and refresh. Its Short should appear without a missing-playlist error. Refresh again and verify that existing entries keep their chronological order.

## Additional context
<!-- Add any other context about the pull request here. -->

Regression tests cover missing playlists, preserved cached dates, chronological ordering, New badges, and failed fallback requests. The full unit suite, lint, and the Electron Shorts-refresh test passed; lint reports one existing locale configuration warning. A live API check confirmed CAIVA’s playlist is missing while its Shorts tab and watch-page publication metadata are available.

Implemented with GPT-6 in the Codex desktop app.
