### PR TITLE
fix: show actual thumbnail progress regardless of watched status

### DIFF
--- a/e2e/tests/offline/history.spec.mjs
+++ b/e2e/tests/offline/history.spec.mjs
@@ -541,7 +541,7 @@ test.describe('watch history with an immediate watched threshold', () => {
       const records = contents.trim().split('\n').filter(Boolean).map(line => JSON.parse(line))
       return records.filter(record => record.videoId === 'ddddddddddd').at(-1)?.watchProgress
     }).toBe(0)
-    await expect(video.locator('.watchedProgressBar')).toHaveAttribute('data-progress', '100')
+    await expect(video.locator('.watchedProgressBar')).toHaveCount(0)
   })
 })
 

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -864,7 +864,7 @@ const progressPercentage = computed(() => {
     return 0
   }
 
-  if (isWatched.value) {
+  if (isWatched.value && watchedPercentageThreshold.value !== 0) {
     return 100
   }
 

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -864,10 +864,6 @@ const progressPercentage = computed(() => {
     return 0
   }
 
-  if (isWatched.value && watchedPercentageThreshold.value !== 0) {
-    return 100
-  }
-
   const percentage = (Math.ceil(watchProgress.value) / lengthSeconds.value) * 100
   return Math.min(percentage, 100)
 })

--- a/tests/unit/thumbnail-progress.test.mjs
+++ b/tests/unit/thumbnail-progress.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import vm from 'node:vm'
+
+import { hasReachedWatchedThreshold, isHistoryEntryWatched } from '../../src/history.js'
+
+const source = await readFile(new URL('../../src/renderer/components/FtListVideo/FtListVideo.vue', import.meta.url), 'utf8')
+const start = source.indexOf('const progressPercentage = computed(() => {')
+assert.notEqual(start, -1)
+const end = source.indexOf('\nconst thumbnailProgressRadius', start)
+assert.notEqual(end, -1)
+const progressCalculation = source.slice(start, end)
+
+function thumbnailProgress({ progress = 150, duration = 600, threshold = 0, watched } = {}) {
+  const entry = {
+    watchProgress: progress,
+    lengthSeconds: duration,
+    isWatched: watched ?? hasReachedWatchedThreshold(progress, duration, threshold),
+  }
+  return vm.runInNewContext(`${progressCalculation}\nprogressPercentage.value`, {
+    computed: getter => ({ value: getter() }),
+    lengthSeconds: { value: entry.lengthSeconds },
+    watchProgress: { value: entry.watchProgress },
+    isWatched: { value: isHistoryEntryWatched(entry) },
+    watchedPercentageThreshold: { value: threshold },
+  })
+}
+
+test('zero watched threshold preserves actual thumbnail progress', () => {
+  assert.equal(thumbnailProgress(), 25)
+  assert.equal(thumbnailProgress({ progress: 0 }), 0)
+  assert.equal(thumbnailProgress({ progress: 450 }), 75)
+  assert.equal(thumbnailProgress({ progress: 600 }), 100)
+  assert.equal(thumbnailProgress({ progress: 700 }), 100)
+})
+
+test('nonzero watched thresholds retain completed bars for watched videos', () => {
+  assert.equal(thumbnailProgress({ threshold: 90, progress: 540 }), 100)
+  assert.equal(thumbnailProgress({ threshold: 90 }), 25)
+  assert.equal(thumbnailProgress({ threshold: 90, watched: true }), 100)
+  assert.equal(thumbnailProgress({ threshold: 100, progress: 540 }), 90)
+})
+
+test('unknown or zero durations do not show thumbnail progress', () => {
+  assert.equal(thumbnailProgress({ duration: null, watched: true }), 0)
+  assert.equal(thumbnailProgress({ duration: 0, watched: true }), 0)
+})

--- a/tests/unit/thumbnail-progress.test.mjs
+++ b/tests/unit/thumbnail-progress.test.mjs
@@ -35,12 +35,15 @@ test('zero watched threshold preserves actual thumbnail progress', () => {
   assert.equal(thumbnailProgress({ progress: 700 }), 100)
 })
 
-test('nonzero watched thresholds retain completed bars for watched videos', () => {
-  assert.equal(thumbnailProgress({ threshold: 90, progress: 540 }), 100)
-  assert.equal(thumbnailProgress({ threshold: 90 }), 25)
-  assert.equal(thumbnailProgress({ threshold: 90, watched: true }), 100)
-  assert.equal(thumbnailProgress({ threshold: 100, progress: 540 }), 90)
-})
+for (const threshold of [0, 1, 50, 90, 100]) {
+  test(`watched status does not override saved progress at threshold ${threshold}`, () => {
+    assert.equal(thumbnailProgress({ threshold, progress: 540 }), 90)
+    assert.equal(thumbnailProgress({ threshold, watched: true }), 25)
+    assert.equal(thumbnailProgress({ threshold, watched: false }), 25)
+    assert.equal(thumbnailProgress({ threshold, progress: 0, watched: true }), 0)
+    assert.equal(thumbnailProgress({ threshold, progress: 600, watched: true }), 100)
+  })
+}
 
 test('unknown or zero durations do not show thumbnail progress', () => {
   assert.equal(thumbnailProgress({ duration: null, watched: true }), 0)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

Videos marked watched could show a full thumbnail progress bar despite having only partially played. At a 0% watch threshold this affected every video as soon as playback started. Thumbnail bars now always reflect the saved playback position.

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #1294

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Remove the watched-status shortcut from thumbnail progress at every threshold. For example, 150 seconds of a 600-second video displays 25% even when the video is marked watched. Restore the E2E expectation that marking a video watched with zero saved progress does not create a full bar.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed thumbnail progress showing 100% for partially played videos marked as watched, including when Watch Percentage Threshold is set to 0%.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Set Watch Percentage Threshold to 0% and enable automatic watch-progress saving.
2. Play part of a video, leave it, and inspect its thumbnail. The bar should match the saved playback position.
3. Reopen the video and confirm it resumes at that position.
4. Set the threshold to 90% and watch a video past that threshold with less than two minutes remaining. It should be marked watched while its bar still reflects the saved playback position.
5. Mark an unplayed video as watched. It should show the watched indicator without a progress bar.

## Additional context
<!-- Add any other context about the pull request here. -->

Regression tests cover saved progress independently of watched status at thresholds of 0%, 1%, 50%, 90%, and 100%. The expanded tests reproduced the incorrect full bars before removal of the shortcut.

Implemented with GPT-6 in the Codex harness.

