### PR TITLE
feat(android): follow Material You system colors

### DIFF
--- a/android/app/src/androidTest/java/org/opentubex/app/MobileAppearanceSettingsTest.java
+++ b/android/app/src/androidTest/java/org/opentubex/app/MobileAppearanceSettingsTest.java
@@ -203,6 +203,112 @@ public class MobileAppearanceSettingsTest {
         }
     }
 
+    @Test
+    public void dynamicColorsFollowNativePaletteAndClearWhenDisabled() throws Exception {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            WebView view = webView(scenario);
+            prepare(view);
+            String store = "document.querySelector('#app').__vue_app__.config.globalProperties.$store";
+            String savedTheme = evaluate(view, store + ".getters.getBaseTheme");
+            try {
+                evaluate(view, "document.querySelector('.profileTrigger').click()");
+                awaitCondition(view, "!!document.querySelector('.quickSettingsContent select')");
+                if (android.os.Build.VERSION.SDK_INT < 31) {
+                    assertEquals("Dynamic option is absent on older Android", "false", evaluate(view,
+                        "!!document.querySelector('.quickSettingsContent option[value=dynamic]')"));
+                    return;
+                }
+                awaitCondition(view, "!!document.querySelector('.quickSettingsContent option[value=dynamic]')");
+                evaluate(view, store + ".commit('setBaseTheme', 'dynamic')");
+                String primary = "document.body.style.getPropertyValue('--primary-color')";
+                awaitCondition(view, primary + " !== ''");
+                android.content.Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+                boolean dark = (context.getResources().getConfiguration().uiMode &
+                    android.content.res.Configuration.UI_MODE_NIGHT_MASK) ==
+                    android.content.res.Configuration.UI_MODE_NIGHT_YES;
+                int colorId = context.getResources().getIdentifier(
+                    "system_accent1_" + (dark ? "200" : "600"), "color", "android");
+                String expected = String.format(java.util.Locale.ROOT, "#%06x", context.getColor(colorId) & 0xffffff);
+                assertEquals("Renderer uses the actual system accent", JSONObject.quote(expected),
+                    evaluate(view, primary + ".toLowerCase()"));
+                assertEquals("Dynamic fields, tracks and text retain accessible contrast", "true", evaluate(view,
+                    """
+                    (() => {
+                        const style = getComputedStyle(document.body);
+                        const color = name => style.getPropertyValue(name).trim();
+                        const luminance = hex => hex.slice(1).match(/../g).map(channel => {
+                            const value = parseInt(channel, 16) / 255;
+                            return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+                        }).reduce((sum, value, i) => sum + value * [0.2126, 0.7152, 0.0722][i], 0);
+                        const contrast = (a, b) => {
+                            const values = [luminance(color(a)), luminance(color(b))].sort((a, b) => b - a);
+                            return (values[0] + 0.05) / (values[1] + 0.05);
+                        };
+                        const surfaces = ['--bg-color', '--card-bg-color', '--search-bar-color', '--dropdown-item-hover-color'];
+                        return document.body.classList.contains('dynamicColors') &&
+                            color('--search-bar-color') !== color('--card-bg-color') && surfaces.every(background =>
+                                ['--primary-text-color', '--secondary-text-color', '--link-color', '--red-500'].every(
+                                    foreground => contrast(foreground, background) >= 4.5) &&
+                                ['--input-border-color', '--slider-track-color', '--toggle-track-color',
+                                 '--toggle-checked-track-color', '--scrollbar-color-hover'].every(
+                                    foreground => contrast(foreground, background) >= 3)) &&
+                            contrast('--toggle-thumb-color', '--toggle-track-color') >= 3 &&
+                            contrast('--toggle-checked-thumb-color', '--toggle-checked-track-color') >= 3;
+                    })()
+                    """));
+                evaluate(view, "document.body.style.removeProperty('--primary-color')");
+                scenario.onActivity(activity -> activity.onConfigurationChanged(
+                    new android.content.res.Configuration(activity.getResources().getConfiguration())));
+                awaitCondition(view, primary + ".toLowerCase() === '" + expected + "'");
+                evaluate(view, store + ".commit('setBaseTheme', 'light')");
+                awaitCondition(view, primary + " === '' && document.body.classList.contains('light')");
+                assertEquals("Dynamic backgrounds are removed", "\"\"", evaluate(view,
+                    "document.body.style.getPropertyValue('--bg-color')"));
+            } finally {
+                evaluate(view, store + ".commit('setBaseTheme', " + savedTheme + ")");
+                restore(view);
+            }
+        }
+    }
+
+    @Test
+    public void systemPaletteChangeUpdatesTheExistingWebView() throws Exception {
+        org.junit.Assume.assumeTrue(android.os.Build.VERSION.SDK_INT >= 31);
+        android.content.Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        android.app.UiAutomation automation = InstrumentationRegistry.getInstrumentation().getUiAutomation();
+        automation.adoptShellPermissionIdentity(android.Manifest.permission.WRITE_SECURE_SETTINGS);
+        String setting = "theme_customization_overlay_packages";
+        String originalPalette = android.provider.Settings.Secure.getString(context.getContentResolver(), setting);
+        String store = "document.querySelector('#app').__vue_app__.config.globalProperties.$store";
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            WebView view = webView(scenario);
+            String savedTheme = evaluate(view, store + ".getters.getBaseTheme");
+            try {
+                evaluate(view, store + ".dispatch('updateBaseTheme', 'dynamic').then(() => window.__themeSaved = true)");
+                awaitCondition(view, "window.__themeSaved === true && document.body.style.getPropertyValue('--primary-color') !== ''");
+                String originalColor = evaluate(view, "document.body.style.getPropertyValue('--primary-color')");
+                String seed = originalPalette != null && originalPalette.contains("FF0066") ? "6750A4" : "FF0066";
+                android.provider.Settings.Secure.putString(context.getContentResolver(), setting,
+                    new JSONObject()
+                        .put("android.theme.customization.system_palette", seed)
+                        .put("android.theme.customization.accent_color", seed)
+                        .put("android.theme.customization.color_source", "preset")
+                        .put("android.theme.customization.theme_style", "TONAL_SPOT")
+                        .toString());
+                awaitCondition(view, store + ".getters.getBaseTheme === 'dynamic' && " +
+                    "document.body.style.getPropertyValue('--primary-color') !== '' && " +
+                    "document.body.style.getPropertyValue('--primary-color') !== " + originalColor);
+            } finally {
+                view = webView(scenario);
+                evaluate(view, store + ".dispatch('updateBaseTheme', " + savedTheme + ").then(() => window.__themeRestored = true)");
+                awaitCondition(view, "window.__themeRestored === true");
+            }
+        } finally {
+            android.provider.Settings.Secure.putString(context.getContentResolver(), setting, originalPalette);
+            automation.dropShellPermissionIdentity();
+        }
+    }
+
     private static WebView webView(ActivityScenario<MainActivity> scenario) throws Exception {
         AtomicReference<WebView> view = new AtomicReference<>();
         scenario.onActivity(activity -> view.set(activity.getBridge().getWebView()));

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -33,7 +33,7 @@
             android:exported="false" />
 
         <activity
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation|density"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation|density|assetsPaths"
             android:name=".MainActivity"
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"

--- a/android/app/src/main/java/org/opentubex/app/AndroidDynamicColorsPlugin.java
+++ b/android/app/src/main/java/org/opentubex/app/AndroidDynamicColorsPlugin.java
@@ -1,0 +1,52 @@
+package org.opentubex.app;
+
+import android.content.res.Configuration;
+import android.os.Build;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+@CapacitorPlugin(name = "AndroidDynamicColors")
+public class AndroidDynamicColorsPlugin extends Plugin {
+    @PluginMethod
+    public void getColors(PluginCall call) {
+        call.resolve(readColors());
+    }
+
+    @Override
+    protected void handleOnConfigurationChanged(Configuration configuration) {
+        notifyListeners("dynamicColorsChanged", readColors());
+    }
+
+    @Override
+    protected void handleOnResume() {
+        notifyListeners("dynamicColorsChanged", readColors());
+    }
+
+    private JSObject readColors() {
+        JSObject result = new JSObject();
+        result.put("supported", Build.VERSION.SDK_INT >= Build.VERSION_CODES.S);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return result;
+
+        JSObject palette = new JSObject();
+        String[] families = { "accent1", "accent2", "accent3", "neutral1", "neutral2" };
+        int[] tones = { 0, 10, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000 };
+        for (String family : families) {
+            JSObject colors = new JSObject();
+            for (int tone : tones) {
+                int id = getContext().getResources().getIdentifier(
+                    "system_" + family + "_" + tone, "color", "android"
+                );
+                colors.put(Integer.toString(tone), String.format(
+                    java.util.Locale.ROOT, "#%06x", getContext().getColor(id) & 0xffffff
+                ));
+            }
+            palette.put(family, colors);
+        }
+        result.put("palette", palette);
+        return result;
+    }
+}

--- a/android/app/src/main/java/org/opentubex/app/MainActivity.java
+++ b/android/app/src/main/java/org/opentubex/app/MainActivity.java
@@ -45,6 +45,7 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(PoTokenPlugin.class);
         registerPlugin(YtDlpPlugin.class);
         registerPlugin(AndroidUiPlugin.class);
+        registerPlugin(AndroidDynamicColorsPlugin.class);
         registerPlugin(AppIconPlugin.class);
         registerPlugin(ScreenshotPlugin.class);
         registerPlugin(PullToRefreshPlugin.class);

--- a/android/app/src/main/java/org/opentubex/app/OpenTubeXApplication.java
+++ b/android/app/src/main/java/org/opentubex/app/OpenTubeXApplication.java
@@ -25,6 +25,28 @@ public final class OpenTubeXApplication extends Application {
         if ((getPackageName() + ":restart").equals(processName)) {
             return;
         }
+        if (android.os.Build.VERSION.SDK_INT == 35) {
+            prepareWebViewResources();
+        }
         AndroidProxy.initialize(this);
     }
+
+    private void prepareWebViewResources() {
+        android.content.pm.PackageInfo provider = android.webkit.WebView.getCurrentWebViewPackage();
+        if (provider == null) return;
+        try {
+            android.content.pm.ApplicationInfo installed = getPackageManager().getApplicationInfo(
+                provider.packageName, android.content.pm.PackageManager.GET_SHARED_LIBRARY_FILES);
+            android.content.pm.ApplicationInfo resources = new android.content.pm.ApplicationInfo();
+            resources.sourceDir = installed.sourceDir;
+            resources.splitSourceDirs = installed.splitSourceDirs;
+            resources.sharedLibraryFiles = installed.sharedLibraryFiles;
+            // Android 15 otherwise pins the provider's current Monet overlays in
+            // every Resources instance. Android 16 filters shared overlays itself.
+            android.content.res.Resources.registerResourcePaths(provider.packageName, resources);
+        } catch (android.content.pm.PackageManager.NameNotFoundException | UnsupportedOperationException error) {
+            android.util.Log.w("DynamicColors", "Unable to prepare WebView resources", error);
+        }
+    }
+
 }

--- a/src/appearanceSettings.js
+++ b/src/appearanceSettings.js
@@ -4,7 +4,7 @@ import { isCustomThemeValue } from './customTheme.js'
 const BUILTIN_BASE_THEMES = new Set(BUILTIN_BASE_THEME_VALUES)
 
 function hasFixedThemeColors(theme) {
-  return FIXED_COLOR_BASE_THEMES.includes(theme) || isCustomThemeValue(theme)
+  return theme === 'dynamic' || FIXED_COLOR_BASE_THEMES.includes(theme) || isCustomThemeValue(theme)
 }
 
 function getThemeClassification(value, customThemes = []) {
@@ -19,7 +19,7 @@ function getThemeClassification(value, customThemes = []) {
 
 function resolveBaseTheme(value, fallback, customThemes = [], allowSystem = true) {
   if (!allowSystem && value === 'system') return fallback
-  if (BUILTIN_BASE_THEMES.has(value) || customThemes.some(({ id }) => value === `custom:${id}`)) {
+  if (value === 'dynamic' || BUILTIN_BASE_THEMES.has(value) || customThemes.some(({ id }) => value === `custom:${id}`)) {
     return value
   }
   return fallback

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -510,6 +510,13 @@ import { lockBodyScroll, unlockBodyScroll } from './components/FtPrompt/scrollLo
 import { vSaferHtml } from './directives/vSaferHtml.js'
 
 import store from './store/index'
+import { androidDynamicColors, getAndroidDynamicColors, onAndroidDynamicColorsChanged } from './helpers/dynamicColors'
+import {
+  exitAndroidApp,
+  getAndroidHardwareKeyboardState,
+  setAndroidPictureInPictureDocumentState,
+  setAndroidSystemBarsBackground
+} from './helpers/androidUi'
 import {
   applyThemeToDocument,
   handleCustomThemeUpdated,
@@ -538,12 +545,6 @@ import {
 } from './helpers/progressPresentation'
 import { fetchReleasePages, findUpdateReleases, formatReleaseChangelog } from './helpers/releaseUpdates'
 import { copyToClipboard, openExternalLink, openInternalPath, shareLink, showApiErrorToast, showToast } from './helpers/utils'
-import {
-  exitAndroidApp,
-  getAndroidHardwareKeyboardState,
-  setAndroidPictureInPictureDocumentState,
-  setAndroidSystemBarsBackground
-} from './helpers/androidUi'
 import { openNotificationSettings } from './helpers/capacitorUi'
 import { initializeCapacitorLiveReminderActions } from './helpers/liveReminders'
 import {
@@ -2713,6 +2714,32 @@ const systemColorScheme = window.matchMedia('(prefers-color-scheme: dark)')
 const systemUsesDarkTheme = ref(systemColorScheme.matches)
 systemColorScheme.addEventListener('change', handleSystemColorSchemeChange)
 
+if (isCapacitor) {
+  let dynamicColorsListener
+  let disposed = false
+  const receiveColors = (colors) => {
+    if (disposed) return
+    androidDynamicColors.value = colors
+    if (baseTheme.value === 'dynamic') updateTheme()
+  }
+  onMounted(async () => {
+    try {
+      dynamicColorsListener = await onAndroidDynamicColorsChanged(receiveColors)
+      if (disposed) {
+        await dynamicColorsListener?.remove()
+        return
+      }
+      receiveColors(await getAndroidDynamicColors())
+    } catch (error) {
+      console.error('Failed to load Android dynamic colors:', error)
+    }
+  })
+  onBeforeUnmount(() => {
+    disposed = true
+    dynamicColorsListener?.remove()
+  })
+}
+
 watch(baseTheme, updateTheme)
 watch(appFont, updateAppFont)
 watch(() => store.getters.getSystemLightTheme, updateTheme)
@@ -2797,7 +2824,7 @@ async function sanitizeAppearanceSettings(customThemes) {
 
 function handleSystemColorSchemeChange(event) {
   systemUsesDarkTheme.value = event.matches
-  if (baseTheme.value === 'system') updateTheme()
+  if (['system', 'dynamic'].includes(baseTheme.value)) updateTheme()
 }
 
 function updateUiRoundness() {

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
@@ -443,6 +443,7 @@ import { localeTranslationPercentages } from '../../i18n/index'
 import { colors } from '../../helpers/colors'
 import { OPEN_COMMAND_PALETTE_EVENT } from '../../helpers/commandPalette'
 import { useColorTranslations } from '../../composables/colors'
+import { androidDynamicColors } from '../../helpers/dynamicColors'
 import { useBaseThemeNames } from '../../composables/baseThemes'
 import { useThumbnailSizeSlider } from '../../composables/useThumbnailSizeSlider'
 import {
@@ -506,10 +507,12 @@ const builtInBaseThemeNames = useBaseThemeNames()
 const customThemes = computed(() => store.getters.getCustomThemes)
 const baseThemeValues = computed(() => [
   ...BUILTIN_BASE_THEME_VALUES,
+  ...(androidDynamicColors.value.supported ? ['dynamic'] : []),
   ...customThemes.value.map(({ id }) => customThemeValue(id))
 ])
 const baseThemeNames = computed(() => [
   ...builtInBaseThemeNames.value,
+  ...(androidDynamicColors.value.supported ? [t('Settings.Theme Settings.Base Theme.Dynamic colors')] : []),
   ...customThemes.value.map(({ name }) => name)
 ])
 const systemThemeOptions = computed(() => {

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
@@ -443,8 +443,7 @@ import { localeTranslationPercentages } from '../../i18n/index'
 import { colors } from '../../helpers/colors'
 import { OPEN_COMMAND_PALETTE_EVENT } from '../../helpers/commandPalette'
 import { useColorTranslations } from '../../composables/colors'
-import { androidDynamicColors } from '../../helpers/dynamicColors'
-import { useBaseThemeNames } from '../../composables/baseThemes'
+import { useBaseThemeOptions } from '../../composables/baseThemes'
 import { useThumbnailSizeSlider } from '../../composables/useThumbnailSizeSlider'
 import {
   MIN_THUMBNAIL_SIZE,
@@ -460,9 +459,7 @@ import {
 } from '../../helpers/quickSettings'
 import { defaultUpdaterId } from '../../store/modules/settings'
 import { switchActiveProfile, translateProfileName as getTranslatedProfileName } from '../../helpers/profileSwitching'
-import { customThemeValue } from '../../../customTheme'
 import { getThemeClassification, hasFixedThemeColors } from '../../../appearanceSettings'
-import { BUILTIN_BASE_THEME_VALUES } from '../../../constants'
 
 const quickHeaderActions = useTemplateRef('quickHeaderActions')
 const { locale, t } = useI18n()
@@ -503,21 +500,8 @@ const profileInitials = computed(() => profileList.value.reduce((initials, profi
   return initials
 }, {}))
 
-const builtInBaseThemeNames = useBaseThemeNames()
-const dynamicThemeIndex = BUILTIN_BASE_THEME_VALUES.indexOf('openTubeXDark') + 1
 const customThemes = computed(() => store.getters.getCustomThemes)
-const baseThemeValues = computed(() => [
-  ...BUILTIN_BASE_THEME_VALUES.slice(0, dynamicThemeIndex),
-  ...(androidDynamicColors.value.supported ? ['dynamic'] : []),
-  ...BUILTIN_BASE_THEME_VALUES.slice(dynamicThemeIndex),
-  ...customThemes.value.map(({ id }) => customThemeValue(id))
-])
-const baseThemeNames = computed(() => [
-  ...builtInBaseThemeNames.value.slice(0, dynamicThemeIndex),
-  ...(androidDynamicColors.value.supported ? [t('Settings.Theme Settings.Base Theme.Dynamic colors')] : []),
-  ...builtInBaseThemeNames.value.slice(dynamicThemeIndex),
-  ...customThemes.value.map(({ name }) => name)
-])
+const { baseThemeValues, baseThemeNames } = useBaseThemeOptions(customThemes)
 const systemThemeOptions = computed(() => {
   const options = { systemLightTheme: [], systemDarkTheme: [] }
   baseThemeValues.value.forEach((value, index) => {

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
@@ -504,15 +504,18 @@ const profileInitials = computed(() => profileList.value.reduce((initials, profi
 }, {}))
 
 const builtInBaseThemeNames = useBaseThemeNames()
+const dynamicThemeIndex = BUILTIN_BASE_THEME_VALUES.indexOf('openTubeXDark') + 1
 const customThemes = computed(() => store.getters.getCustomThemes)
 const baseThemeValues = computed(() => [
-  ...BUILTIN_BASE_THEME_VALUES,
+  ...BUILTIN_BASE_THEME_VALUES.slice(0, dynamicThemeIndex),
   ...(androidDynamicColors.value.supported ? ['dynamic'] : []),
+  ...BUILTIN_BASE_THEME_VALUES.slice(dynamicThemeIndex),
   ...customThemes.value.map(({ id }) => customThemeValue(id))
 ])
 const baseThemeNames = computed(() => [
-  ...builtInBaseThemeNames.value,
+  ...builtInBaseThemeNames.value.slice(0, dynamicThemeIndex),
   ...(androidDynamicColors.value.supported ? [t('Settings.Theme Settings.Base Theme.Dynamic colors')] : []),
+  ...builtInBaseThemeNames.value.slice(dynamicThemeIndex),
   ...customThemes.value.map(({ name }) => name)
 ])
 const systemThemeOptions = computed(() => {

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -458,15 +458,18 @@ const capacitorLayoutModeNames = computed(() => [
 ])
 
 const builtInBaseThemeNames = useBaseThemeNames()
+const dynamicThemeIndex = BUILTIN_BASE_THEME_VALUES.indexOf('openTubeXDark') + 1
 const customThemes = computed(() => store.getters.getCustomThemes)
 const baseThemeValues = computed(() => [
-  ...BUILTIN_BASE_THEME_VALUES,
+  ...BUILTIN_BASE_THEME_VALUES.slice(0, dynamicThemeIndex),
   ...(androidDynamicColors.value.supported ? ['dynamic'] : []),
+  ...BUILTIN_BASE_THEME_VALUES.slice(dynamicThemeIndex),
   ...customThemes.value.map(({ id }) => customThemeValue(id))
 ])
 const baseThemeNames = computed(() => [
-  ...builtInBaseThemeNames.value,
+  ...builtInBaseThemeNames.value.slice(0, dynamicThemeIndex),
   ...(androidDynamicColors.value.supported ? [t('Settings.Theme Settings.Base Theme.Dynamic colors')] : []),
+  ...builtInBaseThemeNames.value.slice(dynamicThemeIndex),
   ...customThemes.value.map(({ name }) => name)
 ])
 function systemThemeOptions(classification) {

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -406,13 +406,11 @@ import QuickSettingsCustomizer from './QuickSettingsCustomizer/QuickSettingsCust
 
 import store from '../store/index'
 import { getThemeClassification, hasFixedThemeColors } from '../../appearanceSettings'
-import { BUILTIN_BASE_THEME_VALUES } from '../../constants'
-import { customThemeIdFromValue, customThemeValue } from '../../customTheme'
+import { customThemeIdFromValue } from '../../customTheme'
 
 import { colors } from '../helpers/colors'
 import { useColorTranslations } from '../composables/colors'
-import { androidDynamicColors } from '../helpers/dynamicColors'
-import { useBaseThemeNames } from '../composables/baseThemes'
+import { useBaseThemeOptions } from '../composables/baseThemes'
 import { useThumbnailSizeSlider } from '../composables/useThumbnailSizeSlider'
 import {
   MIN_THUMBNAIL_SIZE,
@@ -457,21 +455,8 @@ const capacitorLayoutModeNames = computed(() => [
   t('Settings.General Settings.Mobile Layout.Tablet')
 ])
 
-const builtInBaseThemeNames = useBaseThemeNames()
-const dynamicThemeIndex = BUILTIN_BASE_THEME_VALUES.indexOf('openTubeXDark') + 1
 const customThemes = computed(() => store.getters.getCustomThemes)
-const baseThemeValues = computed(() => [
-  ...BUILTIN_BASE_THEME_VALUES.slice(0, dynamicThemeIndex),
-  ...(androidDynamicColors.value.supported ? ['dynamic'] : []),
-  ...BUILTIN_BASE_THEME_VALUES.slice(dynamicThemeIndex),
-  ...customThemes.value.map(({ id }) => customThemeValue(id))
-])
-const baseThemeNames = computed(() => [
-  ...builtInBaseThemeNames.value.slice(0, dynamicThemeIndex),
-  ...(androidDynamicColors.value.supported ? [t('Settings.Theme Settings.Base Theme.Dynamic colors')] : []),
-  ...builtInBaseThemeNames.value.slice(dynamicThemeIndex),
-  ...customThemes.value.map(({ name }) => name)
-])
+const { baseThemeValues, baseThemeNames } = useBaseThemeOptions(customThemes)
 function systemThemeOptions(classification) {
   return baseThemeValues.value.flatMap((value, index) =>
     getThemeClassification(value, customThemes.value) === classification

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -411,6 +411,7 @@ import { customThemeIdFromValue, customThemeValue } from '../../customTheme'
 
 import { colors } from '../helpers/colors'
 import { useColorTranslations } from '../composables/colors'
+import { androidDynamicColors } from '../helpers/dynamicColors'
 import { useBaseThemeNames } from '../composables/baseThemes'
 import { useThumbnailSizeSlider } from '../composables/useThumbnailSizeSlider'
 import {
@@ -460,10 +461,12 @@ const builtInBaseThemeNames = useBaseThemeNames()
 const customThemes = computed(() => store.getters.getCustomThemes)
 const baseThemeValues = computed(() => [
   ...BUILTIN_BASE_THEME_VALUES,
+  ...(androidDynamicColors.value.supported ? ['dynamic'] : []),
   ...customThemes.value.map(({ id }) => customThemeValue(id))
 ])
 const baseThemeNames = computed(() => [
   ...builtInBaseThemeNames.value,
+  ...(androidDynamicColors.value.supported ? [t('Settings.Theme Settings.Base Theme.Dynamic colors')] : []),
   ...customThemes.value.map(({ name }) => name)
 ])
 function systemThemeOptions(classification) {

--- a/src/renderer/composables/baseThemes.js
+++ b/src/renderer/composables/baseThemes.js
@@ -1,7 +1,9 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import { BUILTIN_BASE_THEME_TRANSLATION_KEYS } from '../../constants'
+import { BUILTIN_BASE_THEME_VALUES, BUILTIN_BASE_THEME_TRANSLATION_KEYS } from '../../constants'
+import { customThemeValue } from '../../customTheme'
+import { androidDynamicColors } from '../helpers/dynamicColors'
 
 export function useBaseThemeNames(includeSystem = true) {
   const { tm } = useI18n()
@@ -11,4 +13,22 @@ export function useBaseThemeNames(includeSystem = true) {
     const translations = tm('Settings.Theme Settings.Base Theme')
     return keys.map(key => translations[key] ?? key)
   })
+}
+
+/** Keep the Appearance and quick-settings theme selectors in the same order. */
+export function useBaseThemeOptions(customThemes) {
+  const { t } = useI18n()
+  const builtInNames = useBaseThemeNames()
+  const options = computed(() => {
+    const themes = BUILTIN_BASE_THEME_VALUES.map((value, index) => ({ value, name: builtInNames.value[index] }))
+    if (androidDynamicColors.value.supported) {
+      const index = themes.findIndex(({ value }) => value === 'openTubeXDark') + 1
+      themes.splice(index, 0, { value: 'dynamic', name: t('Settings.Theme Settings.Base Theme.Dynamic colors') })
+    }
+    return themes.concat(customThemes.value.map(({ id, name }) => ({ value: customThemeValue(id), name })))
+  })
+  return {
+    baseThemeValues: computed(() => options.value.map(({ value }) => value)),
+    baseThemeNames: computed(() => options.value.map(({ name }) => name)),
+  }
 }

--- a/src/renderer/helpers/customTheme.js
+++ b/src/renderer/helpers/customTheme.js
@@ -6,15 +6,21 @@ import {
   isCustomThemeValue,
   normalizeCustomTheme,
   normalizeCustomThemes,
-} from '../../customTheme'
-import { PALETTE_BASE_THEMES } from '../../constants'
+} from '../../customTheme.js'
+import { PALETTE_BASE_THEMES } from '../../constants.js'
+
+import { androidDynamicColors, applyDynamicColors } from './dynamicColors.js'
 
 const STORAGE_KEY = 'opentubex-custom-theme'
 let appliedBodyThemeClasses = []
 
 export function applyThemeToDocument(baseTheme, mainColor, secColor, customTheme) {
+  const dynamic = baseTheme === 'dynamic'
+  const dark = window.matchMedia('(prefers-color-scheme: dark)').matches
+  if (dynamic) baseTheme = dark ? 'dark' : 'light'
   const themeClass = isCustomThemeValue(baseTheme) ? 'custom' : (baseTheme || 'system')
   const themeClasses = [themeClass]
+  if (dynamic) themeClasses.push('dynamicColors')
   // Fixed palettes must not inherit selectable accent or destructive overrides.
   if (!PALETTE_BASE_THEMES.includes(themeClass)) {
     themeClasses.push(`main${mainColor || 'Red'}`, `sec${secColor || 'Blue'}`)
@@ -53,6 +59,9 @@ export function applyThemeToDocument(baseTheme, mainColor, secColor, customTheme
       '--accent-color-rgb',
       hexColorToRgbComponents(customTheme.colors.accent)
     )
+  }
+  if (dynamic && androidDynamicColors.value.supported) {
+    applyDynamicColors(androidDynamicColors.value.palette, dark)
   }
 }
 

--- a/src/renderer/helpers/customTheme.js
+++ b/src/renderer/helpers/customTheme.js
@@ -22,7 +22,7 @@ export function applyThemeToDocument(baseTheme, mainColor, secColor, customTheme
   const themeClasses = [themeClass]
   if (dynamic) themeClasses.push('dynamicColors')
   // Fixed palettes must not inherit selectable accent or destructive overrides.
-  if (!PALETTE_BASE_THEMES.includes(themeClass)) {
+  if ((!dynamic || !androidDynamicColors.value.supported) && !PALETTE_BASE_THEMES.includes(themeClass)) {
     themeClasses.push(`main${mainColor || 'Red'}`, `sec${secColor || 'Blue'}`)
   }
   document.body.classList.remove(...appliedBodyThemeClasses)

--- a/src/renderer/helpers/dynamicColors.js
+++ b/src/renderer/helpers/dynamicColors.js
@@ -1,0 +1,98 @@
+import { ref } from 'vue'
+import { registerPlugin } from '@capacitor/core'
+import { CUSTOM_THEME_COLORS, hexColorToRgbComponents } from '../../customTheme.js'
+
+const AndroidDynamicColors = process.env.IS_CAPACITOR ? registerPlugin('AndroidDynamicColors') : null
+
+export function getAndroidDynamicColors() {
+  return AndroidDynamicColors?.getColors() ?? Promise.resolve({ supported: false })
+}
+
+export function onAndroidDynamicColorsChanged(listener) {
+  return AndroidDynamicColors?.addListener('dynamicColorsChanged', listener)
+}
+
+export const androidDynamicColors = ref({ supported: false })
+
+/** Map Android's tonal palette to the existing theme roles. */
+export function dynamicThemeColors(palette, dark) {
+  const tone = (family, light, night) => palette[family]?.[dark ? night : light]
+  const primary = tone('accent1', 600, 200)
+  const onPrimary = tone('accent1', 0, 800)
+  const accent = tone('accent3', 600, 200)
+  const text = tone('neutral1', 900, 100)
+  const secondaryText = tone('neutral2', 700, 200)
+  const surface = tone('neutral1', 50, 900)
+  const raised = tone('neutral1', 100, 800)
+  const hover = tone('neutral2', 100, 800)
+  const colors = {
+    primaryText: text,
+    secondaryText,
+    tertiaryText: secondaryText,
+    title: text,
+    background: surface,
+    cardBackground: raised,
+    secondaryCardBackground: surface,
+    sideNav: surface,
+    searchBar: surface,
+    settingsSearchBar: surface,
+    instanceMenu: raised,
+    primaryInput: palette.neutral1[900],
+    border: tone('neutral2', 600, 300),
+    subtleSurface: hover,
+    primary,
+    primaryHover: tone('accent1', 700, 100),
+    primaryActive: tone('accent1', 800, 50),
+    textWithPrimary: onPrimary,
+    accent,
+    accentHover: tone('accent3', 700, 100),
+    accentActive: tone('accent3', 800, 50),
+    accentLight: tone('accent3', 700, 100),
+    accentVisited: tone('accent2', 600, 200),
+    textWithAccent: tone('accent3', 0, 800),
+    favoriteIcon: accent,
+    // Material's error roles remain red, independently of the wallpaper hue.
+    error: dark ? '#ffb4ab' : '#ba1a1a',
+    destructive: dark ? '#ffb4ab' : '#ba1a1a',
+    destructiveHover: dark ? '#ffdad6' : '#93000a',
+    destructiveActive: dark ? '#ffedea' : '#690005',
+    destructiveText: dark ? '#690005' : '#ffffff',
+    link: accent,
+    linkVisited: tone('accent2', 600, 200),
+    selectionBackground: primary,
+    selectionText: onPrimary,
+    logoPrimary: text,
+    logoSecondary: text,
+    logoTertiary: primary,
+    logoPressed: primary,
+    scrollbar: secondaryText,
+    scrollbarHover: primary,
+    scrollbarActive: primary,
+    scrollbarTextHover: onPrimary,
+    dropdownHover: hover,
+    dropdownHoverText: text,
+    sideNavHover: hover,
+    sideNavHoverText: text,
+    sideNavActive: hover,
+    sideNavActiveText: text,
+    headerHover: hover,
+    headerHoverText: text,
+    headerPressed: hover,
+    headerPressedText: text,
+    coloredHeaderHover: tone('accent1', 700, 100),
+    coloredHeaderHoverText: onPrimary,
+    coloredHeaderPressed: tone('accent1', 800, 50),
+    coloredHeaderPressedText: onPrimary,
+  }
+  return colors
+}
+
+export function applyDynamicColors(palette, dark) {
+  const colors = dynamicThemeColors(palette, dark)
+  for (const [key, property] of CUSTOM_THEME_COLORS) {
+    if (colors[key]) document.body.style.setProperty(property, colors[key])
+  }
+  if (colors.accent) {
+    document.body.style.setProperty('--accent-color-rgb', hexColorToRgbComponents(colors.accent))
+  }
+}

--- a/src/renderer/helpers/dynamicColors.js
+++ b/src/renderer/helpers/dynamicColors.js
@@ -14,6 +14,19 @@ export function onAndroidDynamicColorsChanged(listener) {
 
 export const androidDynamicColors = ref({ supported: false })
 
+export async function initializeAndroidDynamicColors(request = getAndroidDynamicColors()) {
+  let timeout
+  try {
+    // Theme availability must not prevent the application from mounting.
+    androidDynamicColors.value = await Promise.race([
+      request,
+      new Promise(resolve => { timeout = setTimeout(() => resolve({ supported: false }), 1500) }),
+    ])
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
 /** Map Android's tonal palette to the existing theme roles. */
 export function dynamicThemeColors(palette, dark) {
   const tone = (family, light, night) => palette[family]?.[dark ? night : light]

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -11,7 +11,7 @@ import { showExternalPlayerUnsupportedActionToast, showToast } from './helpers/u
 import { installViewTransitions } from './helpers/viewTransitions'
 import { initializeAppScrollbars, overlayScrollbarsDirective } from './helpers/overlayScrollbars'
 import { releaseAutomaticDownloadSchedule } from './helpers/automaticDownloads'
-import { androidDynamicColors, getAndroidDynamicColors } from './helpers/dynamicColors'
+import { initializeAndroidDynamicColors } from './helpers/dynamicColors'
 // import the styles
 import 'overlayscrollbars/styles/overlayscrollbars.css'
 // Only the positioning and stacking rules are used, FtToast supplies the design
@@ -48,7 +48,7 @@ const tabNavigation = initializeTabNavigationService(router, store)
 
 // Resolve native colors before App applies its first theme and system-bar style.
 const dynamicColorsReady = process.env.IS_CAPACITOR
-  ? getAndroidDynamicColors().then(colors => { androidDynamicColors.value = colors }).catch(error => {
+  ? initializeAndroidDynamicColors().catch(error => {
       console.error('Failed to load initial Android dynamic colors:', error)
     })
   : Promise.resolve()

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -11,6 +11,7 @@ import { showExternalPlayerUnsupportedActionToast, showToast } from './helpers/u
 import { installViewTransitions } from './helpers/viewTransitions'
 import { initializeAppScrollbars, overlayScrollbarsDirective } from './helpers/overlayScrollbars'
 import { releaseAutomaticDownloadSchedule } from './helpers/automaticDownloads'
+import { androidDynamicColors, getAndroidDynamicColors } from './helpers/dynamicColors'
 // import the styles
 import 'overlayscrollbars/styles/overlayscrollbars.css'
 // Only the positioning and stacking rules are used, FtToast supplies the design
@@ -45,7 +46,14 @@ installViewTransitions(router)
 
 const tabNavigation = initializeTabNavigationService(router, store)
 
-router.isReady().then(() => {
+// Resolve native colors before App applies its first theme and system-bar style.
+const dynamicColorsReady = process.env.IS_CAPACITOR
+  ? getAndroidDynamicColors().then(colors => { androidDynamicColors.value = colors }).catch(error => {
+      console.error('Failed to load initial Android dynamic colors:', error)
+    })
+  : Promise.resolve()
+
+Promise.all([router.isReady(), dynamicColorsReady]).then(() => {
   app.mount('#app')
   initializeAppScrollbars({ useNativePageScrollbar: process.env.IS_CAPACITOR })
 })

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -3101,3 +3101,52 @@ body .os-scrollbar {
   --primary-shadow-color: rgb(0 0 0 / 35%);
   --focus-ring-contrast-color: #fff;
 }
+
+/* Android system tones supply the palette; these roles keep controls visible
+   against both their fill and the surrounding card. */
+.dynamicColors {
+  --input-border-color: var(--border-color);
+  --slider-track-color: var(--secondary-text-color);
+  --toggle-track-color: var(--secondary-text-color);
+  --toggle-checked-track-color: var(--accent-color);
+  --toggle-thumb-color: var(--bg-color);
+  --toggle-checked-thumb-color: var(--bg-color);
+  --settings-changed-color: var(--accent-color);
+
+  .switch-input:not(:disabled) + .switch-label::after {
+    outline: 2px solid var(--secondary-text-color);
+    outline-offset: -2px;
+  }
+
+  .ft-input-component .ft-input::placeholder {
+    opacity: 1;
+  }
+
+  .forceTextColor :is(.inputAction.enabled, .clearInputTextButton.visible):is(:hover, :active) {
+    color: var(--text-with-main-color);
+  }
+
+  .topNav.topNavBarColor .navFilterButton:not(:hover, :active) {
+    color: #eee;
+  }
+
+  .ft-input-component .list {
+    --scrollbar-color: var(--secondary-text-color);
+  }
+
+  /* Separate the thumb from the track, including during focus and dragging.
+     The thumb is scaled sixfold by the slider component. */
+  .pure-material-slider .input:not(:disabled)::-webkit-slider-thumb {
+    outline: 0.25px solid var(--bg-color);
+    outline-offset: 0;
+  }
+
+  .pure-material-slider .input:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+  }
+
+  .btn:focus-visible {
+    outline-color: currentcolor;
+  }
+}

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -312,10 +312,10 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --logo-text: url('../../_icons/textBlackSmall.svg');
 }
 
-/* Custom and OpenTubeX themes tint the header logo instead of displaying the fixed-color
+/* Custom, OpenTubeX, and dynamic themes tint the header logo instead of displaying the fixed-color
    theme assets. Keeping the assets as masks preserves their sharp edges. */
-:is(.custom, .openTubeXLight, .openTubeXDark) .topNav .logoIcon,
-:is(.custom, .openTubeXLight, .openTubeXDark) .topNav .logoText {
+:is(.custom, .openTubeXLight, .openTubeXDark, .dynamicColors) .topNav .logoIcon,
+:is(.custom, .openTubeXLight, .openTubeXDark, .dynamicColors) .topNav .logoText {
   /* The component's fixed SVG has intentionally high scoped specificity. */
   /* stylelint-disable-next-line declaration-no-important */
   background-image: none !important;
@@ -325,23 +325,23 @@ it can be safely elided. This looks quite pleasant on this theme. */
   mask-position: center;
 }
 
-:is(.custom, .openTubeXLight, .openTubeXDark) .topNav .logoIcon {
+:is(.custom, .openTubeXLight, .openTubeXDark, .dynamicColors) .topNav .logoIcon {
   background-color: var(--logo-primary-color);
   mask-image: var(--logo-icon);
   mask-size: 25px;
 }
 
-:is(.custom, .openTubeXLight, .openTubeXDark) .topNav .logoText {
+:is(.custom, .openTubeXLight, .openTubeXDark, .dynamicColors) .topNav .logoText {
   background-color: var(--logo-secondary-color);
   mask-image: var(--logo-text);
   mask-size: 100px;
 }
 
-:is(.custom, .openTubeXLight, .openTubeXDark) .logo:hover :is(.logoIcon, .logoText) {
+:is(.custom, .openTubeXLight, .openTubeXDark, .dynamicColors) .logo:hover :is(.logoIcon, .logoText) {
   background-color: var(--logo-tertiary-color);
 }
 
-:is(.custom, .openTubeXLight, .openTubeXDark) .logo:active :is(.logoIcon, .logoText) {
+:is(.custom, .openTubeXLight, .openTubeXDark, .dynamicColors) .logo:active :is(.logoIcon, .logoText) {
   background-color: var(--logo-pressed-color);
 }
 
@@ -3105,6 +3105,10 @@ body .os-scrollbar {
 /* Android system tones supply the palette; these roles keep controls visible
    against both their fill and the surrounding card. */
 .dynamicColors {
+  .topNavBarColor .logo :is(.logoIcon, .logoText) {
+    background-color: var(--text-with-main-color);
+  }
+
   --input-border-color: var(--border-color);
   --slider-track-color: var(--secondary-text-color);
   --toggle-track-color: var(--secondary-text-color);

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -394,6 +394,7 @@ Settings:
       Unable to Load: غير قادر على تحميل خطوط النظام المثبتة
     Always Show Scrollbars: إظهار أشرطة التمرير دائمًا
     Base Theme:
+      Dynamic colors: ألوان ديناميكية
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/az.yaml
+++ b/static/locales/ai/az.yaml
@@ -377,6 +377,7 @@ Settings:
       Unable to Load: Quraşdırılmış sistem şriftlərini yükləmək mümkün olmadı
     Always Show Scrollbars: Sürüşdürmə çubuqlarını həmişə göstər
     Base Theme:
+      Dynamic colors: Dinamik rənglər
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -392,6 +392,7 @@ Settings:
       Unable to Load: Не ўдалося загрузіць усталяваныя сістэмныя шрыфты
     Always Show Scrollbars: Заўсёды паказваць палосы пракруткі
     Base Theme:
+      Dynamic colors: Дынамічныя колеры
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -392,6 +392,7 @@ Settings:
       Unable to Load: Инсталираните системни шрифтове не могат да бъдат заредени
     Always Show Scrollbars: Винаги показвай лентите за превъртане
     Base Theme:
+      Dynamic colors: Динамични цветове
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -390,6 +390,7 @@ Settings:
       Unable to Load: "N'eus ket bet gallet kargañ nodrezhoù ar reizhiad staliet"
     Always Show Scrollbars: "Diskouez ar barrennoù dibunañ bepred"
     Base Theme:
+      Dynamic colors: Livioù dinamek
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -514,6 +514,7 @@ Settings:
     Always Show Scrollbars: Mostra sempre les barres de desplaçament
     Hide OpenTubeX Header Logo: Oculta el logotip de l'OpenTubeX de la capçalera
     Base Theme:
+      Dynamic colors: Colors dinàmics
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -390,6 +390,7 @@ Settings:
       Unable to Load: Nainstalovaná systémová písma se nepodařilo načíst
     Always Show Scrollbars: Vždy zobrazovat posuvníky
     Base Theme:
+      Dynamic colors: Dynamické barvy
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -392,6 +392,7 @@ Settings:
       Unable to Load: Nid oedd modd llwytho ffontiau'r system sydd wedi'u gosod
     Always Show Scrollbars: Dangos bariau sgrolio bob amser
     Base Theme:
+      Dynamic colors: Lliwiau deinamig
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -387,6 +387,7 @@ Settings:
       Unable to Load: Installerede systemskrifttyper kunne ikke indlæses
     Always Show Scrollbars: Vis altid rullebjælker
     Base Theme:
+      Dynamic colors: Dynamiske farver
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -394,6 +394,7 @@ Settings:
       Unable to Load: Δεν ήταν δυνατή η φόρτωση των εγκατεστημένων γραμματοσειρών συστήματος
     Always Show Scrollbars: Μόνιμη εμφάνιση γραμμών κύλισης
     Base Theme:
+      Dynamic colors: Δυναμικά χρώματα
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -377,6 +377,7 @@ Settings:
       Unable to Load: Unable to load installed system fonts
     Always Show Scrollbars: Always Show Scrollbars
     Base Theme:
+      Dynamic colors: Dynamic colours
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -396,6 +396,7 @@ Settings:
       Unable to Load: No se pudieron cargar las fuentes instaladas en el sistema
     Always Show Scrollbars: Mostrar siempre las barras de desplazamiento
     Base Theme:
+      Dynamic colors: Colores dinámicos
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -404,6 +404,7 @@ Settings:
       Unable to Load: No se pudieron cargar las fuentes instaladas en el sistema
     Always Show Scrollbars: Mostrar siempre las barras de desplazamiento
     Base Theme:
+      Dynamic colors: Colores dinámicos
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -392,6 +392,7 @@ Settings:
       Unable to Load: No se pudieron cargar las fuentes instaladas en el sistema
     Always Show Scrollbars: Mostrar siempre las barras de desplazamiento
     Base Theme:
+      Dynamic colors: Colores dinámicos
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -390,6 +390,7 @@ Settings:
       Unable to Load: Paigaldatud süsteemifonte ei saa laadida
     Always Show Scrollbars: Kuva kerimisribad alati
     Base Theme:
+      Dynamic colors: Dünaamilised värvid
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -392,6 +392,7 @@ Settings:
       Unable to Load: Ezin izan dira sisteman instalatutako letra-tipoak kargatu
     Always Show Scrollbars: Erakutsi beti korritze-barrak
     Base Theme:
+      Dynamic colors: Kolore dinamikoak
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -392,6 +392,7 @@ Settings:
       Unable to Load: قلم‌های نصب‌شدهٔ سیستم بارگیری نشدند
     Always Show Scrollbars: نمایش همیشگی نوارهای پیمایش
     Base Theme:
+      Dynamic colors: رنگ‌های پویا
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -394,6 +394,7 @@ Settings:
       Unable to Load: Asennettuja järjestelmäfontteja ei voitu ladata
     Always Show Scrollbars: Näytä vierityspalkit aina
     Base Theme:
+      Dynamic colors: Dynaamiset värit
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -390,6 +390,7 @@ Settings:
       Unable to Load: Impossible de charger les polices installées sur le système
     Always Show Scrollbars: Toujours afficher les barres de défilement
     Base Theme:
+      Dynamic colors: Couleurs dynamiques
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -394,6 +394,7 @@ Settings:
       Unable to Load: Non se puideron cargar os tipos de letra instalados no sistema
     Always Show Scrollbars: Amosar sempre as barras de desprazamento
     Base Theme:
+      Dynamic colors: Cores dinámicas
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -394,6 +394,7 @@ Settings:
       Unable to Load: לא ניתן לטעון גופני מערכת מותקנים
     Always Show Scrollbars: הצגת פסי גלילה תמיד
     Base Theme:
+      Dynamic colors: צבעים דינמיים
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -392,6 +392,7 @@ Settings:
       Unable to Load: Instalirane fontove sustava nije moguće učitati
     Always Show Scrollbars: Uvijek prikaži klizne trake
     Base Theme:
+      Dynamic colors: Dinamičke boje
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -390,6 +390,7 @@ Settings:
       Unable to Load: A rendszerre telepített betűkészletek nem tölthetők be
     Always Show Scrollbars: Görgetősávok mindig láthatók
     Base Theme:
+      Dynamic colors: Dinamikus színek
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -394,6 +394,7 @@ Settings:
       Unable to Load: Tidak dapat memuat font sistem yang terpasang
     Always Show Scrollbars: Selalu Tampilkan Bilah Gulir
     Base Theme:
+      Dynamic colors: Warna dinamis
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -394,6 +394,7 @@ Settings:
       Unable to Load: Ekki tókst að hlaða uppsettum kerfisleturgerðum
     Always Show Scrollbars: Sýna alltaf skrunstikur
     Base Theme:
+      Dynamic colors: Breytilegir litir
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -390,6 +390,7 @@ Settings:
       Unable to Load: Impossibile caricare i caratteri installati nel sistema
     Always Show Scrollbars: Mostra sempre le barre di scorrimento
     Base Theme:
+      Dynamic colors: Colori dinamici
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -390,6 +390,7 @@ Settings:
       Unable to Load: インストール済みのシステムフォントを読み込めませんでした
     Always Show Scrollbars: スクロールバーを常に表示
     Base Theme:
+      Dynamic colors: ダイナミックカラー
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -471,6 +471,7 @@ Settings:
       Unable to Load: 설치된 시스템 글꼴을 불러올 수 없습니다
     Always Show Scrollbars: 스크롤바 항상 표시
     Base Theme:
+      Dynamic colors: 다이내믹 색상
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -471,7 +471,7 @@ Settings:
       Unable to Load: 설치된 시스템 글꼴을 불러올 수 없습니다
     Always Show Scrollbars: 스크롤바 항상 표시
     Base Theme:
-      Dynamic colors: 다이내믹 색상
+      Dynamic colors: 동적 색상
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -496,6 +496,7 @@ Settings:
       Unable to Load: Nepavyko įkelti įdiegtų sistemos šriftų
     Always Show Scrollbars: Visada rodyti slankjuostes
     Base Theme:
+      Dynamic colors: Dinaminės spalvos
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -390,6 +390,7 @@ Settings:
       Unable to Load: Kan ikke laste inn installerte systemskrifter
     Always Show Scrollbars: Vis alltid rullefelt
     Base Theme:
+      Dynamic colors: Dynamiske farger
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -394,6 +394,7 @@ Settings:
       Unable to Load: Geïnstalleerde systeemlettertypen kunnen niet worden geladen
     Always Show Scrollbars: Schuifbalken altijd tonen
     Base Theme:
+      Dynamic colors: Dynamische kleuren
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -438,6 +438,7 @@ Settings:
       Unable to Load: Klarte ikkje å laste inn installerte systemskrifter
     Always Show Scrollbars: Vis alltid rullefelt
     Base Theme:
+      Dynamic colors: Dynamiske fargar
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -146,6 +146,7 @@ Settings:
       Catppuccin Macchiato Blue: "Catppuccin Macchiato Niebieski"
       Catppuccin Macchiato Lavender: "Catppuccin Macchiato Lawendowy"
     Base Theme:
+      Dynamic colors: Dynamiczne kolory
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -390,6 +390,7 @@ Settings:
       Unable to Load: Não foi possível carregar os tipos de letra instalados no sistema
     Always Show Scrollbars: Mostrar sempre as barras de deslocamento
     Base Theme:
+      Dynamic colors: Cores dinâmicas
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -394,6 +394,7 @@ Settings:
       Unable to Load: Não foi possível carregar os tipos de letra instalados no sistema
     Always Show Scrollbars: Mostrar sempre as barras de deslocamento
     Base Theme:
+      Dynamic colors: Cores dinâmicas
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -379,6 +379,7 @@ Settings:
       Unable to Load: Não foi possível carregar os tipos de letra instalados no sistema
     Always Show Scrollbars: Mostrar sempre as barras de deslocamento
     Base Theme:
+      Dynamic colors: Cores dinâmicas
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -392,6 +392,7 @@ Settings:
       Unable to Load: Fonturile instalate în sistem nu au putut fi încărcate
     Always Show Scrollbars: Afișează întotdeauna barele de derulare
     Base Theme:
+      Dynamic colors: Culori dinamice
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -369,6 +369,7 @@ Settings:
       Unable to Load: Не удалось загрузить установленные системные шрифты
     Always Show Scrollbars: Всегда показывать полосы прокрутки
     Base Theme:
+      Dynamic colors: Динамические цвета
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -390,6 +390,7 @@ Settings:
       Unable to Load: Nainštalované systémové písma sa nepodarilo načítať
     Always Show Scrollbars: Vždy zobrazovať posúvače
     Base Theme:
+      Dynamic colors: Dynamické farby
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -505,6 +505,7 @@ Settings:
       Unable to Load: Nameščenih sistemskih pisav ni mogoče naložiti
     Always Show Scrollbars: Vedno prikaži drsne trakove
     Base Theme:
+      Dynamic colors: Dinamične barve
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -385,6 +385,7 @@ Settings:
       Unable to Load: Није могуће учитати инсталиране системске фонтове
     Always Show Scrollbars: Увек приказуј траке за померање
     Base Theme:
+      Dynamic colors: Динамичке боје
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -392,6 +392,7 @@ Settings:
       Unable to Load: Det gick inte att läsa in installerade systemtypsnitt
     Always Show Scrollbars: Visa alltid rullningslister
     Base Theme:
+      Dynamic colors: Dynamiska färger
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -395,6 +395,7 @@ Settings:
       Unable to Load: நிறுவப்பட்ட கணினி எழுத்துருக்களை ஏற்ற முடியவில்லை
     Always Show Scrollbars: உருள் பட்டைகளை எப்போதும் காட்டு
     Base Theme:
+      Dynamic colors: மாறும் வண்ணங்கள்
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -390,6 +390,7 @@ Settings:
       Unable to Load: Yüklü sistem yazı tipleri yüklenemedi
     Always Show Scrollbars: Kaydırma Çubuklarını Her Zaman Göster
     Base Theme:
+      Dynamic colors: Dinamik renkler
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -394,6 +394,7 @@ Settings:
       Unable to Load: Не вдалося завантажити встановлені системні шрифти
     Always Show Scrollbars: Завжди показувати смуги прокручування
     Base Theme:
+      Dynamic colors: Динамічні кольори
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -394,6 +394,7 @@ Settings:
       Unable to Load: Không thể tải các phông chữ hệ thống đã cài đặt
     Always Show Scrollbars: Luôn hiện thanh cuộn
     Base Theme:
+      Dynamic colors: Màu động
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -390,6 +390,7 @@ Settings:
       Unable to Load: 无法加载已安装的系统字体
     Always Show Scrollbars: 始终显示滚动条
     Base Theme:
+      Dynamic colors: 动态颜色
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -390,6 +390,7 @@ Settings:
       Unable to Load: 無法載入已安裝的系統字型
     Always Show Scrollbars: 永遠顯示捲軸
     Base Theme:
+      Dynamic colors: 動態色彩
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -455,6 +455,7 @@ Settings:
     Theme Settings: Farbschema
     Match Top Bar with Main Color: Obere Leiste an Hauptfarbe anpassen
     Base Theme:
+      Dynamic colors: Dynamische Farben
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -690,6 +690,7 @@ Settings:
     Hide Side Bar Labels: Hide Side Bar Labels
     Hide OpenTubeX Header Logo: Hide OpenTubeX Header Logo
     Base Theme:
+      Dynamic colors: Dynamic colors
       Tokyo Night Night: Tokyo Night Night
       Tokyo Night Storm: Tokyo Night Storm
       Tokyo Night Moon: Tokyo Night Moon

--- a/tests/unit/dynamic-colors.test.mjs
+++ b/tests/unit/dynamic-colors.test.mjs
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { dynamicThemeColors, applyDynamicColors } from '../../src/renderer/helpers/dynamicColors.js'
+import { hasFixedThemeColors, resolveBaseTheme, resolveSystemTheme } from '../../src/appearanceSettings.js'
+
+function palette() {
+  return Object.fromEntries(['accent1', 'accent2', 'accent3', 'neutral1', 'neutral2'].map((family, i) => [
+    family,
+    Object.fromEntries([0, 10, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]
+      .map(tone => [tone, `#${(i * 10000 + tone).toString(16).padStart(6, '0')}`]))
+  ]))
+}
+
+test('dynamic themes survive settings repair and do not expose manual accents', () => {
+  assert.equal(resolveBaseTheme('dynamic', 'system'), 'dynamic')
+  assert.equal(hasFixedThemeColors('dynamic'), true)
+  assert.equal(resolveSystemTheme('dynamic', 'light'), 'light')
+  assert.equal(resolveSystemTheme('dynamic', 'dark'), 'dark')
+})
+
+test('dynamic palettes use contrasting tones in light and dark mode', () => {
+  const colors = palette()
+  const light = dynamicThemeColors(colors, false)
+  const dark = dynamicThemeColors(colors, true)
+  assert.equal(light.background, colors.neutral1[50])
+  assert.equal(light.primaryText, colors.neutral1[900])
+  assert.equal(light.primary, colors.accent1[600])
+  assert.equal(light.textWithPrimary, colors.accent1[0])
+  assert.equal(dark.background, colors.neutral1[900])
+  assert.equal(dark.primaryText, colors.neutral1[100])
+  assert.equal(dark.primary, colors.accent1[200])
+  assert.equal(dark.textWithPrimary, colors.accent1[800])
+  assert.equal(dark.link, colors.accent3[200])
+  for (const value of Object.values({...light, ...dark})) assert.match(value, /^#[0-9a-f]{6}$/)
+})
+
+test('palette refresh updates existing CSS properties and RGB accents', (t) => {
+  const properties = new Map()
+  const original = globalThis.document
+  globalThis.document = { body: { style: { setProperty: (key, value) => properties.set(key, value) } } }
+  t.after(() => { globalThis.document = original })
+  const colors = palette()
+  applyDynamicColors(colors, false)
+  assert.equal(properties.get('--bg-color'), colors.neutral1[50])
+  colors.accent3[200] = '#abcdef'
+  applyDynamicColors(colors, true)
+  assert.equal(properties.get('--bg-color'), colors.neutral1[900])
+  assert.equal(properties.get('--accent-color-rgb'), '171 205 239')
+})
+
+test('switching back from dynamic colors or a custom-theme preview restores the selected theme', async (t) => {
+  const { applyThemeToDocument } = await import('../../src/renderer/helpers/customTheme.js')
+  const { androidDynamicColors } = await import('../../src/renderer/helpers/dynamicColors.js')
+  const properties = new Map()
+  const classes = new Set()
+  const originalDocument = globalThis.document
+  const originalWindow = globalThis.window
+  globalThis.document = { body: {
+    style: {
+      setProperty: (key, value) => properties.set(key, value),
+      removeProperty: key => properties.delete(key),
+    },
+    classList: {
+      add: (...values) => values.forEach(value => classes.add(value)),
+      remove: (...values) => values.forEach(value => classes.delete(value)),
+    },
+    dataset: {},
+  } }
+  let dark = false
+  globalThis.window = { matchMedia: () => ({ matches: dark }) }
+  androidDynamicColors.value = { supported: true, palette: palette() }
+  t.after(() => {
+    globalThis.document = originalDocument
+    globalThis.window = originalWindow
+    androidDynamicColors.value = { supported: false }
+  })
+  applyThemeToDocument('dynamic', 'Red', 'Blue', null)
+  assert.equal(classes.has('light'), true)
+  assert.equal(classes.has('dynamicColors'), true)
+  assert.equal(properties.get('--bg-color'), palette().neutral1[50])
+  dark = true
+  applyThemeToDocument('dynamic', 'Red', 'Blue', null)
+  assert.equal(classes.has('dark'), true)
+  assert.equal(classes.has('light'), false)
+  assert.equal(properties.get('--bg-color'), palette().neutral1[900])
+  applyThemeToDocument('light', 'Red', 'Blue', null)
+  assert.equal(classes.has('dynamicColors'), false)
+  assert.equal(properties.has('--bg-color'), false)
+  assert.equal(properties.has('--accent-color-rgb'), false)
+  assert.equal(classes.has('light'), true)
+  applyThemeToDocument('dynamic', 'Red', 'Blue', null)
+  assert.equal(properties.get('--primary-color'), palette().accent1[200])
+})
+
+function contrast(first, second) {
+  const luminance = hex => hex.slice(1).match(/../g).map(channel => {
+    const value = parseInt(channel, 16) / 255
+    return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4
+  }).reduce((sum, value, i) => sum + value * [0.2126, 0.7152, 0.0722][i], 0)
+  const values = [luminance(first), luminance(second)].sort((a, b) => b - a)
+  return (values[0] + 0.05) / (values[1] + 0.05)
+}
+
+// Android tonal shades specify perceptual lightness, independent of palette hue.
+function neutralTonalPalette() {
+  const shades = Object.fromEntries(Object.keys(palette().neutral1).map(shade => {
+    const lightness = 100 - Number(shade) / 10
+    const linear = lightness > 8 ? ((lightness + 16) / 116) ** 3 : lightness / 903.3
+    const srgb = linear <= 0.0031308 ? 12.92 * linear : 1.055 * linear ** (1 / 2.4) - 0.055
+    return [shade, '#' + Math.round(srgb * 255).toString(16).padStart(2, '0').repeat(3)]
+  }))
+  return Object.fromEntries(Object.keys(palette()).map(family => [family, shades]))
+}
+
+for (const dark of [false, true]) {
+  test(`dynamic ${dark ? 'dark' : 'light'} controls and text meet contrast thresholds`, () => {
+    const colors = dynamicThemeColors(neutralTonalPalette(), dark)
+    assert.notEqual(colors.searchBar, colors.cardBackground, 'Fields must have a distinct fill')
+    const surfaces = ['background', 'cardBackground', 'secondaryCardBackground', 'searchBar', 'settingsSearchBar', 'subtleSurface', 'dropdownHover', 'sideNavHover']
+    for (const background of surfaces) {
+      for (const foreground of ['primaryText', 'secondaryText', 'tertiaryText', 'link', 'linkVisited', 'error']) {
+        assert.ok(contrast(colors[foreground], colors[background]) >= 4.5, `${foreground} on ${background}`)
+      }
+      for (const foreground of ['border', 'scrollbar', 'scrollbarHover', 'scrollbarActive', 'accent']) {
+        assert.ok(contrast(colors[foreground], colors[background]) >= 3, `${foreground} on ${background}`)
+      }
+    }
+    for (const [foreground, backgrounds] of [
+      ['textWithPrimary', ['primary', 'primaryHover', 'primaryActive', 'coloredHeaderHover', 'coloredHeaderPressed']],
+      ['textWithAccent', ['accent', 'accentHover', 'accentActive', 'accentLight']],
+      ['destructiveText', ['destructive', 'destructiveHover', 'destructiveActive']],
+    ]) {
+      for (const background of backgrounds) assert.ok(contrast(colors[foreground], colors[background]) >= 4.5, `${foreground} on ${background}`)
+    }
+    assert.ok(contrast('#eeeeee', colors.primaryInput) >= 4.5, 'Colored header search text')
+  })
+}

--- a/tests/unit/dynamic-colors.test.mjs
+++ b/tests/unit/dynamic-colors.test.mjs
@@ -77,6 +77,8 @@ test('switching back from dynamic colors or a custom-theme preview restores the 
   applyThemeToDocument('dynamic', 'Red', 'Blue', null)
   assert.equal(classes.has('light'), true)
   assert.equal(classes.has('dynamicColors'), true)
+  assert.equal(classes.has('mainRed'), false)
+  assert.equal(classes.has('secBlue'), false)
   assert.equal(properties.get('--bg-color'), palette().neutral1[50])
   dark = true
   applyThemeToDocument('dynamic', 'Red', 'Blue', null)
@@ -90,6 +92,15 @@ test('switching back from dynamic colors or a custom-theme preview restores the 
   assert.equal(classes.has('light'), true)
   applyThemeToDocument('dynamic', 'Red', 'Blue', null)
   assert.equal(properties.get('--primary-color'), palette().accent1[200])
+  androidDynamicColors.value = { supported: false }
+  for (const isDark of [false, true]) {
+    dark = isDark
+    applyThemeToDocument('dynamic', 'Red', 'Blue', null)
+    assert.equal(classes.has(isDark ? 'dark' : 'light'), true)
+    assert.equal(classes.has(isDark ? 'light' : 'dark'), false)
+    assert.equal(properties.has('--bg-color'), false)
+    assert.equal(properties.has('--accent-color-rgb'), false)
+  }
 })
 
 function contrast(first, second) {

--- a/tests/unit/dynamic-colors.test.mjs
+++ b/tests/unit/dynamic-colors.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { dynamicThemeColors, applyDynamicColors } from '../../src/renderer/helpers/dynamicColors.js'
+import { dynamicThemeColors, applyDynamicColors, initializeAndroidDynamicColors, androidDynamicColors } from '../../src/renderer/helpers/dynamicColors.js'
 import { hasFixedThemeColors, resolveBaseTheme, resolveSystemTheme } from '../../src/appearanceSettings.js'
 
 function palette() {
@@ -98,6 +98,8 @@ test('switching back from dynamic colors or a custom-theme preview restores the 
     applyThemeToDocument('dynamic', 'Red', 'Blue', null)
     assert.equal(classes.has(isDark ? 'dark' : 'light'), true)
     assert.equal(classes.has(isDark ? 'light' : 'dark'), false)
+    assert.equal(classes.has('mainRed'), true)
+    assert.equal(classes.has('secBlue'), true)
     assert.equal(properties.has('--bg-color'), false)
     assert.equal(properties.has('--accent-color-rgb'), false)
   }
@@ -146,3 +148,28 @@ for (const dark of [false, true]) {
     assert.ok(contrast('#eeeeee', colors.primaryInput) >= 4.5, 'Colored header search text')
   })
 }
+
+
+test('startup continues when the native palette request stalls and ignores its late result', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] })
+  t.after(() => { androidDynamicColors.value = { supported: false } })
+  let resolveRequest
+  const request = new Promise(resolve => { resolveRequest = resolve })
+  let ready = false
+  const initialization = initializeAndroidDynamicColors(request).then(() => { ready = true })
+  t.mock.timers.tick(1500)
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(ready, true, 'A stalled native bridge must not block mounting')
+  await initialization
+  assert.equal(androidDynamicColors.value.supported, false)
+  resolveRequest({ supported: true, palette: palette() })
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(androidDynamicColors.value.supported, false, 'Late startup results must not replace live state')
+})
+
+test('startup uses a timely palette and propagates native errors to the fallback handler', async (t) => {
+  t.after(() => { androidDynamicColors.value = { supported: false } })
+  await initializeAndroidDynamicColors(Promise.resolve({ supported: true, palette: palette() }))
+  assert.equal(androidDynamicColors.value.supported, true)
+  await assert.rejects(initializeAndroidDynamicColors(Promise.reject(new Error('bridge failed'))), /bridge failed/)
+})

--- a/tests/unit/dynamic-colors.test.mjs
+++ b/tests/unit/dynamic-colors.test.mjs
@@ -149,7 +149,6 @@ for (const dark of [false, true]) {
   })
 }
 
-
 test('startup continues when the native palette request stalls and ignores its late result', async (t) => {
   t.mock.timers.enable({ apis: ['setTimeout'] })
   t.after(() => { androidDynamicColors.value = { supported: false } })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

Android users can now select Dynamic colors to follow their phone’s Material You palette, including live wallpaper and accent changes.

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #1298

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Adds a local Capacitor plugin for Android 12+ and applies the native palette across app themes. Light and dark controls use contrasting text, fills, and outlines. Existing theme choices remain available.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Follow your Android phone’s Material You palette with the new Dynamic colors theme.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/47bee692-2066-41e8-b2d9-1d9019ba990d">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/a622aa86-5fa9-49af-944f-6925b383927b">
  <img alt="Android Dynamic colors in Appearance settings" src="https://github.com/user-attachments/assets/47bee692-2066-41e8-b2d9-1d9019ba990d">
</picture>

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. On Android 12 or newer, open Appearance → Theme and select Dynamic colors. Check that fields, buttons, switches, and sliders are readable in light and dark mode.
2. Change the system wallpaper or accent while the app is running, then return to the app. Its palette should update without restarting.
3. Select another theme and confirm that its normal colors return.
4. On Android 8–11, confirm that Dynamic colors is absent.

## Additional context
<!-- Add any other context about the pull request here. -->

Android 15 needs a WebView resource-registration workaround to avoid pinning old system color overlays. Android 16 already filters those overlays.

Validation: unit suite and JS/style/YAML lint passed; Android native tests and API 35 instrumentation passed in light/dark modes, including live palette changes in the same WebView. Android 8 / WebView 119 gating was verified. The updated debug APK was also installed on a Pixel 8 Pro.

Implemented and reviewed by GPT-6 in Codex.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/OpenTubeX/OpenTubeX/pull/1340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

