### PR TITLE
fix(subscriptions): show failure toast timeout indicator

### DIFF
--- a/e2e/tests/offline/subscriptions-refresh.spec.mjs
+++ b/e2e/tests/offline/subscriptions-refresh.spec.mjs
@@ -191,6 +191,33 @@ test.describe('invalid per-channel daily video limit', () => {
   })
 })
 
+test.describe('failed subscription refresh summary', () => {
+  test.use({
+    seed: {
+      settings: {
+        ...commonSettings,
+        backendFallback: false,
+        showToastTimeoutIndicator: true
+      },
+      profiles: [profileWith(1)],
+      subscriptionCache: [cachedChannel(0)]
+    }
+  })
+
+  test('starts the timeout indicator when the refresh finishes', async ({ page }) => {
+    await page.route(/^https?:\/\//, route => route.fulfill({ status: 500, body: 'Failed' }))
+    await goTo(page, 'subscriptions')
+
+    await page.getByRole('button', { name: /Refresh Videos/ }).click()
+
+    const summary = page.locator('.toast', { hasText: 'Channels that could not be refreshed' })
+    const indicator = summary.locator('..').locator('.timeout-indicator .embeddedProgressPath')
+    await expect(summary).toBeVisible()
+    await expect(indicator).toBeVisible()
+    await expect(indicator).toHaveCSS('animation-duration', '9.7s')
+  })
+})
+
 test.describe('incremental subscription feed refresh', () => {
   test.use({
     seed: {

--- a/e2e/tests/offline/subscriptions-refresh.spec.mjs
+++ b/e2e/tests/offline/subscriptions-refresh.spec.mjs
@@ -199,13 +199,20 @@ test.describe('failed subscription refresh summary', () => {
         backendFallback: false,
         showToastTimeoutIndicator: true
       },
-      profiles: [profileWith(1)],
-      subscriptionCache: [cachedChannel(0)]
+      profiles: [profileWith(2)],
+      subscriptionCache: [cachedChannel(0), cachedChannel(1)]
     }
   })
 
-  test('starts the timeout indicator when the refresh finishes', async ({ page }) => {
-    await page.route(/^https?:\/\//, route => route.fulfill({ status: 500, body: 'Failed' }))
+  test('starts the timeout indicator when the refresh finishes and restores transient eviction', async ({ page }) => {
+    let releaseSecondFeed
+    const secondFeedBlocked = new Promise(resolve => { releaseSecondFeed = resolve })
+    await page.route(/^https?:\/\//, async (route, request) => {
+      if (request.url().includes('/feeds/videos.xml') && channelIndexFromUrl(request.url()) === 1) {
+        await secondFeedBlocked
+      }
+      await route.fulfill({ status: 500, body: 'Failed' })
+    })
     await goTo(page, 'subscriptions')
 
     await page.getByRole('button', { name: /Refresh Videos/ }).click()
@@ -213,8 +220,19 @@ test.describe('failed subscription refresh summary', () => {
     const summary = page.locator('.toast', { hasText: 'Channels that could not be refreshed' })
     const indicator = summary.locator('..').locator('.timeout-indicator .embeddedProgressPath')
     await expect(summary).toBeVisible()
+    await expect(page.locator('.tab.active .loadingDot')).toBeVisible()
+    await expect(indicator).toHaveCount(0)
+
+    releaseSecondFeed()
     await expect(indicator).toBeVisible()
     await expect(indicator).toHaveCSS('animation-duration', '9.7s')
+
+    for (let index = 0; index < 5; index++) {
+      await page.evaluate(index => {
+        window.ftElectron.showToastOnAllTabs(`Later toast ${index}`, 10000)
+      }, index)
+    }
+    await expect(summary).toHaveCount(0, { timeout: 2000 })
   })
 })
 

--- a/patches/vue-sonner@2.0.9.patch
+++ b/patches/vue-sonner@2.0.9.patch
@@ -2,6 +2,10 @@ diff --git a/lib/index.js b/lib/index.js
 index cd01bb1f1563571946c1470dfdea9d009655d9cd..22f0bff49fa39788c039f07d87653585c6cc7bf5 100644
 --- a/lib/index.js
 +++ b/lib/index.js
+@@ -485,0 +486,3 @@ var Toast_vue_vue_type_script_setup_true_lang_default = /* @__PURE__ */ defineCo
++		watch(duration, (value) => {
++			remainingTime.value = value;
++		}, { flush: "sync" });
 @@ -514,6 +514,7 @@ var Toast_vue_vue_type_script_setup_true_lang_default = /* @__PURE__ */ defineCo
  		function deleteToast() {
  			removed.value = true;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ patchedDependencies:
   '@capawesome/capacitor-app-shortcuts@8.0.2': 2581c86d60ce7892c0b3136523994591d24ee7313bbc5fc9b4ad1c710719c70a
   '@capawesome/capacitor-clipboard@0.1.2': 729c6071cbf0e196e2212b015677cdd162c287dca48137c24250c0d056c9fd5b
   shaka-player@5.1.12: 17d85e267c8958999207ce9d6c29a2ddf18734d0499fb30870ac8a55d90303fa
-  vue-sonner@2.0.9: ae94d00b3ff46bede626a25ac5a36a6cd35987f33d73c14ffc73afbd5767f95c
+  vue-sonner@2.0.9: 1edf0a77b800d7b7f56694e3a77ff40dd2f7ba21658639d2ff90d5173eae26b4
   youtubei.js@18.0.0: 5939f9d50ce37ef8075961245288956568c781818db04171892485bdf96278e9
 
 importers:
@@ -141,7 +141,7 @@ importers:
         version: 5.3.1(@vue/compiler-sfc@3.5.42)(vue@3.5.42(typescript@6.0.3))(webpack@5.110.3)
       vue-sonner:
         specifier: ^2.0.9
-        version: 2.0.9(patch_hash=ae94d00b3ff46bede626a25ac5a36a6cd35987f33d73c14ffc73afbd5767f95c)
+        version: 2.0.9(patch_hash=1edf0a77b800d7b7f56694e3a77ff40dd2f7ba21658639d2ff90d5173eae26b4)
       vuex:
         specifier: ^4.1.0
         version: 4.1.0(vue@3.5.42(typescript@6.0.3))
@@ -11301,7 +11301,7 @@ snapshots:
       - unloader
       - webpack
 
-  vue-sonner@2.0.9(patch_hash=ae94d00b3ff46bede626a25ac5a36a6cd35987f33d73c14ffc73afbd5767f95c): {}
+  vue-sonner@2.0.9(patch_hash=1edf0a77b800d7b7f56694e3a77ff40dd2f7ba21658639d2ff90d5173eae26b4): {}
 
   vue@3.5.42(typescript@6.0.3):
     dependencies:

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -430,9 +430,10 @@ function stopProgressToastPointerTracking() {
 }
 
 /**
- * @param {CustomEvent<{ message: string | (({elapsedMs: number, remainingMs: number}) => string), time: number | null, action: Function | null, abortSignal: AbortSignal | null, image: string | null, icon: [string, string] | null, buttons: { label: string, action?: Function, primary?: boolean, icon?: [string, string] }[], buttonAction: 'open-sync-settings' | null, verticalButtons: boolean, dismissible: boolean, dismissOnAction?: boolean }>} event
+ * @param {CustomEvent<{ message: string | (({elapsedMs: number, remainingMs: number}) => string), time: number | null, action: Function | null, abortSignal: AbortSignal | null, image: string | null, icon: [string, string] | null, buttons: { label: string, action?: Function, primary?: boolean, icon?: [string, string] }[], buttonAction: 'open-sync-settings' | null, verticalButtons: boolean, dismissible: boolean, dismissOnAction?: boolean, control: import('../../helpers/utils').ToastControl | null }>} event
  */
-function open({ detail: { message, time, action, abortSignal, image, icon, buttons, buttonAction, verticalButtons, dismissible, dismissOnAction } }) {
+function open(event) {
+  let { message, time, action, abortSignal, image, icon, buttons, buttonAction, verticalButtons, dismissible, dismissOnAction } = event.detail
   if (buttonAction === 'open-sync-settings') {
     buttons = [{
       label: t('Settings.Sync Settings.Sync Settings'),
@@ -479,6 +480,23 @@ function open({ detail: { message, time, action, abortSignal, image, icon, butto
     onAutoClose: forgetToast
   })
   toastId = id
+  event.detail.control = {
+    startTimeout(nextTime) {
+      if (!Number.isFinite(nextTime) || !liveToasts.includes(id)) return
+
+      time = nextTime
+      state.duration = nextTime
+      sonner.custom(toastItem, {
+        id,
+        duration: nextTime,
+        dismissible: state.dismissible,
+        position: SONNER_POSITION,
+        componentProps: { toast: state },
+        onDismiss: forgetToast,
+        onAutoClose: forgetToast
+      })
+    }
+  }
 
   if (typeof message === 'function') {
     let elapsed = 0

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -484,6 +484,7 @@ function open(event) {
     startTimeout(nextTime) {
       if (!Number.isFinite(nextTime) || !liveToasts.includes(id)) return
 
+      indefiniteToastIds.delete(id)
       time = nextTime
       state.duration = nextTime
       sonner.custom(toastItem, {

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -311,7 +311,8 @@ function notifySubscriptionChannelRefreshed(tab) {
 /** Keep confirmed channel failures visible even when another channel keeps retrying. */
 function createSubscriptionErrorSummary(t) {
   const errors = shallowReactive(new Map())
-  const controller = new AbortController()
+  /** @type {import('./utils').ToastControl | null} */
+  let toastControl = null
   let shown = false
   return {
     add(channel, messages) {
@@ -324,7 +325,7 @@ function createSubscriptionErrorSummary(t) {
       })
       if (shown || subscriptionRefreshErrors.value === errors) return
       shown = true
-      showToast({
+      toastControl = showToast({
         message: () => {
           const names = [...errors.values()].slice(0, 3).map(channel => channel.name).join(', ')
           const channels = errors.size > 3
@@ -333,7 +334,6 @@ function createSubscriptionErrorSummary(t) {
           return t('Subscriptions.Refresh Errors', { channels })
         },
         time: Infinity,
-        abortSignal: controller.signal,
         action: () => {
           shown = false
           subscriptionRefreshErrors.value = errors
@@ -343,7 +343,7 @@ function createSubscriptionErrorSummary(t) {
     },
     finish() {
       // Keep the final details available briefly after completion or cancellation.
-      if (shown) setTimeout(() => controller.abort(), 10000)
+      if (shown) toastControl?.startTimeout(10000)
     }
   }
 }

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -281,11 +281,17 @@ const ERROR_TOAST_ICON = ['fas', 'circle-exclamation']
  */
 
 /**
+ * @typedef {object} ToastControl
+ * @property {(time: number) => void} startTimeout starts a finite timeout for an indefinite toast
+ */
+
+/**
  * @param {string | (({elapsedMs: number, remainingMs: number}) => string) | ToastOptions} message
  *   the message to display, or an options object for more control (e.g. to show an image or icon)
  * @param {number} time
  * @param {Function} action
  * @param {AbortSignal} abortSignal
+ * @returns {ToastControl | null | undefined}
  */
 export function showToast(message, time = null, action = null, abortSignal = null) {
   let image = null
@@ -308,21 +314,23 @@ export function showToast(message, time = null, action = null, abortSignal = nul
     return
   }
 
-  ToastEventBus.dispatchEvent(new CustomEvent('toast-open', {
-    detail: {
-      message,
-      time,
-      action,
-      abortSignal,
-      image,
-      icon,
-      buttons,
-      buttonAction,
-      verticalButtons,
-      dismissible,
-      dismissOnAction,
-    }
-  }))
+  const detail = {
+    message,
+    time,
+    action,
+    abortSignal,
+    image,
+    icon,
+    buttons,
+    buttonAction,
+    verticalButtons,
+    dismissible,
+    dismissOnAction,
+    /** @type {ToastControl | null} */
+    control: null,
+  }
+  ToastEventBus.dispatchEvent(new CustomEvent('toast-open', { detail }))
+  return detail.control
 }
 
 /**

--- a/tests/unit/subscription-network-recovery.test.mjs
+++ b/tests/unit/subscription-network-recovery.test.mjs
@@ -91,7 +91,14 @@ function createRefresh({ online = true, feed = 'Shorts', error = new TypeError('
     getChannelPlaylistId: id => id,
     showApiErrorToast: (...args) => toasts.push(args),
     copyToClipboard: text => copied.push(text),
-    showToast: (...args) => toasts.push(args),
+    showToast: (...args) => {
+      toasts.push(args)
+      return {
+        startTimeout(time) {
+          args[0].time = time
+        }
+      }
+    },
     localApiFetch: fetchLocal,
     fetch: webCors ? async () => { throw new TypeError('Failed to fetch') } : fetchChannel,
     invidiousFetch: fetchInvidious,
@@ -529,6 +536,7 @@ test('one compact refresh notification retains every failed channel and distinct
   await app.refresh({ t: translateSummary })
   assert.equal(app.toasts.length, 1)
   const toast = app.toasts[0][0]
+  assert.equal(toast.time, 10000, 'completion must start the visible timeout indicator')
   assert.equal(toast.message(), 'Channels that could not be refreshed: UC0, UC1, UC2 and 17 more. Click to view details.')
   assert.ok(toast.message().length < 100)
   toast.action()
@@ -588,7 +596,7 @@ test('confirmed HTTP failures stay accessible while another channel retries and 
     app.cancelSubscriptionRefresh()
     await refresh
     assert.equal(app.toasts.length, 1)
-    assert.equal(app.toasts[0][0].abortSignal.aborted, false, 'cancellation must retain the confirmed failures')
+    assert.equal(app.toasts[0][0].time, Infinity, 'opening the details must prevent a stale timeout update')
   } finally {
     app.cancelSubscriptionRefresh()
     await refresh


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Failed-channel notifications stayed configured with an infinite duration throughout subscription refreshes. A separate timer dismissed them ten seconds after completion, so the timeout indicator never appeared.

This adds a toast control that changes the existing notification to a finite duration when the refresh finishes. The toast library patch now resets its internal timer when that duration changes, which keeps hover and hidden-window pausing in sync with the indicator.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Show the timeout indicator on failed-channel notifications after subscription refreshes finish.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Enable the toast timeout indicator in Appearance settings.
2. Refresh subscriptions while at least one channel fetch fails.
3. Confirm the failed-channel notification remains persistent during the refresh.
4. Confirm its timeout indicator starts when the refresh finishes and the notification closes after ten seconds. Hovering the notification should pause both the indicator and timeout.

## Additional context
<!-- Add any other context about the pull request here. -->
The existing notification instance changes duration, so completion does not add a duplicate toast or replace the notification while it is visible.

Prepared by GPT-5 using the Codex desktop app.
