### PR TITLE
test: mock connectivity probes in shared playback fixtures

### DIFF
--- a/e2e/helpers/app.mjs
+++ b/e2e/helpers/app.mjs
@@ -6,6 +6,9 @@ import { brotliCompressSync } from 'node:zlib'
 
 import { test as base, expect, _electron as electron } from '@playwright/test'
 
+// This fixture also runs against candidate builds from the base checkout.
+const INTERNET_CHECK_URL = 'https://connectivitycheck.grapheneos.network/generate_204'
+
 export const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
 
 // Settings that keep tests deterministic and stop the app from phoning home
@@ -22,6 +25,13 @@ const BASE_SETTINGS = {
   // Desktop-sized window so the responsive layout doesn't collapse into
   // its mobile variant (which hides the search bar, among other things).
   bounds: { x: 0, y: 0, width: 1600, height: 900, maximized: false }
+}
+
+/** Blocks unmocked services while keeping the fixture's internet check reachable. */
+export function abortUnmockedRequest(route) {
+  return route.request().url() === INTERNET_CHECK_URL
+    ? route.fulfill({ status: 204 })
+    : route.abort()
 }
 
 /**
@@ -168,6 +178,9 @@ export async function launchApp(userDataDir, extraArgs = [], options = {}) {
       throw error
     }
   }
+  // Tests control WAN reachability independently of the host running them.
+  // Page routes can override these replies to exercise real offline recovery.
+  await electronApp.context().route(INTERNET_CHECK_URL, route => route.fulfill({ status: 204 }))
   await notifyPhase('electronConnected')
 
   const page = await electronApp.firstWindow()

--- a/e2e/helpers/watch.mjs
+++ b/e2e/helpers/watch.mjs
@@ -3,7 +3,7 @@ import { readFile, readdir } from 'node:fs/promises'
 import path from 'node:path'
 import { gunzipSync } from 'node:zlib'
 
-import { repoRoot } from './app.mjs'
+import { abortUnmockedRequest, repoRoot } from './app.mjs'
 import { fixtureKey, SHARED_PLAYER_SCRIPT } from './innertube.mjs'
 import { demoPlayerResponse, routeDemoMedia, routeIframeApi, routeWatchPageHtml, stubPoToken } from './media.mjs'
 
@@ -151,7 +151,7 @@ export async function mockWatchPage(app, page, {
 
   await stubPoToken(app.electronApp)
 
-  await page.route(/^https?:\/\//, (route) => route.abort())
+  await page.route(/^https?:\/\//, abortUnmockedRequest)
   // A missing optional label is an HTTP 404, not a lost connection. Aborting
   // it would leave other SponsorBlock requests waiting for network recovery.
   await page.route('**/api/videoLabels/**', route => route.fulfill({ status: 404, body: '' }))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Prerequisite for #1291.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The performance comparison runs the base checkout’s fixtures against both app builds. Those fixtures abort the connectivity request introduced by #1291, so its candidate waits for internet access and the benchmark times out before playback.

Return a deterministic HTTP 204 for the connectivity endpoint during startup and in the shared Watch fixture. Other unmocked HTTP requests remain blocked. Merge this fixture update first, then rebase #1291 so its performance run uses the updated base.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

The app’s behavior is unchanged. In a development build of #1291, use the shared Watch fixture and confirm fixture playback starts while all network responses remain local.

## Additional context
<!-- Add any other context about the pull request here. -->

The existing CI failure reproduces the missing fixture response. A local smoke run using these exact fixtures completed both warmups and samples against the #1291 application build. Both targets used the same build, so this verifies fixture compatibility rather than performance. ESLint passes. No workflow or performance thresholds changed.

Authored with GPT-6 in Codex.
