### PR TITLE
fix: keep mobile description previews and expand buttons contained

### DIFF
--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
@@ -131,6 +131,8 @@
 }
 
 .videoDescription.short .description {
+  /* Keep room for the expand control when only tags or games are available. */
+  min-block-size: 1lh;
   max-block-size: 4lh;
   overflow: hidden;
 }

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
@@ -190,7 +190,7 @@ const descriptionFadeTop = ref(false)
 const copyButtonOverlapsExpandControl = ref(false)
 // a video can have games but no description, and there is nothing to expand or collapse then,
 // so treat it as expanded. `measureDescription` can't do it, it bails out on a zero height element.
-const isExpanded = computed(() => props.alwaysExpanded || shownDescription === '' || showFullDescription.value)
+const isExpanded = computed(() => !props.previewOnly && (props.alwaysExpanded || shownDescription === '' || showFullDescription.value))
 
 if (props.descriptionHtml !== '') {
   const parsed = parseDescriptionHtml(props.descriptionHtml)
@@ -295,7 +295,7 @@ function isShortDescription() {
 // expanded with no collapse control. Only measure once the element has a real
 // layout, retrying when the tab is first presented.
 function measureDescription() {
-  if (hasMeasured || props.alwaysExpanded) {
+  if (hasMeasured || props.alwaysExpanded || props.previewOnly) {
     return
   }
 

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
@@ -188,8 +188,8 @@ const showFullDescription = ref(false)
 const showControls = ref(false)
 const descriptionFadeTop = ref(false)
 const copyButtonOverlapsExpandControl = ref(false)
-// a video can have games but no description, and there is nothing to expand or collapse then,
-// so treat it as expanded. `measureDescription` can't do it, it bails out on a zero height element.
+// Outside preview mode, show games even when there is no description to expand.
+// `measureDescription` cannot expand empty content because it skips zero-height elements.
 const isExpanded = computed(() => !props.previewOnly && (props.alwaysExpanded || shownDescription === '' || showFullDescription.value))
 
 if (props.descriptionHtml !== '') {

--- a/tests/unit/description-preview.test.mjs
+++ b/tests/unit/description-preview.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const source = await readFile(new URL('../../src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue', import.meta.url), 'utf8')
+const expandedExpression = source.match(/const isExpanded = computed\(\(\) => (.*)\)/)[1]
+const measureBody = source.match(/function measureDescription\(\) \{([\s\S]*?)\n\}/)[1]
+
+function measure({ previewOnly = false, alwaysExpanded = false, short = true, description = 'Sie haben Post\nDer Klassiker von AOL' } = {}) {
+  const context = vm.createContext({
+    props: { previewOnly, alwaysExpanded },
+    shownDescription: description,
+    showFullDescription: { value: false },
+    showControls: { value: false },
+    hasMeasured: false,
+    descriptionContainer: { value: { $el: { clientHeight: 48, scrollHeight: short ? 48 : 240 } } },
+    isShortDescription: () => short,
+    nextTick() {},
+    updateDescriptionLayout() {},
+  })
+  vm.runInContext(`(function () {${measureBody}})()`, context)
+  return vm.runInContext(expandedExpression, context)
+}
+
+test('mobile previews stay collapsed after measuring short descriptions', () => {
+  assert.equal(measure({ previewOnly: true }), false)
+})
+
+test('mobile previews stay collapsed for long and empty descriptions with metadata', () => {
+  assert.equal(measure({ previewOnly: true, short: false }), false)
+  assert.equal(measure({ previewOnly: true, description: '' }), false)
+})
+
+test('regular descriptions expand short content and keep long content collapsed', () => {
+  assert.equal(measure(), true)
+  assert.equal(measure({ short: false }), false)
+  assert.equal(measure({ description: '' }), true)
+  assert.equal(measure({ alwaysExpanded: true, short: false }), true)
+})

--- a/tests/unit/description-preview.test.mjs
+++ b/tests/unit/description-preview.test.mjs
@@ -2,14 +2,25 @@ import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 import test from 'node:test'
 import vm from 'node:vm'
+import { babelParse, parse } from 'vue/compiler-sfc'
 
 const source = await readFile(new URL('../../src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue', import.meta.url), 'utf8')
-const expandedExpression = source.match(/const isExpanded = computed\(\(\) => (.*)\)/)[1]
-const measureBody = source.match(/function measureDescription\(\) \{([\s\S]*?)\n\}/)[1]
+const script = parse(source).descriptor.scriptSetup.content
+const statements = babelParse(script, { sourceType: 'module' }).program.body
+const expandedDeclaration = statements
+  .filter(statement => statement.type === 'VariableDeclaration')
+  .flatMap(statement => statement.declarations)
+  .find(declaration => declaration.id.name === 'isExpanded')
+const measureDeclaration = statements.find(statement => statement.type === 'FunctionDeclaration' && statement.id.name === 'measureDescription')
+assert.ok(expandedDeclaration, 'isExpanded declaration must exist')
+assert.ok(measureDeclaration, 'measureDescription function must exist')
+const expandedExpression = script.slice(expandedDeclaration.init.start, expandedDeclaration.init.end)
+const measureFunction = script.slice(measureDeclaration.start, measureDeclaration.end)
 
 function measure({ previewOnly = false, alwaysExpanded = false, short = true, description = 'Sie haben Post\nDer Klassiker von AOL' } = {}) {
   const context = vm.createContext({
     props: { previewOnly, alwaysExpanded },
+    computed: getter => getter(),
     shownDescription: description,
     showFullDescription: { value: false },
     showControls: { value: false },
@@ -19,22 +30,33 @@ function measure({ previewOnly = false, alwaysExpanded = false, short = true, de
     nextTick() {},
     updateDescriptionLayout() {},
   })
-  vm.runInContext(`(function () {${measureBody}})()`, context)
-  return vm.runInContext(expandedExpression, context)
+  vm.runInContext(`${measureFunction}\nmeasureDescription()`, context)
+  return {
+    expanded: vm.runInContext(expandedExpression, context),
+    measured: context.hasMeasured,
+    showFullDescription: context.showFullDescription.value,
+    showControls: context.showControls.value,
+  }
 }
 
 test('mobile previews stay collapsed after measuring short descriptions', () => {
-  assert.equal(measure({ previewOnly: true }), false)
+  assert.deepEqual(measure({ previewOnly: true }), {
+    expanded: false, measured: false, showFullDescription: false, showControls: false,
+  })
 })
 
 test('mobile previews stay collapsed for long and empty descriptions with metadata', () => {
-  assert.equal(measure({ previewOnly: true, short: false }), false)
-  assert.equal(measure({ previewOnly: true, description: '' }), false)
+  assert.equal(measure({ previewOnly: true, short: false }).expanded, false)
+  assert.equal(measure({ previewOnly: true, description: '' }).expanded, false)
 })
 
 test('regular descriptions expand short content and keep long content collapsed', () => {
-  assert.equal(measure(), true)
-  assert.equal(measure({ short: false }), false)
-  assert.equal(measure({ description: '' }), true)
-  assert.equal(measure({ alwaysExpanded: true, short: false }), true)
+  assert.deepEqual(measure(), {
+    expanded: true, measured: true, showFullDescription: true, showControls: false,
+  })
+  assert.deepEqual(measure({ short: false }), {
+    expanded: false, measured: true, showFullDescription: false, showControls: true,
+  })
+  assert.equal(measure({ description: '' }).expanded, true)
+  assert.equal(measure({ alwaysExpanded: true, short: false }).expanded, true)
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

Short mobile descriptions could expand inside the preview while leaving the “more” control above the text. Keep previews collapsed and reserve room for the control when only tags or games are available.

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Mobile previews no longer inherit automatic expansion for short descriptions. The full description remains available through the existing panel.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. On a phone, open a video with a short description and tags. Confirm the preview hides tags and keeps “more” within the card.
2. Tap “more” and confirm the panel shows the complete description and tags.
3. Check a long description and a video with tags or games but no description. The preview control should remain inside the card.

## Additional context
<!-- Add any other context about the pull request here. -->

Regression tests pass. A headless Chromium layout check reproduced the empty-preview overflow using the app font and verified the fix at portrait/landscape widths and four zoom levels. Lint passed with an existing warning. The full unit suite encountered an unrelated live-chat polling failure and heap exhaustion.

The phone preview was introduced after the latest stable release. No linked issue.

Implemented with GPT-6 in the Codex desktop harness.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/OpenTubeX/OpenTubeX/pull/1337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

