### PR TITLE
fix: keep mobile scrollbars steady during swipes

### DIFF
--- a/e2e/tests/offline/phone-review.spec.mjs
+++ b/e2e/tests/offline/phone-review.spec.mjs
@@ -324,11 +324,21 @@ for (const panel of ['description', 'comments', 'chapters', 'transcript', 'queue
 
 test('panel scrollbar positioning follows the compositor scroll timeline', async ({ app, page }) => {
   await mockPlayableWatchPage(app, page, { captionTranslations: true })
+  const cues = Array.from({ length: 30 }, (_, index) => (
+    `00:00:${String(index).padStart(2, '0')}.000 --> 00:00:${String(index + 1).padStart(2, '0')}.000\nCaption ${index + 1}`
+  ))
+  await page.route('https://www.youtube.com/api/timedtext**', route => route.fulfill({
+    contentType: 'text/vtt',
+    body: `WEBVTT\n\n${cues.join('\n\n')}\n`,
+  }))
   await openMockedVideo(page)
   await setWindowSize(app, page, { width: 480, height: 800 })
   const watch = await watchViewHandle(page)
   await watch.evaluate(vm => vm.openPhonePanel('transcript'))
-  const track = page.locator('.mobileSheet[open] .os-scrollbar-vertical').last()
+  const segments = page.locator('.mobileSheet[open] .transcriptSegments')
+  await expect(segments.getByRole('listitem')).toHaveCount(30)
+  await expect.poll(() => segments.evaluate(el => el.scrollHeight > el.clientHeight)).toBe(true)
+  const track = segments.locator(':scope > .os-scrollbar-vertical')
   await expect(track).toBeAttached()
-  expect(await track.evaluate(el => el.getAnimations().some(animation => animation.timeline?.constructor.name === 'ScrollTimeline'))).toBe(true)
+  await expect.poll(() => track.evaluate(el => el.getAnimations().some(animation => animation.timeline?.constructor.name === 'ScrollTimeline'))).toBe(true)
 })

--- a/e2e/tests/offline/update-modal.spec.mjs
+++ b/e2e/tests/offline/update-modal.spec.mjs
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs'
 
-import { test, expect, goTo, waitForAppReady } from '../../helpers/app.mjs'
+import { test, expect, goTo, waitForAppReady, setWindowSize } from '../../helpers/app.mjs'
 
 const RELEASES_URL = /^https:\/\/api\.github\.com\/repos\/OpenTubeX\/OpenTubeX\/releases/
 const COMMIT_HASH = '3904e64f503cde6be8793606a04ad69c5d57cef0'
@@ -58,6 +58,69 @@ async function showUpdatePrompt(page, releases) {
   const notification = await showUpdateNotification(page, releases)
   await notification.getByRole('button', { name: 'See changes and update' }).click()
   await expect(page.locator('.changeLogTitle')).toBeVisible()
+}
+
+for (const uiScale of [100, 95]) {
+  test(`release-note scrollbar stays anchored during touch scrolling without scroll callbacks at ${uiScale}%`, async ({ app, page }) => {
+    await showUpdatePrompt(page, [
+      release(`OpenTubeX ${newestUpdateVersion}`, `v${newestUpdateVersion}-beta`,
+        `<details open><summary>Show changes</summary>\n\n${Array.from({ length: 60 }, (_, index) => `- Release note ${index + 1}: scrolling through the latest improvements and fixes on a phone.`).join('\n')}\n\n</details>`)
+    ])
+    await page.evaluate(scale => window.ftElectron.setZoomFactor(scale / 100), uiScale)
+    await setWindowSize(app, page, { width: 480, height: 800 })
+    const scroller = page.locator('.changeLogText')
+    const scrollbar = scroller.locator(':scope > .os-scrollbar-vertical')
+    await expect(scrollbar).toBeAttached()
+    // Touch scrolling can advance on the compositor before JS scroll listeners
+    // run. Suppress those callbacks to check the scrollbar in that exact state.
+    const resumeScrollEvents = await scroller.evaluateHandle(element => {
+      const suppressScroll = event => {
+        if (event.target === element) event.stopImmediatePropagation()
+      }
+      document.addEventListener('scroll', suppressScroll, { capture: true })
+      return () => document.removeEventListener('scroll', suppressScroll, { capture: true })
+    })
+    const initial = await scrollbar.boundingBox()
+    const box = await scroller.boundingBox()
+    const session = await page.context().newCDPSession(page)
+    await session.send('Emulation.setTouchEmulationEnabled', { enabled: true, maxTouchPoints: 1 })
+    const point = { x: box.x + box.width / 2, y: box.y + box.height - 30 }
+    await session.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [point] })
+    for (const distance of [30, 60, 90, 120, 150, 180]) {
+      await session.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: [{ ...point, y: point.y - distance }] })
+    }
+    await session.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] })
+    await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBeGreaterThan(50)
+    await expect.poll(async () => Math.abs((await scrollbar.boundingBox()).y - initial.y)).toBeLessThanOrEqual(1)
+    await resumeScrollEvents.evaluate(resume => resume())
+    await resumeScrollEvents.dispose()
+    await session.detach()
+
+    await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
+    await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBeGreaterThan(50)
+    for (const size of [{ width: 481, height: 1000 }, { width: 1000, height: 900 }]) {
+      await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
+      await setWindowSize(app, page, size)
+      await expect.poll(() => scroller.evaluate(element => {
+        const content = element.firstElementChild
+        const end = content.getBoundingClientRect().bottom - element.getBoundingClientRect().top +
+          element.scrollTop - element.clientTop - element.clientHeight
+        return Math.abs(element.scrollTop - Math.max(0, end))
+      })).toBeLessThanOrEqual(1)
+      await expect.poll(() => scrollbar.evaluate(element => {
+        const track = element.querySelector('.os-scrollbar-track').getBoundingClientRect()
+        const handle = element.querySelector('.os-scrollbar-handle').getBoundingClientRect()
+        return Math.abs(handle.bottom - track.bottom)
+      })).toBeLessThanOrEqual(1)
+    }
+
+    await scroller.locator('summary').evaluate(element => element.click())
+    await expect.poll(() => scroller.evaluate(element => ({
+      scrollTop: element.scrollTop,
+      hasScrollbar: !element.querySelector('.os-scrollbar-vertical').classList.contains('os-scrollbar-unusable'),
+      overflows: element.scrollHeight > element.clientHeight + 1,
+    }))).toEqual({ scrollTop: 0, hasScrollbar: false, overflows: false })
+  })
 }
 
 test('the update notification stays dismissed for the current app session', async ({ page }) => {

--- a/e2e/tests/offline/update-modal.spec.mjs
+++ b/e2e/tests/offline/update-modal.spec.mjs
@@ -80,7 +80,13 @@ for (const uiScale of [100, 95]) {
       document.addEventListener('scroll', suppressScroll, { capture: true })
       return () => document.removeEventListener('scroll', suppressScroll, { capture: true })
     })
-    const initial = await scrollbar.boundingBox()
+    // The dialog itself can still move during its opening animation. Compare
+    // the track with its viewport in the same frame, not with the screen.
+    const trackOffset = () => scroller.evaluate(element => {
+      const track = element.querySelector(':scope > .os-scrollbar-vertical')
+      return track.getBoundingClientRect().top - element.getBoundingClientRect().top
+    })
+    const initialOffset = await trackOffset()
     const box = await scroller.boundingBox()
     const session = await page.context().newCDPSession(page)
     await session.send('Emulation.setTouchEmulationEnabled', { enabled: true, maxTouchPoints: 1 })
@@ -91,7 +97,7 @@ for (const uiScale of [100, 95]) {
     }
     await session.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] })
     await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBeGreaterThan(50)
-    await expect.poll(async () => Math.abs((await scrollbar.boundingBox()).y - initial.y)).toBeLessThanOrEqual(1)
+    await expect.poll(async () => Math.abs(await trackOffset() - initialOffset)).toBeLessThanOrEqual(1)
     await resumeScrollEvents.evaluate(resume => resume())
     await resumeScrollEvents.dispose()
     await session.detach()

--- a/e2e/tests/offline/update-modal.spec.mjs
+++ b/e2e/tests/offline/update-modal.spec.mjs
@@ -125,7 +125,8 @@ for (const uiScale of [100, 95]) {
       scrollTop: element.scrollTop,
       hasScrollbar: !element.querySelector('.os-scrollbar-vertical').classList.contains('os-scrollbar-unusable'),
       overflows: element.scrollHeight > element.clientHeight + 1,
-    }))).toEqual({ scrollTop: 0, hasScrollbar: false, overflows: false })
+      trackAnimations: element.querySelector('.os-scrollbar-vertical').getAnimations().length,
+    }))).toEqual({ scrollTop: 0, hasScrollbar: false, overflows: false, trackAnimations: 0 })
   })
 }
 

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -350,6 +350,11 @@
   overflow-wrap: break-word;
 }
 
+.changeLogContent {
+  /* Include the first and last Markdown block margins in scroll clamping. */
+  display: flow-root;
+}
+
 .changeLogText :deep(img) {
   display: block;
   max-inline-size: 100%;

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -120,12 +120,18 @@
         </h1>
       </template>
       <div
-        v-safer-html.lenient="updateChangelog"
+        ref="changeLogScroller"
         v-overlay-scrollbars
         class="changeLogText"
         dir="ltr"
         lang="en"
-      />
+      >
+        <div
+          ref="changeLogContent"
+          v-safer-html.lenient="updateChangelog"
+          class="changeLogContent"
+        />
+      </div>
       <FtFlexBox>
         <FtButton
           :label="t('Download From Site')"
@@ -490,6 +496,7 @@ import { App as CapacitorApp } from '@capacitor/app'
 import { Capacitor, SystemBars, SystemBarsStyle } from '@capacitor/core'
 import { clampOverlayScrollTop, restoreOverlayScrollTop } from './helpers/overlayScrollbars'
 import { computed, defineAsyncComponent, nextTick, onBeforeUnmount, onMounted, provide, ref, shallowRef, unref, useId, useTemplateRef, watch } from 'vue'
+import { useScrollClamp } from './composables/useScrollClamp'
 import { useI18n } from 'vue-i18n'
 import { routerKey, useRoute, useRouter } from 'vue-router'
 
@@ -2830,6 +2837,7 @@ updateThumbnailListSize()
 const showReleaseNotes = ref(false)
 const changeLogTitle = ref('')
 const updateChangelog = ref('')
+useScrollClamp(useTemplateRef('changeLogScroller'), useTemplateRef('changeLogContent'))
 const DISMISSED_UPDATE_VERSION_STORAGE_KEY = 'opentubex-dismissed-update-version'
 /** @type {{ tagName: string, versionNumber: string } | null} */
 let availableUpdate = null

--- a/src/renderer/helpers/overlayScrollbars.js
+++ b/src/renderer/helpers/overlayScrollbars.js
@@ -94,8 +94,9 @@ function synchronizeScrollbarPosition(element, instance) {
   const update = () => {
     if (suspended) return
     const { overflowAmount } = instance.state()
-    // The library still handles two-axis scrollers and older WebViews.
-    if (overflowAmount.x > 1) {
+    // Only vertical overflow needs synchronization. The library still handles
+    // two-axis scrollers and older WebViews.
+    if (overflowAmount.x > 1 || overflowAmount.y <= 0) {
       animations.forEach(animation => animation.cancel())
       animations = []
       previousRange = -1

--- a/src/renderer/helpers/overlayScrollbars.js
+++ b/src/renderer/helpers/overlayScrollbars.js
@@ -29,7 +29,7 @@ const instances = new Map()
 /** @type {WeakMap<import('overlayscrollbars').OverlayScrollbars, () => void>} */
 const removeScrollSpeedHandlers = new WeakMap()
 const SCROLL_BOUNDARY_TOLERANCE = 1
-const suspendSheetScrollbars = new WeakMap()
+const suspendScrollbarPosition = new WeakMap()
 
 function scrollbarOptions(initialization) {
   const options = {
@@ -73,15 +73,19 @@ function create(initialization) {
     optimizeBodyScrollbarDrag(instance)
   } else if (initialization.elements?.viewport instanceof HTMLElement) {
     reconcileScrollbarOnResize(initialization.elements.viewport, instance)
-    synchronizeSheetScrollbarPosition(initialization.elements.viewport, instance)
+    synchronizeScrollbarPosition(initialization.elements.viewport, instance)
   }
 
   return instance
 }
 
-/** Keep a panel's scrollbar track fixed during compositor-driven touch scrolling. */
-function synchronizeSheetScrollbarPosition(element, instance) {
-  if (!window.ScrollTimeline || !element.closest('.mobileSheetEnabled')) return
+/**
+ * Keep nested scrollbar tracks fixed during compositor-driven touch scrolling.
+ * The library positions tracks inside a reused viewport from scroll events,
+ * which can arrive after Chromium has already painted the scrolled content.
+ */
+function synchronizeScrollbarPosition(element, instance) {
+  if (!window.ScrollTimeline) return
   const timeline = new window.ScrollTimeline({ source: element, axis: 'y' })
   const { scrollbarVertical, scrollbarHorizontal } = instance.elements()
   let animations = []
@@ -103,7 +107,7 @@ function synchronizeSheetScrollbarPosition(element, instance) {
     if (animations.length) animations.forEach(animation => animation.effect.setKeyframes(frames))
     else animations = [scrollbarVertical, scrollbarHorizontal].map(({ scrollbar }) => scrollbar.animate(frames, { timeline }))
   }
-  suspendSheetScrollbars.set(instance, () => {
+  suspendScrollbarPosition.set(instance, () => {
     suspended = true
     animations.forEach(animation => animation.cancel())
     animations = []
@@ -116,7 +120,7 @@ function synchronizeSheetScrollbarPosition(element, instance) {
   update()
   instance.on('updated', update)
   instance.on('destroyed', () => {
-    suspendSheetScrollbars.delete(instance)
+    suspendScrollbarPosition.delete(instance)
     animations.forEach(animation => animation.cancel())
   })
 }
@@ -198,31 +202,36 @@ function reconcileScrollbarOnResize(element, instance) {
 
     resizeFrame = requestAnimationFrame(() => {
       resizeFrame = null
-      const height = element.clientHeight
-      const scrollTop = element.scrollTop
-      const maximumScrollTop = Math.max(0, element.scrollHeight - height)
-      // Content can shrink (trimmed live chat) or the viewport can grow after a
-      // dock transition while an obsolete end offset is still applied — that
-      // parks the view on empty space until the user scrolls up.
-      if (scrollTop > maximumScrollTop + 1) {
-        element.scrollTop = maximumScrollTop
-        instance.update(true)
+      const resumeScrollbars = suspendScrollbarPosition.get(instance)?.()
+      try {
+        const height = element.clientHeight
+        const scrollTop = element.scrollTop
+        const maximumScrollTop = Math.max(0, element.scrollHeight - height)
+        // Content can shrink (trimmed live chat) or the viewport can grow after a
+        // dock transition while an obsolete end offset is still applied — that
+        // parks the view on empty space until the user scrolls up.
+        if (scrollTop > maximumScrollTop + 1) {
+          element.scrollTop = maximumScrollTop
+          instance.update(true)
+          previousHeight = height
+          return
+        }
+
+        const grewAtOldEnd = height > previousHeight &&
+          scrollTop > 0 &&
+          scrollTop >= maximumScrollTop - 1
         previousHeight = height
-        return
-      }
 
-      const grewAtOldEnd = height > previousHeight &&
-        scrollTop > 0 &&
-        scrollTop >= maximumScrollTop - 1
-      previousHeight = height
+        if (grewAtOldEnd) {
+          element.scrollTop = 0
+          instance.update(true)
+          element.scrollTop = Math.min(scrollTop, instance.state().overflowAmount.y)
+        }
 
-      if (grewAtOldEnd) {
-        element.scrollTop = 0
         instance.update(true)
-        element.scrollTop = Math.min(scrollTop, instance.state().overflowAmount.y)
+      } finally {
+        resumeScrollbars?.()
       }
-
-      instance.update(true)
     })
   })
 
@@ -470,7 +479,7 @@ export function clampOverlayScrollTop(element, contentElement = null) {
   const instance = OverlayScrollbars(element)
   // A compositor animation can retain the old track offset during this DOM update.
   // Remove that overflow contribution before measuring the shortened content.
-  const resumeScrollbars = suspendSheetScrollbars.get(instance)?.()
+  const resumeScrollbars = suspendScrollbarPosition.get(instance)?.()
   try {
     const scrollOffsetElement = instance?.elements().scrollOffsetElement ?? element
     instance?.update(true)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #1317

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Scrollbars in mobile release notes and other nested scroll areas can jump during swipes because their tracks wait for JavaScript scroll callbacks while the content already moves. Apply the existing mobile-sheet scroll-timeline positioning to nested vertical scrollers throughout the app, and only animate tracks while vertical overflow exists.

Suspend that positioning while reconciling viewport sizes, and clamp release notes against a stable content wrapper after collapsing sections or resizing, so shortened content leaves no stale offset or empty scroll range.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Scrollbars in mobile dialogs and menus stay in place during swipes.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/48d5e50f-3af5-435b-acbd-5f2ea7da5b57">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/c95f621e-0099-416a-86e5-ae646037b447">
  <img alt="Mobile release-note scrollbar stays in place during touch scrolling" src="https://github.com/user-attachments/assets/48d5e50f-3af5-435b-acbd-5f2ea7da5b57">
</picture>

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open an available update's release notes at phone size and swipe repeatedly in both directions. The scrollbar should stay at the edge of the content area and move smoothly with the content.
2. Scroll to the bottom, then enlarge the window or rotate to landscape. The content should end at the viewport edge without blank space, and the thumb should match the new scroll range. Repeat at 95% UI Scale.
3. Collapse an expanded release-note section and try mobile language/playlist searches. Shortened content should have no obsolete scroll offset or usable scrollbar when it fits.

## Additional context
<!-- Add any other context about the pull request here. -->


Validation: the regression failed before the fix with a scrollbar displacement of about 321 CSS pixels. Touch, resize, and collapse checks pass at 100% and 95% scale; existing scrollbar, update-dialog, and affected mobile-picker/panel checks also pass. Unit tests pass, with 1,801 passes and two skips. After rebasing, the unrelated player-runtime allocation test once hit its interruption deadline under concurrent load; it passed alone and on a complete unit-suite retry. Lint passes with one existing Vue i18n configuration warning.

Two-axis scrollers and WebViews without ScrollTimeline retain the existing library fallback.

Implemented with GPT-6 in Codex desktop.

