### PR TITLE
fix(ui): lower connection banner when overlays cover mobile navigation

### DIFF
--- a/e2e/tests/offline/connection-status.spec.mjs
+++ b/e2e/tests/offline/connection-status.spec.mjs
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
-import { test, expect, goToSettingsSection, latestSettings } from '../../helpers/app.mjs'
+import { test, expect, goTo, goToSettingsSection, latestSettings } from '../../helpers/app.mjs'
 import { createInternetProbe, INTERNET_CHECK_URL } from '../../../src/renderer/helpers/internetConnectivity.js'
 
 test.use({ seed: { settings: { fetchSubscriptionsAutomatically: false } } })
@@ -30,6 +30,43 @@ test('internet probe works with browser web security enabled', async ({ app }) =
 })
 
 for (const scale of [1, 1.25]) {
+  test(`connection banner follows navbar coverage at UI scale ${scale}`, async ({ page }) => {
+    await page.setViewportSize({ width: 480, height: 800 })
+    await page.evaluate(scale => window.ftElectron.setZoomFactor(scale), scale)
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    await page.evaluate(() => {
+      Object.defineProperty(navigator, 'onLine', { configurable: true, value: false })
+      window.dispatchEvent(new Event('offline'))
+    })
+    const banner = page.locator('.connection-status-holder')
+    await expect(banner).toBeVisible()
+    const bottomGap = () => banner.evaluate(element => window.innerHeight - element.getBoundingClientRect().bottom)
+    await expect.poll(bottomGap).toBeCloseTo(60, 0)
+    await goTo(page, 'settings')
+    await expect(page.locator('.settingsWindow')).toHaveClass(/maximized/)
+    await expect.poll(bottomGap).toBeCloseTo(0, 0)
+    await page.locator('.app').evaluate(element => element.classList.add('capacitorPhoneLayout'))
+    await page.evaluate(() => document.documentElement.style.setProperty('--safe-area-inset-bottom', '24px'))
+    await expect.poll(bottomGap).toBeCloseTo(24, 0)
+    await page.locator('.settingsWindowHeader').getByRole('button', { name: 'Close', exact: true }).click()
+    await expect(page.locator('.settingsWindow')).toBeHidden()
+    await expect.poll(bottomGap).toBeCloseTo(84, 0)
+
+    // The mobile sheet component is developed separately; exercise its DOM contract.
+    await page.evaluate(() => {
+      const sheet = document.createElement('dialog')
+      sheet.className = 'mobileSheet'
+      document.body.append(sheet)
+    })
+    const sheet = page.locator('dialog.mobileSheet')
+    await expect.poll(bottomGap).toBeCloseTo(84, 0)
+    await sheet.evaluate(element => element.show())
+    await expect.poll(bottomGap).toBeCloseTo(24, 0)
+    await sheet.evaluate(element => element.close())
+    await expect.poll(bottomGap).toBeCloseTo(84, 0)
+    await sheet.evaluate(element => element.remove())
+  })
+
   test(`connection banner pauses requests and confirms recovery at UI scale ${scale}`, async ({ page }) => {
     await page.setViewportSize({ width: 480, height: 800 })
     await page.locator('.app').evaluate(element => element.classList.add('capacitorPhoneLayout'))

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -733,7 +733,9 @@ body:has(.app.capacitorPhoneLayout) {
   }
 }
 
-body:has(.app) :fullscreen .connection-status-holder {
+body:has(.app) :fullscreen .connection-status-holder,
+body:has(.mobileSheet[open]) .connection-status-holder,
+body:has(.app .settingsWindow.maximized) .connection-status-holder {
   inset-block-end: var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0));
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description

The connection banner leaves an empty navbar-sized gap when Settings covers the mobile navigation. Move it to the bottom safe area while a maximized settings window or an open mobile sheet covers the navbar, and restore navigation clearance when it closes.
<!-- Please write a clear and concise description of what the pull request does. -->

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Keep the connection banner at the bottom when mobile settings or sheets cover the navigation bar.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing

1. Narrow the app to a phone-sized window and disconnect the network. The connection banner should sit above the bottom navigation.
2. Open Settings. The banner should move to the bottom edge, respecting the system safe area. Close Settings and confirm it moves back above navigation.
3. Repeat at 125% UI scale. Where mobile sheets are available, opening and closing one should produce the same positioning change. Modal sheets may cover the banner.
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

## Additional context

The mobile-sheet component is being developed separately; the regression test exercises its open-dialog DOM contract. Validation: connection-banner E2E tests at 100% and 125% scale, unit tests, and lint. Standards review found a missing sheet regression test, which is now included; spec review found no issues.

Created with GPT-6 in Codex desktop.
<!-- Add any other context about the pull request here. -->
