### PR TITLE
fix(tabs): preserve loaded videos across interrupted startup

### DIFF
--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -2548,6 +2548,7 @@ export class TabManager {
     const tab = this.tabs.get(tabId)
     if (!tab) return
 
+    this._deferredStartupWatchTabIds.delete(tabId)
     tab.mountDeferred = false
     this._startupMountQueue.delete(tabId)
     tab.loadState = 'mounting'
@@ -2569,6 +2570,7 @@ export class TabManager {
       return false
     }
 
+    this._deferredStartupWatchTabIds.delete(tabId)
     tab.loadState = 'mounting'
     tab.mountDeferred = deferMount
     if (deferMount) this._startupMountQueue.add(tabId)
@@ -2586,6 +2588,10 @@ export class TabManager {
    */
   async unloadTab(tabId) {
     const tab = this.tabs.get(tabId)
+    if (tab?.loadState === 'unloaded' && this._deferredStartupWatchTabIds.delete(tabId)) {
+      await this._saveSession()
+      return true
+    }
     if (!tab || tab.loadState === 'unloaded' || tab.loadState === 'unloading') {
       return false
     }
@@ -3152,7 +3158,9 @@ export class TabManager {
           color: TabManager.normalizeTabColor(tab.color),
           groupId: tab.groupId,
           skipSilence: tab.skipSilence === true,
-          isUnloaded: tab.loadState === 'unloaded' || this._deferredUnloadTabIds.has(tab.id),
+          // Startup deferral delays mounting without changing the saved load intent.
+          isUnloaded: (tab.loadState === 'unloaded' && !this._deferredStartupWatchTabIds.has(tab.id)) ||
+            this._deferredUnloadTabIds.has(tab.id),
           ...(tab.placementOpenerTabId != null && {
             placementOpenerTabId: tab.placementOpenerTabId
           })
@@ -3204,7 +3212,8 @@ export class TabManager {
         isPinned: tab.isPinned,
         color: tab.color,
         groupId: tab.groupId,
-        isUnloaded: tab.isUnloaded || this._deferredUnloadTabIds.has(tab.id),
+        isUnloaded: (tab.isUnloaded && !this._deferredStartupWatchTabIds.has(tab.id)) ||
+          this._deferredUnloadTabIds.has(tab.id),
         ...(this.tabs.get(tab.id)?.placementOpenerTabId != null && {
           placementOpenerTabId: this.tabs.get(tab.id).placementOpenerTabId
         }),

--- a/tests/unit/tab-startup.test.mjs
+++ b/tests/unit/tab-startup.test.mjs
@@ -14,13 +14,17 @@ const hooks = registerHooks({
     if (specifier.endsWith('/datastores/handlers/base.js')) {
       return { shortCircuit: true, url: 'data:text/javascript,' + encodeURIComponent(`
         export const settings = { _findOne: async () => null };
-        export const tabSession = { save: async () => {} };
+        export const tabSession = {
+          saved: null,
+          async save(id, data) { this.saved = structuredClone(data); }
+        };
       `) }
     }
     return nextResolve(specifier, context)
   }
 })
 const { TabManager } = await import('../../src/main/tabs/TabManager.js')
+const { tabSession } = await import('../../src/datastores/handlers/base.js')
 hooks.deregister()
 const { createTabAvatarFileName } = await import('../../src/main/tabs/tabPreviewCache.js')
 
@@ -122,6 +126,52 @@ test('restored background pages do not compete with the initial selected page mo
   assert.deepEqual([...manager.tabs.values()].filter(tab => tab.loadState === 'mounting' && !tab.mountDeferred).map(tab => tab.id), ['tab-9'])
   assert.ok(manager.getSyncSession().tabs.every(tab => !tab.isUnloaded), 'queued tabs keep their saved loaded state')
 })
+
+for (const persistence of ['disk', 'sync']) {
+  test(`restarting from ${persistence} while the selected video loads preserves background video load state`, async t => {
+    const manager = createManager(t)
+    const saved = session(4)
+    saved.tabs[0].url = 'app://bundle/index.html#/watch/background'
+    saved.tabs[2].url = 'app://bundle/index.html#/watch/unloaded'
+    saved.tabs[2].isUnloaded = true
+    saved.tabs[3].url = 'app://bundle/index.html#/watch/selected'
+    await manager.restoreFromData(saved, { restoreTabLoadState: true })
+    await manager._saveSession()
+    const snapshot = persistence === 'disk' ? tabSession.saved : manager.getSyncSession()
+    assert.deepEqual(snapshot.tabs.map(tab => tab.isUnloaded), [false, false, true, false])
+    const restarted = createManager(t)
+    await restarted.restoreFromData(snapshot, { restoreTabLoadState: true })
+    restarted.setTabLoading('tab-3', true)
+    restarted.setTabLoading('tab-3', false)
+    await new Promise(setImmediate)
+    assert.notEqual(restarted.tabs.get('tab-0').loadState, 'unloaded')
+    assert.equal(restarted.tabs.get('tab-2').loadState, 'unloaded')
+  })
+}
+
+for (const action of ['unload', 'load', 'reload']) {
+  test(`${action} overrides a deferred startup video's saved load state`, async t => {
+    const manager = createManager(t)
+    const saved = session(2)
+    for (const tab of saved.tabs) tab.url = `app://bundle/index.html#/watch/${tab.id}`
+    await manager.restoreFromData(saved, { restoreTabLoadState: true })
+    if (action === 'unload') {
+      assert.equal(await manager.unloadTab('tab-0'), true)
+    } else {
+      if (action === 'load') manager.loadTab('tab-0')
+      else manager.reloadTab('tab-0')
+      const tab = manager.tabs.get('tab-0')
+      manager.markTabMountFailed(tab.id, tab.mountRevision)
+    }
+    manager.setTabLoading('tab-1', true)
+    manager.setTabLoading('tab-1', false)
+    await new Promise(setImmediate)
+    assert.equal(manager.tabs.get('tab-0').loadState, 'unloaded')
+    await manager._saveSession()
+    assert.equal(tabSession.saved.tabs[0].isUnloaded, true)
+    assert.equal(manager.getSyncSession().tabs[0].isUnloaded, true)
+  })
+}
 
 async function tick(t, milliseconds = 50) {
   t.mock.timers.tick(milliseconds)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Reported in the originating Codex task; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Background videos could remain unloaded after relaunch despite the setting to restore their previous load state. While startup waited for the selected video, session saves incorrectly recorded the deferred videos as intentionally unloaded.

Preserve their loaded state in local saves and sync snapshots until startup resumes them. Explicit load, reload, and unload actions cancel the deferred startup entry so it cannot override the resulting state.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Keep background videos scheduled to load after restarting the app while the selected video is still loading.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Set startup behavior to restore the previous tab load state, load several video tabs, and leave one video selected.
2. Restart, then close the app while the selected video is still loading. Restart again and allow it to finish loading.
3. Verify that previously loaded background videos load again and intentionally unloaded tabs remain unloaded.

## Additional context
<!-- Add any other context about the pull request here. -->

Regression tests cover interrupted startup through local and sync snapshots, plus explicit load/reload/unload overrides. Full unit tests, lint, and four Electron session-restore checks passed.

Changes made with GPT-6 in the Codex desktop app.
