### PR TITLE
fix(comments): keep the load-more spinner visible on desktop

### DIFF
--- a/e2e/tests/offline/comment-spinner.spec.mjs
+++ b/e2e/tests/offline/comment-spinner.spec.mjs
@@ -1,0 +1,31 @@
+import { test, expect } from '../../helpers/app.mjs'
+import { openMockedVideo } from '../../helpers/player.mjs'
+import { mockPlayableWatchPage } from '../../helpers/watch.mjs'
+
+test.use({ seed: { settings: { videoPlaybackEngine: 'built-in', ytDlpPlaybackEngineDefaultMigration: true } } })
+
+for (const zoom of [1, 1.25]) {
+  test(`desktop comment pagination spinner is visible without further scrolling at ${zoom * 100}% scale`, async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await openMockedVideo(page)
+    await expect(page.locator('.comment').first()).toBeVisible()
+    await app.electronApp.evaluate(({ BrowserWindow }, zoom) => {
+      BrowserWindow.getAllWindows()[0].webContents.setZoomFactor(zoom)
+    }, zoom)
+    let release
+    const pending = new Promise(resolve => { release = resolve })
+    await page.route('**/youtubei/v1/next*', async route => {
+      await pending
+      await route.fallback()
+    })
+    try {
+      await page.locator('.commentAutoLoadSentinel').evaluate(element => element.scrollIntoView({ block: 'end', behavior: 'instant' }))
+      const spinner = page.getByRole('status', { name: 'Load More Comments' })
+      await expect(spinner).toBeAttached()
+      await expect(spinner).toBeInViewport({ ratio: 0.9, timeout: 500 })
+    } finally {
+      release()
+      await page.unrouteAll({ behavior: 'wait' })
+    }
+  })
+}

--- a/src/renderer/components/CommentSection/CommentSection.css
+++ b/src/renderer/components/CommentSection/CommentSection.css
@@ -229,6 +229,10 @@
   min-block-size: 1px;
 }
 
+.commentAutoLoadSpace {
+  min-block-size: 64px;
+}
+
 .getCommentsTitle {
   padding-block: 8px;
   text-align: center;
@@ -846,8 +850,4 @@
   inline-size: max-content;
   max-inline-size: calc(100vw - 40px);
   inset-inline-end: 0;
-}
-
-.phoneCommentCard .commentAutoLoadSpace {
-  min-block-size: 64px;
 }

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -592,7 +592,7 @@
         v-if="!isLoading && !isLoadingMoreComments"
         v-observe-visibility="observeVisibilityOptions"
         class="commentAutoLoadSentinel"
-        :class="{ commentAutoLoadSpace: phonePanelHeader && canAutomaticallyLoadMoreComments }"
+        :class="{ commentAutoLoadSpace: canAutomaticallyLoadMoreComments }"
       >
       <!--
         Dummy element to be observed by Intersection Observer


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
Reported during desktop testing; no linked issue.
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Scrolling to the bottom of desktop comments could start loading the next page while leaving its spinner below the viewport. The desktop trigger reserved only 1px; phone panels already reserved the spinner's 64px height. Apply that existing space reservation to desktop comments so the spinner stays visible without further scrolling.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Keep the comments loading spinner visible when scrolling to load more comments on desktop.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a video with enough comments for multiple pages and enable automatic loading of paginated content.
2. Scroll to the bottom of the comments, then stop scrolling. The loading spinner should remain visible while the next page loads. A throttled connection makes this easier to check.
3. Repeat with UI Scale set to 125%, then check the comments in the phone layout.

## Additional context
<!-- Add any other context about the pull request here. -->

Validation: reproduced the offscreen spinner before the fix at 100% and 125% Electron zoom. Both desktop regression cases and the existing phone-panel spinner test pass after the fix. The unit suite passed with 1,815 tests and 2 skips; lint passed with one existing warning in an unrelated test. Standards and spec reviews found no issues.

Changes made with GPT-6 in the Codex harness.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/OpenTubeX/OpenTubeX/pull/1339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

