### PR TITLE
fix(android): prevent countdown holes in the scrolling mini-player

### DIFF
--- a/e2e/tests/offline/android-native-screen.spec.mjs
+++ b/e2e/tests/offline/android-native-screen.spec.mjs
@@ -160,11 +160,8 @@ test('inline playback presents the native surface without copying frames through
   await page.evaluate(() => window.nativeScreenTest.destroy())
 })
 
-test('SABR and preroll countdown rings cover native transport buttons', async ({ app, page }) => {
-  await mockPlayableWatchPage(app, page)
-  await openMockedVideo(page)
-  await openNativeScreen(page, false)
-  await page.evaluate(() => {
+async function addCountdownNotice(page) {
+  await page.locator('.ftVideoPlayer').evaluate(player => {
     // Both native source timers use this shared ring. Supply the notice without
     // requiring a remote SABR server to request backoff during an offline test.
     const overlay = document.createElement('div')
@@ -172,7 +169,6 @@ test('SABR and preroll countdown rings cover native transport buttons', async ({
     const ring = document.createElement('div')
     ring.className = 'countdownProgress'
     ring.textContent = '1.2s'
-    const player = document.querySelector('.ftVideoPlayer')
     for (const attribute of player.getAttributeNames().filter(name => name.startsWith('data-v-'))) {
       overlay.setAttribute(attribute, '')
       ring.setAttribute(attribute, '')
@@ -180,6 +176,13 @@ test('SABR and preroll countdown rings cover native transport buttons', async ({
     overlay.append(ring)
     player.append(overlay)
   })
+}
+
+test('SABR and preroll countdown rings cover native transport buttons', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  await openMockedVideo(page)
+  await openNativeScreen(page, false)
+  await addCountdownNotice(page)
   const ring = page.locator('.countdownProgress')
   await expect(ring).toBeVisible()
   for (const fullscreen of [false, true]) {
@@ -195,6 +198,62 @@ test('SABR and preroll countdown rings cover native transport buttons', async ({
   }
   await page.evaluate(() => window.nativeScreenTest.destroy())
 })
+
+for (const uiScale of [100, 125]) {
+  test.describe(`native countdown scrolling at ${uiScale}%`, () => {
+    test.use({ seed: { settings: { videoPlaybackEngine: 'built-in', ytDlpPlaybackEngineDefaultMigration: true, uiScale, enterFullscreenOnDisplayRotate: false } } })
+    test('does not cut a hole for a hidden backoff countdown during mini-player scrolling', async ({ app, page }) => {
+      await mockPlayableWatchPage(app, page)
+      await openMockedVideo(page)
+      await openNativeScreen(page, false)
+      const player = page.locator('.ftVideoPlayer')
+      await addCountdownNotice(page)
+      await player.evaluate(element => window.scrollTo(0, window.scrollY + element.getBoundingClientRect().bottom))
+      await expect(player).toHaveClass(/scrollMiniPlayer/)
+      await expect(player).not.toHaveAttribute('data-native-player-transition')
+      // Match the Android template's Teleport into the floating player layer.
+      await player.evaluate(element => document.querySelector('#cross-tab-mini-player-layer').append(element))
+      const ring = page.locator('.countdownProgress')
+      const clipsRing = () => ring.evaluate(element => {
+        const box = element.getBoundingClientRect()
+        return window.nativeLayoutTest.menus.some(menu =>
+          Math.abs(menu.x - box.x) < 1 && Math.abs(menu.y - box.y) < 1 &&
+          Math.abs(menu.width - box.width) < 1 && Math.abs(menu.height - box.height) < 1)
+      })
+      await expect(ring).toBeVisible()
+      await expect.poll(clipsRing).toBe(true)
+      for (const action of ['scroll', 'gesture', 'transition']) {
+        await player.evaluate((element, action) => {
+          if (action === 'scroll') window.nativeScreenTest.action('scroll-start')
+          else if (action === 'gesture') element.dispatchEvent(new CustomEvent('native-player-gesture', { detail: true }))
+          else {
+            const layout = window.nativeScreenTestController.layout
+            window.nativeScreenTestController.layout = async value => {
+              await layout(value)
+              if (value.transition) await new Promise(resolve => { window.finishCountdownMotion = resolve })
+            }
+            const bounds = element.getBoundingClientRect().toJSON()
+            element.dispatchEvent(new CustomEvent('native-player-transition', {
+              cancelable: true, detail: { from: bounds, to: bounds, duration: 200 }
+            }))
+          }
+        }, action)
+        await expect(ring).toBeHidden()
+        // Android raises its texture above the page during motion. A retained
+        // countdown rectangle cuts straight through it to the chapters below.
+        await expect.poll(clipsRing).toBe(false)
+        await player.evaluate((element, action) => {
+          if (action === 'scroll') window.nativeScreenTest.action('scroll-end')
+          else if (action === 'gesture') element.dispatchEvent(new CustomEvent('native-player-gesture', { detail: false }))
+          else window.finishCountdownMotion()
+        }, action)
+        await expect(ring).toBeVisible()
+        await expect.poll(clipsRing).toBe(true)
+      }
+      await page.evaluate(() => window.nativeScreenTest.destroy())
+    })
+  })
+}
 
 for (const uiScale of [100, 125]) {
   test.describe(`inline native surface at ${uiScale}%`, () => {

--- a/src/renderer/helpers/player/androidNativeScreen.js
+++ b/src/renderer/helpers/player/androidNativeScreen.js
@@ -48,8 +48,11 @@ export function createAndroidNativeScreen({ element, container, getController, g
     endGesture()
     const sequence = ++transitionSequence
     const { from, to, duration } = event.detail
-    transitioning = true
     container.toggleAttribute('data-native-player-transition', true)
+    // Flush the hidden overlays' exclusions before native animation freezes
+    // layout updates and raises the video above the WebView.
+    syncLayout()
+    transitioning = true
     // The native animator owns the moving video. Keep the WebView at the
     // destination, ready for the handoff once its final clip has been drawn.
     syncInlineBackground(false)
@@ -233,7 +236,10 @@ export function createAndroidNativeScreen({ element, container, getController, g
     }
     const appChrome = open ? [] : appChromeElements
     const globalMenus = open ? [] : globalMenuElements.filter(menu => !container.contains(menu))
+    // Hidden notices retain their layout box during native scrolling/gestures.
+    // Clipping that box would punch through the raised video into the page.
     const menuElements = [...playerMenus, ...countdowns, ...globalMenus, ...appChrome]
+      .filter(menu => menu.checkVisibility?.({ checkOpacity: true, checkVisibilityCSS: true }) !== false)
     const pageScroll = followsPageScroll()
     const nativeY = y => pageScroll ? Math.round((y + window.scrollY) * 1000) / 1000 : y
     const menus = menuElements.map(menu => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Scrolling on Android while a SABR backoff countdown was visible could punch a square hole through the floating player, exposing the page or a stale countdown underneath.

Exclude invisible overlays from native clipping and refresh those exclusions before mini-player animation pauses layout updates. Add regression coverage for scrolling, dragging, and transitions at 100% and 125% UI scale.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed a square hole appearing in the Android mini-player when scrolling during a playback backoff countdown.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
1. Run this branch's Android dev build and open a video.
2. While a SABR backoff countdown is showing, scroll until the floating mini-player appears, then keep swiping the page. The video must remain intact without a square opening.
3. Stop scrolling. The countdown should reappear in the player and continue decreasing.
4. Drag the mini-player, then scroll back to the inline player. Neither movement should retain a countdown-shaped hole.
5. Let the timer expire. Its overlay should disappear normally.

<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

## Additional context
<!-- Add any other context about the pull request here. -->
Reproduced on the API 35 emulator with local video playback and the real SABR timer forced to 120 seconds through a temporary console hook. During a native swipe, the original build retained the hidden countdown's 94×94 CSS-pixel exclusion; the fixed build removed it, kept the video intact, and restored the countdown when scrolling stopped. Timer expiration also cleared the overlay. Capture hooks are not included in this PR. Physical-device verification is deferred.

The independent Standards and Spec reviews have no remaining findings after extracting duplicated countdown test setup.

Local validation passed: 1,673 unit tests, lint, and seven focused E2E checks on the rebased branch. Android debug builds and native unit checks also passed.

Implemented with GPT-6 in the Codex harness.

