### PR TITLE
fix: remove redundant splash loading text

### DIFF
--- a/e2e/tests/offline/startup-splash.spec.mjs
+++ b/e2e/tests/offline/startup-splash.spec.mjs
@@ -28,7 +28,7 @@ for (const [theme, background, zoom] of [
         await expect(page.locator('.topNav')).toHaveCount(0)
         await expect(page.locator('#app')).toHaveAttribute('inert', '')
         expect(await page.locator('.startupCurtain').first().evaluate(element => getComputedStyle(element).backgroundColor)).toBe(background)
-        await expect(page.locator('.startupLabel')).toHaveText('Wird geladen…')
+        await expect(page.locator('.startupLabel')).toHaveCount(0)
         const geometry = await page.locator('#startup-splash').evaluate(element => {
           const bounds = element.getBoundingClientRect()
           const logo = element.querySelector('.startupLogo').getBoundingClientRect()
@@ -59,7 +59,6 @@ for (const [theme, background, zoom] of [
             window.__startupColors.push(getComputedStyle(curtain).backgroundColor)
             window.__startupPalettes.push(JSON.stringify({
               folds: getComputedStyle(curtain).backgroundImage,
-              label: getComputedStyle(document.querySelector('.startupLabel')).color,
               progress: getComputedStyle(document.querySelector('.startupProgress')).backgroundImage
             }))
             requestAnimationFrame(sampleColors)

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -24,7 +24,6 @@
       <div class="startupCurtain startupCurtainRight" aria-hidden="true"></div>
       <canvas class="startupFabric" aria-hidden="true" hidden></canvas>
       <div class="startupLogo" aria-hidden="true"><%= startupSplash.logo %></div>
-      <div class="startupLabel">OpenTubeX</div>
       <div class="startupTrack" aria-hidden="true"><div class="startupProgress"></div></div>
     </div>
     <script><%= startupSplash.script %></script>

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -531,7 +531,7 @@ import {
 } from './helpers/mobileLinkActions'
 import { startProgressBarOperation } from './helpers/progressBar'
 import { initializePlatformInfo, isLinuxWayland } from './helpers/platform'
-import { revealStartupSplash, updateStartupSplashLabel } from './helpers/startupSplash'
+import { revealStartupSplash } from './helpers/startupSplash'
 import {
   shouldShowProgressStartToast,
   shouldUseProgressToast,
@@ -1416,8 +1416,6 @@ onMounted(async () => {
     updateTheme()
   })
   updateTheme()
-
-  if (isElectron) updateStartupSplashLabel(t('Theme Discovery.Loading'))
 
   if (defaultInvidiousInstance.value === '') {
     await store.dispatch('setRandomCurrentInvidiousInstance')

--- a/src/renderer/helpers/startupSplash.js
+++ b/src/renderer/helpers/startupSplash.js
@@ -15,16 +15,6 @@ export function curtainExtent(elapsedMs, depth) {
   return Math.max(0, Math.min(1, 0.08 + 0.92 * response - 0.15 * exit * exit * (3 - 2 * exit)))
 }
 
-export function updateStartupSplashLabel(label) {
-  const element = document.querySelector('#startup-splash .startupLabel')
-  if (element) element.textContent = label
-  try {
-    localStorage.setItem('startup-loading-label', label)
-  } catch {
-    // Storage is optional; the current window still has its translated label.
-  }
-}
-
 export function revealStartupSplash() {
   const splash = document.getElementById('startup-splash')
   if (!splash || splash.dataset.revealing) return
@@ -104,7 +94,7 @@ export function revealStartupSplash() {
     draw(0)
     canvas.hidden = false
     splash.querySelectorAll('.startupCurtain').forEach(element => { element.hidden = true })
-    for (const element of splash.querySelectorAll('.startupLogo, .startupLabel, .startupTrack')) {
+    for (const element of splash.querySelectorAll('.startupLogo, .startupTrack')) {
       animations.push(element.animate([{ opacity: 1 }, { opacity: 0 }], { duration: 120, fill: 'forwards' }))
     }
     const start = performance.now()

--- a/src/renderer/startup/boot.js
+++ b/src/renderer/startup/boot.js
@@ -11,13 +11,6 @@
     document.getElementById('startup-splash')?.remove()
     document.getElementById('app')?.removeAttribute('inert')
   }
-  try {
-    const label = localStorage.getItem('startup-loading-label')
-    const element = document.querySelector('#startup-splash .startupLabel')
-    if (label && element) element.textContent = label
-  } catch {
-    // A fresh profile or unavailable storage still has the logo and progress bar.
-  }
   // Electron's ready-to-show can wait for deferred scripts. Announce the
   // splash's own frame so the native window need not wait for the main bundle.
   requestAnimationFrame(() => window.ftElectron?.startupSplashReady())

--- a/src/renderer/startup/splash.css
+++ b/src/renderer/startup/splash.css
@@ -57,15 +57,6 @@
   block-size: 100%;
 }
 
-.startupLabel {
-  position: absolute;
-  inset-block-end: 22px;
-  inline-size: 100%;
-  text-align: center;
-  color: var(--splash-foreground);
-  font-size: 12px;
-}
-
 .startupTrack {
   position: absolute;
   inset-block-end: 0;

--- a/tests/unit/startup-splash.test.mjs
+++ b/tests/unit/startup-splash.test.mjs
@@ -24,9 +24,8 @@ test('all fabric leaves the viewport within the shortened reveal', () => {
   }
 })
 
-test('the initial splash uses native appearance and cached plain-text localization without the renderer', async () => {
+test('the initial splash uses native appearance without the renderer', async () => {
   const properties = new Map()
-  const label = { textContent: 'OpenTubeX' }
   const script = await readFile(new URL('../../src/renderer/startup/boot.js', import.meta.url), 'utf8')
   let presented = false
   let paint
@@ -37,20 +36,15 @@ test('the initial splash uses native appearance and cached plain-text localizati
     } },
     requestAnimationFrame: callback => { paint = callback },
     document: {
-      documentElement: { style: { setProperty: (name, value) => properties.set(name, value) } },
-      querySelector: () => label
-    },
-    localStorage: { getItem: () => 'Wird geladen…' }
+      documentElement: { style: { setProperty: (name, value) => properties.set(name, value) } }
+    }
   }
   vm.runInNewContext(script, context)
   assert.equal(properties.get('--startup-background'), '#1e1e2e')
   assert.equal(properties.get('--startup-foreground'), '#eeeeee')
-  assert.equal(label.textContent, 'Wird geladen…')
   assert.equal(presented, false)
   paint()
   assert.equal(presented, true)
-  context.localStorage.getItem = () => { throw new Error('Storage unavailable') }
-  assert.doesNotThrow(() => vm.runInNewContext(script, context))
 })
 
 for (const hideSplash of [true, false, undefined]) {
@@ -59,7 +53,6 @@ for (const hideSplash of [true, false, undefined]) {
     let removed = false
     let inert = true
     let presented = false
-    const label = { textContent: 'OpenTubeX' }
     vm.runInNewContext(script, {
       window: { ftElectron: {
         startupAppearance: { hideSplash },
@@ -69,10 +62,8 @@ for (const hideSplash of [true, false, undefined]) {
         documentElement: {},
         getElementById: id => id === 'startup-splash'
           ? { remove: () => { removed = true } }
-          : { removeAttribute: name => { if (name === 'inert') inert = false } },
-        querySelector: () => removed ? null : label
+          : { removeAttribute: name => { if (name === 'inert') inert = false } }
       },
-      localStorage: { getItem: () => 'Loading…' },
       requestAnimationFrame: callback => callback()
     })
     assert.equal(removed, hideSplash === true)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No related issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The startup splash showed loading text beneath the logo even though the progress bar already communicates that the app is loading. This removes the redundant label and its localization, cache, styling, and animation code while keeping the progress bar and accessible busy state.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Start the desktop app with the startup splash enabled.
2. Reload the app or open a new window.
3. Confirm the splash shows the centered logo and bottom progress bar without loading text, then reveals the app normally.

## Additional context
<!-- Add any other context about the pull request here. -->

Created by GPT-5 in the Codex desktop app.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/OpenTubeX/OpenTubeX/pull/1325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

