### PR TITLE
fix(android): keep seek previews above playback controls

### DIFF
--- a/src/renderer/helpers/player/androidNativeScreen.js
+++ b/src/renderer/helpers/player/androidNativeScreen.js
@@ -241,6 +241,8 @@ export function createAndroidNativeScreen({ element, container, getController, g
       container.checkVisibility?.({ checkOpacity: true, checkVisibilityCSS: true }) !== false
     // Notices need the same native clipping and touch priority as menus.
     const playerMenus = [...container.querySelectorAll('.shaka-overflow-menu:not(.shaka-hidden), .shaka-settings-menu:not(.shaka-hidden), .shaka-sub-menu:not(.shaka-hidden), .shaka-context-menu:not(.shaka-hidden), .skippedSegmentsWrapper')]
+    // Seek previews cover native buttons without becoming Back-dismissable menus.
+    const seekPreviews = [...container.querySelectorAll('.shaka-player-ui-thumbnail-container')]
     const countdowns = [...container.querySelectorAll('.countdownProgress')]
     // Global dialogs such as Quick Settings can cover only one native button.
     // Keep their whole rectangle above native controls, not just the center hit.
@@ -256,7 +258,7 @@ export function createAndroidNativeScreen({ element, container, getController, g
       .filter(menu => menu.checkVisibility?.({ checkVisibilityCSS: true }) !== false)
     // Hidden notices retain their layout box during native scrolling/gestures.
     // Clipping that box would punch through the raised video into the page.
-    const menuElements = [...playerMenus, ...countdowns, ...globalMenus, ...appChrome]
+    const menuElements = [...playerMenus, ...seekPreviews, ...countdowns, ...globalMenus, ...appChrome]
       .filter(menu => menu.checkVisibility?.({ checkOpacity: true, checkVisibilityCSS: true }) !== false)
     const pageScroll = followsPageScroll()
     const nativeY = y => pageScroll ? Math.round((y + window.scrollY) * 1000) / 1000 : y

--- a/tests/unit/android-native-screen.test.mjs
+++ b/tests/unit/android-native-screen.test.mjs
@@ -7,7 +7,7 @@ import { overrideShakaMethods } from '../../src/renderer/helpers/player/override
 const source = (await readFile(new URL('../../src/renderer/helpers/player/androidNativeScreen.js', import.meta.url), 'utf8'))
   .replace(/^import .*\n/gm, '').replace('export function ', 'function ')
 
-async function fixture({ fullscreen = true, chrome = [], dialogs = [], deferTransitions = false, deferFullscreen = false } = {}) {
+async function fixture({ fullscreen = true, chrome = [], dialogs = [], previews = [], deferTransitions = false, deferFullscreen = false } = {}) {
   const snapshots = []
   const snapshotInvalidations = []
   let publishSnapshot
@@ -32,11 +32,14 @@ async function fixture({ fullscreen = true, chrome = [], dialogs = [], deferTran
   const controlsElement = { hasAttribute: () => shown, getBoundingClientRect: () => bounds }
   const container = Object.assign(new EventTarget(), {
     classList: { contains: name => panel && ['fullscreenDockLayoutOpen', 'chaptersOverlayOpen'].includes(name) },
-    contains: () => false,
+    contains: element => previews.includes(element),
     getBoundingClientRect: () => bounds,
     toggleAttribute() {},
     getAnimations: () => animating ? [{ playState: 'running' }] : [],
-    querySelectorAll(selector) { return menu && selector.includes('shaka-overflow-menu') ? [{ getAnimations: () => [], getBoundingClientRect: () => ({ x: 400, y: 100, width: 200, height: 240 }) }] : [] },
+    querySelectorAll(selector) {
+      if (selector.includes('.shaka-player-ui-thumbnail-container')) return previews
+      return menu && selector.includes('shaka-overflow-menu') ? [{ getAnimations: () => [], getBoundingClientRect: () => ({ x: 400, y: 100, width: 200, height: 240 }) }] : []
+    },
     querySelector(selector) {
       if (selector === '.countdownPoster' && poster) return {}
       if (selector === '.shaka-controls-container') return controlsElement
@@ -510,3 +513,39 @@ test('reset detaches mini controls before the native screen is reused', async ()
   assert.ok(f.snapshots.length > 1, 'The snapshot helper remains usable after reset')
   f.screen.destroy()
 })
+
+for (const fullscreen of [false, true]) {
+  test(`seek previews clip native transport buttons while visible (${fullscreen ? 'fullscreen' : 'inline'})`, async () => {
+    let visible = false
+    const bounds = { x: 220.25, y: 100.5, width: 200, height: 140 }
+    const preview = {
+      checkVisibility: () => visible,
+      getAnimations: () => [],
+      getBoundingClientRect: () => bounds
+    }
+    const f = await fixture({ fullscreen, previews: [preview] })
+    assert.equal(f.layouts.at(-1).menus.length, 0)
+    visible = true
+    f.change({})
+    await f.flush()
+    assert.deepEqual(JSON.parse(JSON.stringify(f.layouts.at(-1).menus)), [{ ...bounds, pageScroll: !fullscreen }],
+      'The entire thumbnail and timestamp must exclude native control drawing')
+    assert.equal(f.layouts.at(-1).overlayActive, false, 'A seek preview must not consume Android Back as a menu')
+    bounds.x = 340.75
+    f.change({})
+    await f.flush()
+    assert.equal(f.layouts.at(-1).menus[0].x, bounds.x)
+    if (!fullscreen) {
+      f.window.scrollY = 40.25
+      bounds.y -= 40.25
+      f.window.dispatchEvent(new Event('scroll'))
+      await f.flush()
+      assert.equal(f.layouts.at(-1).menus[0].y, 100.5, 'Inline clipping follows native page scrolling')
+    }
+    visible = false
+    f.change({})
+    await f.flush()
+    assert.equal(f.layouts.at(-1).menus.length, 0, 'Hiding the preview must restore native drawing')
+    f.screen.destroy()
+  })
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Reported directly; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Android seekbar thumbnail previews appeared behind the native play/pause and seek buttons. Include visible previews in the existing native clipping rectangles so the full preview stays above those buttons in inline and fullscreen playback. Moving or dismissing the preview updates the clipping without treating it as a Back-dismissable menu.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed Android seekbar thumbnail previews appearing behind the playback controls.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a video with seekbar thumbnails in the Android development app and show the playback controls.
2. Drag along the seekbar until the preview overlaps the center buttons. The thumbnail and timestamp should remain unobscured.
3. Move and release the scrubber. The preview should move cleanly, and the native controls should reappear when it closes.
4. Repeat in fullscreen and inline playback, including after scrolling the page.

## Additional context
<!-- Add any other context about the pull request here. -->
Validation: the new regression cases failed before the fix and pass afterward. The full unit suite passed with 1,817 tests and two skips; lint passed with one existing warning. The Android debug build, native unit tests, and all 26 native screen instrumentation tests passed. On Android 8.0 / API 26 with Chrome WebView 119.0.6045.193, native window captures confirmed clipping through the real bridge in both inline and fullscreen modes. The captures use a diagnostic colored rectangle rather than user-facing thumbnails, so they are omitted from release-note media.

Implemented with GPT-6 in Codex.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/OpenTubeX/OpenTubeX/pull/1338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

