### PR TITLE
fix(android): keep fullscreen toasts visible at the selected position

### DIFF
--- a/e2e/tests/offline/android-native-screen.spec.mjs
+++ b/e2e/tests/offline/android-native-screen.spec.mjs
@@ -1824,3 +1824,52 @@ for (const iconPack of ['material', 'remix']) {
     })
   }
 }
+
+test.describe('native fullscreen toast positions', () => {
+  test.use({ seed: { settings: { videoPlaybackEngine: 'built-in', ytDlpPlaybackEngineDefaultMigration: true, uiScale: 95 } } })
+
+  for (const layout of ['capacitorPhoneLayout', 'capacitorTabletLayout']) {
+    test(`fullscreen toasts use the selected screen edge in ${layout}`, async ({ app, page }) => {
+      await mockPlayableWatchPage(app, page)
+      await openMockedVideo(page)
+      await setWindowSize(app, page, { width: 1000, height: 480 })
+      await openNativeScreen(page)
+      await page.evaluate(layout => {
+        const app = document.querySelector('.app')
+        const keepLayout = () => {
+          if (!app.classList.contains(layout)) app.classList.add(layout)
+        }
+        new MutationObserver(keepLayout).observe(app, { attributeFilter: ['class'] })
+        keepLayout()
+        document.documentElement.style.setProperty('--safe-area-inset-top', '13px')
+        document.documentElement.style.setProperty('--safe-area-inset-bottom', '17px')
+        window.ftElectron.showToastOnAllTabs('Fullscreen position test', 120000)
+      }, layout)
+      const toast = page.locator('.toast', { hasText: 'Fullscreen position test' })
+      await expect(toast).toBeVisible()
+      for (const size of [{ width: 480, height: 800 }, { width: 1000, height: 480 }]) {
+        await setWindowSize(app, page, size)
+        for (const position of ['top-left', 'top-center', 'top-right', 'bottom-left', 'bottom-center', 'bottom-right']) {
+          await page.evaluate(position => document.querySelector('#app').__vue_app__.config.globalProperties.$store.commit('setToastPosition', position), position)
+          await expect.poll(() => toast.evaluate((element, position) => {
+            const bounds = element.getBoundingClientRect()
+            const holder = element.closest('[data-sonner-toaster]')
+            const style = getComputedStyle(holder)
+            const top = position.startsWith('top')
+            const expected = parseFloat(style.getPropertyValue(top ? '--offset-top' : '--offset-bottom')) + (top ? 13 : 17)
+            const actual = top ? bounds.top : innerHeight - bounds.bottom
+            const horizontal = position.endsWith('center')
+              ? Math.abs(bounds.left + bounds.width / 2 - innerWidth / 2)
+              : position.endsWith('left')
+                ? Math.abs(bounds.left - parseFloat(style.getPropertyValue('--offset-left')))
+                : Math.abs(innerWidth - bounds.right - parseFloat(style.getPropertyValue('--offset-right')))
+            return Math.max(Math.abs(actual - expected), horizontal)
+          }, position), { message: `${layout} ${position} must use fullscreen edge insets` }).toBeLessThan(1)
+        }
+      }
+      await page.evaluate(() => window.nativeScreenTest.hide())
+      await expect(page.locator('[data-native-player-screen] .toast')).toHaveCount(0)
+      await expect(toast).toBeVisible()
+    })
+  }
+})

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -733,7 +733,18 @@ body:has(.app.capacitorPhoneLayout) {
   }
 }
 
-body:has(.app) :fullscreen .connection-status-holder,
+/* Fullscreen hides app headers and navigation. Keep only the toast's normal
+   edge inset and the device safe area, regardless of phone/tablet layout. */
+body:has(.app) :is(:fullscreen, [data-native-player-screen]) .toast-holder[data-sonner-toaster] {
+  /* stylelint-disable-next-line length-zero-no-unit -- added to lengths inside calc() */
+  --mobile-toast-inset: 0px;
+}
+
+body:has(.app) :is(:fullscreen, [data-native-player-screen]) .toast-holder[data-sonner-toaster]:is(.position-top-left, .position-top-center, .position-top-right) {
+  inset-block: calc(var(--offset-top) + var(--safe-area-inset-top, env(safe-area-inset-top, 0px))) auto;
+}
+
+body:has(.app) :is(:fullscreen, [data-native-player-screen]) .connection-status-holder,
 body:has(.mobileSheet[open]) .connection-status-holder,
 body:has(.app .settingsWindow.maximized) .connection-status-holder {
   inset-block-end: var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0));

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -312,7 +312,8 @@ const toastProgressRadius = computed(() => 12 * store.getters.getUiRoundness / 1
 const toastProgressLineWidth = computed(() => Math.min(4, Math.max(2, 2 * store.getters.getUiRoundness / 100)))
 
 function updateFullscreenTarget() {
-  fullscreenTarget.value = document.fullscreenElement
+  // Android's native player uses a fixed container instead of browser fullscreen.
+  fullscreenTarget.value = document.fullscreenElement || document.querySelector('[data-native-player-screen]')
 }
 
 /**

--- a/tests/unit/toast-fullscreen.test.mjs
+++ b/tests/unit/toast-fullscreen.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const source = await readFile(new URL('../../src/renderer/components/FtToast/FtToast.vue', import.meta.url), 'utf8')
+const handler = source.match(/function updateFullscreenTarget\(\) \{[\s\S]*?\n\}/)[0]
+
+for (const mode of ['android', 'browser']) {
+  test(`toasts follow ${mode} fullscreen entry and exit`, () => {
+    const player = { id: 'player' }
+    const fullscreenTarget = { value: null }
+    let nativePlayer = null
+    const document = {
+      fullscreenElement: null,
+      querySelector(selector) {
+        assert.equal(selector, '[data-native-player-screen]')
+        return nativePlayer
+      }
+    }
+    const update = vm.runInNewContext(`${handler}; updateFullscreenTarget`, { document, fullscreenTarget })
+    update()
+    assert.equal(fullscreenTarget.value, null)
+
+    if (mode === 'android') nativePlayer = player
+    else document.fullscreenElement = player
+    update()
+    assert.equal(fullscreenTarget.value, player, 'Toasts must move inside the visible fullscreen player')
+
+    nativePlayer = null
+    document.fullscreenElement = null
+    update()
+    assert.equal(fullscreenTarget.value, null, 'Toasts must return to their normal location on exit')
+  })
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

Android fullscreen playback hid toast notifications. Once visible, they retained spacing for hidden phone and tablet headers, pushing them away from the selected screen edge.

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Reported directly in the task; no linked GitHub issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Move toast notifications into the native fullscreen player and remove app-navigation offsets while retaining device safe areas. Restore their normal placement on fullscreen exit. Regression coverage checks all six positions, phone/tablet layouts, both orientations, and fractional UI scale.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed toast notifications being hidden or misplaced during fullscreen video playback on Android.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
![Top-right toast aligned with the fullscreen video viewport](https://github.com/user-attachments/assets/b05cb82a-84e7-453c-8819-cf9256828182)

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. On Android, choose each toast position in settings and play a video in fullscreen.
2. Copy a timestamp link to trigger a toast. It should appear at the selected corner or horizontal center, with normal edge spacing.
3. Rotate the device, then exit and re-enter fullscreen. Toasts should remain visible and follow the selected position.

## Additional context
<!-- Add any other context about the pull request here. -->

Validation: 1,794 unit tests passed with two skips. Targeted fullscreen layout checks passed for phone/tablet layouts at 95% UI scale. All six positions were measured in Android 8.0 with Chrome WebView 119; native playback visibility was also verified on Android 15 with WebView 124. Lint passed with one pre-existing warning. The toast uses the same dark surface in both themes.

Changes prepared by GPT-6 in the Codex desktop harness.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/OpenTubeX/OpenTubeX/pull/1324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

