### PR TITLE
feat(player): swipe between Watch and the mini player

### DIFF
--- a/android/app/src/androidTest/java/org/opentubex/app/NativePlaybackScreenTest.java
+++ b/android/app/src/androidTest/java/org/opentubex/app/NativePlaybackScreenTest.java
@@ -148,7 +148,7 @@ public class NativePlaybackScreenTest {
             assertNotEquals("The native controls cannot cover the scrolling countdown", android.graphics.Color.MAGENTA, image.getPixel(240, 220));
             assertEquals("The old countdown opening must close", android.graphics.Color.MAGENTA, image.getPixel(240, 330));
             image.recycle();
-            screen.animateVideo(new double[] { 0, 60, 400, 225 }, new double[] { 100, 200, 300, 168.75, 1000 }, 1200, 12, () -> {});
+            screen.animateVideo(new double[] { 0, 60, 400, 225 }, new double[] { 100, 200, 300, 168.75, 1000 }, 1200, 12, true, () -> {});
             assertTrue("Changing the video coordinate mode cannot move document-coordinate exclusions", screen.isOverMenu(240, 220));
             assertFalse(screen.isOverMenu(240, 330));
         });
@@ -183,7 +183,7 @@ public class NativePlaybackScreenTest {
             frame.getChildAt(0).setVisibility(View.INVISIBLE);
             web.setBackgroundColor(android.graphics.Color.RED);
             screen.setMenuBounds(new android.graphics.RectF[] { new android.graphics.RectF(0, 0, 1000, 80) });
-            screen.animateVideo(new double[] { 0, 0, 500, 281.25 }, new double[] { 100, 0, 400, 225, 1000 }, 1200, 12, () -> {});
+            screen.animateVideo(new double[] { 0, 0, 500, 281.25 }, new double[] { 100, 0, 400, 225, 1000 }, 1200, 12, false, () -> {});
             assertTrue("Moving video must draw over opaque route content", screen.indexOfChild(frame) > screen.indexOfChild((View) web.getParent()));
             assertFalse("Transport buttons must not travel separately from the video", controls.isFullyVisible());
         }, (screen, controls, web, engine) -> {
@@ -318,7 +318,7 @@ public class NativePlaybackScreenTest {
             frame[0] = screen.getChildAt(0);
             web.holdVisualState = true;
             screen.setGestureActive(true);
-            screen.animateVideo(new double[] { 200, 200, 400, 225 }, new double[] { 100, 200, 400, 225, 1000 }, 0, 12, screen::finishVideoTransition);
+            screen.animateVideo(new double[] { 200, 200, 400, 225 }, new double[] { 100, 200, 400, 225, 1000 }, 0, 12, false, screen::finishVideoTransition);
         }, (screen, controls, web, engine) -> {
             assertNotNull("The finished animation must release the previous gesture", web.heldVisualState);
             web.heldVisualState.onComplete(web.heldVisualStateId);
@@ -342,7 +342,7 @@ public class NativePlaybackScreenTest {
             if (mode.equals("resize")) {
                 screen.setGestureActive(true);
             } else if (mode.equals("animation")) {
-                screen.animateVideo(new double[] { 200, 200, 400, 225 }, new double[] { 100, 100, 600, 337.5, 1000 }, 1200, 12, () -> {});
+                screen.animateVideo(new double[] { 200, 200, 400, 225 }, new double[] { 100, 100, 600, 337.5, 1000 }, 1200, 12, false, () -> {});
             } else {
                 swipePage(screen);
                 if (mode.equals("handoff")) {
@@ -378,12 +378,12 @@ public class NativePlaybackScreenTest {
         withScreen((screen, controls, web, engine) -> {
             screen.setFullscreen(false);
             screen.setInlineVisible(true);
-            screen.animateVideo(new double[] { 0, 100, 1000, 562.5 }, new double[] { 600, 500, 350, 196.875, 1000 }, 1200, 12, () -> {});
+            screen.animateVideo(new double[] { 0, 100, 1000, 562.5 }, new double[] { 600, 500, 350, 196.875, 1000 }, 1200, 12, false, () -> {});
         }, (screen, controls, web, engine) -> {
             View frame = screen.getChildAt(screen.getChildCount() - 1);
             float left = frame.getTranslationX();
             float top = frame.getTranslationY();
-            screen.animateVideo(new double[] { 600, 500, 350, 196.875 }, new double[] { 0, 100, 1000, 562.5, 1000 }, 1200, 0, () -> {});
+            screen.animateVideo(new double[] { 600, 500, 350, 196.875 }, new double[] { 0, 100, 1000, 562.5, 1000 }, 1200, 0, false, () -> {});
             assertEquals("Reversing a transition must not jump to its old DOM destination", left, frame.getTranslationX(), 1f);
             assertEquals(top, frame.getTranslationY(), 1f);
         });
@@ -424,7 +424,7 @@ public class NativePlaybackScreenTest {
         withScreen((screen, controls, web, engine) -> {
             screen.setFullscreen(false);
             screen.setInlineVisible(true);
-            screen.animateVideo(new double[] { 0, 100, 1000, 562.5 }, new double[] { 600, 500, 350, 196.875, 1000 }, 0, 12, () -> {});
+            screen.animateVideo(new double[] { 0, 100, 1000, 562.5 }, new double[] { 600, 500, 350, 196.875, 1000 }, 0, 12, false, () -> {});
             View videoFrame = screen.getChildAt(screen.getChildCount() - 1);
             web.holdVisualState = true;
             screen.finishVideoTransition();

--- a/android/app/src/main/java/org/opentubex/app/AndroidPlaybackPlugin.java
+++ b/android/app/src/main/java/org/opentubex/app/AndroidPlaybackPlugin.java
@@ -112,7 +112,7 @@ public class AndroidPlaybackPlugin extends Plugin {
                         return;
                     }
                     screen.animateVideo(origin, target, Math.max(0, Math.min(1200, transition.optLong("duration", 300))),
-                        (float) Math.max(0, Math.min(1000, transition.optDouble("radius", 0))), call::resolve);
+                        (float) Math.max(0, Math.min(1000, transition.optDouble("radius", 0))), call.getBoolean("pageScroll", false), call::resolve);
                     return;
                 }
                 screen.setFollowsPageScroll(call.getBoolean("pageScroll", false));

--- a/android/app/src/main/java/org/opentubex/app/NativePlaybackScreen.java
+++ b/android/app/src/main/java/org/opentubex/app/NativePlaybackScreen.java
@@ -512,8 +512,8 @@ final class NativePlaybackScreen extends FrameLayout implements TextureView.Surf
         videoFrame.setScaleY((float) (fittedHeight * scale / textureHeight));
     }
 
-    void animateVideo(double[] from, double[] to, long duration, float radius, Runnable finished) {
-        followsPageScroll = false;
+    void animateVideo(double[] from, double[] to, long duration, float radius, boolean targetPageScroll, Runnable finished) {
+        followsPageScroll = targetPageScroll;
         gestureActive = false;
         double scale = getWidth() / to[4];
         // A reversal starts where the native frame is actually being drawn,
@@ -534,7 +534,9 @@ final class NativePlaybackScreen extends FrameLayout implements TextureView.Surf
         animation.addUpdateListener(value -> {
             float progress = (float) value.getAnimatedValue();
             double x = origin[0] + (to[0] - origin[0]) * progress;
-            double y = origin[1] + (to[1] - origin[1]) * progress;
+            // The inline destination keeps moving while a smooth scroll settles.
+            double targetY = to[1] + (targetPageScroll ? pageScrollDelta(to[4]) : 0);
+            double y = origin[1] + (targetY - origin[1]) * progress;
             double width = origin[2] + (to[2] - origin[2]) * progress;
             double height = origin[3] + (to[3] - origin[3]) * progress;
             double frameScale = getWidth() / to[4];

--- a/e2e/tests/offline/inline-mini-player-drag.spec.mjs
+++ b/e2e/tests/offline/inline-mini-player-drag.spec.mjs
@@ -1,0 +1,58 @@
+import { test, expect, setWindowSize } from '../../helpers/app.mjs'
+import { openMockedVideo } from '../../helpers/player.mjs'
+import { mockPlayableWatchPage } from '../../helpers/watch.mjs'
+
+test.use({ seed: { settings: { videoPlaybackEngine: 'built-in', ytDlpPlaybackEngineDefaultMigration: true, enableVideoZoom: false, enableMobileFullscreenSwipe: false } } })
+
+async function openMobilePlayer(app, page) {
+  await mockPlayableWatchPage(app, page)
+  const video = await openMockedVideo(page)
+  await video.evaluate(element => element.pause())
+  await setWindowSize(app, page, { width: 480, height: 850 })
+  await page.evaluate(() => {
+    Object.defineProperty(navigator, 'maxTouchPoints', { configurable: true, get: () => 5 })
+    const app = document.querySelector('.app')
+    const mobile = () => { if (!app.classList.contains('capacitorTabs')) app.classList.add('capacitorTabs') }
+    new MutationObserver(mobile).observe(app, { attributeFilter: ['class'] })
+    mobile()
+  })
+  return page.locator('.ftVideoPlayer')
+}
+
+test('Shorts overflow is clipped while dragging into the mini player', async ({ app, page }) => {
+  const player = await openMobilePlayer(app, page)
+  await player.evaluate(element => element.classList.add('shortsPlayer'))
+  await expect(player).toHaveCSS('overflow', 'visible')
+  await player.evaluate(element => element.setAttribute('data-inline-mini-drag', ''))
+  await expect(player).toHaveCSS('overflow', 'clip')
+})
+
+test('disabled fullscreen and zoom gestures allow upward scrolling and downward docking', async ({ app, page }) => {
+  const player = await openMobilePlayer(app, page)
+  const bounds = await player.boundingBox()
+  const cdp = await page.context().newCDPSession(page)
+  const point = { x: bounds.x + bounds.width / 2, y: bounds.y + bounds.height / 2 }
+  try {
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [point] })
+    for (const distance of [16, 32, 48, 64, 80]) {
+      await cdp.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: [{ ...point, y: point.y - distance }] })
+      await page.waitForTimeout(30)
+    }
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] })
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(20)
+    await expect(player).not.toHaveClass(/mobileFullscreenSwiping/)
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'instant' }))
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0)
+    const restored = await player.boundingBox()
+    const start = { x: restored.x + restored.width / 2, y: restored.y + restored.height / 2 }
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [start] })
+    for (const distance of [16, 32, 64, 100]) {
+      await cdp.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: [{ ...start, y: start.y + distance }] })
+      await page.waitForTimeout(30)
+    }
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] })
+    await expect(player).toHaveClass(/scrollMiniPlayer/)
+  } finally {
+    await cdp.detach()
+  }
+})

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -237,6 +237,13 @@
   touch-action: pan-x;
 }
 
+/* Downward drags still dock the player when fullscreen swipes are disabled.
+   Leave upward gestures to page scrolling unless another player gesture owns them. */
+.app.capacitorTabs :deep(.ftVideoPlayer:not(.scrollMiniPlayer, .mobileFullscreenSwipeEnabled, .mobileSideSwipesEnabled, .videoZoomTouchEnabled)),
+.app.capacitorTabs :deep(.ftVideoPlayer:not(.scrollMiniPlayer, .mobileFullscreenSwipeEnabled, .mobileSideSwipesEnabled, .videoZoomTouchEnabled) .ft-quick-playback-rate-bar) {
+  touch-action: pan-x pan-down;
+}
+
 /* Chromium may claim the first finger as a pan before the second finger lands,
    cancelling the pointer stream before the player can recognize a pinch. */
 .app.capacitorTabs :deep(.ftVideoPlayer.videoZoomTouchEnabled) {

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -232,14 +232,14 @@
 /* The player owns vertical touch movement on mobile so a short drag can enter
    or leave fullscreen without fighting page scrolling. The layout class lives
    on this component while the player is inside a child component. */
-.app.capacitorTabs :deep(.ftVideoPlayer:is(.mobileFullscreenSwipeEnabled, .mobileSideSwipesEnabled):not(.scrollMiniPlayer)),
-.app.capacitorTabs :deep(.ftVideoPlayer:is(.mobileFullscreenSwipeEnabled, .mobileSideSwipesEnabled):not(.scrollMiniPlayer) .ft-quick-playback-rate-bar) {
+.app.capacitorTabs :deep(.ftVideoPlayer:not(.scrollMiniPlayer)),
+.app.capacitorTabs :deep(.ftVideoPlayer:not(.scrollMiniPlayer) .ft-quick-playback-rate-bar) {
   touch-action: pan-x;
 }
 
 /* Chromium may claim the first finger as a pan before the second finger lands,
    cancelling the pointer stream before the player can recognize a pinch. */
-.app.capacitorTabs :deep(.ftVideoPlayer.videoZoomTouchEnabled:not(.scrollMiniPlayer)) {
+.app.capacitorTabs :deep(.ftVideoPlayer.videoZoomTouchEnabled) {
   touch-action: none;
 }
 
@@ -811,4 +811,13 @@
     right: var(--vertical-tab-bar-width, 220px);
   }
   /* stylelint-enable liberty/use-logical-spec */
+}
+
+.app.capacitorTabs :deep(.ftVideoPlayer[data-inline-mini-drag]) {
+  z-index: 100;
+}
+
+.app.capacitorTabs :deep(.ftVideoPlayer[data-inline-mini-drag] .shaka-controls-container) {
+  opacity: 0;
+  pointer-events: none;
 }

--- a/src/renderer/components/TabContent/TabWatchContent.vue
+++ b/src/renderer/components/TabContent/TabWatchContent.vue
@@ -1,15 +1,23 @@
 <template>
   <div
-    v-show="isWatchRoute"
-    :inert="!isWatchRoute"
-    :aria-hidden="String(!isWatchRoute)"
+    ref="previewHost"
+    class="watchPreviewHost"
   >
-    <component
-      :is="component"
-      v-if="watchRoute"
-      ref="watchView"
-      class="routerView"
-    />
+    <div
+      v-show="isWatchRoute || previewStyle"
+      ref="watchRoot"
+      :class="{ watchDragPreview: previewStyle }"
+      :style="previewStyle"
+      :inert="!isWatchRoute && !previewActive"
+      :aria-hidden="String(!isWatchRoute)"
+    >
+      <component
+        :is="component"
+        v-if="watchRoute"
+        ref="watchView"
+        class="routerView"
+      />
+    </div>
   </div>
 </template>
 
@@ -29,13 +37,23 @@ const props = defineProps({
 })
 
 const navigation = getTabNavigationService()
+const watchRoot = useTemplateRef('watchRoot')
+const previewHost = useTemplateRef('previewHost')
+const previewActive = ref(false)
+const previewStyle = shallowRef(null)
+let previewNavigation = null
+let previewUsedBack = false
+let previewScroll = null
+let previewOrigin = null
+let previewRestoring = false
 const watchView = useTemplateRef('watchView')
 // Freeze the watch route while browsing, so its route watchers do not reload
 // or tear down the video when the tab moves to another page.
 const watchRoute = shallowRef(null)
 const retained = ref(false)
+const minimized = ref(false)
 const isWatchRoute = computed(() => props.route.path.startsWith('/watch/'))
-const presented = computed(() => props.presented && isWatchRoute.value)
+const presented = computed(() => props.presented && (isWatchRoute.value || previewActive.value))
 const detached = computed(() => retained.value && !isWatchRoute.value)
 const enabled = computed(() => store.getters.getKeepPlayingOnNavigation)
 const component = computed(() => watchRoute.value && resolveRouteComponent(watchRoute.value))
@@ -69,8 +87,8 @@ const unregister = tabLifecycleService.register(props.tabId, {
     if (!isWatchRoute.value) return
     // Android teleports even the scrolling mini player outside this view.
     const player = watchView.value?.$refs.player
-    retained.value = enabled.value && !context.to.path.startsWith('/watch/') &&
-      player?.hasLoaded === true && !player.isPaused()
+    retained.value = Boolean(player) && !context.to.path.startsWith('/watch/') &&
+      (minimized.value || (enabled.value && player.hasLoaded === true && !player.isPaused()))
     if (retained.value) {
       const tab = store.getters.getTabById(props.tabId)
       const entry = tab?.history[tab.historyIndex]
@@ -85,6 +103,7 @@ const unregister = tabLifecycleService.register(props.tabId, {
     if (isWatchRoute.value) {
       if (retained.value && watchTitle) navigation.setTitle(props.tabId, watchTitle, watchTitleOptions)
       retained.value = false
+      minimized.value = false
       await run('activate', context)
     }
   },
@@ -108,8 +127,132 @@ const router = navigation.createRouterFacade(props.tabId)
 const watchRouter = Object.create(router)
 Object.defineProperty(watchRouter, 'currentRoute', { value: computed(() => watchRoute.value) })
 provide(routerKey, watchRouter)
+async function minimize() {
+  minimized.value = true
+  const tab = store.getters.getTabById(props.tabId)
+  const previous = tab?.history[tab.historyIndex - 1]?.route
+  previewUsedBack = Boolean(previous && !previous.path.startsWith('/watch/'))
+  if (previewUsedBack) {
+    await navigation.back(props.tabId)
+  } else {
+    await navigation.push(props.tabId, '/subscriptions')
+  }
+  if (isWatchRoute.value) minimized.value = false
+}
+
+function beginMinimizePreview() {
+  if (previewActive.value) return
+  previewRestoring = false
+  previewScroll = { left: window.scrollX, top: window.scrollY }
+  const bounds = watchRoot.value.getBoundingClientRect()
+  // Use an explicit positioned host: Chromium versions disagree on whether
+  // inline-size query containers establish a fixed-position containing block.
+  const parentBounds = previewHost.value.getBoundingClientRect()
+  previewOrigin = {
+    left: bounds.left - (parentBounds?.left ?? 0),
+    top: bounds.top - (parentBounds?.top ?? 0)
+  }
+  previewStyle.value = {
+    left: `${previewOrigin.left}px`,
+    top: `${previewOrigin.top}px`,
+    width: `${bounds.width}px`,
+    height: `${window.innerHeight - bounds.top}px`
+  }
+  window.addEventListener('scroll', updatePreviewPosition, { passive: true })
+  previewActive.value = true
+  previewNavigation = minimize().catch(error => {
+    console.error('Unable to preview previous page', error)
+  })
+}
+
+function beginRestorePreview() {
+  if (previewActive.value || !detached.value) return false
+  previewRestoring = true
+  previewScroll = { left: window.scrollX, top: window.scrollY }
+  const parentBounds = previewHost.value.getBoundingClientRect()
+  previewOrigin = {
+    left: window.scrollX,
+    top: window.scrollY
+  }
+  previewStyle.value = {
+    left: `${previewOrigin.left}px`,
+    top: `${previewOrigin.top}px`,
+    width: `${parentBounds.width}px`,
+    height: `${window.innerHeight - parentBounds.top - window.scrollY}px`
+  }
+  watchRoot.value.style.opacity = '0'
+  watchRoot.value.firstElementChild.style.opacity = '0'
+  previewActive.value = true
+  window.addEventListener('scroll', updatePreviewPosition, { passive: true })
+  return true
+}
+
+function updatePreviewPosition() {
+  const root = watchRoot.value
+  if (!root || !previewOrigin) return
+  root.style.left = `${previewOrigin.left + window.scrollX - previewScroll.left}px`
+  root.style.top = `${previewOrigin.top + window.scrollY - previewScroll.top}px`
+}
+
+function updateMinimizePreview(progress) {
+  const root = watchRoot.value
+  if (!root) return
+  if (!previewRestoring) {
+    root.style.opacity = String(1 - progress)
+    return
+  }
+  // Cover the previous page first. Watch content only fades in once its
+  // background is opaque, so the two pages never show through each other.
+  const reveal = 1 - progress
+  root.style.opacity = String(Math.max(0, Math.min(1, (reveal - 0.08) / 0.22)))
+  root.firstElementChild.style.opacity = String(Math.max(0, Math.min(1, (reveal - 0.3) / 0.7)))
+}
+
+async function finishMinimizePreview(commit) {
+  if (previewRestoring) {
+    if (commit && !disposed) {
+      await navigation.push(props.tabId, watchRoute.value.fullPath)
+      window.scrollTo({ left: 0, top: 0, behavior: 'instant' })
+    }
+    return
+  }
+  await previewNavigation
+  if (!commit && !isWatchRoute.value && !disposed) {
+    if (previewUsedBack) await navigation.forward(props.tabId)
+    else await navigation.back(props.tabId)
+    window.scrollTo({ ...previewScroll, behavior: 'instant' })
+  }
+}
+
+function clearMinimizePreview() {
+  previewActive.value = false
+  previewNavigation = null
+  previewStyle.value = null
+  watchRoot.value?.style.removeProperty('opacity')
+  watchRoot.value?.firstElementChild.style.removeProperty('opacity')
+  window.removeEventListener('scroll', updatePreviewPosition)
+}
+
+async function dismiss() {
+  if (!detached.value) return
+  await dispose()
+  if (!isWatchRoute.value) {
+    retained.value = false
+    minimized.value = false
+    watchRoute.value = null
+  }
+}
+
 provide(watchNavigationKey, {
+  dismiss,
   detached,
+  minimized,
+  minimize,
+  beginMinimizePreview,
+  beginRestorePreview,
+  updateMinimizePreview,
+  finishMinimizePreview,
+  clearMinimizePreview,
   tabPresented: computed(() => props.presented),
   setTitle: (title, options) => {
     watchTitle = title
@@ -144,7 +287,23 @@ watch(enabled, value => {
 }, { flush: 'sync' })
 
 onBeforeUnmount(() => {
+  window.removeEventListener('scroll', updatePreviewPosition)
   unregister()
   dispose()
 })
 </script>
+
+<style scoped>
+.watchPreviewHost {
+  position: relative;
+}
+
+.watchDragPreview {
+  position: absolute;
+  z-index: 100;
+  pointer-events: none;
+  overflow: clip;
+  background: var(--bg-color);
+  will-change: opacity;
+}
+</style>

--- a/src/renderer/components/TabContent/TabWatchContent.vue
+++ b/src/renderer/components/TabContent/TabWatchContent.vue
@@ -8,7 +8,7 @@
       ref="watchRoot"
       :class="{ watchDragPreview: previewStyle }"
       :style="previewStyle"
-      :inert="!isWatchRoute && !previewActive"
+      :inert="!isWatchRoute"
       :aria-hidden="String(!isWatchRoute)"
     >
       <component

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -4155,6 +4155,15 @@ html[data-reduced-motion='reduce'] .musicVisualizerCanvas {
   pointer-events: none;
 }
 
+.ftVideoPlayer[data-inline-mini-drag] {
+  overflow: clip;
+  isolation: isolate;
+}
+
+.ftVideoPlayer[data-inline-mini-drag] > .player {
+  border-radius: inherit;
+}
+
 .ftVideoPlayer.scrollMiniPlayer {
   box-shadow: 0 8px 28px rgb(0 0 0 / 45%);
   border-radius: calc(10px * var(--ui-roundness));

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -244,7 +244,7 @@ html[data-reduced-motion='reduce'] .musicVisualizerCanvas {
   transition-delay: 0s, 0s;
 }
 
-.ftVideoPlayer.shortsPlayer:not(.scrollMiniPlayer) {
+.ftVideoPlayer.shortsPlayer:not(.scrollMiniPlayer, [data-inline-mini-drag]) {
   /*
     Keep the container from becoming a focus-scroll area and let the seek
     thumb extend below the video. The video itself owns the rounded crop.

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -3734,8 +3734,36 @@ export default defineComponent({
       videoZoomPanReady.value = videoZoomPointerInside && videoZoomPannable.value && event.shiftKey
     }
 
+    // Teleporting the player releases Chromium's pointer capture. Keep the
+    // active stream on window so a fast swipe can finish outside the player.
+    const playerPointerIds = new Set()
+    function trackPlayerPointer(event) {
+      playerPointerIds.add(event.pointerId)
+      window.addEventListener('pointermove', handlePlayerPointerMove, true)
+      window.addEventListener('pointerup', handlePlayerPointerEnd, true)
+      window.addEventListener('pointercancel', handlePlayerPointerEnd, true)
+    }
+    function handlePlayerPointerMove(event) {
+      if (playerPointerIds.has(event.pointerId)) handleVideoZoomPointerMove(event)
+    }
+    function handlePlayerPointerEnd(event) {
+      if (!playerPointerIds.has(event.pointerId)) return
+      playerPointerIds.delete(event.pointerId)
+      if (!playerPointerIds.size) clearPlayerPointers()
+      if (event.type === 'pointercancel') handleVideoZoomPointerCancel(event)
+      else handleVideoZoomPointerUp(event)
+    }
+    function clearPlayerPointers() {
+      playerPointerIds.clear()
+      window.removeEventListener('pointermove', handlePlayerPointerMove, true)
+      window.removeEventListener('pointerup', handlePlayerPointerEnd, true)
+      window.removeEventListener('pointercancel', handlePlayerPointerEnd, true)
+    }
+    onBeforeUnmount(clearPlayerPointers)
+
     /** @param {PointerEvent} event */
     function handleVideoZoomPointerDown(event) {
+      trackPlayerPointer(event)
       if (event.pointerType === 'touch' && !event.isPrimary && temporaryPlaybackRatePointerId !== null) {
         temporaryPlaybackRatePointerCancelled = true
         finishTemporaryPlaybackRateHold(TEMPORARY_PLAYBACK_RATE_POINTER_SOURCE)
@@ -4923,14 +4951,20 @@ export default defineComponent({
         ? store.getters[side === 'left' ? 'getMobileLeftSwipeAction' : 'getMobileRightSwipeAction']
         : 'disabled',
       adjustments: mobileAdjustments,
+      miniPlayerDrag: {
+        begin: restoring => beginScrollMiniPlayerDrag(restoring),
+        move: (x, y) => moveScrollMiniPlayerDrag(x, y),
+        finish: commit => finishScrollMiniPlayerDrag(commit),
+        cancel: () => cancelScrollMiniPlayerDrag(),
+      },
       setFullscreenMetadata,
       setShowUiOnPaused,
       showOverlayControls,
       togglePlayerFullScreen: () => ui?.getControls().toggleFullScreen(),
     })
 
-    function resetMobileAdjustments() {
-      cancelMobileFullscreenGesture()
+    function resetMobileAdjustments(preserveGesture = false) {
+      if (!preserveGesture) cancelMobileFullscreenGesture()
       mobileAdjustments.reset()
     }
 
@@ -6513,6 +6547,11 @@ export default defineComponent({
         : null
     }
     const {
+      scrollMiniPlayerDragStyle,
+      beginScrollMiniPlayerDrag,
+      moveScrollMiniPlayerDrag,
+      finishScrollMiniPlayerDrag,
+      cancelScrollMiniPlayerDrag,
       deactivateScrollMiniPlayer,
       dismissCrossTabMiniPlayer,
       handleFullscreenButtonClick,
@@ -6579,8 +6618,10 @@ export default defineComponent({
       isActiveTab.value && !scrollMiniPlayerActive.value && mobileAdjustmentsVisible.value &&
       isFullscreen.value && store.getters.getMobileFullscreenBrightness)
     watch(mobileFullscreenBrightnessActive, enabled => mobileAdjustments.setFullscreenBrightness(Boolean(enabled)))
-    watch([isActiveTab, scrollMiniPlayerActive, mobileAdjustmentsVisible, () => props.videoId], () => {
-      resetMobileAdjustments()
+    watch([isActiveTab, scrollMiniPlayerActive, mobileAdjustmentsVisible, () => props.videoId], ([active, , visible, videoId], [, , , previousVideoId]) => {
+      // Revealing retained Watch during an upward drag presents this player
+      // again. That transition must not cancel the gesture that caused it.
+      resetMobileAdjustments(Boolean(scrollMiniPlayerDragStyle.value && active && visible && videoId === previousVideoId))
       if (mobileFullscreenBrightnessActive.value) mobileAdjustments.setFullscreenBrightness(true)
     })
     watch(() => [store.getters.getMobileLeftSwipeAction, store.getters.getMobileRightSwipeAction], () => {
@@ -11623,6 +11664,7 @@ export default defineComponent({
       scrollMiniPlayerDismissed,
       scrollMiniPlaceholderHeight,
       scrollMiniPlayerStyle,
+      scrollMiniPlayerDragStyle,
       scrollMiniPlayerStashed,
       scrollMiniPlayerStashedSide,
       scrollMiniIsPaused,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -32,7 +32,7 @@
       aria-hidden="true"
     />
     <div
-      v-if="scrollMiniPlayerActive"
+      v-if="scrollMiniPlayerActive || scrollMiniPlayerDragStyle"
       ref="scrollMiniPlaceholder"
       class="scrollMiniPlaceholder"
       :style="{ height: `${scrollMiniPlaceholderHeight}px` }"
@@ -41,7 +41,7 @@
     <!-- eslint-disable vue/html-indent -->
     <Teleport
       to="#cross-tab-mini-player-layer"
-      :disabled="!scrollMiniPlayerDetached && !(useNativePlayback && scrollMiniPlayerActive)"
+      :disabled="!scrollMiniPlayerDragStyle && !scrollMiniPlayerDetached && !(useNativePlayback && scrollMiniPlayerActive)"
     >
     <!-- Keep controls visibility out of :class: Vue would erase Shaka's
          no-cursor class when the controls time out. -->
@@ -97,6 +97,7 @@
         captionCssVariables,
         captionPlayerVariables,
         scrollMiniPlayerActive ? scrollMiniPlayerStyle : undefined,
+        scrollMiniPlayerDragStyle,
         mobileFullscreenSwipeStyle,
         shortsPlayer ? { '--shorts-aspect-ratio': shortsAspectRatio } : undefined
       ]"
@@ -106,9 +107,6 @@
       @pointerenter="handleVideoZoomPointerEnter"
       @pointerleave="handleVideoZoomPointerLeave"
       @pointerdown.capture="handleVideoZoomPointerDown"
-      @pointermove.capture="handleVideoZoomPointerMove"
-      @pointerup.capture="handleVideoZoomPointerUp"
-      @pointercancel.capture="handleVideoZoomPointerCancel"
       @touchend.capture="handlePlayerTouchEnd"
       @focusin="handlePlayerFocusIn"
       @focusout="handleScrollMiniPlayerLeave"

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useMobileFullscreenGestures.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useMobileFullscreenGestures.js
@@ -16,6 +16,7 @@ export function useMobileFullscreenGestures({
   seekOnDoubleTap,
   getSwipeAction = () => 'disabled',
   adjustments,
+  miniPlayerDrag,
   setFullscreenMetadata,
   setShowUiOnPaused,
   showOverlayControls,
@@ -57,7 +58,7 @@ export function useMobileFullscreenGestures({
   }
 
   function isSwipeControlTarget(target) {
-    return target instanceof Element && target.closest('.shaka-controls-button-panel, .shaka-play-button') !== null
+    return target instanceof Element && target.closest('.shaka-controls-button-panel, .shaka-play-button, .scrollMiniPlayPause, .scrollMiniPointerLayer') !== null
   }
 
   function startMobileFullscreenGesture(event) {
@@ -69,8 +70,7 @@ export function useMobileFullscreenGestures({
       !isCapacitorMobilePlayer() ||
       event.pointerType !== 'touch' ||
       event.button !== 0 ||
-      !event.isPrimary ||
-      isScrollMiniPlayerActive()
+      !event.isPrimary
     ) {
       return
     }
@@ -90,7 +90,8 @@ export function useMobileFullscreenGestures({
       return
     }
 
-    const surfaceTap = isPlayerSurfaceTarget(event.target)
+    const surfaceTap = isPlayerSurfaceTarget(event.target) ||
+      (isScrollMiniPlayerActive() && event.target === getContainer())
     if (!surfaceTap) {
       clearTimeout(mobileSurfaceTapTimer)
       mobileSurfaceTapTimer = null
@@ -103,7 +104,8 @@ export function useMobileFullscreenGestures({
     const bounds = getContainer()?.getBoundingClientRect()
     const relativeX = bounds?.width > 0 ? (event.clientX - bounds.left) / bounds.width : 0.5
     const side = relativeX <= 0.35 ? 'left' : relativeX >= 0.65 ? 'right' : null
-    const action = side ? getSwipeAction(side) : 'disabled'
+    const restoring = isScrollMiniPlayerActive()
+    const action = side && !restoring ? getSwipeAction(side) : 'disabled'
     mobileFullscreenGesture = {
       pointerId: event.pointerId,
       startX: event.clientX,
@@ -111,6 +113,7 @@ export function useMobileFullscreenGestures({
       startTime: performance.now(),
       surfaceTap,
       fullscreen: isFullscreenActive(),
+      restoring,
       distance: 0,
       tapDirection: relativeX <= 0.35 ? -1 : relativeX >= 0.65 ? 1 : 0,
       controlsShownAtStart: getControls()?.getControlsContainer().hasAttribute('shown') === true,
@@ -139,6 +142,20 @@ export function useMobileFullscreenGestures({
       clearTimeout(mobileSurfaceTapTimer)
       mobileSurfaceTapTimer = null
       lastMobileSideTap = null
+    }
+    const dragDistance = deltaY * (mobileFullscreenGesture.restoring ? -1 : 1)
+    if (!mobileFullscreenGesture.fullscreen && mobileFullscreenGesture.action === 'disabled' &&
+      (mobileFullscreenGesture.minimizing || (dragDistance >= 8 && dragDistance > Math.abs(deltaX)))) {
+      if (!mobileFullscreenGesture.minimizing) {
+        if (!miniPlayerDrag?.begin(mobileFullscreenGesture.restoring)) return false
+        mobileFullscreenGesture.minimizing = true
+        getContainer()?.setPointerCapture(event.pointerId)
+      }
+      mobileFullscreenGesture.distance = Math.max(0, dragDistance)
+      miniPlayerDrag.move(deltaX, mobileFullscreenGesture.restoring ? Math.min(0, deltaY) : Math.max(0, deltaY))
+      event.preventDefault()
+      event.stopPropagation()
+      return true
     }
     if (mobileFullscreenGesture.action !== 'disabled') {
       if (!mobileFullscreenGesture.adjusting) {
@@ -223,6 +240,18 @@ export function useMobileFullscreenGestures({
 
     const gesture = mobileFullscreenGesture
     mobileFullscreenGesture = null
+    if (gesture.minimizing) {
+      const container = getContainer()
+      if (container?.hasPointerCapture(event.pointerId)) container.releasePointerCapture(event.pointerId)
+      mobilePlayerSuppressClickUntil = performance.now() + 350
+      mobileSurfaceSuppressTouchEndUntil = performance.now() + 350
+      mobileControlSuppressClickUntil = performance.now() + 350
+      event.preventDefault()
+      event.stopImmediatePropagation()
+      miniPlayerDrag.finish(gesture.distance >= 64)
+      return true
+    }
+    if (gesture.restoring) return false
     if (gesture.adjusting) {
       adjustments.finish()
       const container = getContainer()
@@ -293,6 +322,7 @@ export function useMobileFullscreenGestures({
     mobileSurfaceTapTimer = null
     lastMobileSideTap = null
     const wasActive = mobileFullscreenGesture !== null || mobileFullscreenSwiping.value
+    if (mobileFullscreenGesture?.minimizing) miniPlayerDrag.finish(false)
     if (mobileFullscreenGesture?.adjusting) {
       adjustments.cancel()
       mobilePlayerSuppressClickUntil = performance.now() + 350
@@ -433,6 +463,7 @@ export function useMobileFullscreenGestures({
 
   onUnmounted(() => {
     clearMobileSeekFeedback()
+    miniPlayerDrag?.cancel()
     adjustments?.cancel()
     clearTimeout(mobileFullscreenSettleTimer)
     clearTimeout(mobileSurfaceTapTimer)

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
@@ -71,7 +71,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
   const watchNavigation = inject(watchNavigationKey, null)
   const scrollMiniVideoAspectRatio = ref(DEFAULT_ASPECT_RATIO)
   const scrollMiniPlayerEnabled = computed(() => store.getters.getScrollMiniPlayerEnabled)
-  const scrollMiniPlayerOnAllTabs = computed(() => store.getters.getKeepPlayingOnNavigation || store.getters.getScrollMiniPlayerOnAllTabs)
+  const scrollMiniPlayerOnAllTabs = computed(() => watchNavigation?.minimized?.value || store.getters.getKeepPlayingOnNavigation || store.getters.getScrollMiniPlayerOnAllTabs)
   const autoPictureInPictureOnTabChange = computed(
     () => !store.getters.getKeepPlayingOnNavigation &&
       !(watchNavigation?.detached.value && watchNavigation.tabPresented.value) &&
@@ -99,7 +99,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
   const crossTabMiniPlayerCandidate = {
     canShow: () => canShowCrossTabMiniPlayer(),
     hide: () => deactivateScrollMiniPlayer(),
-    show: () => activateScrollMiniPlayer(false),
+    show: () => { if (!inlineDrag) activateScrollMiniPlayer(false) },
   }
 
   const scrollMiniPlayerStyle = computed(() => scrollMiniPlayerRectToStyle(scrollMiniPlayerRect.value))
@@ -145,6 +145,160 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
   /** @type {number | null} */
   let scrollMiniScrollFrame = null
 
+  // Cache geometry once. Pointer moves only write a compositor transform, at
+  // most once per frame; the native screen observes the same moving bounds.
+  const scrollMiniPlayerDragStyle = ref(null)
+  let inlineDrag = null
+  let inlineDragFrame = null
+
+  function beginScrollMiniPlayerDrag(restoring = false) {
+    const element = container.value
+    if (inlineDrag || !element || !watchNavigation?.beginMinimizePreview ||
+      scrollMiniPlayerActive.value !== restoring || !canUseScrollMiniPlayerBase()) return false
+    if (restoring && !watchNavigation.detached.value) return false
+    cancelScrollMiniPlayerLayoutAnimation()
+    updateScrollMiniVideoAspectRatio()
+    const from = element.getBoundingClientRect()
+    const saved = getSavedScrollMiniPlayerRect('tab')
+    const to = clampScrollMiniPlayerRect(saved
+      ? reanchorScrollMiniPlayerRect(saved, scrollMiniVideoAspectRatio.value)
+      : getDefaultScrollMiniPlayerRect(scrollMiniVideoAspectRatio.value), scrollMiniVideoAspectRatio.value)
+    inlineDrag = { from, to, y: 0, progress: 0, restoring }
+    if (!restoring) scrollMiniPlaceholderHeight.value = from.height
+    scrollMiniPlayerDragStyle.value = {
+      position: 'fixed',
+      left: `${from.left}px`,
+      top: `${from.top}px`,
+      width: `${from.width}px`,
+      height: `${from.height}px`,
+      margin: '0',
+      zIndex: '150'
+    }
+    if (restoring) {
+      if (!watchNavigation.beginRestorePreview()) {
+        inlineDrag = null
+        scrollMiniPlayerDragStyle.value = null
+        return false
+      }
+      const drag = inlineDrag
+      // The retained Watch page becomes measurable after its overlay is shown.
+      drag.ready = nextTick(() => {
+        if (inlineDrag !== drag) return
+        const bounds = scrollMiniPlaceholder.value.getBoundingClientRect()
+        drag.to = { left: bounds.left, top: bounds.top, width: bounds.width, height: bounds.height }
+        renderScrollMiniPlayerDrag()
+      })
+    } else {
+      watchNavigation.beginMinimizePreview()
+    }
+    element.style.transformOrigin = 'top left'
+    element.style.willChange = 'transform'
+    element.setAttribute('data-inline-mini-drag', '')
+    element.dispatchEvent(new CustomEvent('native-player-gesture', { detail: true }))
+    return true
+  }
+
+  function getInlineDragDistance(drag) {
+    return Math.max(1, Math.abs(drag.to.top - drag.from.y))
+  }
+
+  function renderInlineDragProgress(progress) {
+    const { from, to, restoring } = inlineDrag
+    inlineDrag.progress = progress
+    const fade = Math.min(1, progress * getInlineDragDistance(inlineDrag) / 96)
+    watchNavigation.updateMinimizePreview(restoring ? 1 - progress : fade)
+    const x = (to.left - from.x) * progress
+    const y = (to.top - from.y) * progress
+    const scaleX = 1 + (to.width / from.width - 1) * progress
+    const scaleY = 1 + (to.height / from.height - 1) * progress
+    const roundness = Math.min(1, (restoring ? 1 - progress : progress) * 5)
+    const style = container.value.style
+    style.transform = `translate(${x}px, ${y}px) scale(${scaleX}, ${scaleY})`
+    style.borderRadius = `calc(10px * var(--ui-roundness) * ${roundness})`
+  }
+
+  function renderScrollMiniPlayerDrag() {
+    inlineDragFrame = null
+    if (!inlineDrag || inlineDrag.settling) return
+    renderInlineDragProgress(Math.min(1, Math.abs(inlineDrag.y) / getInlineDragDistance(inlineDrag)))
+  }
+
+  function moveScrollMiniPlayerDrag(_x, y) {
+    if (!inlineDrag || inlineDrag.finishing) return
+    inlineDrag.y = y
+    if (inlineDragFrame === null) inlineDragFrame = requestAnimationFrame(renderScrollMiniPlayerDrag)
+  }
+
+  function settleScrollMiniPlayerDrag(commit) {
+    const drag = inlineDrag
+    const target = commit ? 1 : 0
+    if (isReducedMotionEnabled() || drag.progress === target) {
+      renderInlineDragProgress(target)
+      return Promise.resolve()
+    }
+    drag.settling = true
+    const from = drag.progress
+    const started = performance.now()
+    const duration = SCROLL_MINI_LAYOUT_ANIMATION_DURATION_MS / getAnimationSpeedMultiplier(store.getters.getAnimationSpeed)
+    return new Promise(resolve => {
+      drag.resolveSettle = resolve
+      const frame = now => {
+        inlineDragFrame = null
+        if (inlineDrag !== drag) return resolve()
+        const time = Math.max(0, Math.min(1, (now - started) / duration))
+        const progress = 1 - (1 - time) ** 3
+        renderInlineDragProgress(from + (target - from) * progress)
+        if (time === 1) resolve()
+        else inlineDragFrame = requestAnimationFrame(frame)
+      }
+      inlineDragFrame = requestAnimationFrame(frame)
+    })
+  }
+
+  function cancelScrollMiniPlayerDrag() {
+    if (inlineDragFrame !== null) cancelAnimationFrame(inlineDragFrame)
+    inlineDragFrame = null
+    inlineDrag?.resolveSettle?.()
+    inlineDrag = null
+    scrollMiniPlayerDragStyle.value = null
+    watchNavigation?.clearMinimizePreview()
+    if (!scrollMiniPlayerActive.value) scrollMiniPlaceholderHeight.value = 0
+    const element = container.value
+    if (!element) return
+    element.style.removeProperty('transform')
+    element.style.removeProperty('transform-origin')
+    element.style.removeProperty('will-change')
+    element.style.removeProperty('border-radius')
+    element.removeAttribute('data-inline-mini-drag')
+    element.dispatchEvent(new CustomEvent('native-player-gesture', { detail: false }))
+  }
+
+  async function finishScrollMiniPlayerDrag(commit) {
+    if (!inlineDrag || inlineDrag.finishing) return
+    const drag = inlineDrag
+    drag.finishing = true
+    await drag.ready
+    if (inlineDrag !== drag || !container.value) return
+    if (inlineDragFrame !== null) cancelAnimationFrame(inlineDragFrame)
+    renderScrollMiniPlayerDrag()
+    await settleScrollMiniPlayerDrag(commit)
+    if (inlineDrag !== drag || !container.value) return
+    // Navigation and layout changes happen behind the completed preview, after
+    // the video has reached the same endpoint as the normal mini-player motion.
+    await watchNavigation.finishMinimizePreview(commit)
+    if (inlineDrag !== drag || !container.value) return
+    if (drag.restoring && commit) {
+      deactivateScrollMiniPlayer()
+    } else if (commit && watchNavigation.detached.value) {
+      activateScrollMiniPlayer(false)
+      scrollMiniPlayerStashedSide.value = null
+      scrollMiniPlayerRestoreRect = null
+      applyScrollMiniPlayerRect(drag.to, false, true)
+    }
+    cancelScrollMiniPlayerDrag()
+    updateScrollMiniPlayer({ animateActivation: false })
+  }
+
   function updateScrollMiniVideoAspectRatio() {
     const videoElement = video.value
     if (!videoElement?.videoWidth || !videoElement.videoHeight) {
@@ -176,6 +330,9 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
   }
 
   function getScrollMiniPlaceholderLayoutHeight() {
+    // Navigation hides the retained Watch view before it teleports the player.
+    // The drag's original measurement remains valid during that handoff.
+    if (inlineDrag) return Math.max(inlineDrag.from.height, inlineDrag.from.width * 9 / 16)
     return getScrollMiniInlineLayoutHeight(container.value, lastKnownInlinePlayerHeight)
   }
 
@@ -414,7 +571,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
       !autoPictureInPictureOnTabChange.value &&
       scrollMiniPlayerOnAllTabs.value &&
       canUseScrollMiniPlayerBase() &&
-      (isCrossTabMiniPlayerOwner(crossTabMiniPlayerCandidate) || !videoElement.paused)
+      (watchNavigation?.minimized?.value || isCrossTabMiniPlayerOwner(crossTabMiniPlayerCandidate) || !videoElement.paused)
   }
 
   function canUseScrollMiniPlayer() {
@@ -754,6 +911,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
 
   /** @param {{ animateActivation?: boolean }} [options] */
   function updateScrollMiniPlayer({ animateActivation = true } = {}) {
+    if (inlineDrag) return
     if (!isActiveTab.value) {
       refreshCrossTabMiniPlayer(crossTabMiniPlayerCandidate)
     }
@@ -879,6 +1037,10 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
 
     if (scrollMiniPlayerDetached.value && tabId) {
       if (watchNavigation?.detached.value) {
+        if (watchNavigation.tabPresented.value && beginScrollMiniPlayerDrag(true)) {
+          finishScrollMiniPlayerDrag(true)
+          return
+        }
         watchNavigation.returnToVideo()
       }
       if (process.env.IS_CAPACITOR) {
@@ -898,6 +1060,10 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
 
     if (!scrollMiniPlayerDetached.value) return
 
+    if (watchNavigation?.detached.value) {
+      watchNavigation.dismiss()
+      return
+    }
     scrollMiniPlayerDismissed.value = true
   }
 
@@ -1181,7 +1347,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
   })
 
   watch(isActiveTab, (active) => {
-    if (scrollMiniPlayerActive.value) {
+    if (scrollMiniPlayerActive.value && !inlineDrag) {
       // A tab switch can change modes without deactivating the mini player.
       // Cancel unfinished gestures so they cannot overwrite the new mode's position.
       cancelScrollMiniPlayerBounce()
@@ -1233,6 +1399,11 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
   )
 
   return {
+    scrollMiniPlayerDragStyle,
+    beginScrollMiniPlayerDrag,
+    moveScrollMiniPlayerDrag,
+    finishScrollMiniPlayerDrag,
+    cancelScrollMiniPlayerDrag,
     deactivateScrollMiniPlayer,
     dismissCrossTabMiniPlayer,
     handleFullscreenButtonClick,

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
@@ -281,22 +281,27 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     if (inlineDrag !== drag || !container.value) return
     if (inlineDragFrame !== null) cancelAnimationFrame(inlineDragFrame)
     renderScrollMiniPlayerDrag()
-    await settleScrollMiniPlayerDrag(commit)
-    if (inlineDrag !== drag || !container.value) return
-    // Navigation and layout changes happen behind the completed preview, after
-    // the video has reached the same endpoint as the normal mini-player motion.
-    await watchNavigation.finishMinimizePreview(commit)
-    if (inlineDrag !== drag || !container.value) return
-    if (drag.restoring && commit) {
-      deactivateScrollMiniPlayer()
-    } else if (commit && watchNavigation.detached.value) {
-      activateScrollMiniPlayer(false)
-      scrollMiniPlayerStashedSide.value = null
-      scrollMiniPlayerRestoreRect = null
-      applyScrollMiniPlayerRect(drag.to, false, true)
+    try {
+      await settleScrollMiniPlayerDrag(commit)
+      if (inlineDrag !== drag || !container.value) return
+      // Navigation and layout changes happen behind the completed preview, after
+      // the video has reached the same endpoint as the normal mini-player motion.
+      await watchNavigation.finishMinimizePreview(commit)
+      if (inlineDrag !== drag || !container.value) return
+      if (drag.restoring && commit) {
+        deactivateScrollMiniPlayer()
+      } else if (commit && watchNavigation.detached.value) {
+        activateScrollMiniPlayer(false)
+        scrollMiniPlayerStashedSide.value = null
+        scrollMiniPlayerRestoreRect = null
+        applyScrollMiniPlayerRect(drag.to, false, true)
+      }
+    } finally {
+      if (inlineDrag === drag) {
+        cancelScrollMiniPlayerDrag()
+        updateScrollMiniPlayer({ animateActivation: false })
+      }
     }
-    cancelScrollMiniPlayerDrag()
-    updateScrollMiniPlayer({ animateActivation: false })
   }
 
   function updateScrollMiniVideoAspectRatio() {
@@ -1323,6 +1328,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     cancelScrollMiniPlayerBounce()
     cancelScrollMiniPlayerLayoutAnimation()
     cancelPendingScrollMiniScrollFrame()
+    cancelScrollMiniPlayerDrag()
 
     endScrollMiniPointerSession()
     clearScrollMiniVolumeHideTimeout()

--- a/src/renderer/helpers/player/androidNativeScreen.js
+++ b/src/renderer/helpers/player/androidNativeScreen.js
@@ -43,7 +43,7 @@ export function createAndroidNativeScreen({ element, container, getController, g
       endTransition()
       return
     }
-    if (!attached || open || hasVideoCanvas?.()) return
+    if (!attached || open || hasVideoCanvas?.() || container.querySelector('.countdownPoster')) return
     event.preventDefault()
     endGesture()
     const sequence = ++transitionSequence
@@ -57,8 +57,11 @@ export function createAndroidNativeScreen({ element, container, getController, g
     // destination, ready for the handoff once its final clip has been drawn.
     syncInlineBackground(false)
     const rect = ({ x, y, width, height }) => ({ x, y, width, height })
+    const pageScroll = followsPageScroll()
     event.detail.finished = getController().layout({
       ...rect(to),
+      y: to.y + (pageScroll ? window.scrollY : 0),
+      pageScroll,
       viewportWidth: window.innerWidth,
       transition: { from: rect(from), duration, radius: parseFloat(getComputedStyle(container).borderTopLeftRadius) || 0 }
     }).catch(onError).finally(() => {
@@ -70,7 +73,7 @@ export function createAndroidNativeScreen({ element, container, getController, g
   function handleGesture(event) {
     if (!attached || open || hasVideoCanvas?.()) return
     gestureActive = event.detail === true
-    container.toggleAttribute('data-native-player-gesture', gestureActive)
+    container.toggleAttribute('data-native-player-gesture', gestureActive && !container.querySelector('.countdownPoster'))
     // Pointer handlers update Vue geometry in the same turn. Send the final
     // rectangle and reopen the cutout together after that update has rendered.
     scheduleLayout()
@@ -112,7 +115,7 @@ export function createAndroidNativeScreen({ element, container, getController, g
   }
 
   function followsPageScroll() {
-    return !open && !container.classList.contains('scrollMiniPlayer') && !container.classList.contains('fullWindow')
+    return !open && !gestureActive && !container.classList.contains('scrollMiniPlayer') && !container.classList.contains('fullWindow')
   }
 
   function syncInlineBackground(visible) {
@@ -216,6 +219,9 @@ export function createAndroidNativeScreen({ element, container, getController, g
   function syncLayout() {
     frame = null
     if ((!open && !attached) || transitioning) return
+    const poster = Boolean(container.querySelector('.countdownPoster'))
+    const nativeGesture = gestureActive && !poster
+    container.toggleAttribute('data-native-player-gesture', nativeGesture)
     const bounds = element.getBoundingClientRect()
     const sharedControls = container.querySelector('.shaka-controls-container')
     const controlBounds = sharedControls?.getBoundingClientRect() ?? bounds
@@ -258,15 +264,15 @@ export function createAndroidNativeScreen({ element, container, getController, g
       height: bounds.height,
       viewportWidth: window.innerWidth,
       pageScroll,
-      miniPlayer: container.classList.contains('scrollMiniPlayer'),
-      gestureActive,
+      miniPlayer: !poster && (nativeGesture || container.classList.contains('scrollMiniPlayer')),
+      gestureActive: nativeGesture,
       radius: parseFloat(getComputedStyle(container).borderTopLeftRadius) || 0,
       controlsX: controlBounds.x,
       controlsY: nativeY(controlBounds.y),
       controlsWidth: controlBounds.width,
       controlsHeight: controlBounds.height,
       videoVisible: visible,
-      controlsVisible: visible && controlBounds.width > 0 && controlBounds.height > 0 &&
+      controlsVisible: visible && !gestureActive && controlBounds.width > 0 && controlBounds.height > 0 &&
         !container.querySelector('.endedPoster') &&
         !container.classList.contains('scrollMiniPlayer') && sharedControls?.hasAttribute('shown') === true,
       // Android clips and routes touches around these rectangles. A browser

--- a/tests/unit/android-native-screen.test.mjs
+++ b/tests/unit/android-native-screen.test.mjs
@@ -393,6 +393,7 @@ test('loading poster stays above an empty native surface throughout a drag', asy
   f.container.dispatchEvent(gesture)
   await f.flush()
   assert.equal(f.layouts.at(-1).gestureActive, false)
+  assert.equal(f.layouts.at(-1).controlsVisible, false, 'Loading controls stay hidden while their poster is dragged')
   assert.equal(f.layouts.at(-1).miniPlayer, false)
   assert.equal(f.layouts.at(-1).videoVisible, true, 'Keep rendering below the poster so the first frame can arrive')
   f.change({ loadingPoster: false })

--- a/tests/unit/android-native-screen.test.mjs
+++ b/tests/unit/android-native-screen.test.mjs
@@ -22,6 +22,7 @@ async function fixture({ fullscreen = true, chrome = [], dialogs = [], deferTran
   let panel = false
   let recommendations = false
   let ended = false
+  let poster = false
   let animating = false
   let id = 0
   const bounds = { x: 0, y: 0, width: 640, height: 360 }
@@ -34,6 +35,7 @@ async function fixture({ fullscreen = true, chrome = [], dialogs = [], deferTran
     getAnimations: () => animating ? [{ playState: 'running' }] : [],
     querySelectorAll(selector) { return menu && selector.includes('shaka-overflow-menu') ? [{ getAnimations: () => [], getBoundingClientRect: () => ({ x: 400, y: 100, width: 200, height: 240 }) }] : [] },
     querySelector(selector) {
+      if (selector === '.countdownPoster' && poster) return {}
       if (selector === '.shaka-controls-container') return controlsElement
       if (selector === '.endedPoster' && (ended || recommendations)) return { getBoundingClientRect: () => bounds }
       if (selector === '.endedScreen' && recommendations) return { getBoundingClientRect: () => bounds }
@@ -73,7 +75,8 @@ async function fixture({ fullscreen = true, chrome = [], dialogs = [], deferTran
   if (fullscreen) await screen.show()
   else await screen.attach()
   await flush()
-  return { screen, container, layouts, presentations, completeTransitions, completeFullscreen, fullscreenEvents, bounds, observers, window, styleWrites, flush, change({ visible = shown, menuOpen = menu, panelOpen = panel, containerAnimating = animating, endedRecommendations = recommendations, playbackEnded = ended }) {
+  return { screen, container, layouts, presentations, completeTransitions, completeFullscreen, fullscreenEvents, bounds, observers, window, styleWrites, flush, change({ visible = shown, menuOpen = menu, panelOpen = panel, containerAnimating = animating, endedRecommendations = recommendations, playbackEnded = ended, loadingPoster = poster }) {
+    poster = loadingPoster
     shown = visible; menu = menuOpen; panel = panelOpen
     recommendations = endedRecommendations
     ended = playbackEnded
@@ -119,6 +122,9 @@ test('live dragging and resizing keeps the page cutout fixed and restores its fi
   gesture(true)
   await f.flush()
   assert.equal(f.layouts.at(-1).gestureActive, true)
+  assert.equal(f.layouts.at(-1).miniPlayer, true, 'Inline drags must raise the native texture too')
+  assert.equal(f.layouts.at(-1).pageScroll, false, 'Drag bounds use viewport coordinates')
+  assert.equal(f.layouts.at(-1).controlsVisible, false)
   f.styleWrites.length = 0
   for (let i = 0; i < 20; i++) {
     f.bounds.width += 0.125
@@ -378,3 +384,43 @@ for (const fullscreen of [false, true]) {
   })
 
 }
+
+test('loading poster stays above an empty native surface throughout a drag', async () => {
+  const f = await fixture({ fullscreen: false })
+  f.change({ loadingPoster: true })
+  const gesture = new Event('native-player-gesture')
+  gesture.detail = true
+  f.container.dispatchEvent(gesture)
+  await f.flush()
+  assert.equal(f.layouts.at(-1).gestureActive, false)
+  assert.equal(f.layouts.at(-1).miniPlayer, false)
+  assert.equal(f.layouts.at(-1).videoVisible, true, 'Keep rendering below the poster so the first frame can arrive')
+  f.change({ loadingPoster: false })
+  await f.flush()
+  assert.equal(f.layouts.at(-1).gestureActive, true)
+  assert.equal(f.layouts.at(-1).videoVisible, true)
+  f.screen.destroy()
+})
+
+test('returning to a scrolling page sends a document-relative animation destination', async () => {
+  const f = await fixture({ fullscreen: false })
+  f.window.scrollY = 271.0857
+  const event = new Event('native-player-transition', { cancelable: true })
+  event.detail = { from: { x: 205, y: 723, width: 240, height: 135 }, to: { x: 0, y: 111 - f.window.scrollY, width: 460.8, height: 259.2 }, duration: 300 }
+  f.container.dispatchEvent(event)
+  await event.detail.finished
+  const motion = f.layouts.find(layout => layout.transition)
+  assert.equal(motion.pageScroll, true)
+  assert.ok(Math.abs(motion.y - 111) < 0.001)
+  f.screen.destroy()
+})
+
+test('loading poster uses the browser animation instead of raising an empty texture', async () => {
+  const f = await fixture({ fullscreen: false })
+  f.change({ loadingPoster: true })
+  const motion = new Event('native-player-transition', { cancelable: true })
+  motion.detail = { from: f.bounds, to: { ...f.bounds, x: 100 }, duration: 300 }
+  f.container.dispatchEvent(motion)
+  assert.equal(motion.defaultPrevented, false)
+  f.screen.destroy()
+})

--- a/tests/unit/inline-mini-player-drag.test.mjs
+++ b/tests/unit/inline-mini-player-drag.test.mjs
@@ -7,7 +7,7 @@ import { getScrollMiniInlineLayoutHeight } from '../../src/renderer/helpers/scro
 const source = readFileSync(new URL('../../src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js', import.meta.url), 'utf8')
 const dragSource = source.slice(source.indexOf('  let inlineDrag ='), source.indexOf('  function updateScrollMiniVideoAspectRatio'))
 
-function fixture({ reducedMotion = false, available = true, restoring = false } = {}) {
+function fixture({ reducedMotion = false, available = true, restoring = false, finishRejects = false } = {}) {
   let reads = 0
   let navigations = 0
   let previewProgress = 0
@@ -40,7 +40,10 @@ function fixture({ reducedMotion = false, available = true, restoring = false } 
       beginMinimizePreview() { navigations++ },
       beginRestorePreview() { return true },
       updateMinimizePreview(progress) { previewProgress = progress },
-      async finishMinimizePreview(commit) { if (!commit) navigations-- },
+      async finishMinimizePreview(commit) {
+        if (finishRejects) throw new Error('handoff failed')
+        if (!commit) navigations--
+      },
       clearMinimizePreview() {},
     },
     nextTick: async callback => callback(),
@@ -116,6 +119,17 @@ test('committing minimizes once and reduced motion skips the release animation',
   assert.equal(f.destination().left, 172.25)
   assert.equal(f.animations.length, 0)
   assert.equal(f.style.transform, undefined)
+})
+
+test('failed preview handoff still clears inline drag state', async () => {
+  const f = fixture({ reducedMotion: true, finishRejects: true })
+  f.methods.beginScrollMiniPlayerDrag()
+  f.methods.moveScrollMiniPlayerDrag(0, 200)
+  await assert.rejects(f.methods.finishScrollMiniPlayerDrag(true), /handoff failed/)
+  assert.equal(f.style.transform, undefined)
+  assert.equal(f.style.willChange, undefined)
+  assert.equal(f.events.at(-1), false)
+  assert.equal(f.methods.beginScrollMiniPlayerDrag(), true)
 })
 
 test('unavailable playback does not capture a drag', () => {

--- a/tests/unit/inline-mini-player-drag.test.mjs
+++ b/tests/unit/inline-mini-player-drag.test.mjs
@@ -1,0 +1,246 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+import { getScrollMiniInlineLayoutHeight } from '../../src/renderer/helpers/scrollMiniPlayer.js'
+
+const source = readFileSync(new URL('../../src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js', import.meta.url), 'utf8')
+const dragSource = source.slice(source.indexOf('  let inlineDrag ='), source.indexOf('  function updateScrollMiniVideoAspectRatio'))
+
+function fixture({ reducedMotion = false, available = true, restoring = false } = {}) {
+  let reads = 0
+  let navigations = 0
+  let previewProgress = 0
+  let activated = false
+  let deactivated = false
+  const stash = { value: 'left' }
+  let destination = null
+  const frames = new Map()
+  const animations = []
+  const events = []
+  const style = { removeProperty(key) { delete this[key.replace(/-([a-z])/g, (_, c) => c.toUpperCase())] } }
+  const from = restoring
+    ? { x: 172.25, y: 570.75, width: 210.5, height: 118.40625 }
+    : { x: 10.25, y: 80.5, width: 390.5, height: 219.65625 }
+  const to = { left: 172.25, top: 570.75, width: 210.5, height: 118.40625 }
+  const container = { value: {
+    style, offsetHeight: 219.65625,
+    setAttribute() {}, removeAttribute() {},
+    getBoundingClientRect() { reads++; return from },
+    dispatchEvent(event) { events.push(event.detail) },
+  } }
+  const methods = vm.runInNewContext(`${dragSource}\n({ beginScrollMiniPlayerDrag, moveScrollMiniPlayerDrag, finishScrollMiniPlayerDrag, cancelScrollMiniPlayerDrag })`, {
+    container,
+    performance: { now: () => 0 },
+    SCROLL_MINI_LAYOUT_ANIMATION_DURATION_MS: 300,
+    getAnimationSpeedMultiplier: () => 1,
+    store: { getters: { getAnimationSpeed: 1 } },
+    watchNavigation: {
+      detached: { value: true }, minimize() {},
+      beginMinimizePreview() { navigations++ },
+      beginRestorePreview() { return true },
+      updateMinimizePreview(progress) { previewProgress = progress },
+      async finishMinimizePreview(commit) { if (!commit) navigations-- },
+      clearMinimizePreview() {},
+    },
+    nextTick: async callback => callback(),
+    scrollMiniPlaceholder: { value: { getBoundingClientRect: () => ({ left: 0, top: 80, width: 390, height: 219.375 }) } },
+    scrollMiniPlaceholderHeight: { value: 0 },
+    scrollMiniPlayerDragStyle: { value: null },
+    scrollMiniPlayerActive: { value: restoring },
+    scrollMiniVideoAspectRatio: { value: 16 / 9 },
+    canUseScrollMiniPlayerBase: () => available,
+    cancelScrollMiniPlayerLayoutAnimation() {},
+    updateScrollMiniVideoAspectRatio() {},
+    clampScrollMiniPlayerRect: rect => rect,
+    scrollMiniPlayerStashedSide: stash,
+    scrollMiniPlayerRestoreRect: null,
+    applyScrollMiniPlayerRect(rect) { destination = rect },
+    getSavedScrollMiniPlayerRect: () => to,
+    reanchorScrollMiniPlayerRect: rect => rect,
+    requestAnimationFrame(callback) { frames.set(1, callback); return 1 },
+    cancelAnimationFrame(id) { frames.delete(id) },
+    CustomEvent: class { constructor(name, { detail }) { this.detail = detail } },
+    activateScrollMiniPlayer() { activated = true },
+    deactivateScrollMiniPlayer() { deactivated = true },
+    updateScrollMiniPlayer() {},
+    isReducedMotionEnabled: () => reducedMotion,
+    scrollMiniPlayerAnimating: { value: false },
+    scrollMiniLayoutAnimationSequence: 0,
+    animateScrollMiniPlayerLayout: (...args) => { animations.push(args) },
+    console,
+  })
+  return { methods, style, frames, events, animations, stash, progress: () => previewProgress, destination: () => destination, reads: () => reads, navigations: () => navigations, activated: () => activated, deactivated: () => deactivated }
+}
+
+test('drag batches pointer samples into one transform without reading layout per move', () => {
+  const f = fixture()
+  assert.equal(f.methods.beginScrollMiniPlayerDrag(), true)
+  for (let y = 1; y <= 100; y++) f.methods.moveScrollMiniPlayerDrag(12.5, y)
+  assert.equal(f.frames.size, 1)
+  assert.equal(f.reads(), 1)
+  f.frames.get(1)()
+  assert.match(f.style.transform, /^translate\([\d.]+px, [\d.]+px\) scale\(0\.\d+, 0\.\d+\)$/)
+  assert.equal(f.reads(), 1)
+  assert.equal(f.progress(), 1)
+  assert.equal(f.events[0], true)
+})
+
+test('cancellation removes pending frames and restores the original player without navigation', async () => {
+  const f = fixture()
+  f.methods.beginScrollMiniPlayerDrag()
+  f.methods.moveScrollMiniPlayerDrag(0, 30)
+  const finished = f.methods.finishScrollMiniPlayerDrag(false)
+  await Promise.resolve()
+  const frame = f.frames.get(1)
+  f.frames.delete(1)
+  frame(300)
+  await finished
+  assert.equal(f.frames.size, 0)
+  assert.equal(f.style.transform, undefined)
+  assert.equal(f.style.willChange, undefined)
+  assert.equal(f.navigations(), 0)
+  assert.equal(f.events.at(-1), false)
+  assert.equal(f.animations.length, 0)
+})
+
+test('committing minimizes once and reduced motion skips the release animation', async () => {
+  const f = fixture({ reducedMotion: true })
+  f.methods.beginScrollMiniPlayerDrag()
+  f.methods.moveScrollMiniPlayerDrag(0, 200)
+  await f.methods.finishScrollMiniPlayerDrag(true)
+  await f.methods.finishScrollMiniPlayerDrag(true)
+  assert.equal(f.navigations(), 1)
+  assert.equal(f.activated(), true)
+  assert.equal(f.stash.value, null)
+  assert.equal(f.destination().left, 172.25)
+  assert.equal(f.animations.length, 0)
+  assert.equal(f.style.transform, undefined)
+})
+
+test('unavailable playback does not capture a drag', () => {
+  const f = fixture({ available: false })
+  assert.equal(f.methods.beginScrollMiniPlayerDrag(), false)
+  assert.equal(f.reads(), 0)
+  assert.equal(f.events.length, 0)
+})
+
+test('navigation can hide the watch view without losing the drag handoff dimensions', () => {
+  const measure = source.match(/function getScrollMiniPlaceholderLayoutHeight\(\) \{[\s\S]*?\n  \}/)[0]
+  const height = vm.runInNewContext(`(${measure})()`, {
+    inlineDrag: { from: { width: 412.19049, height: 231.857147 } },
+    container: { value: { offsetWidth: 0, offsetHeight: 0 } },
+    lastKnownInlinePlayerHeight: 232,
+    getScrollMiniInlineLayoutHeight,
+  })
+  assert.ok(height > 231 && height < 233)
+})
+
+
+test('Watch starts fading immediately, independently of the mini-player destination', () => {
+  const f = fixture()
+  f.methods.beginScrollMiniPlayerDrag()
+  f.methods.moveScrollMiniPlayerDrag(0, 24)
+  f.frames.get(1)()
+  assert.equal(f.progress(), 0.25)
+})
+
+
+for (const commit of [true, false]) {
+  test(`upward drag expands toward Watch and ${commit ? 'restores' : 'keeps'} the mini player`, async () => {
+    const f = fixture({ restoring: true, reducedMotion: true })
+    assert.equal(f.methods.beginScrollMiniPlayerDrag(true), true)
+    f.methods.moveScrollMiniPlayerDrag(0, -24)
+    f.frames.get(1)()
+    assert.equal(f.progress(), 1 - 24 / 490.75)
+    await f.methods.finishScrollMiniPlayerDrag(commit)
+    assert.equal(f.deactivated(), commit)
+    assert.equal(f.style.transform, undefined)
+    assert.equal(f.events.at(-1), false)
+  })
+}
+
+test('drag follows the same fixed path regardless of sideways finger movement', () => {
+  const f = fixture()
+  f.methods.beginScrollMiniPlayerDrag()
+  f.methods.moveScrollMiniPlayerDrag(0, 100)
+  f.frames.get(1)()
+  const path = f.style.transform
+  f.methods.moveScrollMiniPlayerDrag(95, 100)
+  f.frames.get(1)()
+  assert.equal(f.style.transform, path)
+})
+
+test('drag cannot overshoot the saved mini-player endpoint', () => {
+  const f = fixture()
+  f.methods.beginScrollMiniPlayerDrag()
+  f.methods.moveScrollMiniPlayerDrag(0, 1000)
+  f.frames.get(1)()
+  const endpoint = f.style.transform
+  f.methods.moveScrollMiniPlayerDrag(0, 1500)
+  f.frames.get(1)()
+  assert.equal(f.style.transform, endpoint)
+})
+
+test('return keeps the preview in place until the player reaches the inline endpoint', async () => {
+  const f = fixture({ restoring: true })
+  f.methods.beginScrollMiniPlayerDrag(true)
+  f.methods.moveScrollMiniPlayerDrag(0, -24)
+  const finished = f.methods.finishScrollMiniPlayerDrag(true)
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(f.deactivated(), false)
+  const before = f.style.transform
+  let frame = f.frames.get(1)
+  f.frames.delete(1)
+  frame(-1)
+  assert.equal(f.style.transform, before, 'A frame timestamp before pointerup cannot move backward')
+  frame = f.frames.get(1)
+  f.frames.delete(1)
+  frame(150)
+  assert.equal(f.deactivated(), false)
+  frame = f.frames.get(1)
+  f.frames.delete(1)
+  frame(300)
+  await finished
+  assert.equal(f.deactivated(), true)
+  assert.equal(f.style.transform, undefined)
+  assert.equal(f.style.borderRadius, undefined)
+})
+
+test('vertical player displacement matches the finger before reaching its endpoint', () => {
+  const f = fixture()
+  f.methods.beginScrollMiniPlayerDrag()
+  f.methods.moveScrollMiniPlayerDrag(80, 100)
+  f.frames.get(1)()
+  const y = Number(f.style.transform.match(/translate\([^,]+, ([\d.]+)px/)[1])
+  assert.ok(Math.abs(y - 100) < 0.001, `Player moved ${y}px for a 100px swipe`)
+})
+
+test('return button uses the same preview and continuous path as an upward swipe', () => {
+  const returnSource = source.slice(source.indexOf('  function scrollMiniScrollToTop('), source.indexOf('  function dismissCrossTabMiniPlayer('))
+  const calls = []
+  vm.runInNewContext(`${returnSource}\nscrollMiniScrollToTop()`, {
+    scrollMiniPlayerDetached: { value: true }, tabId: 'tab',
+    watchNavigation: { detached: { value: true }, tabPresented: { value: true }, returnToVideo: () => calls.push('navigate') },
+    beginScrollMiniPlayerDrag: restoring => { calls.push(['begin', restoring]); return true },
+    finishScrollMiniPlayerDrag: commit => calls.push(['finish', commit]),
+    process: { env: { IS_CAPACITOR: true } },
+    getCapacitorTabService: () => ({ activateTab: () => calls.push('activate') })
+  })
+  assert.equal(JSON.stringify(calls), JSON.stringify([['begin', true], ['finish', true]]))
+})
+
+for (const navigatedAway of [false, true]) {
+  test(`close ${navigatedAway ? 'disposes a retained page' : 'only hides a player from another tab'}`, () => {
+    const handler = source.slice(source.indexOf('  function dismissCrossTabMiniPlayer('), source.indexOf('  function scrollMiniTogglePlayPause('))
+    const dismissed = { value: false }
+    let disposals = 0
+    vm.runInNewContext(`${handler}\ndismissCrossTabMiniPlayer()`, {
+      scrollMiniPlayerDetached: { value: true },
+      scrollMiniPlayerDismissed: dismissed,
+      watchNavigation: { detached: { value: navigatedAway }, dismiss: () => { disposals++ } }
+    })
+    assert.equal(disposals, navigatedAway ? 1 : 0)
+    assert.equal(dismissed.value, !navigatedAway)
+  })
+}

--- a/tests/unit/mobile-player-adjustment-lifecycle.test.mjs
+++ b/tests/unit/mobile-player-adjustment-lifecycle.test.mjs
@@ -34,7 +34,7 @@ test('fullscreen brightness follows Android visibility when Chromium remains vis
   scope.run(() => vm.runInNewContext(lifecycle, {
     ref, computed, watch, document, isAppHidden,
     process: { env: { IS_CAPACITOR: true } },
-    isActiveTab: ref(true), scrollMiniPlayerActive: ref(false), isFullscreen,
+    isActiveTab: ref(true), scrollMiniPlayerActive: ref(false), scrollMiniPlayerDragStyle: ref(null), isFullscreen,
     props: { videoId: 'test' },
     store: { getters: { getMobileFullscreenBrightness: true } },
     mobileAdjustments,

--- a/tests/unit/mobile-player-gestures.test.mjs
+++ b/tests/unit/mobile-player-gestures.test.mjs
@@ -309,3 +309,15 @@ test('upward swipe also starts on the mini-player transparent touch layer', t =>
   g.finishMobileFullscreenGesture(event(210, 300, { target }))
   assert.deepEqual(calls.at(-1), ['drag-finish', true])
 })
+
+test('a rejected scroll-mini-player restore never enters fullscreen or retains capture', t => {
+  const { gestures: g, event, calls, captures } = fixture(t, { mini: true, minimize: false })
+  g.startMobileFullscreenGesture(event(210, 300))
+  for (const y of [288, 260, 180]) {
+    assert.equal(g.moveMobileFullscreenGesture(event(210, y)), false)
+    assert.equal(g.mobileFullscreenSwiping.value, false)
+  }
+  assert.equal(g.finishMobileFullscreenGesture(event(210, 180)), false)
+  assert.equal(calls.includes('fullscreen'), false)
+  assert.equal(captures.size, 0)
+})

--- a/tests/unit/mobile-player-gestures.test.mjs
+++ b/tests/unit/mobile-player-gestures.test.mjs
@@ -12,7 +12,7 @@ class ElementStub {
   closest(selectors) { return this.selector && selectors.includes(this.selector) ? this : null }
 }
 
-function fixture(t, { left = 'brightness', right = 'volume', fullscreenSwipe = true, mobile = true, mini = false, height = 200.5, nativeReplay = false } = {}) {
+function fixture(t, { left = 'brightness', right = 'volume', fullscreenSwipe = true, mobile = true, mini = false, height = 200.5, nativeReplay = false, minimize = false } = {}) {
   t.mock.method(globalThis, 'setTimeout', setTimeout)
   const previous = { document: globalThis.document, window: globalThis.window, Element: globalThis.Element }
   globalThis.Element = ElementStub
@@ -46,6 +46,12 @@ function fixture(t, { left = 'brightness', right = 'volume', fullscreenSwipe = t
           : target => target === surface,
         isScrollMiniPlayerActive: () => mini,
         getSwipeAction: side => side === 'left' ? left : right,
+        miniPlayerDrag: {
+          begin: () => { if (minimize) calls.push('drag-begin'); return minimize },
+          move: (x, y) => calls.push(['drag-move', x, y]),
+          finish: commit => calls.push(['drag-finish', commit]),
+          cancel() {},
+        },
         adjustments: {
           begin: action => calls.push(['begin', action]),
           update: delta => calls.push(['update', delta]),
@@ -189,3 +195,117 @@ for (const [placement, x] of [['toolbar', 50], ['center', 210]]) {
     assert.deepEqual(calls, [])
   })
 }
+
+for (const fullscreenSwipe of [true, false]) {
+  test(`center drag minimizes independently of fullscreen swipe setting (${fullscreenSwipe})`, t => {
+    const { gestures: g, event, calls, captures } = fixture(t, { minimize: true, fullscreenSwipe })
+    g.startMobileFullscreenGesture(event(210, 150))
+    assert.equal(g.moveMobileFullscreenGesture(event(212, 190)), true)
+    assert.equal(g.moveMobileFullscreenGesture(event(214, 260)), true)
+    assert.equal(g.finishMobileFullscreenGesture(event(214, 260)), true)
+    assert.deepEqual(calls, ['drag-begin', ['drag-move', 2, 40], ['drag-move', 4, 110], ['drag-finish', true]])
+    assert.equal(captures.size, 0)
+    const click = event(214, 260)
+    g.handleMobilePlayerSurfaceClick(click)
+    assert.equal(calls.includes('show'), false)
+    assert.equal(calls.includes('fullscreen'), false)
+  })
+}
+
+test('short or reversed center drag returns to the inline player', t => {
+  const { gestures: g, event, calls } = fixture(t, { minimize: true })
+  g.startMobileFullscreenGesture(event(210, 150))
+  g.moveMobileFullscreenGesture(event(210, 250))
+  g.moveMobileFullscreenGesture(event(210, 170))
+  g.finishMobileFullscreenGesture(event(210, 170))
+  assert.deepEqual(calls.at(-1), ['drag-finish', false])
+})
+
+for (const secondFinger of [false, true]) {
+  test(`canceling minimization restores the inline player (${secondFinger ? 'second finger' : 'pointer cancel'})`, t => {
+    const { gestures: g, event, calls, captures } = fixture(t, { minimize: true })
+    g.startMobileFullscreenGesture(event(210, 150))
+    g.moveMobileFullscreenGesture(event(210, 250))
+    if (secondFinger) g.startMobileFullscreenGesture(event(220, 200, { pointerId: 2, isPrimary: false }))
+    else g.cancelMobileFullscreenGesture(event())
+    assert.deepEqual(calls.at(-1), ['drag-finish', false])
+    assert.equal(captures.size, 0)
+    g.finishMobileFullscreenGesture(event(210, 250))
+    assert.equal(calls.filter(call => Array.isArray(call) && call[0] === 'drag-finish').length, 1)
+  })
+}
+
+test('side adjustments retain priority over minimization', t => {
+  const { gestures: g, event, calls } = fixture(t, { minimize: true })
+  g.startMobileFullscreenGesture(event(50, 150))
+  g.moveMobileFullscreenGesture(event(50, 250))
+  g.finishMobileFullscreenGesture(event(50, 250))
+  assert.equal(calls.includes('drag-begin'), false)
+  assert.deepEqual(calls[0], ['begin', 'brightness'])
+})
+
+
+for (const distance of [24, 120]) {
+  test(`upward mini-player swipe ${distance}px restores or cancels`, t => {
+    const { gestures: g, event, calls } = fixture(t, { mini: true, minimize: true })
+    g.startMobileFullscreenGesture(event(210, 400))
+    assert.equal(g.moveMobileFullscreenGesture(event(210, 400 - distance)), true)
+    assert.equal(g.finishMobileFullscreenGesture(event(210, 400 - distance)), true)
+    assert.deepEqual(calls, ['drag-begin', ['drag-move', 0, -distance], ['drag-finish', distance >= 64]])
+  })
+}
+
+test('a teleported player receives release outside its DOM and removes window listeners', () => {
+  const start = playerSource.indexOf('    const playerPointerIds =')
+  const end = playerSource.indexOf('    onBeforeUnmount(clearPlayerPointers)', start)
+  const handlers = new Map()
+  const calls = []
+  const track = vm.runInNewContext(`${playerSource.slice(start, end)}; trackPlayerPointer`, {
+    window: {
+      addEventListener: (type, handler) => handlers.set(type, handler),
+      removeEventListener: type => handlers.delete(type),
+    },
+    handleVideoZoomPointerMove: e => calls.push(['move', e.pointerId]),
+    handleVideoZoomPointerUp: e => calls.push(['up', e.pointerId]),
+    handleVideoZoomPointerCancel: e => calls.push(['cancel', e.pointerId]),
+  })
+  track({ pointerId: 7 })
+  handlers.get('pointermove')({ pointerId: 8 })
+  handlers.get('pointermove')({ pointerId: 7, target: {} })
+  handlers.get('pointerup')({ pointerId: 7, target: {}, type: 'pointerup' })
+  assert.deepEqual(calls, [['move', 7], ['up', 7]])
+  assert.equal(handlers.size, 0)
+  track({ pointerId: 9 })
+  handlers.get('pointercancel')({ pointerId: 9, type: 'pointercancel' })
+  assert.deepEqual(calls.at(-1), ['cancel', 9])
+  assert.equal(handlers.size, 0)
+})
+
+test('revealing Watch preserves an upward drag but hiding the app or changing video cancels it', () => {
+  const start = playerSource.indexOf('    watch([isActiveTab, scrollMiniPlayerActive, mobileAdjustmentsVisible, () => props.videoId]')
+  const end = playerSource.indexOf('\n    watch(', start + 10)
+  let changed
+  const resets = []
+  vm.runInNewContext(playerSource.slice(start, end), {
+    watch: (_sources, callback) => { changed = callback },
+    isActiveTab: {}, scrollMiniPlayerActive: {}, mobileAdjustmentsVisible: {}, props: { videoId: 'video' },
+    scrollMiniPlayerDragStyle: { value: {} },
+    mobileFullscreenBrightnessActive: { value: false },
+    resetMobileAdjustments: preserve => resets.push(preserve),
+  })
+  changed([true, true, true, 'video'], [false, true, true, 'video'])
+  changed([false, true, true, 'video'], [true, true, true, 'video'])
+  changed([true, true, false, 'video'], [true, true, true, 'video'])
+  changed([true, true, true, 'other'], [true, true, true, 'video'])
+  assert.deepEqual(resets, [true, false, false, false])
+})
+
+
+test('upward swipe also starts on the mini-player transparent touch layer', t => {
+  const { gestures: g, event, calls } = fixture(t, { mini: true, minimize: true })
+  const target = new ElementStub('.scrollMiniPointerLayer')
+  g.startMobileFullscreenGesture(event(210, 400, { target }))
+  assert.equal(g.moveMobileFullscreenGesture(event(210, 300, { target })), true)
+  g.finishMobileFullscreenGesture(event(210, 300, { target }))
+  assert.deepEqual(calls.at(-1), ['drag-finish', true])
+})

--- a/tests/unit/navigation-playback.test.mjs
+++ b/tests/unit/navigation-playback.test.mjs
@@ -75,13 +75,7 @@ function mountWatch(t, { paused = false, hasLoaded = true, mounted = true, enabl
   return {
     props, getters, provides, lifecycle, previewRoot, previewStyle, hostBounds, viewport, listeners, titles, updateTitle,
     disposals: () => disposals,
-    async navigate(path) {
-      const to = { path, fullPath: path, params: {} }
-      await lifecycle.beforeNavigate({ to, from: props.route })
-      props.route = to
-      await nextTick()
-      await lifecycle.afterNavigate({ to })
-    }
+    navigate
   }
 }
 

--- a/tests/unit/navigation-playback.test.mjs
+++ b/tests/unit/navigation-playback.test.mjs
@@ -10,28 +10,54 @@ const source = (await readFile(new URL('../../src/renderer/components/TabContent
 const titleSource = (await readFile(new URL('../../src/renderer/tabs/TabContext.js', import.meta.url), 'utf8'))
   .replace(/^import .*$/gm, '').replace(/^export /gm, '')
 
-function mountWatch(t, { paused = false, hasLoaded = true, mounted = true } = {}) {
+function mountWatch(t, { paused = false, hasLoaded = true, mounted = true, enabled = true, previous = '/history', loaded = hasLoaded } = {}) {
   const route = { path: '/watch/video', fullPath: '/watch/video', params: { id: 'video' } }
   const props = reactive({ tabId: 'tab', route, presented: true })
-  const getters = reactive({ getKeepPlayingOnNavigation: true, getTabById: () => ({ history: [] }) })
+  const getters = reactive({ getKeepPlayingOnNavigation: enabled, getTabById: () => ({ historyIndex: previous ? 1 : 0, history: previous ? [{ route: { path: previous } }] : [] }) })
   const provides = new Map()
   const unmount = []
   const titles = []
   const scope = effectScope()
   const video = { paused, ended: false }
+  const previewRoot = {
+    closest: () => ({ getBoundingClientRect: () => hostBounds }),
+    getBoundingClientRect: () => ({ left: 0, top: 60.25, width: 412.25 }),
+    firstElementChild: { style: { removeProperty(key) { delete this[key] } } },
+    style: {
+      setProperty(key, value) { this[key] = value },
+      removeProperty(key) { delete this[key] }
+    }
+  }
+  const hostBounds = { left: 0, top: 60.25, width: 412.25 }
+  const listeners = new Map()
+  const viewport = {
+    scrollX: 0, scrollY: 20, innerHeight: 800,
+    scrollTo(position) { this.lastScroll = position; this.scrollX = position.left; this.scrollY = position.top },
+    addEventListener(name, callback) { listeners.set(name, callback) },
+    removeEventListener(name) { listeners.delete(name) }
+  }
   let lifecycle
   let disposals = 0
-  scope.run(() => vm.runInNewContext(source, {
+  async function navigate(path) {
+    const to = { path, fullPath: path, params: {} }
+    await lifecycle.beforeNavigate({ to, from: props.route })
+    props.route = to
+    await nextTick()
+    await lifecycle.afterNavigate({ to })
+  }
+  const previewStyle = scope.run(() => vm.runInNewContext(`${source}\npreviewStyle`, {
     computed, nextTick, reactive, ref, shallowRef, watch,
+    window: viewport,
+    isReducedMotionEnabled: () => true,
     defineProps: () => props,
     // The native scroll mini player lives outside the watch view's DOM tree.
     // Its component reference must remain usable without a DOM video descendant.
-    useTemplateRef: () => ref(mounted ? { $refs: { player: { hasLoaded, isPaused: () => video.paused } }, querySelector: () => null } : null),
+    useTemplateRef: name => name === 'watchRoot' ? ref(previewRoot) : name === 'previewHost' ? ref({ getBoundingClientRect: () => hostBounds }) : ref(mounted ? { $refs: { player: { hasLoaded: loaded, isPaused: () => video.paused } }, querySelector: () => null } : null),
     provide: (key, value) => provides.set(key, value),
     onBeforeUnmount: callback => unmount.push(callback),
     store: { getters },
     resolveRouteComponent: () => ({}),
-    getTabNavigationService: () => ({ createRouterFacade: () => ({}), setTitle: (...args) => titles.push(args) }),
+    getTabNavigationService: () => ({ createRouterFacade: () => ({}), setTitle: (...args) => titles.push(args), back: () => navigate(props.route.path === '/subscriptions' ? '/watch/video' : previous), forward: () => navigate('/watch/video'), push: (_id, path) => navigate(path) }),
     tabLifecycleService: { register: (_id, hooks) => { lifecycle = hooks; return () => {} } },
     tabLifecycleKey: 'lifecycle', tabPresentedKey: 'presented', watchNavigationKey: 'navigation',
     routeLocationKey: 'route', routerKey: 'router', console
@@ -47,7 +73,7 @@ function mountWatch(t, { paused = false, hasLoaded = true, mounted = true } = {}
     scope.stop()
   })
   return {
-    props, getters, provides, lifecycle, titles, updateTitle,
+    props, getters, provides, lifecycle, previewRoot, previewStyle, hostBounds, viewport, listeners, titles, updateTitle,
     disposals: () => disposals,
     async navigate(path) {
       const to = { path, fullPath: path, params: {} }
@@ -141,4 +167,163 @@ test('retains the current history title when a later entry repeats the watch URL
   await mounted.navigate('/watch/video')
   assert.equal(mounted.titles.at(-1)[1], 'Watch')
   assert.equal(mounted.titles.at(-1)[2].resolveHistoryEntry, false)
+})
+
+for (const paused of [true, false]) {
+  test(`explicit minimization retains playback with navigation retention disabled (paused=${paused})`, async t => {
+    const mounted = mountWatch(t, { paused, enabled: false })
+    const navigation = mounted.provides.get('navigation')
+    await navigation.minimize()
+    assert.equal(mounted.props.route.path, '/history')
+    assert.equal(mounted.disposals(), 0)
+    assert.equal(navigation.detached.value, true)
+    assert.equal(navigation.minimized.value, true)
+    assert.equal(mounted.getters.getKeepPlayingOnNavigation, false)
+    await navigation.returnToVideo()
+    assert.equal(mounted.props.route.path, '/watch/video')
+    assert.equal(navigation.minimized.value, false)
+    assert.equal(navigation.detached.value, false)
+  })
+}
+
+for (const previous of [null, '/watch/other']) {
+  test(`minimization has a browsing fallback when history is ${previous}`, async t => {
+    const mounted = mountWatch(t, { previous })
+    await mounted.provides.get('navigation').minimize()
+    assert.equal(mounted.props.route.path, '/subscriptions')
+    assert.equal(mounted.disposals(), 0)
+  })
+}
+
+
+for (const commit of [false, true]) {
+  test(`drag reveals the browsing page before release and ${commit ? 'commits' : 'cancels'}`, async t => {
+    const mounted = mountWatch(t, { paused: true, enabled: false })
+    const navigation = mounted.provides.get('navigation')
+    navigation.beginMinimizePreview()
+    await new Promise(resolve => setImmediate(resolve))
+    assert.equal(mounted.props.route.path, '/history')
+    assert.equal(mounted.provides.get('presented').value, true, 'The gesture keeps the player presented')
+    assert.equal(mounted.disposals(), 0)
+    navigation.updateMinimizePreview(0.5)
+    assert.equal(mounted.previewRoot.style.opacity, '0.5')
+    mounted.viewport.scrollY = 320.125
+    mounted.listeners.get('scroll')()
+    assert.equal(mounted.previewRoot.style.top, '300.125px')
+    await navigation.finishMinimizePreview(commit)
+    navigation.clearMinimizePreview(commit)
+    assert.equal(mounted.props.route.path, commit ? '/history' : '/watch/video')
+    assert.equal(mounted.provides.get('presented').value, !commit)
+    assert.equal(mounted.previewRoot.style.opacity, undefined)
+    assert.equal(mounted.listeners.has('scroll'), false)
+    assert.equal(mounted.disposals(), 0)
+  })
+}
+
+
+for (const commit of [false, true]) {
+  test(`upward drag reveals retained Watch before release and ${commit ? 'restores' : 'cancels'}`, async t => {
+    const mounted = mountWatch(t, { paused: true, enabled: false })
+    const navigation = mounted.provides.get('navigation')
+    navigation.beginMinimizePreview()
+    await navigation.finishMinimizePreview(true)
+    navigation.clearMinimizePreview(true)
+    assert.equal(navigation.beginRestorePreview(), true)
+    assert.equal(mounted.props.route.path, '/history')
+    assert.equal(mounted.provides.get('presented').value, true)
+    assert.equal(mounted.previewRoot.style.opacity, '0')
+    navigation.updateMinimizePreview(0.75)
+    assert.ok(Number(mounted.previewRoot.style.opacity) > 0)
+    await navigation.finishMinimizePreview(commit)
+    navigation.clearMinimizePreview(!commit)
+    assert.equal(mounted.props.route.path, commit ? '/watch/video' : '/history')
+    assert.equal(mounted.disposals(), 0)
+    assert.equal(mounted.listeners.has('scroll'), false)
+  })
+}
+
+
+test('upward reveal begins early and never blends the two pages', async t => {
+  const mounted = mountWatch(t)
+  const navigation = mounted.provides.get('navigation')
+  await navigation.minimize()
+  navigation.beginRestorePreview()
+  for (const progress of [0, 0.04, 0.08]) {
+    navigation.updateMinimizePreview(1 - progress)
+    assert.equal(Number(mounted.previewRoot.style.opacity), 0)
+  }
+  for (const progress of [0.1, 0.2, 0.3, 0.5, 0.85, 0.95, 1]) {
+    navigation.updateMinimizePreview(1 - progress)
+    const background = Number(mounted.previewRoot.style.opacity)
+    const content = Number(mounted.previewRoot.firstElementChild.style.opacity)
+    assert.ok(content === 0 || background === 1, 'Watch content appears only over its opaque background')
+  }
+})
+
+
+test('returning from the mini player restores Watch at the top without a second scroll', async t => {
+  const mounted = mountWatch(t)
+  const navigation = mounted.provides.get('navigation')
+  mounted.viewport.scrollY = 120.75
+  navigation.beginMinimizePreview()
+  await navigation.finishMinimizePreview(true)
+  navigation.clearMinimizePreview()
+  mounted.viewport.scrollY = 300.125
+  navigation.beginRestorePreview()
+  await navigation.finishMinimizePreview(true)
+  assert.equal(mounted.viewport.scrollY, 0)
+  assert.equal(mounted.viewport.lastScroll.behavior, 'instant')
+})
+
+for (const commit of [true, false]) {
+  test(`swiping a loading video keeps its component through ${commit ? 'minimization' : 'cancellation'}`, async t => {
+    const mounted = mountWatch(t, { loaded: false, paused: true, enabled: false })
+    const navigation = mounted.provides.get('navigation')
+    navigation.beginMinimizePreview()
+    await new Promise(resolve => setImmediate(resolve))
+    assert.equal(mounted.disposals(), 0)
+    assert.equal(navigation.detached.value, true)
+    await navigation.finishMinimizePreview(commit)
+    navigation.clearMinimizePreview()
+    assert.equal(mounted.disposals(), 0)
+    assert.equal(navigation.detached.value, commit)
+    if (commit) await navigation.returnToVideo()
+    assert.equal(mounted.props.route.path, '/watch/video')
+  })
+}
+
+test('closing the retained mini player disposes and unmounts Watch', async t => {
+  const mounted = mountWatch(t)
+  const navigation = mounted.provides.get('navigation')
+  await navigation.minimize()
+  assert.equal(typeof navigation.dismiss, 'function')
+  await navigation.dismiss()
+  assert.equal(mounted.disposals(), 1)
+  assert.equal(navigation.detached.value, false)
+  assert.equal(navigation.minimized.value, false)
+  assert.equal(mounted.props.route.path, '/history')
+})
+
+test('upward preview starts fading after a short swipe', async t => {
+  const mounted = mountWatch(t)
+  const navigation = mounted.provides.get('navigation')
+  await navigation.minimize()
+  navigation.beginRestorePreview()
+  navigation.updateMinimizePreview(0.8)
+  assert.ok(Number(mounted.previewRoot.style.opacity) > 0)
+  assert.equal(Number(mounted.previewRoot.firstElementChild.style.opacity), 0)
+})
+
+test('restoring after resizing uses the current Watch host geometry', async t => {
+  const mounted = mountWatch(t)
+  const navigation = mounted.provides.get('navigation')
+  await navigation.minimize()
+  mounted.hostBounds.width = 800.5
+  mounted.hostBounds.top = -139.75
+  mounted.viewport.scrollY = 220
+  mounted.viewport.innerHeight = 600
+  navigation.beginRestorePreview()
+  assert.equal(mounted.previewStyle.value.width, '800.5px')
+  assert.equal(mounted.previewStyle.value.top, '220px')
+  assert.equal(mounted.previewStyle.value.height, '519.75px')
 })


### PR DESCRIPTION
Dragging the video down now reveals the previous page and smoothly docks playback in the mini player. Swipe up to return to Watch.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes #1312

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The player follows the existing mini-player path with vertical finger tracking, rounded corners, and staged page fades. Loading keeps the thumbnail and playback alive. Returning while scrolling follows the moving page, and restoring after rotation uses the current layout.

Closing playback retained after page navigation unmounts it. Closing a mini player from another tab only hides it and keeps the video tab open.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Swipe down on the Android video player to keep watching in the mini player while browsing, then swipe up to return.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. On Android, open a video from a browsing page and drag down from its center. The page underneath should appear as the player shrinks along its normal path. Try short canceled swipes and fast releases.
2. Swipe up from the mini player. The background should fade in early, followed by Watch content without the two pages showing through each other. Rotate while browsing, then restore again.
3. Repeat while the video is loading. The thumbnail should remain visible and give way to the first video frame.
4. Scroll Watch until its scroll mini player appears, then scroll back up. The return should stay smooth as the page settles.
5. Press × after navigating away: playback should close. Switch to another tab and press × on its mini player: the original video tab should remain open.

## Additional context
<!-- Add any other context about the pull request here. -->

Implemented and reviewed with GPT-6 in Codex.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/OpenTubeX/OpenTubeX/pull/1336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

