### PR TITLE
fix: preserve mobile panels across fullscreen and PiP

### DIFF
--- a/e2e/tests/offline/phone-panel-presentation.spec.mjs
+++ b/e2e/tests/offline/phone-panel-presentation.spec.mjs
@@ -88,3 +88,33 @@ test('comments retain their inner scroll position through fullscreen rotation an
   await expect.poll(() => viewport.evaluate(el => el.scrollTop)).toBe(0)
   await expect(viewport.locator('.os-scrollbar-vertical')).toHaveClass(/os-scrollbar-unusable/)
 })
+
+for (const mode of ['native', 'browser']) {
+  test(`fullscreen playlist action opens above a suspended phone panel (${mode})`, async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await openMockedVideo(page)
+    await setWindowSize(app, page, { width: 480, height: 800 })
+    if (mode === 'browser') await page.setViewportSize({ width: 480, height: 800 })
+    const watch = await watchViewHandle(page)
+    await watch.evaluate(vm => vm.openPhonePanel('description'))
+    const panel = page.locator('.dockedSheet[open]')
+    await expect(panel).toBeVisible()
+    const player = page.locator('.ftVideoPlayer')
+    await player.evaluate((el, mode) => mode === 'native'
+      ? el.setAttribute('data-native-player-screen', '')
+      : el.requestFullscreen(), mode)
+    await expect(panel).toHaveCount(0)
+    await player.locator('.fullscreenPlaylistAction > button').click({ force: true })
+    const picker = page.locator('.mobileSheet[open]')
+    await expect(picker.locator('.playlistSearch')).toBeVisible()
+    expect(await picker.evaluate(el => el.matches(':modal'))).toBe(true)
+    await picker.getByRole('button', { name: 'Close', exact: true }).click()
+    await expect(picker).toHaveCount(0)
+    await player.evaluate((el, mode) => mode === 'native'
+      ? el.removeAttribute('data-native-player-screen')
+      : document.exitFullscreen(), mode)
+    await expect(panel).toBeVisible()
+    await expect(panel).toContainText('Description')
+    await expect(page.locator('.playlistSearch')).toHaveCount(0)
+  })
+}

--- a/e2e/tests/offline/phone-panel-presentation.spec.mjs
+++ b/e2e/tests/offline/phone-panel-presentation.spec.mjs
@@ -1,0 +1,90 @@
+import { test, expect, setWindowSize } from '../../helpers/app.mjs'
+import { openMockedVideo } from '../../helpers/player.mjs'
+import { mockPlayableWatchPage, watchViewHandle } from '../../helpers/watch.mjs'
+
+test.use({ seed: { settings: { animationSpeed: 0, videoPlaybackEngine: 'built-in', ytDlpPlaybackEngineDefaultMigration: true } } })
+
+for (const zoom of [1, 0.95]) {
+  for (const mode of ['native', 'browser', 'pip']) {
+    test(`phone panel survives ${mode} and clamps shorter content at ${zoom} UI scale`, async ({ app, page }) => {
+      await mockPlayableWatchPage(app, page)
+      await openMockedVideo(page)
+      await setWindowSize(app, page, { width: 480, height: 800 })
+      await page.evaluate(zoom => window.ftElectron.setZoomFactor(zoom), zoom)
+      if (mode === 'browser') await page.setViewportSize({ width: Math.round(480 / zoom), height: Math.round(800 / zoom) })
+      const watch = await watchViewHandle(page)
+      await watch.evaluate(vm => {
+        vm.videoDescription = 'Description line\n'.repeat(100)
+        vm.videoDescriptionHtml = ''
+        vm.openPhonePanel('description')
+      })
+      const sheet = page.locator('.dockedSheet[open]')
+      await expect(sheet).toBeVisible()
+      const description = await sheet.locator('.description').elementHandle()
+      await description.evaluate(el => { el.textContent = 'Description line\n'.repeat(100) })
+      const viewport = sheet.locator('.phonePanelScroller')
+      await expect.poll(() => viewport.evaluate(el => el.scrollHeight - el.clientHeight)).toBeGreaterThan(100)
+      await viewport.evaluate(el => { el.scrollTop = el.scrollHeight })
+      const position = await viewport.evaluate(el => el.scrollTop)
+      const player = page.locator('.ftVideoPlayer')
+      for (const shorten of [false, true]) {
+        await player.evaluate((el, mode) => {
+          if (mode === 'native') el.setAttribute('data-native-player-screen', '')
+          else if (mode === 'browser') return el.requestFullscreen()
+          else document.body.classList.add('androidPictureInPicture')
+        }, mode)
+        await expect(sheet).toHaveCount(0)
+        if (mode === 'pip') await setWindowSize(app, page, { width: 450, height: 270 })
+        if (shorten) await description.evaluate(el => { el.textContent = 'Short description' })
+        if (mode === 'pip') await setWindowSize(app, page, { width: 480, height: 800 })
+        await player.evaluate((el, mode) => {
+          if (mode === 'native') el.removeAttribute('data-native-player-screen')
+          else if (mode === 'browser') return document.exitFullscreen()
+          else document.body.classList.remove('androidPictureInPicture')
+        }, mode)
+        await expect(sheet).toBeVisible()
+        await expect.poll(async () => {
+          const panel = await sheet.boundingBox()
+          const video = await player.boundingBox()
+          return Math.abs(panel.y - video.y - video.height)
+        }).toBeLessThan(2)
+        if (!shorten) {
+          await expect.poll(() => viewport.evaluate(el => el.scrollTop)).toBeCloseTo(position, 0)
+        } else {
+          await expect.poll(() => viewport.evaluate(el => el.scrollTop)).toBe(0)
+          await expect(viewport.locator('.os-scrollbar-vertical')).toHaveClass(/os-scrollbar-unusable/)
+          await expect.poll(() => viewport.evaluate(el => el.scrollHeight - el.clientHeight)).toBeLessThanOrEqual(1)
+        }
+      }
+    })
+  }
+}
+
+test('comments retain their inner scroll position through fullscreen rotation and clamp on PiP return', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  await openMockedVideo(page)
+  await setWindowSize(app, page, { width: 480, height: 800 })
+  await page.locator('.phoneCommentsButton').click()
+  const sheet = page.locator('.dockedSheet[open]')
+  const viewport = sheet.locator('.commentsContentWrapper')
+  await expect(sheet.locator('.comment').first()).toBeVisible()
+  await expect.poll(() => viewport.evaluate(el => el.scrollHeight - el.clientHeight)).toBeGreaterThan(800)
+  await viewport.evaluate(el => { el.scrollTop = 800 })
+  const player = page.locator('.ftVideoPlayer')
+  await player.evaluate(el => el.setAttribute('data-native-player-screen', ''))
+  await expect(sheet).toHaveCount(0)
+  await setWindowSize(app, page, { width: 800, height: 480 })
+  await player.evaluate(el => el.removeAttribute('data-native-player-screen'))
+  await expect(sheet).toBeVisible()
+  await setWindowSize(app, page, { width: 480, height: 800 })
+  await expect.poll(() => viewport.evaluate(el => el.scrollTop)).toBeCloseTo(800, 0)
+  await viewport.evaluate(el => { el.scrollTop = el.scrollHeight })
+  const comments = await sheet.locator('.comment').first().locator('..').elementHandle()
+  await page.evaluate(() => document.body.classList.add('androidPictureInPicture'))
+  await expect(sheet).toHaveCount(0)
+  await comments.evaluate(el => { el.textContent = 'Only remaining comment' })
+  await page.evaluate(() => document.body.classList.remove('androidPictureInPicture'))
+  await expect(sheet).toBeVisible()
+  await expect.poll(() => viewport.evaluate(el => el.scrollTop)).toBe(0)
+  await expect(viewport.locator('.os-scrollbar-vertical')).toHaveClass(/os-scrollbar-unusable/)
+})

--- a/e2e/tests/offline/phone-review.spec.mjs
+++ b/e2e/tests/offline/phone-review.spec.mjs
@@ -89,6 +89,7 @@ for (const mode of ['native', 'browser']) {
     await mockPlayableWatchPage(app, page)
     await openMockedVideo(page)
     await setWindowSize(app, page, { width: 480, height: 800 })
+    if (mode === 'browser') await page.setViewportSize({ width: 480, height: 800 })
     const watch = await watchViewHandle(page)
     await watch.evaluate(vm => vm.openPhonePanel('description'))
     const sheet = page.locator('.mobileSheet[open]')
@@ -99,7 +100,7 @@ for (const mode of ['native', 'browser']) {
       ? el.setAttribute('data-native-player-screen', '')
       : el.requestFullscreen(), mode)
     await watch.evaluate(vm => vm.openPhonePanel('description'))
-    await expect(sheet).not.toHaveClass(/dockedSheet/)
+    await expect(sheet).toHaveCount(0)
     await page.locator('.ftVideoPlayer').evaluate((el, mode) => mode === 'native'
       ? el.removeAttribute('data-native-player-screen')
       : document.exitFullscreen(), mode)

--- a/src/renderer/components/FtAddToPlaylistDropdown/FtAddToPlaylistDropdown.vue
+++ b/src/renderer/components/FtAddToPlaylistDropdown/FtAddToPlaylistDropdown.vue
@@ -1,6 +1,6 @@
 <template>
   <FtMobileSheet
-    below-player
+    :below-player="belowPlayer"
     :enabled="phoneLayout"
     :open="sheetOpen"
     :title="t('User Playlists.Save to')"
@@ -89,6 +89,7 @@ import { getVideoThumbnailUrl, showToast } from '../../helpers/utils'
 import thumbnailPlaceholder from '../../assets/img/thumbnail_placeholder.svg'
 
 const props = defineProps({
+  belowPlayer: { type: Boolean, default: true },
   videoData: {
     type: Object,
     required: true

--- a/src/renderer/components/FtMobileSheet/FtMobileSheet.vue
+++ b/src/renderer/components/FtMobileSheet/FtMobileSheet.vue
@@ -1,6 +1,6 @@
 <template>
   <Teleport
-    :to="teleportTarget"
+    to=".app"
     :disabled="!docked"
   >
     <dialog
@@ -61,6 +61,7 @@
 import { FtIcon } from '@opentubex/icons'
 import { computed, inject, nextTick, onBeforeUnmount, onUpdated, ref, shallowRef, useTemplateRef, watch } from 'vue'
 import { usePhoneLayout } from '../../composables/usePhoneLayout'
+import { isAppHidden } from '../../helpers/appVisibility'
 import { applyAnimationSpeed } from '../../helpers/animationSpeed'
 import { lockBodyScroll, unlockBodyScroll } from '../FtPrompt/scrollLock'
 
@@ -71,7 +72,7 @@ const props = defineProps({
   back: { type: Boolean, default: false },
   belowPlayer: { type: Boolean, default: false }
 })
-const emit = defineEmits(['close', 'back', 'closed'])
+const emit = defineEmits(['close', 'back', 'closed', 'suspend', 'resume'])
 const dialog = useTemplateRef('dialog')
 let locked = false
 let previousFocus = null
@@ -85,13 +86,22 @@ const dragOffset = ref(0)
 const visibleTop = computed(() => Math.max(0, (expanded.value ? 0 : sheetTop.value) + Math.min(0, dragOffset.value)))
 const fullscreenElement = shallowRef(document.fullscreenElement)
 const playerCoversWindow = ref(false)
-const docked = computed(() => props.enabled && props.belowPlayer && getPlayer !== null &&
-  !fullscreenElement.value && !playerCoversWindow.value)
-const teleportTarget = computed(() => fullscreenElement.value ?? '.app')
+const appHidden = ref(isAppHidden())
+const pictureInPicture = ref(document.body.classList.contains('androidPictureInPicture'))
+const docked = computed(() => props.enabled && props.belowPlayer && getPlayer !== null)
+const suspended = computed(() => docked.value &&
+  (!!fullscreenElement.value || playerCoversWindow.value || appHidden.value || pictureInPicture.value))
+function updateVisibility() {
+  appHidden.value = isAppHidden()
+}
+document.addEventListener('visibilitychange', updateVisibility)
+const pictureInPictureObserver = new MutationObserver(updatePresentation)
+pictureInPictureObserver.observe(document.body, { attributes: true, attributeFilter: ['class'] })
 let observedPlayer = null
 let presentationObserver = null
 function updatePresentation() {
   fullscreenElement.value = document.fullscreenElement
+  pictureInPicture.value = document.body.classList.contains('androidPictureInPicture')
   const player = getPlayer?.() ?? null
   if (player !== observedPlayer) {
     presentationObserver?.disconnect()
@@ -121,6 +131,7 @@ let animation
 let closing = false
 let resumePlayback = null
 let openingSequence = 0
+let presentationSuspended = false
 
 function restorePlayback() {
   if (!landscape.value) resumePlayback?.()
@@ -128,7 +139,7 @@ function restorePlayback() {
 }
 
 function measurePlayer() {
-  if (!docked.value || !props.open) return
+  if (!docked.value || !props.open || suspended.value) return
   const player = getPlayer?.()
   if (!player) return
   let bounds = player.getBoundingClientRect()
@@ -141,9 +152,24 @@ function measurePlayer() {
   sheetTop.value = Math.max(0, bounds.bottom)
 }
 
-watch([dialog, () => props.enabled, () => props.open, docked, fullscreenElement], async ([element, enabled, open], previous) => {
+watch([dialog, () => props.enabled, () => props.open, docked, fullscreenElement, suspended], async ([element, enabled, open], previous) => {
   const sequence = ++openingSequence
   if (!element) return
+  if (suspended.value && enabled && open) {
+    if (element.open) {
+      emit('suspend')
+      element.close()
+      release(true)
+      presentationSuspended = true
+    }
+    return
+  }
+  if (presentationSuspended && (!enabled || !open)) {
+    presentationSuspended = false
+    expanded.value = false
+    restorePlayback()
+    emit('closed')
+  }
   if (element.open && (docked.value !== previous[3] || fullscreenElement.value !== previous[4])) {
     element.close()
     release()
@@ -162,7 +188,7 @@ watch([dialog, () => props.enabled, () => props.open, docked, fullscreenElement]
       const player = getPlayer?.()
       player?.setAttribute('data-phone-panel-video', '')
       await preparePanel?.()
-      if (sequence !== openingSequence || !docked.value || !props.enabled || !props.open || dialog.value !== element) {
+      if (sequence !== openingSequence || !docked.value || suspended.value || !props.enabled || !props.open || dialog.value !== element) {
         player?.removeAttribute('data-phone-panel-video')
         return
       }
@@ -174,7 +200,7 @@ watch([dialog, () => props.enabled, () => props.open, docked, fullscreenElement]
           window.scrollBy({ top: bounds.top - toolbarBottom, behavior: 'instant' })
         }
       }
-      expanded.value = landscape.value
+      if (!presentationSuspended) expanded.value = landscape.value
       measurePlayer()
       element.show()
       animation = applyAnimationSpeed(element.animate([
@@ -196,6 +222,11 @@ watch([dialog, () => props.enabled, () => props.open, docked, fullscreenElement]
     lockBodyScroll()
     locked = true
     await nextTick()
+    if (sequence !== openingSequence || !element.open) return
+    if (presentationSuspended) {
+      presentationSuspended = false
+      emit('resume')
+    }
     if (docked.value) element.querySelector('button')?.focus({ preventScroll: true })
   } else if ((!enabled || !open) && element.open) {
     if (!closing) {
@@ -215,7 +246,7 @@ watch([dialog, () => props.enabled, () => props.open, docked, fullscreenElement]
 }, { flush: 'post' })
 
 watch(landscape, (value) => {
-  if (value && props.open && docked.value && !expanded.value) {
+  if (value && props.open && docked.value && !suspended.value && !expanded.value) {
     expanded.value = true
   }
 })
@@ -272,7 +303,7 @@ function dismiss() {
   emit(props.back ? 'back' : 'close')
 }
 
-function release() {
+function release(preservePresentation = false) {
   closing = false
   if (!locked) return
   const anotherPanelOpen = document.querySelector('.dockedSheet[open]') !== null
@@ -282,16 +313,20 @@ function release() {
   window.removeEventListener('scroll', measurePlayer, true)
   window.visualViewport?.removeEventListener('resize', measurePlayer)
   animation?.cancel()
-  expanded.value = false
-  restorePlayback()
+  if (!preservePresentation) {
+    expanded.value = false
+    restorePlayback()
+  }
   cancelDrag()
   unlockBodyScroll()
   locked = false
-  if (!anotherPanelOpen && previousFocus?.isConnected) previousFocus.focus({ preventScroll: true })
+  if (!preservePresentation && !anotherPanelOpen && previousFocus?.isConnected) previousFocus.focus({ preventScroll: true })
 }
 onBeforeUnmount(() => {
   openingSequence++
   document.removeEventListener('fullscreenchange', updatePresentation)
+  document.removeEventListener('visibilitychange', updateVisibility)
+  pictureInPictureObserver.disconnect()
   presentationObserver?.disconnect()
   dialog.value?.close()
   release()

--- a/src/renderer/components/FtMobileSheet/FtMobileSheet.vue
+++ b/src/renderer/components/FtMobileSheet/FtMobileSheet.vue
@@ -305,6 +305,10 @@ function dismiss() {
 
 function release(preservePresentation = false) {
   closing = false
+  if (!preservePresentation) {
+    expanded.value = false
+    restorePlayback()
+  }
   if (!locked) return
   const anotherPanelOpen = document.querySelector('.dockedSheet[open]') !== null
   if (!anotherPanelOpen) getPlayer?.()?.removeAttribute('data-phone-panel-video')
@@ -313,10 +317,6 @@ function release(preservePresentation = false) {
   window.removeEventListener('scroll', measurePlayer, true)
   window.visualViewport?.removeEventListener('resize', measurePlayer)
   animation?.cancel()
-  if (!preservePresentation) {
-    expanded.value = false
-    restorePlayback()
-  }
   cancelDrag()
   unlockBodyScroll()
   locked = false

--- a/src/renderer/components/FtPhonePanel/FtPhonePanel.css
+++ b/src/renderer/components/FtPhonePanel/FtPhonePanel.css
@@ -15,6 +15,12 @@
   overscroll-behavior: contain;
 }
 
+/* Restore explicit reading positions across fullscreen/PiP orientation reflow. */
+.phonePanelScroller,
+.phonePanelContent :deep([data-overlayscrollbars-viewport]) {
+  overflow-anchor: none;
+}
+
 .phonePanelContent {
   display: flow-root;
 }

--- a/src/renderer/components/FtPhonePanel/FtPhonePanel.vue
+++ b/src/renderer/components/FtPhonePanel/FtPhonePanel.vue
@@ -10,6 +10,8 @@
       below-player
       @close="emit('close')"
       @closed="handleClosed"
+      @suspend="suspendReadingPosition"
+      @resume="resumeReadingPosition"
     >
       <template
         v-if="customHeader"
@@ -41,7 +43,7 @@
 import { computed, nextTick, provide, ref, useTemplateRef, watch } from 'vue'
 import FtMobileSheet from '../FtMobileSheet/FtMobileSheet.vue'
 import { useScrollClamp } from '../../composables/useScrollClamp'
-import { restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
+import { clampOverlayScrollTop, restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
 
 const props = defineProps({
   enabled: { type: Boolean, default: false },
@@ -70,6 +72,24 @@ watch(() => props.open, async (open) => {
     clamp()
   }
 }, { flush: 'pre' })
+
+let suspendedScrollPositions = []
+function suspendReadingPosition() {
+  const element = scroller.value
+  if (!element) return
+  suspendedScrollPositions = [element, ...element.querySelectorAll('[data-overlayscrollbars-viewport]')]
+    .map(viewport => [viewport, viewport.scrollTop])
+}
+
+function resumeReadingPosition() {
+  for (const [element, position] of suspendedScrollPositions) {
+    if (!element.isConnected) continue
+    restoreOverlayScrollTop(element, position)
+    clampOverlayScrollTop(element, element === scroller.value ? content.value : null)
+  }
+  suspendedScrollPositions = []
+  clamp()
+}
 
 function handleClosed() {
   panelRendered.value = false

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -544,7 +544,10 @@
           dropdown-position-x="left"
           dropdown-position-y="top"
         >
-          <FtAddToPlaylistDropdown :video-data="playlistVideoData" />
+          <FtAddToPlaylistDropdown
+            :video-data="playlistVideoData"
+            :below-player="false"
+          />
         </FtIconButton>
         <button
           v-if="quickBookmarkEnabled"

--- a/tests/unit/mobile-sheet-presentation.test.mjs
+++ b/tests/unit/mobile-sheet-presentation.test.mjs
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import vm from 'node:vm'
+import { computed, effectScope, nextTick, reactive, ref, shallowRef, watch } from 'vue'
+
+const source = (await readFile(new URL('../../src/renderer/components/FtMobileSheet/FtMobileSheet.vue', import.meta.url), 'utf8'))
+  .split('<script setup>')[1].split('</script>')[0].replace(/^import .*\n/gm, '')
+
+function mountSheet(t) {
+  const scope = effectScope()
+  const cleanup = []
+  const landscape = ref(false)
+  const props = reactive({ enabled: true, open: false, belowPlayer: true })
+  const player = Object.assign(new EventTarget(), {
+    coversWindow: false,
+    matches() { return this.coversWindow },
+    setAttribute() {}, removeAttribute() {},
+    getBoundingClientRect: () => ({ top: 50, bottom: 300 })
+  })
+  const element = {
+    open: false, style: {},
+    show() { this.open = true }, showModal() { this.open = true }, close() { this.open = false },
+    animate: () => ({ cancel() {}, finished: Promise.resolve() }), querySelector: () => null
+  }
+  const dialog = shallowRef(element)
+  const document = Object.assign(new EventTarget(), {
+    fullscreenElement: null, activeElement: null, querySelector: () => null,
+    body: { classList: { contains: () => false } }
+  })
+  const window = Object.assign(new EventTarget(), { scrollBy() {} })
+  const events = []
+  const context = {
+    computed, ref, shallowRef, watch, nextTick, document, window, innerHeight: 800,
+    isAppHidden: () => !!document.hidden,
+    defineProps: () => props, defineEmits: () => (...args) => events.push(args),
+    useTemplateRef: () => dialog, usePhoneLayout: () => landscape,
+    inject: name => name === 'phonePanelPlayer' ? () => player : null,
+    onBeforeUnmount: callback => cleanup.push(callback), onUpdated() {},
+    MutationObserver: class { observe() {} disconnect() {} },
+    ResizeObserver: class { observe() {} disconnect() {} },
+    applyAnimationSpeed: animation => animation, lockBodyScroll() {}, unlockBodyScroll() {},
+    matchMedia: () => ({ matches: true }), getComputedStyle: () => ({ transform: 'none', opacity: 1 })
+  }
+  scope.run(() => vm.runInNewContext(source + '\nglobalThis.state = { expanded, updatePresentation, sheetStyle };', context))
+  t.after(() => { cleanup.forEach(callback => callback()); scope.stop() })
+  return { ...context, element, player, props, landscape, events,
+    async settle() { await nextTick(); await nextTick(); await nextTick() }
+  }
+}
+
+for (const mode of ['native', 'browser', 'fullwindow']) {
+  test(`an open below-player sheet hides during ${mode} fullscreen and returns below the player`, async t => {
+    const sheet = mountSheet(t)
+    sheet.props.open = true
+    await sheet.settle()
+    assert.equal(sheet.element.open, true)
+    if (mode === 'browser') sheet.document.fullscreenElement = sheet.player
+    else sheet.player.coversWindow = true
+    sheet.state.updatePresentation()
+    await sheet.settle()
+    assert.equal(sheet.element.open, false, 'the panel must not cover fullscreen video')
+    assert.equal(sheet.props.open, true, 'fullscreen must retain the selected panel')
+    assert.equal(sheet.events.some(([event]) => event === 'closed'), false)
+    sheet.document.fullscreenElement = null
+    sheet.player.coversWindow = false
+    sheet.state.updatePresentation()
+    await sheet.settle()
+    assert.equal(sheet.element.open, true)
+    assert.equal(sheet.state.expanded.value, false)
+  })
+}
+
+test('a transient landscape viewport while hidden does not maximize the returning panel', async t => {
+  const sheet = mountSheet(t)
+  sheet.props.open = true
+  await sheet.settle()
+  sheet.document.hidden = true
+  sheet.document.dispatchEvent(new Event('visibilitychange'))
+  sheet.landscape.value = true
+  await sheet.settle()
+  sheet.landscape.value = false
+  sheet.document.hidden = false
+  sheet.document.dispatchEvent(new Event('visibilitychange'))
+  await sheet.settle()
+  assert.equal(sheet.state.expanded.value, false, 'PiP must not change the panel expansion')
+})
+
+for (const expanded of [false, true]) {
+  test(`PiP retains ${expanded ? 'expanded' : 'docked'} presentation while Chromium stays visible`, async t => {
+    const sheet = mountSheet(t)
+    sheet.props.open = true
+    await sheet.settle()
+    sheet.state.expanded.value = expanded
+    sheet.document.body.classList.contains = () => true
+    sheet.state.updatePresentation()
+    await sheet.settle()
+    assert.equal(sheet.element.open, false)
+    sheet.landscape.value = true
+    await sheet.settle()
+    sheet.landscape.value = false
+    sheet.document.body.classList.contains = () => false
+    sheet.state.updatePresentation()
+    await sheet.settle()
+    assert.equal(sheet.element.open, true)
+    assert.equal(sheet.state.expanded.value, expanded)
+    assert.deepEqual(sheet.events.map(([event]) => event), ['suspend', 'resume'])
+  })
+}
+
+test('closing a suspended panel does not reopen it on return', async t => {
+  const sheet = mountSheet(t)
+  sheet.props.open = true
+  await sheet.settle()
+  sheet.player.coversWindow = true
+  sheet.state.updatePresentation()
+  await sheet.settle()
+  sheet.props.open = false
+  await sheet.settle()
+  sheet.player.coversWindow = false
+  sheet.state.updatePresentation()
+  await sheet.settle()
+  assert.equal(sheet.element.open, false)
+  assert.deepEqual(sheet.events.map(([event]) => event), ['suspend', 'closed'])
+})
+
+test('ordinary modal sheets remain available while the player is fullscreen', async t => {
+  const sheet = mountSheet(t)
+  sheet.props.belowPlayer = false
+  sheet.player.coversWindow = true
+  sheet.state.updatePresentation()
+  sheet.props.open = true
+  await sheet.settle()
+  assert.equal(sheet.element.open, true)
+  assert.deepEqual(sheet.events, [])
+})

--- a/tests/unit/mobile-sheet-presentation.test.mjs
+++ b/tests/unit/mobile-sheet-presentation.test.mjs
@@ -138,7 +138,7 @@ test('ordinary modal sheets remain available while the player is fullscreen', as
   assert.deepEqual(sheet.events, [])
 })
 
-test('unmounting a suspended expanded sheet restores playback once', async t => {
+test('unmounting a suspended expanded sheet restores playback', async t => {
   let restorations = 0
   const sheet = mountSheet(t, () => () => { restorations++ })
   sheet.props.open = true
@@ -161,6 +161,4 @@ test('unmounting a suspended expanded sheet restores playback once', async t => 
   sheet.unmount()
   assert.equal(restorations, 1, 'unmount must restore retained playback')
   assert.equal(sheet.state.expanded.value, false)
-  sheet.unmount()
-  assert.equal(restorations, 1)
 })

--- a/tests/unit/mobile-sheet-presentation.test.mjs
+++ b/tests/unit/mobile-sheet-presentation.test.mjs
@@ -7,7 +7,7 @@ import { computed, effectScope, nextTick, reactive, ref, shallowRef, watch } fro
 const source = (await readFile(new URL('../../src/renderer/components/FtMobileSheet/FtMobileSheet.vue', import.meta.url), 'utf8'))
   .split('<script setup>')[1].split('</script>')[0].replace(/^import .*\n/gm, '')
 
-function mountSheet(t) {
+function mountSheet(t, expandPanel = null) {
   const scope = effectScope()
   const cleanup = []
   const landscape = ref(false)
@@ -20,6 +20,7 @@ function mountSheet(t) {
   })
   const element = {
     open: false, style: {},
+    getBoundingClientRect: () => ({ top: 300, height: 500 }),
     show() { this.open = true }, showModal() { this.open = true }, close() { this.open = false },
     animate: () => ({ cancel() {}, finished: Promise.resolve() }), querySelector: () => null
   }
@@ -35,16 +36,18 @@ function mountSheet(t) {
     isAppHidden: () => !!document.hidden,
     defineProps: () => props, defineEmits: () => (...args) => events.push(args),
     useTemplateRef: () => dialog, usePhoneLayout: () => landscape,
-    inject: name => name === 'phonePanelPlayer' ? () => player : null,
+    inject: name => name === 'phonePanelPlayer' ? () => player : name === 'expandPhonePanel' ? expandPanel : null,
+    performance,
     onBeforeUnmount: callback => cleanup.push(callback), onUpdated() {},
     MutationObserver: class { observe() {} disconnect() {} },
     ResizeObserver: class { observe() {} disconnect() {} },
     applyAnimationSpeed: animation => animation, lockBodyScroll() {}, unlockBodyScroll() {},
     matchMedia: () => ({ matches: true }), getComputedStyle: () => ({ transform: 'none', opacity: 1 })
   }
-  scope.run(() => vm.runInNewContext(source + '\nglobalThis.state = { expanded, updatePresentation, sheetStyle };', context))
-  t.after(() => { cleanup.forEach(callback => callback()); scope.stop() })
-  return { ...context, element, player, props, landscape, events,
+  scope.run(() => vm.runInNewContext(source + '\nglobalThis.state = { expanded, updatePresentation, sheetStyle, startDrag, moveDrag, endDrag };', context))
+  const unmount = () => { cleanup.splice(0).forEach(callback => callback()); scope.stop() }
+  t.after(unmount)
+  return { ...context, element, player, props, landscape, events, unmount,
     async settle() { await nextTick(); await nextTick(); await nextTick() }
   }
 }
@@ -133,4 +136,31 @@ test('ordinary modal sheets remain available while the player is fullscreen', as
   await sheet.settle()
   assert.equal(sheet.element.open, true)
   assert.deepEqual(sheet.events, [])
+})
+
+test('unmounting a suspended expanded sheet restores playback once', async t => {
+  let restorations = 0
+  const sheet = mountSheet(t, () => () => { restorations++ })
+  sheet.props.open = true
+  await sheet.settle()
+  const event = {
+    button: 0, pointerId: 1, clientY: 400,
+    target: { closest: () => null },
+    currentTarget: { setPointerCapture() {} }
+  }
+  sheet.state.startDrag(event)
+  sheet.state.moveDrag({ ...event, clientY: 300 })
+  sheet.state.endDrag(event)
+  await sheet.settle()
+  assert.equal(sheet.state.expanded.value, true)
+  sheet.player.coversWindow = true
+  sheet.state.updatePresentation()
+  await sheet.settle()
+  assert.equal(sheet.element.open, false)
+  assert.equal(restorations, 0, 'suspension must preserve the playback callback')
+  sheet.unmount()
+  assert.equal(restorations, 1, 'unmount must restore retained playback')
+  assert.equal(sheet.state.expanded.value, false)
+  sheet.unmount()
+  assert.equal(restorations, 1)
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #1311

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

An open mobile panel covered the video in fullscreen and could return from PiP maximized with an invalid scroll offset.

Suspend below-player panels during fullscreen and PiP, preserving the selected panel and expansion state. Keep the hidden sheet in place, restore its outer and nested scroll positions on return, and clamp shorter content. Disable scroll anchoring in panel viewports so the final orientation reflow cannot shift the restored position. The fullscreen Add to playlist action explicitly uses a modal so it remains available while watch panels are suspended.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a video in a phone-sized window or the Android app, open comments or another panel, and scroll down.
2. Enter fullscreen. The panel should disappear. Exit fullscreen and confirm it returns at the same size and reading position.
3. While fullscreen, open Add to playlist. Confirm the picker opens normally, closes normally, and does not replace the suspended watch panel.
4. Enter Android PiP and return to the app. Confirm the panel stays below the player and retains its reading position. Repeat after expanding the panel.
5. Scroll to the bottom, shorten the panel content using a filter, and repeat the transition. Confirm there is no empty space or obsolete scrollbar range. Also check a non-100% UI scale.

## Additional context
<!-- Add any other context about the pull request here. -->

The mobile panels have not appeared in a stable release, so this is marked Not noteworthy.

Validation: lint, the full unit suite run serially, Android native unit tests, and 18 filtered Electron regressions passed. Android lab verification used Android 8.0/API 26 with Chrome WebView 119.0.6045.193 and covered real fullscreen/PiP return, retained reading position, and shorter-content clamping.

Implemented and reviewed with GPT-6 in Codex.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/OpenTubeX/OpenTubeX/pull/1327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


