### PR TITLE
feat(navigation): hide mobile nav on scroll down, show on scroll up

### DIFF
--- a/android/app/src/androidTest/java/org/opentubex/app/MobileAppearanceSettingsTest.java
+++ b/android/app/src/androidTest/java/org/opentubex/app/MobileAppearanceSettingsTest.java
@@ -17,6 +17,68 @@ import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class MobileAppearanceSettingsTest {
+    @Test
+    public void bottomNavigationFollowsPageScrollAtDifferentScales() throws Exception {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            WebView view = webView(scenario);
+            // First-run tutorial makes the navigation inert and locks native scrolling.
+            awaitCondition(view, "localStorage.getItem('opentubex.tutorial.audience') === 'completed' || !!document.querySelector('.tutorialActions button')");
+            evaluate(view, "document.querySelector('.tutorialActions button')?.click()");
+            awaitCondition(view, "!document.querySelector('.tutorialOverlay')");
+            try {
+                prepare(view);
+                evaluate(view, """
+                    (() => {
+                        const content = document.createElement('div');
+                        content.id = 'mobile-navigation-scroll-fixture';
+                        content.style.height = '4000px';
+                        document.querySelector('.routerView').append(content);
+                    })()
+                    """);
+                for (int scale : new int[] {100, 125, 150}) {
+                    evaluate(view, "document.querySelector('#app').__vue_app__.config.globalProperties.$store.commit('setUiScale', " + scale + ")");
+                    awaitCondition(view, "Math.abs(window.visualViewport.scale - " + scale / 100.0 + ") < 0.01");
+                    evaluate(view, "window.scrollTo(0, 0)");
+                    awaitCondition(view, "window.scrollY === 0 && !document.querySelector('.sideNav').classList.contains('scrollHidden')");
+                    evaluate(view, "document.querySelector('#mobile-navigation-scroll-fixture').dispatchEvent(new Event('scroll'))");
+                    assertEquals("Nested scrolling leaves the navigation visible", "true", evaluate(view,
+                        "!document.querySelector('.sideNav').classList.contains('scrollHidden')"));
+                    evaluate(view, "window.__navigationPageHeight = document.scrollingElement.scrollHeight; window.scrollTo(0, 400)");
+                    awaitCondition(view, "document.querySelector('.sideNav').getBoundingClientRect().top >= window.innerHeight - 1");
+                    assertEquals("Hiding keeps the page height and scroll position stable", "true", evaluate(view,
+                        "document.scrollingElement.scrollHeight === window.__navigationPageHeight && Math.abs(window.scrollY - 400) <= 1"));
+                    evaluate(view, "window.scrollTo(0, 360)");
+                    awaitCondition(view, """
+                        (() => {
+                            const nav = document.querySelector('.sideNav');
+                            const rect = nav.getBoundingClientRect();
+                            return !nav.classList.contains('scrollHidden') && rect.top < window.innerHeight - 40 &&
+                                Math.abs(rect.bottom - window.innerHeight) <= 1;
+                        })()
+                        """);
+                    evaluate(view, "window.scrollTo(0, 600)");
+                    awaitCondition(view, "document.querySelector('.sideNav').classList.contains('scrollHidden')");
+                    evaluate(view, "document.querySelector('.sideNav .navOption').focus({ preventScroll: true })");
+                    assertEquals("Navigation receives keyboard focus: " + evaluate(view,
+                        "JSON.stringify({ active: document.activeElement.outerHTML, inert: document.querySelector('.sideNav').inert, prompts: document.querySelector('#app').__vue_app__.config.globalProperties.$store.getters.isAnyPromptOpen })"),
+                        "true", evaluate(view, "document.activeElement === document.querySelector('.sideNav .navOption')"));
+                    awaitCondition(view, "!document.querySelector('.sideNav').classList.contains('scrollHidden')");
+                    evaluate(view, "document.activeElement.blur(); window.scrollTo(0, 800)");
+                    awaitCondition(view, "document.querySelector('.sideNav').classList.contains('scrollHidden')");
+                    evaluate(view, "window.scrollTo(0, 0)");
+                    awaitCondition(view, "!document.querySelector('.sideNav').classList.contains('scrollHidden')");
+                }
+                evaluate(view, "window.scrollTo(0, 400)");
+                awaitCondition(view, "document.querySelector('.sideNav').classList.contains('scrollHidden')");
+                evaluate(view, "document.querySelector('#app').__vue_app__.config.globalProperties.$router.push('/userplaylists')");
+                awaitCondition(view, "document.querySelector('#app').__vue_app__.config.globalProperties.$route.path === '/userplaylists' && !document.querySelector('.sideNav').classList.contains('scrollHidden')");
+            } finally {
+                evaluate(view, "document.querySelector('#mobile-navigation-scroll-fixture')?.remove(); delete window.__navigationPageHeight; window.scrollTo(0, 0)");
+                restore(view);
+            }
+        }
+    }
+
     private static final String SCROLL_STATE = """
         (() => {
             const viewport = document.querySelector('.quickSettingsMenu .quickSettingsScroll');

--- a/android/app/src/androidTest/java/org/opentubex/app/MobileAppearanceSettingsTest.java
+++ b/android/app/src/androidTest/java/org/opentubex/app/MobileAppearanceSettingsTest.java
@@ -32,6 +32,15 @@ public class MobileAppearanceSettingsTest {
                         const content = document.createElement('div');
                         content.id = 'mobile-navigation-scroll-fixture';
                         content.style.height = '4000px';
+                        // A native test viewport exercises real DOM scroll events.
+                        const nested = document.createElement('div');
+                        nested.id = 'mobile-navigation-nested-fixture';
+                        nested.style.cssText = 'height:100px;overflow:auto';
+                        const inner = document.createElement('div');
+                        inner.style.height = '1000px';
+                        nested.append(inner);
+                        nested.addEventListener('scroll', () => { nested.dataset.scrolled = 'true'; });
+                        content.append(nested);
                         document.querySelector('.routerView').append(content);
                     })()
                     """);
@@ -40,9 +49,12 @@ public class MobileAppearanceSettingsTest {
                     awaitCondition(view, "Math.abs(window.visualViewport.scale - " + scale / 100.0 + ") < 0.01");
                     evaluate(view, "window.scrollTo(0, 0)");
                     awaitCondition(view, "window.scrollY === 0 && !document.querySelector('.sideNav').classList.contains('scrollHidden')");
-                    evaluate(view, "document.querySelector('#mobile-navigation-scroll-fixture').dispatchEvent(new Event('scroll'))");
+                    evaluate(view, "document.querySelector('#mobile-navigation-nested-fixture').scrollTop = 0");
+                    awaitCondition(view, "document.querySelector('#mobile-navigation-nested-fixture').scrollTop === 0");
+                    evaluate(view, "(() => { const nested = document.querySelector('#mobile-navigation-nested-fixture'); delete nested.dataset.scrolled; nested.scrollTop = 400; })()");
+                    awaitCondition(view, "(() => { const nested = document.querySelector('#mobile-navigation-nested-fixture'); return nested.scrollTop === 400 && nested.dataset.scrolled === 'true'; })()");
                     assertEquals("Nested scrolling leaves the navigation visible", "true", evaluate(view,
-                        "!document.querySelector('.sideNav').classList.contains('scrollHidden')"));
+                        "!document.querySelector('.sideNav').classList.contains('scrollHidden') && window.scrollY === 0"));
                     evaluate(view, "window.__navigationPageHeight = document.scrollingElement.scrollHeight; window.scrollTo(0, 400)");
                     awaitCondition(view, "document.querySelector('.sideNav').getBoundingClientRect().top >= window.innerHeight - 1");
                     assertEquals("Hiding keeps the page height and scroll position stable", "true", evaluate(view,

--- a/src/renderer/components/SideNav/SideNav.css
+++ b/src/renderer/components/SideNav/SideNav.css
@@ -288,6 +288,8 @@
   }
 
   .sideNav {
+    --hide-on-scroll: 1;
+
     box-sizing: border-box;
     inset-inline-start: 0;
     position: fixed;
@@ -298,6 +300,12 @@
     inset-block: auto 0;
     padding-block-end: var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0));
     overflow-y: hidden;
+    transition: transform 180ms ease;
+  }
+
+  .sideNav.scrollHidden:not(:has(:focus-visible)) {
+    transform: translateY(100%);
+    pointer-events: none;
   }
 
   .topNavOption {
@@ -326,6 +334,12 @@
 
   .hiddenLabels {
     inline-size: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sideNav {
+    transition: none;
   }
 }
 

--- a/src/renderer/components/SideNav/SideNav.css
+++ b/src/renderer/components/SideNav/SideNav.css
@@ -300,11 +300,14 @@
     inset-block: auto 0;
     padding-block-end: var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0));
     overflow-y: hidden;
-    transition: transform 180ms ease;
+    transform: translateY(0);
+    transition: transform 280ms cubic-bezier(0.2, 0, 0, 1);
   }
 
   .sideNav.scrollHidden:not(:has(:focus-visible)) {
     transform: translateY(100%);
+    transition-duration: 220ms;
+    transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
     pointer-events: none;
   }
 

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -273,17 +273,24 @@ const route = useRoute()
 const innerRef = useTemplateRef('innerRef')
 const scrollHidden = ref(false)
 const navigationScroll = createMobileNavigationScroll()
+let hideOnScroll = false
 
 function resetScrollVisibility() {
   navigationScroll.reset(window.scrollY)
   scrollHidden.value = false
 }
 
-function updateScrollVisibility() {
+function updateScrollLayout() {
   const nav = innerRef.value?.closest('.sideNav')
-  // Check the rendered layout, including Android's phone/tablet overrides.
-  if (!nav || getComputedStyle(nav).getPropertyValue('--hide-on-scroll').trim() !== '1' ||
-    nav.querySelector(':focus-visible, [aria-expanded="true"]')) {
+  // Resolve the CSS layout on mount/resize, not on every page scroll.
+  hideOnScroll = nav != null && getComputedStyle(nav).getPropertyValue('--hide-on-scroll').trim() === '1'
+  resetScrollVisibility()
+}
+
+function updateScrollVisibility() {
+  if (!hideOnScroll) return
+  const nav = innerRef.value?.closest('.sideNav')
+  if (!nav || nav.querySelector(':focus-visible, [aria-expanded="true"]')) {
     resetScrollVisibility()
     return
   }
@@ -366,9 +373,9 @@ watch([isOpen, hideText, displayedActiveSubscriptions], () => {
 })
 
 onMounted(() => {
-  resetScrollVisibility()
+  updateScrollLayout()
   window.addEventListener('scroll', updateScrollVisibility, { passive: true })
-  window.addEventListener('resize', resetScrollVisibility)
+  window.addEventListener('resize', updateScrollLayout)
   updateIndicator()
   navMutationObserver = new MutationObserver(() => nextTick(updateIndicator))
   navMutationObserver.observe(innerRef.value, { childList: true, subtree: true })
@@ -377,7 +384,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   window.removeEventListener('scroll', updateScrollVisibility)
-  window.removeEventListener('resize', resetScrollVisibility)
+  window.removeEventListener('resize', updateScrollLayout)
   clearTimeout(remeasureTimeoutId)
   navMutationObserver?.disconnect()
   window.removeEventListener('resize', updateIndicatorAfterResize)

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -1,9 +1,10 @@
 <template>
   <FtFlexBox
     class="sideNav"
-    :class="[{ opened: isOpen, expanded: isOpen || props.forceExpanded }, applyHiddenLabels]"
+    :class="[{ opened: isOpen, expanded: isOpen || props.forceExpanded, scrollHidden }, applyHiddenLabels]"
     data-tutorial="navigation"
     role="navigation"
+    @focusin="resetScrollVisibility"
   >
     <div
       ref="innerRef"
@@ -116,6 +117,7 @@ import { filterAvailableNavigationItems } from '../../../navigationAvailability'
 import { deepCopy, localizeAndAddKeyboardShortcutToActionTitle } from '../../helpers/utils'
 import { getConfiguredKeyboardShortcuts } from '../../../constants'
 import { NAVIGATION_ITEM_DEFINITIONS } from '../../../navigationItems'
+import { createMobileNavigationScroll } from '../../helpers/mobileNavigationScroll'
 
 const { locale, t } = useI18n()
 const appKeyboardShortcuts = computed(() => getConfiguredKeyboardShortcuts(
@@ -269,6 +271,25 @@ const historyTitle = computed(() => {
 // ===== Sliding active-route indicator =====
 const route = useRoute()
 const innerRef = useTemplateRef('innerRef')
+const scrollHidden = ref(false)
+const navigationScroll = createMobileNavigationScroll()
+
+function resetScrollVisibility() {
+  navigationScroll.reset(window.scrollY)
+  scrollHidden.value = false
+}
+
+function updateScrollVisibility() {
+  const nav = innerRef.value?.closest('.sideNav')
+  // Check the rendered layout, including Android's phone/tablet overrides.
+  if (!nav || getComputedStyle(nav).getPropertyValue('--hide-on-scroll').trim() !== '1' ||
+    nav.querySelector(':focus-visible, [aria-expanded="true"]')) {
+    resetScrollVisibility()
+    return
+  }
+  const page = document.scrollingElement
+  scrollHidden.value = navigationScroll.update(window.scrollY, page.scrollHeight - page.clientHeight)
+}
 /** @type {import('vue').Ref<Record<string, string> | null>} */
 const indicatorStyle = ref(null)
 
@@ -328,7 +349,10 @@ function updateIndicatorAfterResize() {
   remeasureTimeoutId = setTimeout(updateIndicator, 200)
 }
 
-watch(() => route.fullPath, () => nextTick(updateIndicator))
+watch(() => route.fullPath, () => {
+  resetScrollVisibility()
+  nextTick(updateIndicator)
+})
 watch([
   () => activeProfile.value._id,
   () => activeProfile.value.subscriptions.length
@@ -342,6 +366,9 @@ watch([isOpen, hideText, displayedActiveSubscriptions], () => {
 })
 
 onMounted(() => {
+  resetScrollVisibility()
+  window.addEventListener('scroll', updateScrollVisibility, { passive: true })
+  window.addEventListener('resize', resetScrollVisibility)
   updateIndicator()
   navMutationObserver = new MutationObserver(() => nextTick(updateIndicator))
   navMutationObserver.observe(innerRef.value, { childList: true, subtree: true })
@@ -349,6 +376,8 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+  window.removeEventListener('scroll', updateScrollVisibility)
+  window.removeEventListener('resize', resetScrollVisibility)
   clearTimeout(remeasureTimeoutId)
   navMutationObserver?.disconnect()
   window.removeEventListener('resize', updateIndicatorAfterResize)

--- a/src/renderer/helpers/mobileNavigationScroll.js
+++ b/src/renderer/helpers/mobileNavigationScroll.js
@@ -1,0 +1,32 @@
+// Accumulate small scroll steps without reacting to subpixel jitter or overscroll.
+export function createMobileNavigationScroll() {
+  let anchor = 0
+  let hidden = false
+
+  return {
+    reset(position) {
+      anchor = Math.max(0, position)
+      hidden = false
+    },
+    update(position, maximum) {
+      const top = Math.max(0, Math.min(position, Math.max(0, maximum)))
+      if (top <= 8) {
+        hidden = false
+        anchor = 0
+      } else if (hidden) {
+        anchor = Math.max(anchor, top)
+        if (anchor - top >= 8) {
+          hidden = false
+          anchor = top
+        }
+      } else {
+        anchor = Math.min(anchor, top)
+        if (top - anchor >= 8) {
+          hidden = true
+          anchor = top
+        }
+      }
+      return hidden
+    }
+  }
+}

--- a/tests/unit/mobile-navigation-scroll.test.mjs
+++ b/tests/unit/mobile-navigation-scroll.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createMobileNavigationScroll } from '../../src/renderer/helpers/mobileNavigationScroll.js'
+
+test('hides downward and reveals upward after a small accumulated movement', () => {
+  const nav = createMobileNavigationScroll()
+  nav.reset(0)
+  assert.equal(nav.update(4, 1000), false)
+  assert.equal(nav.update(9, 1000), true)
+  assert.equal(nav.update(200, 1000), true)
+  assert.equal(nav.update(197.5, 1000), true)
+  assert.equal(nav.update(191.5, 1000), false)
+})
+
+test('clamps overscroll, reveals at the top and resets after navigation', () => {
+  const nav = createMobileNavigationScroll()
+  nav.reset(0)
+  assert.equal(nav.update(100, 100), true)
+  assert.equal(nav.update(120, 100), true)
+  assert.equal(nav.update(100, 100), true)
+  assert.equal(nav.update(-10, 100), false)
+  assert.equal(nav.update(0, 100), false)
+  nav.update(80, 100)
+  nav.reset(80)
+  assert.equal(nav.update(80, 100), false)
+  assert.equal(nav.update(90, 100), true)
+  assert.equal(nav.update(0, 0), false)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

The mobile bottom navigation stays visible while scrolling through long lists. It now slides away on downward scroll and returns when scrolling back up.

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes #1313

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Accumulate small scroll movements to avoid flickering, and translate the bar without changing the page height. Restore it at the page top, after navigation, and for keyboard focus. Keep open navigation menus visible and respect reduced motion.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
The mobile bottom navigation now hides when scrolling down and reappears when scrolling up.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/ce5c7b0f-757b-4ff6-8c00-8ad3129fe1f8">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/4d8f4856-a59f-4323-a970-049006a24c61">
  <img alt="Mobile bottom navigation slides out when scrolling down and back in when scrolling up" src="https://github.com/user-attachments/assets/ce5c7b0f-757b-4ff6-8c00-8ad3129fe1f8">
</picture>

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a long video list in the phone layout and scroll down. The bottom navigation should slide out without shifting the list.
2. Scroll back up a little. The bar should return without needing to reach the top.
3. Open another page, return to the page top, or focus a navigation item with the keyboard. The bar should be visible.
4. Repeat at 125% and 150% UI scale. With reduced motion enabled, visibility should change without a slide animation.

## Additional context
<!-- Add any other context about the pull request here. -->

Validation: Android 8.0 with Chrome WebView 119.0.6045.193 passed the navigation instrumentation test at 100%, 125%, and 150% UI scale on 411px and 375px phone layouts. Android debug build and native unit tests passed. Lint and four navigation E2E checks passed. The full unit suite passed with serial execution: 1,795 passed and two skipped. The default parallel run hit player-runtime and subscription-recovery timing failures under machine load; the focused rerun also passed.

Standards and spec reviews found no actionable findings.

Implemented with GPT-6 in Codex.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/OpenTubeX/OpenTubeX/pull/1329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



