### PR TITLE
fix(player): resolve navigation, gesture, and sandbox review findings

### DIFF
--- a/android/app/src/androidTest/java/org/opentubex/app/NativePlaybackScreenTest.java
+++ b/android/app/src/androidTest/java/org/opentubex/app/NativePlaybackScreenTest.java
@@ -283,7 +283,7 @@ public class NativePlaybackScreenTest {
             android.graphics.Bitmap image = android.graphics.Bitmap.createBitmap(screen.getWidth(), screen.getHeight(), android.graphics.Bitmap.Config.ARGB_8888);
             screen.draw(new android.graphics.Canvas(image));
             assertEquals("The resized video must cover page content outside its old cutout", android.graphics.Color.MAGENTA,
-                image.getPixel((int) (150 * screen.getWidth() / 1000f), (int) (250 * screen.getWidth() / 1000f)));
+                image.getPixel((int) (120 * screen.getWidth() / 1000f), (int) (250 * screen.getWidth() / 1000f)));
             image.recycle();
             screen.setGestureActive(false);
             assertNotNull(web.heldVisualState);

--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -2302,6 +2302,43 @@ test.describe('navigation playback lifecycle', () => {
     await expect(page.locator('.ftVideoPlayer')).toHaveCount(0)
   })
 
+  test('returning during retained-player disposal mounts fresh playable video', async ({ app, page }) => {
+    await openDemoVideo({ app, page })
+    const component = await page.evaluateHandle(findWatchComponent)
+    const original = await page.locator('.ftVideoPlayer video').elementHandle()
+    await page.getByRole('button', { name: 'Expand side navigation', exact: true }).click()
+    await goTo(page, 'history')
+    const disposal = await component.evaluateHandle(component => {
+      const watch = component.proxy
+      const originalRouteChange = watch.handleRouteChange
+      let release
+      const gate = new Promise(resolve => { release = resolve })
+      const state = { release, started: false, returned: false }
+      watch.handleRouteChange = async (...args) => {
+        state.started = true
+        await gate
+        return originalRouteChange(...args)
+      }
+      return state
+    })
+    try {
+      await component.evaluate(component => component.proxy.$store.dispatch('updateKeepPlayingOnNavigation', false))
+      await expect.poll(() => disposal.evaluate(state => state.started)).toBe(true)
+      await component.evaluate((component, state) => {
+        component.proxy.tabRouter.push('/watch/jNQXAC9IVRw').then(() => { state.returned = true })
+      }, disposal)
+      await expect(page).toHaveURL(/#\/history$/)
+      expect(await disposal.evaluate(state => state.returned)).toBe(false)
+    } finally {
+      await disposal.evaluate(state => state.release())
+    }
+    await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+    const video = page.locator('.ftVideoPlayer video')
+    await expect(video).toBeVisible()
+    expect(await video.evaluate((element, old) => element === old, original)).toBe(false)
+    await expect.poll(() => video.evaluate(element => !element.paused && element.readyState >= 2)).toBe(true)
+  })
+
   test('replaces retained playback when opening another video', async ({ app, page }) => {
     await openDemoVideo({ app, page })
     await page.getByRole('button', { name: 'Expand side navigation', exact: true }).click()
@@ -2346,5 +2383,17 @@ test.describe('retained navigation player across tabs', () => {
     await page.getByRole('link', { name: 'Go to Subscriptions', exact: true }).click()
     await page.locator('.tabBar .tab').first().getByRole('button', { name: 'Close Tab', exact: true }).click()
     await expect(page.locator('.ftVideoPlayer')).toHaveCount(0)
+  })
+})
+
+test.describe('navigation playback with automatic tab picture-in-picture enabled', () => {
+  test.use({ seed: { settings: { ...PLAYER_SEED, keepPlayingOnNavigation: true, autoPictureInPictureTriggers: ['tab'] } } })
+
+  test('keeps the outgoing video in the mini player', async ({ app, page }) => {
+    const { firstVideo, firstPlayer } = await openCrossTabMiniPlayerOverWatchTab({ app, page })
+    await expect(firstPlayer).toBeVisible()
+    await expect(firstPlayer).toHaveClass(/scrollMiniPlayer/)
+    await expect.poll(() => firstVideo.evaluate(element => element.paused)).toBe(false)
+    expect(await page.evaluate(() => document.pictureInPictureElement === null)).toBe(true)
   })
 })

--- a/src/renderer/components/TabContent/TabWatchContent.vue
+++ b/src/renderer/components/TabContent/TabWatchContent.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, provide, reactive, ref, shallowRef, useTemplateRef, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, provide, reactive, ref, shallowRef, useTemplateRef, watch } from 'vue'
 import { routeLocationKey, routerKey } from 'vue-router'
 import store from '../../store/index'
 import { resolveRouteComponent } from '../../router/index'
@@ -43,6 +43,8 @@ const injectedRoute = reactive({})
 const hooks = new Set()
 let disposed = false
 let watchTitle = ''
+let watchTitleOptions
+let disposalPromise = null
 
 async function run(name, context) {
   for (const entry of [...hooks]) {
@@ -54,22 +56,26 @@ async function run(name, context) {
   }
 }
 
-async function dispose(context) {
-  if (disposed || !watchRoute.value) return
+function dispose(context) {
+  if (disposed || !watchRoute.value) return disposalPromise
   disposed = true
-  await run('beforeDispose', context)
+  disposalPromise = run('beforeDispose', context)
+  return disposalPromise
 }
 
 const unregister = tabLifecycleService.register(props.tabId, {
   async beforeNavigate(context) {
+    await disposalPromise
     if (!isWatchRoute.value) return
     // Android teleports even the scrolling mini player outside this view.
     const player = watchView.value?.$refs.player
     retained.value = enabled.value && !context.to.path.startsWith('/watch/') &&
       player?.hasLoaded === true && !player.isPaused()
     if (retained.value) {
-      watchTitle = store.getters.getTabById(props.tabId)?.history
-        .findLast(entry => entry.route.fullPath === watchRoute.value.fullPath)?.title || ''
+      const entry = store.getters.getTabById(props.tabId)?.history
+        .findLast(entry => entry.route.fullPath === watchRoute.value.fullPath)
+      watchTitle = entry?.title || ''
+      watchTitleOptions = { resolveHistoryEntry: entry?.titlePending !== true }
       await run('deactivate', context)
     } else {
       await dispose(context)
@@ -77,7 +83,7 @@ const unregister = tabLifecycleService.register(props.tabId, {
   },
   async afterNavigate(context) {
     if (isWatchRoute.value) {
-      if (retained.value && watchTitle) navigation.setTitle(props.tabId, watchTitle)
+      if (retained.value && watchTitle) navigation.setTitle(props.tabId, watchTitle, watchTitleOptions)
       retained.value = false
       await run('activate', context)
     }
@@ -105,7 +111,10 @@ provide(routerKey, watchRouter)
 provide(watchNavigationKey, {
   detached,
   tabPresented: computed(() => props.presented),
-  setTitle: title => { watchTitle = title },
+  setTitle: (title, options) => {
+    watchTitle = title
+    watchTitleOptions = options
+  },
   returnToVideo: () => navigation.push(props.tabId, watchRoute.value.fullPath)
 })
 
@@ -123,15 +132,16 @@ watch(() => props.route, route => {
   }
 }, { immediate: true })
 
-watch(enabled, async value => {
+watch(enabled, value => {
   if (!value && detached.value) {
-    await dispose()
-    if (!isWatchRoute.value) {
+    // Finish cleanup and unmount before a return can mount a fresh Watch.
+    disposalPromise = dispose().then(async () => {
       retained.value = false
       watchRoute.value = null
-    }
+      await nextTick()
+    })
   }
-})
+}, { flush: 'sync' })
 
 onBeforeUnmount(() => {
   unregister()

--- a/src/renderer/components/TabContent/TabWatchContent.vue
+++ b/src/renderer/components/TabContent/TabWatchContent.vue
@@ -72,8 +72,8 @@ const unregister = tabLifecycleService.register(props.tabId, {
     retained.value = enabled.value && !context.to.path.startsWith('/watch/') &&
       player?.hasLoaded === true && !player.isPaused()
     if (retained.value) {
-      const entry = store.getters.getTabById(props.tabId)?.history
-        .findLast(entry => entry.route.fullPath === watchRoute.value.fullPath)
+      const tab = store.getters.getTabById(props.tabId)
+      const entry = tab?.history[tab.historyIndex]
       watchTitle = entry?.title || ''
       watchTitleOptions = { resolveHistoryEntry: entry?.titlePending !== true }
       await run('deactivate', context)

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useAutoPictureInPicture.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useAutoPictureInPicture.js
@@ -59,7 +59,7 @@ export function useAutoPictureInPicture({
   const autoPictureInPictureTriggers = computed(() => store.getters.getAutoPictureInPictureTriggers)
   const androidAutoPictureInPicture = computed(() => store.getters.getAndroidAutoPictureInPicture)
 
-  const triggerOnTabChange = computed(() => autoPictureInPictureTriggers.value.includes('tab'))
+  const triggerOnTabChange = computed(() => !store.getters.getKeepPlayingOnNavigation && autoPictureInPictureTriggers.value.includes('tab'))
   const triggerOnMinimize = computed(() => autoPictureInPictureTriggers.value.includes('minimize'))
   const triggerOnBlur = computed(() => autoPictureInPictureTriggers.value.includes('blur'))
   const autoPipEnabled = computed(() => autoPictureInPictureTriggers.value.length > 0)
@@ -335,7 +335,7 @@ export function useAutoPictureInPicture({
     stopActiveTabWatch = null
   }
 
-  watch(autoPictureInPictureTriggers, updateAutoPip)
+  watch([autoPictureInPictureTriggers, triggerOnTabChange], updateAutoPip)
   watch(androidAutoPictureInPicture, updateAutoPip)
   watch(isAndroidPictureInPictureTarget, updateAutoPip)
 

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
@@ -73,7 +73,8 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
   const scrollMiniPlayerEnabled = computed(() => store.getters.getScrollMiniPlayerEnabled)
   const scrollMiniPlayerOnAllTabs = computed(() => store.getters.getKeepPlayingOnNavigation || store.getters.getScrollMiniPlayerOnAllTabs)
   const autoPictureInPictureOnTabChange = computed(
-    () => !(watchNavigation?.detached.value && watchNavigation.tabPresented.value) &&
+    () => !store.getters.getKeepPlayingOnNavigation &&
+      !(watchNavigation?.detached.value && watchNavigation.tabPresented.value) &&
       store.getters.getAutoPictureInPictureTriggers.includes('tab')
   )
   const scrollMiniPlayerActive = ref(false)
@@ -977,6 +978,8 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     scrollMiniPointerSession = null
     syncNativeMiniPlayerGesture()
     document.body.classList.remove('scroll-mini-player-grabbing')
+    window.removeEventListener('pointerup', handleScrollMiniVolumePointerUpWindow)
+    window.removeEventListener('pointercancel', handleScrollMiniVolumePointerUpWindow)
     window.removeEventListener('pointermove', handleScrollMiniPointerMoveWindow)
     window.removeEventListener('pointerup', handleScrollMiniPointerUpWindow)
     window.removeEventListener('pointercancel', handleScrollMiniPointerUpWindow)

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
@@ -741,11 +741,11 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     scrollMiniResizeHandleOnLightBg.value = false
     scrollMiniPlayPauseHiddenByTimer = false
     clearScrollMiniPlayPauseHideTimeout()
-    clearScrollMiniVolumeHideTimeout()
-    scrollMiniVolumeExpanded.value = false
 
     cancelScrollMiniPlayerBounce()
     endScrollMiniPointerSession()
+    clearScrollMiniVolumeHideTimeout()
+    scrollMiniVolumeExpanded.value = false
 
     if (previousRect) {
       animateScrollMiniPlayerLayout(previousRect, false, animationSequence)
@@ -975,6 +975,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
   }
 
   function endScrollMiniPointerSession() {
+    if (scrollMiniPointerSession?.type === 'volume') scheduleScrollMiniVolumeHide()
     scrollMiniPointerSession = null
     syncNativeMiniPlayerGesture()
     document.body.classList.remove('scroll-mini-player-grabbing')
@@ -1152,13 +1153,13 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     }
 
     clearScrollMiniPlayPauseHideTimeout()
-    clearScrollMiniVolumeHideTimeout()
 
     cancelScrollMiniPlayerBounce()
     cancelScrollMiniPlayerLayoutAnimation()
     cancelPendingScrollMiniScrollFrame()
 
     endScrollMiniPointerSession()
+    clearScrollMiniVolumeHideTimeout()
     window.removeEventListener('pointerup', handleScrollMiniVolumePointerUpWindow)
     window.removeEventListener('pointercancel', handleScrollMiniVolumePointerUpWindow)
     window.removeEventListener('scroll', handleScrollMiniWindowScroll)

--- a/src/renderer/helpers/api/player-script-evaluator.js
+++ b/src/renderer/helpers/api/player-script-evaluator.js
@@ -17,6 +17,8 @@ export class PlayerScriptEvaluator {
   evaluate(code) {
     return new Promise((resolve, reject) => {
       if (typeof code !== 'string') throw new TypeError('Player code must be a string')
+      // Bound source before structured cloning allocates another host copy.
+      if (code.length > 4 * 1024 * 1024) throw new Error('Player code is too large')
       if (!this.worker) {
         const worker = this.createWorker()
         this.worker = worker

--- a/src/renderer/helpers/api/player-script-runtime.js
+++ b/src/renderer/helpers/api/player-script-runtime.js
@@ -11,7 +11,10 @@ let modulePromise
  * @returns {Promise<unknown>}
  */
 export async function evaluatePlayerCode(code, { timeoutMs = 5000, memoryLimitBytes = 64 * 1024 * 1024 } = {}) {
-  modulePromise ??= newQuickJSWASMModuleFromVariant(variant)
+  modulePromise ??= newQuickJSWASMModuleFromVariant(variant).catch(error => {
+    modulePromise = undefined
+    throw error
+  })
   const quickjs = await modulePromise
   const runtime = quickjs.newRuntime()
   runtime.setMemoryLimit(memoryLimitBytes)

--- a/src/renderer/helpers/platformSettings.js
+++ b/src/renderer/helpers/platformSettings.js
@@ -8,6 +8,7 @@ export const DEVICE_LOCAL_SETTING_KEYS = new Set([
   'enableClosedAppSubscriptionRefresh',
   'enableMobileFullscreenSwipe',
   'enablePullToRefresh',
+  'keepPlayingOnNavigation',
   'mobileFullscreenBrightness',
   'mobileLeftSwipeAction',
   'mobileRightSwipeAction',

--- a/src/renderer/tabs/TabContext.js
+++ b/src/renderer/tabs/TabContext.js
@@ -32,7 +32,7 @@ export function useTabTitle() {
       return
     }
     if (watchNavigation?.detached.value) {
-      watchNavigation.setTitle(title)
+      watchNavigation.setTitle(title, options)
       return
     }
 

--- a/tests/unit/mini-player-lifecycle.test.mjs
+++ b/tests/unit/mini-player-lifecycle.test.mjs
@@ -2,40 +2,58 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import test from 'node:test'
 import vm from 'node:vm'
-import { computed, reactive } from 'vue'
+import { computed, effectScope, reactive, ref, watch } from 'vue'
 
-const miniSource = readFileSync(new URL('../../src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js', import.meta.url), 'utf8')
-const pipSource = readFileSync(new URL('../../src/renderer/components/ft-shaka-video-player/opentubex/useAutoPictureInPicture.js', import.meta.url), 'utf8')
+// Execute the entire composable. Stub its platform/layout dependencies, while
+// retaining Vue watchers, pointer events, and the real volume timeout behavior.
+const source = readFileSync(new URL('../../src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js', import.meta.url), 'utf8')
+  .replace(/^import\s[\s\S]*?from\s+['"][^'"]+['"];?\s*$/gm, '')
+  .replace(/^export /gm, '')
 
-test('keep-playing navigation takes precedence over the automatic tab PiP trigger', () => {
-  const getters = reactive({ getKeepPlayingOnNavigation: true, getAutoPictureInPictureTriggers: ['tab'] })
-  const mini = miniSource.slice(miniSource.indexOf('  const autoPictureInPictureOnTabChange ='), miniSource.indexOf('\n  )', miniSource.indexOf('  const autoPictureInPictureOnTabChange =')) + 4)
-  const pip = pipSource.match(/  const triggerOnTabChange = computed\([^\n]+/)[0]
-  const context = { computed, store: { getters }, watchNavigation: { detached: { value: false }, tabPresented: { value: false } }, autoPictureInPictureTriggers: computed(() => getters.getAutoPictureInPictureTriggers) }
-  const miniTrigger = vm.runInNewContext(`${mini}; autoPictureInPictureOnTabChange`, context)
-  const pipTrigger = vm.runInNewContext(`${pip}; triggerOnTabChange`, context)
-  assert.equal(miniTrigger.value, false)
-  assert.equal(pipTrigger.value, false)
-  getters.getKeepPlayingOnNavigation = false
-  assert.equal(miniTrigger.value, true)
-  assert.equal(pipTrigger.value, true)
-})
-
-test('ending a volume pointer session removes its window callbacks', () => {
-  const functions = ['handleScrollMiniVolumePointerDown', 'handleScrollMiniVolumePointerUpWindow', 'endScrollMiniPointerSession']
-    .map(name => miniSource.match(new RegExp(`  function ${name}\\([^]*?\\n  }`))[0]).join('\n')
+function mountMiniPlayer(t) {
+  t.mock.timers.enable({ apis: ['setTimeout'] })
+  const scope = effectScope()
   const window = new EventTarget()
-  let hides = 0
-  const context = vm.createContext({
-    window, document: { body: { classList: { remove() {} } } },
-    scrollMiniPlayerActive: { value: true }, scrollMiniPlayerRect: { value: {} },
-    showScrollMiniVolume() {}, syncNativeMiniPlayerGesture() {},
-    scheduleScrollMiniVolumeHide: () => { hides++ },
-    handleScrollMiniPointerMoveWindow() {}, handleScrollMiniPointerUpWindow() {}
+  window.setTimeout = t.mock.fn(setTimeout)
+  const isActiveTab = ref(true)
+  const rect = { left: 10, top: 10, width: 360, height: 202 }
+  const create = vm.runInNewContext(`${source}; useScrollMiniPlayer`, {
+    computed, ref, watch, inject: () => null, watchNavigationKey: Symbol(),
+    nextTick() {}, window, clearTimeout,
+    document: { body: { classList: { remove() {} } } },
+    store: { getters: reactive({ getAutoPictureInPictureTriggers: [] }) },
+    DEFAULT_ASPECT_RATIO: 16 / 9,
+    getDefaultScrollMiniPlayerRect: () => ({ ...rect }),
+    getSavedScrollMiniPlayerRect: () => null,
+    parseScrollMiniPlayerSavedRect: () => null,
+    setSavedScrollMiniPlayerRect() {},
+    getViewportInsets: () => ({ left: 0, right: 0, top: 0, bottom: 0 }),
+    clampScrollMiniPlayerRect: value => ({ ...value }),
+    pickScrollMiniVerticalAnchor: () => null,
+    getScrollMiniVerticalAnchor: () => ({}),
+    getResizeHandleCorner: () => 'bottom-right',
+    markCrossTabMiniPlayerActive() {}, markCrossTabMiniPlayerInactive() {},
+    unregisterCrossTabMiniPlayer() {}
   })
-  vm.runInContext(`let scrollMiniPointerSession = null; ${functions};
-    handleScrollMiniVolumePointerDown({ clientX: 0, clientY: 0 }); endScrollMiniPointerSession()`, context)
+  const player = scope.run(() => create({
+    container: ref(null), fullWindowEnabled: ref(false), getUi: () => null,
+    isActiveTab, pictureInPictureActive: ref(false), props: reactive({ format: 'video', videoId: 'video' }),
+    video: ref(null)
+  }))
+  player.scrollMiniPlayerActive.value = true
+  t.after(() => { player.teardownScrollMiniPlayer(); scope.stop() })
+  return { player, window, isActiveTab }
+}
+
+test('tab changes end held volume gestures and hide the expanded control', t => {
+  const { player, window, isActiveTab } = mountMiniPlayer(t)
+  player.handleScrollMiniVolumePointerDown({ clientX: 0, clientY: 0 })
+  assert.equal(player.scrollMiniVolumeExpanded.value, true)
+  isActiveTab.value = false
+  t.mock.timers.tick(1000)
+  assert.equal(player.scrollMiniVolumeExpanded.value, false)
+  const scheduled = window.setTimeout.mock.callCount()
   window.dispatchEvent(new Event('pointerup'))
   window.dispatchEvent(new Event('pointercancel'))
-  assert.equal(hides, 0)
+  assert.equal(window.setTimeout.mock.callCount(), scheduled)
 })

--- a/tests/unit/mini-player-lifecycle.test.mjs
+++ b/tests/unit/mini-player-lifecycle.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+import { computed, reactive } from 'vue'
+
+const miniSource = readFileSync(new URL('../../src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js', import.meta.url), 'utf8')
+const pipSource = readFileSync(new URL('../../src/renderer/components/ft-shaka-video-player/opentubex/useAutoPictureInPicture.js', import.meta.url), 'utf8')
+
+test('keep-playing navigation takes precedence over the automatic tab PiP trigger', () => {
+  const getters = reactive({ getKeepPlayingOnNavigation: true, getAutoPictureInPictureTriggers: ['tab'] })
+  const mini = miniSource.slice(miniSource.indexOf('  const autoPictureInPictureOnTabChange ='), miniSource.indexOf('\n  )', miniSource.indexOf('  const autoPictureInPictureOnTabChange =')) + 4)
+  const pip = pipSource.match(/  const triggerOnTabChange = computed\([^\n]+/)[0]
+  const context = { computed, store: { getters }, watchNavigation: { detached: { value: false }, tabPresented: { value: false } }, autoPictureInPictureTriggers: computed(() => getters.getAutoPictureInPictureTriggers) }
+  const miniTrigger = vm.runInNewContext(`${mini}; autoPictureInPictureOnTabChange`, context)
+  const pipTrigger = vm.runInNewContext(`${pip}; triggerOnTabChange`, context)
+  assert.equal(miniTrigger.value, false)
+  assert.equal(pipTrigger.value, false)
+  getters.getKeepPlayingOnNavigation = false
+  assert.equal(miniTrigger.value, true)
+  assert.equal(pipTrigger.value, true)
+})
+
+test('ending a volume pointer session removes its window callbacks', () => {
+  const functions = ['handleScrollMiniVolumePointerDown', 'handleScrollMiniVolumePointerUpWindow', 'endScrollMiniPointerSession']
+    .map(name => miniSource.match(new RegExp(`  function ${name}\\([^]*?\\n  }`))[0]).join('\n')
+  const window = new EventTarget()
+  let hides = 0
+  const context = vm.createContext({
+    window, document: { body: { classList: { remove() {} } } },
+    scrollMiniPlayerActive: { value: true }, scrollMiniPlayerRect: { value: {} },
+    showScrollMiniVolume() {}, syncNativeMiniPlayerGesture() {},
+    scheduleScrollMiniVolumeHide: () => { hides++ },
+    handleScrollMiniPointerMoveWindow() {}, handleScrollMiniPointerUpWindow() {}
+  })
+  vm.runInContext(`let scrollMiniPointerSession = null; ${functions};
+    handleScrollMiniVolumePointerDown({ clientX: 0, clientY: 0 }); endScrollMiniPointerSession()`, context)
+  window.dispatchEvent(new Event('pointerup'))
+  window.dispatchEvent(new Event('pointercancel'))
+  assert.equal(hides, 0)
+})

--- a/tests/unit/navigation-playback.test.mjs
+++ b/tests/unit/navigation-playback.test.mjs
@@ -7,31 +7,39 @@ import { computed, effectScope, nextTick, reactive, ref, shallowRef, watch } fro
 const source = (await readFile(new URL('../../src/renderer/components/TabContent/TabWatchContent.vue', import.meta.url), 'utf8'))
   .split('<script setup>')[1].split('</script>')[0].replace(/^import .*$/gm, '')
 
-function mountWatch(t, { paused = false } = {}) {
+const titleSource = (await readFile(new URL('../../src/renderer/tabs/TabContext.js', import.meta.url), 'utf8'))
+  .replace(/^import .*$/gm, '').replace(/^export /gm, '')
+
+function mountWatch(t, { paused = false, hasLoaded = true, mounted = true } = {}) {
   const route = { path: '/watch/video', fullPath: '/watch/video', params: { id: 'video' } }
   const props = reactive({ tabId: 'tab', route, presented: true })
   const getters = reactive({ getKeepPlayingOnNavigation: true, getTabById: () => ({ history: [] }) })
   const provides = new Map()
   const unmount = []
+  const titles = []
   const scope = effectScope()
   const video = { paused, ended: false }
   let lifecycle
   let disposals = 0
   scope.run(() => vm.runInNewContext(source, {
-    computed, reactive, ref, shallowRef, watch,
+    computed, nextTick, reactive, ref, shallowRef, watch,
     defineProps: () => props,
     // The native scroll mini player lives outside the watch view's DOM tree.
     // Its component reference must remain usable without a DOM video descendant.
-    useTemplateRef: () => ref({ $refs: { player: { hasLoaded: true, isPaused: () => video.paused } }, querySelector: () => null }),
+    useTemplateRef: () => ref(mounted ? { $refs: { player: { hasLoaded, isPaused: () => video.paused } }, querySelector: () => null } : null),
     provide: (key, value) => provides.set(key, value),
     onBeforeUnmount: callback => unmount.push(callback),
     store: { getters },
     resolveRouteComponent: () => ({}),
-    getTabNavigationService: () => ({ createRouterFacade: () => ({}), setTitle() {} }),
+    getTabNavigationService: () => ({ createRouterFacade: () => ({}), setTitle: (...args) => titles.push(args) }),
     tabLifecycleService: { register: (_id, hooks) => { lifecycle = hooks; return () => {} } },
     tabLifecycleKey: 'lifecycle', tabPresentedKey: 'presented', watchNavigationKey: 'navigation',
     routeLocationKey: 'route', routerKey: 'router', console
   }))
+  const updateTitle = vm.runInNewContext(`${titleSource}; useTabTitle()`, {
+    inject: key => key.description === 'watch-navigation' ? provides.get('navigation') : null,
+    onBeforeUnmount: callback => unmount.push(callback)
+  })
   provides.get('lifecycle').register('tab', { beforeDispose: () => { disposals++ } })
   t.after(async () => {
     unmount.forEach(callback => callback())
@@ -39,7 +47,7 @@ function mountWatch(t, { paused = false } = {}) {
     scope.stop()
   })
   return {
-    props, getters, provides, lifecycle,
+    props, getters, provides, lifecycle, titles, updateTitle,
     disposals: () => disposals,
     async navigate(path) {
       const to = { path, fullPath: path, params: {} }
@@ -80,4 +88,42 @@ test('disabling retention disposes the hidden player only once', async t => {
   await nextTick()
   await mounted.lifecycle.beforeDispose()
   assert.equal(mounted.disposals(), 1)
+})
+
+for (const options of [{ hasLoaded: false }, { mounted: false }]) {
+  test(`does not retain unavailable playback ${JSON.stringify(options)}`, async t => {
+    const mounted = mountWatch(t, options)
+    await mounted.navigate('/subscriptions')
+    assert.equal(mounted.disposals(), 1)
+    assert.equal(mounted.provides.get('navigation').detached.value, false)
+  })
+}
+
+test('restores detached title options without resolving pending metadata', async t => {
+  const mounted = mountWatch(t)
+  await mounted.navigate('/subscriptions')
+  const options = { resolveHistoryEntry: false }
+  mounted.updateTitle('Watch', options)
+  await mounted.navigate('/watch/video')
+  assert.equal(mounted.titles.at(-1)[1], 'Watch')
+  assert.equal(mounted.titles.at(-1)[2], options)
+})
+
+test('return navigation waits for disabled retained playback to finish disposal', async t => {
+  const mounted = mountWatch(t)
+  await mounted.navigate('/subscriptions')
+  let finish
+  const pending = new Promise(resolve => { finish = resolve })
+  mounted.provides.get('lifecycle').register('tab', { beforeDispose: () => pending })
+  mounted.getters.getKeepPlayingOnNavigation = false
+  await nextTick()
+  let returned = false
+  const returning = mounted.navigate('/watch/video').then(() => { returned = true })
+  await new Promise(resolve => setImmediate(resolve))
+  const returnedDuringDisposal = returned
+  finish()
+  await returning
+  assert.equal(returnedDuringDisposal, false)
+  assert.equal(mounted.disposals(), 1)
+  assert.equal(mounted.provides.get('navigation').detached.value, false)
 })

--- a/tests/unit/navigation-playback.test.mjs
+++ b/tests/unit/navigation-playback.test.mjs
@@ -127,3 +127,18 @@ test('return navigation waits for disabled retained playback to finish disposal'
   assert.equal(mounted.disposals(), 1)
   assert.equal(mounted.provides.get('navigation').detached.value, false)
 })
+
+test('retains the current history title when a later entry repeats the watch URL', async t => {
+  const mounted = mountWatch(t)
+  mounted.getters.getTabById = () => ({
+    historyIndex: 0,
+    history: [
+      { route: { fullPath: '/watch/video' }, title: 'Watch', titlePending: true },
+      { route: { fullPath: '/watch/video' }, title: 'Later title', titlePending: false }
+    ]
+  })
+  await mounted.navigate('/subscriptions')
+  await mounted.navigate('/watch/video')
+  assert.equal(mounted.titles.at(-1)[1], 'Watch')
+  assert.equal(mounted.titles.at(-1)[2].resolveHistoryEntry, false)
+})

--- a/tests/unit/platform-settings.test.mjs
+++ b/tests/unit/platform-settings.test.mjs
@@ -17,6 +17,7 @@ test('platform-specific settings stay local to every device', () => {
     'enableClosedAppSubscriptionRefresh',
     'enableMobileFullscreenSwipe',
     'enablePullToRefresh',
+    'keepPlayingOnNavigation',
     'mobileFullscreenBrightness',
     'mobileLeftSwipeAction',
     'mobileRightSwipeAction',

--- a/tests/unit/player-script-evaluator.test.mjs
+++ b/tests/unit/player-script-evaluator.test.mjs
@@ -48,3 +48,15 @@ for (const event of ['error', 'messageerror', 'timeout']) {
     assert.equal(await next, 'recovered')
   })
 }
+
+test('rejects oversized player source before copying it to a worker', async () => {
+  const worker = new FakeWorker()
+  const evaluator = new PlayerScriptEvaluator(() => worker)
+  const pending = evaluator.evaluate(' '.repeat(4 * 1024 * 1024 + 1))
+  const rejection = assert.rejects(pending, /too large/)
+  // Complete an incorrectly accepted request so the failing test leaves no timer.
+  if (worker.requests.length) worker.reply({ id: worker.requests[0].id, result: null })
+  await rejection
+  assert.equal(worker.requests.length, 0)
+  assert.equal(evaluator.requests.size, 0)
+})

--- a/tests/unit/player-script-runtime.test.mjs
+++ b/tests/unit/player-script-runtime.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import test from 'node:test'
+import vm from 'node:vm'
 import { gunzipSync } from 'node:zlib'
 import { Player, Platform } from 'youtubei.js'
 
@@ -70,4 +71,27 @@ test('recovers after memory exhaustion with objects retained on the global objec
     memoryLimitBytes: 2 * 1024 * 1024
   }), /out of memory/)
   assert.equal(await evaluatePlayerCode('return 42'), 42)
+})
+
+test('retries WASM initialization after a transient failure', async () => {
+  let attempts = 0
+  const source = readFileSync(new URL('../../src/renderer/helpers/api/player-script-runtime.js', import.meta.url), 'utf8')
+    .replace(/^import .*$/gm, '').replace('export async function', 'async function')
+  const runtime = {
+    setMemoryLimit() {}, setMaxStackSize() {}, setInterruptHandler() {}, dispose() {},
+    newContext: () => ({
+      evalCode: () => ({ dispose() {} }), unwrapResult: value => value,
+      dump: () => 42, dispose() {}
+    })
+  }
+  const evaluate = vm.runInNewContext(`${source}; evaluatePlayerCode`, {
+    variant: {},
+    newQuickJSWASMModuleFromVariant: async () => {
+      if (++attempts === 1) throw new Error('temporary initialization failure')
+      return { newRuntime: () => runtime }
+    }
+  })
+  await assert.rejects(evaluate('return 42'), /temporary initialization failure/)
+  assert.equal(await evaluate('return 42'), 42)
+  assert.equal(attempts, 2)
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

Follow-up to review comments on #1282, #1273, and #1299.
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description

Post-merge reviews of #1282, #1273, and #1299 found playback lifecycle gaps and missing sandbox input limits. This fixes interrupted volume gestures and their hide timers, keeps the navigation-playback preference local to each device, preserves unresolved title metadata from the current history entry, and waits for retained-player teardown before returning to a fresh Watch instance. Navigation playback now takes precedence over automatic tab PiP. Player scripts larger than 4 Mi UTF-16 code units are rejected before worker cloning, and failed WASM initialization can retry.

Regression coverage includes the teardown race, competing PiP settings, unavailable players, and a corrected Android resize pixel sample. The preflight finding was dismissed because synthetic responses to trusted app preflights are intentional; actual API errors remain intact.
<!-- Please write a clear and concise description of what the pull request does. -->

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing

1. Enable navigation playback and automatic PiP on tab change. Play a video and switch tabs; playback should continue in the in-app mini player. Disable navigation playback and verify the existing automatic PiP preference applies again.
2. Navigate away from a playing video, disable navigation playback, and return immediately. The video should load in a fresh player and play normally. Repeat at 125% UI scale.
3. Start dragging the mini-player volume slider, then leave or switch tabs before releasing. Reopening the mini player should have no callbacks left from the old gesture.
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

## Additional context

Validation: the full unit suite initially passed with 1,800 tests and two skipped. A later run under concurrent build load hit the existing timeout-versus-OOM race in two QuickJS tests; all seven runtime tests passed when rerun alone. Lint passed with one existing i18n warning. Packaged Electron navigation checks passed, including the deterministic teardown race, conflicting PiP preferences, and 100%/125% UI scale. The packaged player-script isolation, timeout, OOM recovery, and responsiveness test also passed alone after the same load-related OOM timeout. The corrected Android drawing test passed on Android 8/API 26 with Chrome 119 WebView.

Implemented with GPT-6 in the Codex desktop app.
<!-- Add any other context about the pull request here. -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/OpenTubeX/OpenTubeX/pull/1319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



Follow-up validation: all nine focused lifecycle/history regressions, lint, and ten packaged Electron navigation/PiP tests passed. The full unit run had 1,799 passes, two skips, and the existing QuickJS allocation test hit its timeout instead of its memory limit; that test also timed out on an isolated rerun. CI passed the unit suite on the preceding PR commit.
