### PR TITLE
fix(tabs): remove OpenTubeX suffix from synced phone tabs

### DIFF
--- a/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.vue
+++ b/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.vue
@@ -275,7 +275,7 @@
                         @click="openOtherDeviceSession({ ...activeOtherDeviceSession, tabs: [tab] })"
                       >
                         <CapacitorTabPreview :tab="tab" />
-                        <span dir="auto">{{ tab.title || tab.url }}</span>
+                        <span dir="auto">{{ formatTabTitle(tab.title) || tab.url }}</span>
                       </button>
                     </div>
                   </article>
@@ -351,6 +351,7 @@ import { formatDeviceSessionLabel, shouldShowOtherDeviceSessions } from '../../h
 import { showToast } from '../../helpers/utils'
 import { getCapacitorTabService } from '../../tabs/CapacitorTabService'
 import { getSyncedTabPreview } from '../../tabs/tabPreview'
+import { formatTabTitle } from '../../tabs/tabTitle'
 import FtPrompt from '../FtPrompt/FtPrompt.vue'
 import { captureBeforeTabOrganizer } from '../../tabs/capacitorTabPreviews'
 import CapacitorTabPreview from './CapacitorTabPreview.vue'

--- a/tests/unit/synced-tab-title.test.mjs
+++ b/tests/unit/synced-tab-title.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import { compile, createSSRApp } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+
+const source = readFileSync(new URL('../../src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.vue', import.meta.url), 'utf8')
+const label = source.slice(source.indexOf('class="capacitorPhoneSyncedTabList"')).match(/<span dir="auto">.*?<\/span>/)[0]
+const titleSource = readFileSync(new URL('../../src/renderer/tabs/tabTitle.js', import.meta.url), 'utf8')
+  .replace("import packageDetails from '@root/package.json'", `const packageDetails = ${readFileSync(new URL('../../package.json', import.meta.url), 'utf8')}`)
+const { formatTabTitle } = await import(`data:text/javascript;base64,${Buffer.from(titleSource).toString('base64')}`)
+
+for (const [title, expected] of [
+  ['Subscriptions - OpenTubeX', 'Subscriptions'],
+  ['A video - OpenTubeX', 'A video'],
+  ['OpenTubeX tutorial - part 1 - OpenTubeX', 'OpenTubeX tutorial - part 1'],
+  ['Mobile title', 'Mobile title'],
+  ['', '/subscriptions'],
+]) {
+  test(`phone synced tab label displays ${JSON.stringify(expected)}`, async () => {
+    const app = createSSRApp({
+      setup: () => ({ tab: { title, url: '/subscriptions' }, formatTabTitle }),
+      render: compile(label),
+    })
+    assert.equal(await renderToString(app), `<span dir="auto">${expected}</span>`)
+  })
+}

--- a/tests/unit/synced-tab-title.test.mjs
+++ b/tests/unit/synced-tab-title.test.mjs
@@ -2,13 +2,34 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import test from 'node:test'
 import { compile, createSSRApp } from 'vue'
+import { compileScript, parse } from 'vue/compiler-sfc'
 import { renderToString } from 'vue/server-renderer'
 
-const source = readFileSync(new URL('../../src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.vue', import.meta.url), 'utf8')
-const label = source.slice(source.indexOf('class="capacitorPhoneSyncedTabList"')).match(/<span dir="auto">.*?<\/span>/)[0]
-const titleSource = readFileSync(new URL('../../src/renderer/tabs/tabTitle.js', import.meta.url), 'utf8')
+const componentUrl = new URL('../../src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.vue', import.meta.url)
+const { descriptor } = parse(readFileSync(componentUrl, 'utf8'))
+
+function* elements(node) {
+  if (node.type === 1) yield node
+  for (const child of node.children ?? []) yield* elements(child)
+}
+
+const syncedTabButtons = [...elements(descriptor.template.ast)].filter(node => (
+  node.tag === 'button' && node.props.some(prop => (
+    prop.name === 'class' && prop.value?.content.split(/\s+/).includes('capacitorPhoneSyncedTabTarget')
+  ))
+))
+assert.equal(syncedTabButtons.length, 1, 'select the synced-tab card button')
+const labels = syncedTabButtons[0].children.filter(node => node.tag === 'span')
+assert.equal(labels.length, 1, 'the synced-tab card has one direct title label')
+const label = labels[0].loc.source
+
+const { imports } = compileScript(descriptor, { id: 'synced-tab-title-test' })
+const formatterImport = imports.formatTabTitle
+assert.ok(formatterImport, 'the component must import its tab title formatter')
+const titleSource = readFileSync(new URL(`${formatterImport.source}.js`, componentUrl), 'utf8')
   .replace("import packageDetails from '@root/package.json'", `const packageDetails = ${readFileSync(new URL('../../package.json', import.meta.url), 'utf8')}`)
-const { formatTabTitle } = await import(`data:text/javascript;base64,${Buffer.from(titleSource).toString('base64')}`)
+const titleModule = await import(`data:text/javascript;base64,${Buffer.from(titleSource).toString('base64')}`)
+const bindings = { [formatterImport.local]: titleModule[formatterImport.imported] }
 
 for (const [title, expected] of [
   ['Subscriptions - OpenTubeX', 'Subscriptions'],
@@ -19,7 +40,7 @@ for (const [title, expected] of [
 ]) {
   test(`phone synced tab label displays ${JSON.stringify(expected)}`, async () => {
     const app = createSSRApp({
-      setup: () => ({ tab: { title, url: '/subscriptions' }, formatTabTitle }),
+      setup: () => ({ tab: { title, url: '/subscriptions' }, ...bindings }),
       render: compile(label),
     })
     assert.equal(await renderToString(app), `<span dir="auto">${expected}</span>`)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #1316

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Tabs from other devices show titles such as `Subscriptions - OpenTubeX` in the phone switcher. Reuse the existing tab title formatter so the card displays `Subscriptions`, matching the desktop organizer and preserving the URL fallback.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Remove the redundant OpenTubeX suffix from other-device tab titles in the phone tab switcher.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. On desktop, open Subscriptions and sync tabs to a phone using separate device sessions.
2. In the phone tab switcher, open Tabs From Other Devices and select the desktop.
3. Confirm the card reads `Subscriptions` without ` - OpenTubeX`. Open the card and confirm it still navigates to Subscriptions.

## Additional context
<!-- Add any other context about the pull request here. -->


Validation: all five rendered-label regression cases pass. The test also detects a removed formatter import and tolerates an unrelated sibling span before the synced-tab card button. CI unit tests, lint, all E2E shards, CodeQL, and performance checks pass. Locally, the full unit suite encountered an unrelated player-runtime error mismatch (`out of memory` expected, `interrupted` received), which did not reproduce in CI.

Implemented with GPT-6 in the Codex desktop app.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/OpenTubeX/OpenTubeX/pull/1321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


