### PR TITLE
fix: parse newer YouTube panels and comment responses

### DIFF
--- a/patches/youtubei.js@18.0.0.patch
+++ b/patches/youtubei.js@18.0.0.patch
@@ -42,10 +42,43 @@ index 0000000000000000000000000000000000000000..7f5b5872e1a87cda497e7b4c14444fa4
 +    }
 +}
 diff --git a/dist/src/parser/nodes.d.ts b/dist/src/parser/nodes.d.ts
-index 270a1d15489deec9645e790215b544b42b372307..7837992e5fb0e1a723f7c2636103761dc5ea24a6 100644
+index 270a1d15489deec9645e790215b544b42b372307..a4504dd14432fee77c9afdd92b99c9721adaee72 100644
 --- a/dist/src/parser/nodes.d.ts
 +++ b/dist/src/parser/nodes.d.ts
-@@ -542,5 +542,6 @@ export { default as VideoSecondaryInfo } from './classes/VideoSecondaryInfo.js';
+@@ -86,6 +86,7 @@ export { default as UpdateEngagementPanelContentCommand } from './classes/comman
+ export { default as AuthorCommentBadge } from './classes/comments/AuthorCommentBadge.js';
+ export { default as CommentActionButtons } from './classes/comments/CommentActionButtons.js';
+ export { default as CommentDialog } from './classes/comments/CommentDialog.js';
++export { default as CommentFilterContextView } from './classes/CommentFilterContextView.js';
+ export { default as CommentReplies } from './classes/comments/CommentReplies.js';
+ export { default as CommentReplyDialog } from './classes/comments/CommentReplyDialog.js';
+ export { default as CommentsEntryPointHeader } from './classes/comments/CommentsEntryPointHeader.js';
+@@ -109,6 +110,7 @@ export { default as CompactStation } from './classes/CompactStation.js';
+ export { default as CompactVideo } from './classes/CompactVideo.js';
+ export { default as CompositeVideoPrimaryInfo } from './classes/CompositeVideoPrimaryInfo.js';
+ export { default as ConfirmDialog } from './classes/ConfirmDialog.js';
++export { default as ContentLoading } from './classes/ContentLoading.js';
+ export { default as ContentListItemView } from './classes/ContentListItemView.js';
+ export { default as ContentMetadataView } from './classes/ContentMetadataView.js';
+ export { default as ContentPreviewImageView } from './classes/ContentPreviewImageView.js';
+@@ -220,6 +222,7 @@ export { default as ImageBannerView } from './classes/ImageBannerView.js';
+ export { default as IncludingResultsFor } from './classes/IncludingResultsFor.js';
+ export { default as InfoPanelContainer } from './classes/InfoPanelContainer.js';
+ export { default as InfoPanelContent } from './classes/InfoPanelContent.js';
++export { default as InterstitialView } from './classes/InterstitialView.js';
+ export { default as InfoRow } from './classes/InfoRow.js';
+ export { default as InteractiveTabbedHeader } from './classes/InteractiveTabbedHeader.js';
+ export { default as ItemSection } from './classes/ItemSection.js';
+@@ -371,6 +374,7 @@ export { default as PlayerCaptchaView } from './classes/PlayerCaptchaView.js';
+ export { default as PlayerCaptionsTracklist } from './classes/PlayerCaptionsTracklist.js';
+ export { default as PlayerControlsOverlay } from './classes/PlayerControlsOverlay.js';
+ export { default as PlayerErrorMessage } from './classes/PlayerErrorMessage.js';
++export { default as PlayerInterstitial } from './classes/PlayerInterstitial.js';
+ export { default as PlayerLegacyDesktopYpcOffer } from './classes/PlayerLegacyDesktopYpcOffer.js';
+ export { default as PlayerLegacyDesktopYpcTrailer } from './classes/PlayerLegacyDesktopYpcTrailer.js';
+ export { default as PlayerLiveStoryboardSpec } from './classes/PlayerLiveStoryboardSpec.js';
+@@ -541,6 +545,7 @@ export { default as VideoPrimaryInfo } from './classes/VideoPrimaryInfo.js';
+ export { default as VideoSecondaryInfo } from './classes/VideoSecondaryInfo.js';
  export { default as VideoSummaryContentView } from './classes/VideoSummaryContentView.js';
  export { default as VideoSummaryParagraphView } from './classes/VideoSummaryParagraphView.js';
 +export { default as VideoTitleHeaderView } from './classes/VideoTitleHeaderView.js';
@@ -53,10 +86,43 @@ index 270a1d15489deec9645e790215b544b42b372307..7837992e5fb0e1a723f7c2636103761d
  export { default as ViewCountFactoid } from './classes/ViewCountFactoid.js';
  export { default as WatchCardCompactVideo } from './classes/WatchCardCompactVideo.js';
 diff --git a/dist/src/parser/nodes.js b/dist/src/parser/nodes.js
-index 3511b11a22302980a4c1b57bbc897a307e1e51bd..240195d26d731f5e347d5192e96d57e5b0af71ce 100644
+index ed9b62636c238d9a21bac7e2b78a4042ce6efe45..c14752245565fc3e647264f6618804cfd4bafe93 100644
 --- a/dist/src/parser/nodes.js
 +++ b/dist/src/parser/nodes.js
-@@ -544,5 +544,6 @@ export { default as VideoSecondaryInfo } from './classes/VideoSecondaryInfo.js';
+@@ -88,6 +88,7 @@ export { default as UpdateEngagementPanelContentCommand } from './classes/comman
+ export { default as AuthorCommentBadge } from './classes/comments/AuthorCommentBadge.js';
+ export { default as CommentActionButtons } from './classes/comments/CommentActionButtons.js';
+ export { default as CommentDialog } from './classes/comments/CommentDialog.js';
++export { default as CommentFilterContextView } from './classes/CommentFilterContextView.js';
+ export { default as CommentReplies } from './classes/comments/CommentReplies.js';
+ export { default as CommentReplyDialog } from './classes/comments/CommentReplyDialog.js';
+ export { default as CommentsEntryPointHeader } from './classes/comments/CommentsEntryPointHeader.js';
+@@ -111,6 +112,7 @@ export { default as CompactStation } from './classes/CompactStation.js';
+ export { default as CompactVideo } from './classes/CompactVideo.js';
+ export { default as CompositeVideoPrimaryInfo } from './classes/CompositeVideoPrimaryInfo.js';
+ export { default as ConfirmDialog } from './classes/ConfirmDialog.js';
++export { default as ContentLoading } from './classes/ContentLoading.js';
+ export { default as ContentListItemView } from './classes/ContentListItemView.js';
+ export { default as ContentMetadataView } from './classes/ContentMetadataView.js';
+ export { default as ContentPreviewImageView } from './classes/ContentPreviewImageView.js';
+@@ -222,6 +224,7 @@ export { default as ImageBannerView } from './classes/ImageBannerView.js';
+ export { default as IncludingResultsFor } from './classes/IncludingResultsFor.js';
+ export { default as InfoPanelContainer } from './classes/InfoPanelContainer.js';
+ export { default as InfoPanelContent } from './classes/InfoPanelContent.js';
++export { default as InterstitialView } from './classes/InterstitialView.js';
+ export { default as InfoRow } from './classes/InfoRow.js';
+ export { default as InteractiveTabbedHeader } from './classes/InteractiveTabbedHeader.js';
+ export { default as ItemSection } from './classes/ItemSection.js';
+@@ -373,6 +376,7 @@ export { default as PlayerCaptchaView } from './classes/PlayerCaptchaView.js';
+ export { default as PlayerCaptionsTracklist } from './classes/PlayerCaptionsTracklist.js';
+ export { default as PlayerControlsOverlay } from './classes/PlayerControlsOverlay.js';
+ export { default as PlayerErrorMessage } from './classes/PlayerErrorMessage.js';
++export { default as PlayerInterstitial } from './classes/PlayerInterstitial.js';
+ export { default as PlayerLegacyDesktopYpcOffer } from './classes/PlayerLegacyDesktopYpcOffer.js';
+ export { default as PlayerLegacyDesktopYpcTrailer } from './classes/PlayerLegacyDesktopYpcTrailer.js';
+ export { default as PlayerLiveStoryboardSpec } from './classes/PlayerLiveStoryboardSpec.js';
+@@ -543,6 +547,7 @@ export { default as VideoPrimaryInfo } from './classes/VideoPrimaryInfo.js';
+ export { default as VideoSecondaryInfo } from './classes/VideoSecondaryInfo.js';
  export { default as VideoSummaryContentView } from './classes/VideoSummaryContentView.js';
  export { default as VideoSummaryParagraphView } from './classes/VideoSummaryParagraphView.js';
 +export { default as VideoTitleHeaderView } from './classes/VideoTitleHeaderView.js';
@@ -406,3 +472,209 @@ diff --git a/dist/src/utils/ProtoUtils.js b/dist/src/utils/ProtoUtils.js
  }
  export function encodeNextParams(video_ids, playlist_title) {
      const writer = NextParams.encode({ videoId: video_ids, playlistTitle: playlist_title });
+diff --git a/dist/src/parser/classes/CommentFilterContextView.d.ts b/dist/src/parser/classes/CommentFilterContextView.d.ts
+new file mode 100644
+index 0000000000000000000000000000000000000000..38ae8fba7c1c76c25f316b3b989e65694a8ba096
+--- /dev/null
++++ b/dist/src/parser/classes/CommentFilterContextView.d.ts
+@@ -0,0 +1,8 @@
++import { YTNode } from '../helpers.js';
++import { type RawNode } from '../index.js';
++import Text from './misc/Text.js';
++export default class CommentFilterContextView extends YTNode {
++    static type: string;
++    text: Text;
++    constructor(data: RawNode);
++}
+diff --git a/dist/src/parser/classes/CommentFilterContextView.js b/dist/src/parser/classes/CommentFilterContextView.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..25d0c68d41f6253b8442c0ed9067bf126c965e18
+--- /dev/null
++++ b/dist/src/parser/classes/CommentFilterContextView.js
+@@ -0,0 +1,10 @@
++import { YTNode } from '../helpers.js';
++import Text from './misc/Text.js';
++export default class CommentFilterContextView extends YTNode {
++    static type = 'CommentFilterContextView';
++    text;
++    constructor(data) {
++        super();
++        this.text = Text.fromAttributed(data.text);
++    }
++}
+diff --git a/dist/src/parser/classes/ContentLoading.d.ts b/dist/src/parser/classes/ContentLoading.d.ts
+new file mode 100644
+index 0000000000000000000000000000000000000000..ba9d9c00d7d88de7d36e3714bfdbd8269ae7d656
+--- /dev/null
++++ b/dist/src/parser/classes/ContentLoading.d.ts
+@@ -0,0 +1,8 @@
++import { YTNode } from '../helpers.js';
++import { type RawNode } from '../index.js';
++
++export default class ContentLoading extends YTNode {
++    static type: string;
++    use_spinner: boolean;
++    constructor(data: RawNode);
++}
+diff --git a/dist/src/parser/classes/ContentLoading.js b/dist/src/parser/classes/ContentLoading.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..0823bb69830d316d06a5d4c82904e8a0239c945a
+--- /dev/null
++++ b/dist/src/parser/classes/ContentLoading.js
+@@ -0,0 +1,10 @@
++import { YTNode } from '../helpers.js';
++
++export default class ContentLoading extends YTNode {
++    static type = 'ContentLoading';
++    use_spinner;
++    constructor(data) {
++        super();
++        this.use_spinner = data.useSpinner;
++    }
++}
+diff --git a/dist/src/parser/classes/EngagementPanelSectionList.d.ts b/dist/src/parser/classes/EngagementPanelSectionList.d.ts
+index f9a57b0fe2835c9929d0b94c9c69be7d2fd8a0b6..7781e54b6e0246083d23510fd503d8933fcbfcde 100644
+--- a/dist/src/parser/classes/EngagementPanelSectionList.d.ts
++++ b/dist/src/parser/classes/EngagementPanelSectionList.d.ts
+@@ -9,10 +9,11 @@ import ProductList from './ProductList.js';
+ import SectionList from './SectionList.js';
+ import StructuredDescriptionContent from './StructuredDescriptionContent.js';
+ import VideoAttributeView from './VideoAttributeView.js';
++import ContentLoading from './ContentLoading.js';
+ export default class EngagementPanelSectionList extends YTNode {
+     static type: string;
+     header: EngagementPanelTitleHeader | null;
+-    content: PlaylistCollaborationView | VideoAttributeView | SectionList | ContinuationItem | ClipSection | StructuredDescriptionContent | MacroMarkersList | ProductList | null;
++    content: PlaylistCollaborationView | VideoAttributeView | SectionList | ContinuationItem | ClipSection | StructuredDescriptionContent | MacroMarkersList | ProductList | ContentLoading | null;
+     target_id?: string;
+     panel_identifier?: string;
+     identifier?: {
+diff --git a/dist/src/parser/classes/EngagementPanelSectionList.js b/dist/src/parser/classes/EngagementPanelSectionList.js
+index 66690decd06b861f47529a511960365e6fb672c3..df9ebfe1a3e03c66e8c0cbd1f7ed5acd5c7027ac 100644
+--- a/dist/src/parser/classes/EngagementPanelSectionList.js
++++ b/dist/src/parser/classes/EngagementPanelSectionList.js
+@@ -9,6 +9,7 @@ import ProductList from './ProductList.js';
+ import SectionList from './SectionList.js';
+ import StructuredDescriptionContent from './StructuredDescriptionContent.js';
+ import VideoAttributeView from './VideoAttributeView.js';
++import ContentLoading from './ContentLoading.js';
+ export default class EngagementPanelSectionList extends YTNode {
+     static type = 'EngagementPanelSectionList';
+     header;
+@@ -23,7 +24,7 @@ export default class EngagementPanelSectionList extends YTNode {
+         this.content = Parser.parseItem(data.content, [
+             PlaylistCollaborationView, VideoAttributeView, SectionList,
+             ContinuationItem, ClipSection, StructuredDescriptionContent,
+-            MacroMarkersList, ProductList
++            MacroMarkersList, ProductList, ContentLoading
+         ]);
+         this.panel_identifier = data.panelIdentifier;
+         if ('identifier' in data) {
+diff --git a/dist/src/parser/classes/InterstitialView.d.ts b/dist/src/parser/classes/InterstitialView.d.ts
+new file mode 100644
+index 0000000000000000000000000000000000000000..9e6a4f81906be3258f2e6e98b20bcd882d8ccea6
+--- /dev/null
++++ b/dist/src/parser/classes/InterstitialView.d.ts
+@@ -0,0 +1,11 @@
++import { YTNode } from '../helpers.js';
++import { type RawNode } from '../index.js';
++import Text from './misc/Text.js';
++import ButtonView from './ButtonView.js';
++export default class InterstitialView extends YTNode {
++    static type: string;
++    title: Text;
++    description: Text;
++    primary_button: ButtonView | null;
++    constructor(data: RawNode);
++}
+diff --git a/dist/src/parser/classes/InterstitialView.js b/dist/src/parser/classes/InterstitialView.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..4a6a56df003866441f0fb5c451571c76dbecc3e2
+--- /dev/null
++++ b/dist/src/parser/classes/InterstitialView.js
+@@ -0,0 +1,16 @@
++import { YTNode } from '../helpers.js';
++import { Parser } from '../index.js';
++import Text from './misc/Text.js';
++import ButtonView from './ButtonView.js';
++export default class InterstitialView extends YTNode {
++    static type = 'InterstitialView';
++    title;
++    description;
++    primary_button;
++    constructor(data) {
++        super();
++        this.title = Text.fromAttributed(data.title);
++        this.description = Text.fromAttributed(data.description);
++        this.primary_button = Parser.parseItem(data.primaryButton, ButtonView);
++    }
++}
+diff --git a/dist/src/parser/classes/PlayerInterstitial.d.ts b/dist/src/parser/classes/PlayerInterstitial.d.ts
+new file mode 100644
+index 0000000000000000000000000000000000000000..9ff26cbb55d1fda78d4f72c253882e163cb2578b
+--- /dev/null
++++ b/dist/src/parser/classes/PlayerInterstitial.d.ts
+@@ -0,0 +1,8 @@
++import { YTNode } from '../helpers.js';
++import { type RawNode } from '../index.js';
++import InterstitialView from './InterstitialView.js';
++export default class PlayerInterstitial extends YTNode {
++    static type: string;
++    content: InterstitialView | null;
++    constructor(data: RawNode);
++}
+diff --git a/dist/src/parser/classes/PlayerInterstitial.js b/dist/src/parser/classes/PlayerInterstitial.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..652e7c006017ad83e2872bdf3e7e24277712fe8c
+--- /dev/null
++++ b/dist/src/parser/classes/PlayerInterstitial.js
+@@ -0,0 +1,11 @@
++import { YTNode } from '../helpers.js';
++import { Parser } from '../index.js';
++import InterstitialView from './InterstitialView.js';
++export default class PlayerInterstitial extends YTNode {
++    static type = 'PlayerInterstitial';
++    content;
++    constructor(data) {
++        super();
++        this.content = Parser.parseItem(data.content, InterstitialView);
++    }
++}
+diff --git a/dist/src/parser/classes/StructuredDescriptionContent.d.ts b/dist/src/parser/classes/StructuredDescriptionContent.d.ts
+index 29052ffc49d8b40e2c36faf387032485e5e77285..5410c117de4954fd4769eb74f2f4f84ff7eba102 100644
+--- a/dist/src/parser/classes/StructuredDescriptionContent.d.ts
++++ b/dist/src/parser/classes/StructuredDescriptionContent.d.ts
+@@ -14,8 +14,10 @@ import ExpandableMetadata from './ExpandableMetadata.js';
+ import MerchandiseShelf from './MerchandiseShelf.js';
+ import HypeFanCreditsSectionView from './HypeFanCreditsSectionView.js';
+ import VideoDescriptionYouchatSectionView from './VideoDescriptionYouchatSectionView.js';
++import VideoTitleHeaderView from './VideoTitleHeaderView.js';
++import Shelf from './Shelf.js';
+ export default class StructuredDescriptionContent extends YTNode {
+     static type: string;
+-    items: ObservedArray<VideoDescriptionHeader | ExpandableVideoDescriptionBody | VideoDescriptionMusicSection | VideoDescriptionInfocardsSection | VideoDescriptionTranscriptSection | VideoDescriptionCourseSection | VideoDescriptionYouchatSectionView | HorizontalCardList | ReelShelf | VideoAttributesSectionView | HowThisWasMadeSectionView | ExpandableMetadata | MerchandiseShelf | HypeFanCreditsSectionView>;
++    items: ObservedArray<VideoDescriptionHeader | ExpandableVideoDescriptionBody | VideoDescriptionMusicSection | VideoDescriptionInfocardsSection | VideoDescriptionTranscriptSection | VideoDescriptionCourseSection | VideoDescriptionYouchatSectionView | HorizontalCardList | ReelShelf | VideoAttributesSectionView | HowThisWasMadeSectionView | ExpandableMetadata | MerchandiseShelf | HypeFanCreditsSectionView | VideoTitleHeaderView | Shelf>;
+     constructor(data: RawNode);
+ }
+diff --git a/dist/src/parser/classes/StructuredDescriptionContent.js b/dist/src/parser/classes/StructuredDescriptionContent.js
+index dc4ba3a66eed7051370c883503cf5309e8f253cc..acf606459353271a2565f4c09bf87073db2dbdd0 100644
+--- a/dist/src/parser/classes/StructuredDescriptionContent.js
++++ b/dist/src/parser/classes/StructuredDescriptionContent.js
+@@ -14,6 +14,8 @@ import ExpandableMetadata from './ExpandableMetadata.js';
+ import MerchandiseShelf from './MerchandiseShelf.js';
+ import HypeFanCreditsSectionView from './HypeFanCreditsSectionView.js';
+ import VideoDescriptionYouchatSectionView from './VideoDescriptionYouchatSectionView.js';
++import VideoTitleHeaderView from './VideoTitleHeaderView.js';
++import Shelf from './Shelf.js';
+ export default class StructuredDescriptionContent extends YTNode {
+     static type = 'StructuredDescriptionContent';
+     items;
+@@ -23,7 +25,7 @@ export default class StructuredDescriptionContent extends YTNode {
+             VideoDescriptionHeader, ExpandableVideoDescriptionBody, VideoDescriptionMusicSection,
+             VideoDescriptionInfocardsSection, VideoDescriptionCourseSection, VideoDescriptionTranscriptSection,
+             VideoDescriptionYouchatSectionView, HorizontalCardList, ReelShelf, VideoAttributesSectionView,
+-            HowThisWasMadeSectionView, ExpandableMetadata, MerchandiseShelf, HypeFanCreditsSectionView
++            HowThisWasMadeSectionView, ExpandableMetadata, MerchandiseShelf, HypeFanCreditsSectionView, VideoTitleHeaderView, Shelf
+         ]);
+     }
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ patchedDependencies:
   '@capawesome/capacitor-clipboard@0.1.2': 729c6071cbf0e196e2212b015677cdd162c287dca48137c24250c0d056c9fd5b
   shaka-player@5.1.12: 17d85e267c8958999207ce9d6c29a2ddf18734d0499fb30870ac8a55d90303fa
   vue-sonner@2.0.9: 1edf0a77b800d7b7f56694e3a77ff40dd2f7ba21658639d2ff90d5173eae26b4
-  youtubei.js@18.0.0: 5939f9d50ce37ef8075961245288956568c781818db04171892485bdf96278e9
+  youtubei.js@18.0.0: 9e43863918786ead8955fc486018ceca9b9d5d0d27d947d9de5f3ec93eac38cf
 
 importers:
 
@@ -147,7 +147,7 @@ importers:
         version: 4.1.0(vue@3.5.42(typescript@6.0.3))
       youtubei.js:
         specifier: ^18.0.0
-        version: 18.0.0(patch_hash=5939f9d50ce37ef8075961245288956568c781818db04171892485bdf96278e9)
+        version: 18.0.0(patch_hash=9e43863918786ead8955fc486018ceca9b9d5d0d27d947d9de5f3ec93eac38cf)
       quickjs-emscripten-core:
         specifier: ^0.32.0
         version: 0.32.0
@@ -11583,7 +11583,7 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  youtubei.js@18.0.0(patch_hash=5939f9d50ce37ef8075961245288956568c781818db04171892485bdf96278e9):
+  youtubei.js@18.0.0(patch_hash=9e43863918786ead8955fc486018ceca9b9d5d0d27d947d9de5f3ec93eac38cf):
     dependencies:
       '@bufbuild/protobuf': 2.12.1
       fflate: 0.8.3

--- a/tests/unit/youtubei-parser-panels.test.mjs
+++ b/tests/unit/youtubei-parser-panels.test.mjs
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { Parser, YTNodes } from 'youtubei.js'
+
+// These shapes reproduce the missing nodes and rejected children in the console log.
+test('retains video title headers and shelves in structured descriptions', (t) => {
+  const warn = t.mock.method(console, 'warn', () => {})
+  const panel = Parser.parseItem({
+    engagementPanelSectionListRenderer: {
+      content: {
+        structuredDescriptionContentRenderer: {
+          items: [
+            { videoTitleHeaderViewModel: { videoTitle: { content: 'Video title' } } },
+            { shelfRenderer: { title: { simpleText: 'Related videos' } } }
+          ]
+        }
+      }
+    }
+  })
+  assert.equal(warn.mock.callCount(), 0)
+  assert.equal(panel.content.items.length, 2)
+  assert.ok(panel.content.items[0] instanceof YTNodes.VideoTitleHeaderView)
+  assert.ok(panel.content.items[1] instanceof YTNodes.Shelf)
+})
+
+test('parses loading panel content without runtime parser generation or type mismatches', (t) => {
+  const warn = t.mock.method(console, 'warn', () => {})
+  const panel = Parser.parseItem({
+    engagementPanelSectionListRenderer: {
+      content: { contentLoadingRenderer: { useSpinner: true } }
+    }
+  })
+  assert.equal(warn.mock.callCount(), 0)
+  assert.ok(panel.content instanceof YTNodes.ContentLoading)
+  assert.equal(panel.content.use_spinner, true)
+})
+
+test('parses player interstitials and their text and button without runtime generation', (t) => {
+  const warn = t.mock.method(console, 'warn', () => {})
+  const node = Parser.parseItem({
+    playerInterstitialRenderer: {
+      content: {
+        interstitialViewModel: {
+          title: { content: 'Before you continue' },
+          description: { content: 'Please confirm' },
+          primaryButton: { buttonViewModel: { title: 'Continue' } },
+          loggingDirectives: { trackingParams: 'fixture', visibility: { types: '1' } }
+        }
+      }
+    }
+  })
+  assert.equal(warn.mock.callCount(), 0)
+  assert.ok(node instanceof YTNodes.PlayerInterstitial)
+  assert.ok(node.content instanceof YTNodes.InterstitialView)
+  assert.equal(node.content.title.toString(), 'Before you continue')
+  assert.equal(node.content.description.toString(), 'Please confirm')
+  assert.ok(node.content.primary_button instanceof YTNodes.ButtonView)
+  assert.equal(node.content.primary_button.title, 'Continue')
+})
+
+test('parses comment filter context text without runtime parser generation', (t) => {
+  const warn = t.mock.method(console, 'warn', () => {})
+  const node = Parser.parseItem({
+    commentFilterContextViewModel: { text: { content: 'Top comments' } }
+  })
+  assert.equal(warn.mock.callCount(), 0)
+  assert.ok(node instanceof YTNodes.CommentFilterContextView)
+  assert.equal(node.text.toString(), 'Top comments')
+})

--- a/tests/unit/youtubei-parser-panels.test.mjs
+++ b/tests/unit/youtubei-parser-panels.test.mjs
@@ -59,12 +59,23 @@ test('parses player interstitials and their text and button without runtime gene
   assert.equal(node.content.primary_button.title, 'Continue')
 })
 
-test('parses comment filter context text without runtime parser generation', (t) => {
+test('retains comment filter context in a reloaded comment response without runtime generation', (t) => {
   const warn = t.mock.method(console, 'warn', () => {})
-  const node = Parser.parseItem({
-    commentFilterContextViewModel: { text: { content: 'Top comments' } }
+  const response = Parser.parseResponse({
+    onResponseReceivedEndpoints: [{
+      reloadContinuationItemsCommand: {
+        targetId: 'comments-section',
+        continuationItems: [{
+          commentFilterContextViewModel: { text: { content: 'Top comments' } }
+        }]
+      }
+    }]
   })
   assert.equal(warn.mock.callCount(), 0)
+  const command = response.on_response_received_endpoints[0]
+  assert.equal(command.target_id, 'comments-section')
+  assert.equal(command.contents.length, 1)
+  const node = command.contents[0]
   assert.ok(node instanceof YTNodes.CommentFilterContextView)
   assert.equal(node.text.toString(), 'Top comments')
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

Reported through a user-provided console log; no linked issue.

<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description

YouTube responses containing newer description, loading, interstitial, and comment nodes produce parser warnings, and unsupported panel children are discarded. Extend the existing YouTube.js 18.0.0 patch with the four missing node classes and allow the reported children in their panels, with matching declarations and regression tests.

<!-- Please write a clear and concise description of what the pull request does. -->

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Handle newer YouTube description, loading, interstitial, and comment responses without parser errors.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing

1. Run this branch in dev mode with the Local API and open videos, their descriptions, and comments.
2. Check the developer console while navigating. Responses containing the affected nodes should no longer report missing parsers for `PlayerInterstitial`, `InterstitialView`, `ContentLoading`, or `CommentFilterContextView`, or panel type mismatches for `VideoTitleHeaderView`, `Shelf`, or `ContentLoading`. YouTube controls when these response variants appear.

<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

## Additional context

Compared upstream `main` at `ef3afbe435edc86ba3357b6fa951548ee3d46053`. The existing [VideoTitleHeaderView backport](https://github.com/LuanRT/YouTube.js/pull/1238) already matches upstream; the parent allowlist gaps and four missing classes remain upstream. These additions are local fixes based on the logged node shapes.

Validation: all 1,913 unit tests passed, with 2 skipped; lint, YAML lint, targeted test lint, and frozen-lockfile installation passed. The four new regression tests failed before the fix and passed afterward. Fixtures reconstruct the logged shapes; the original browsing session was not replayed. Lint reports one existing i18n configuration warning.

Changes made with GPT-6 through the Codex desktop app.

<!-- Add any other context about the pull request here. -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/OpenTubeX/OpenTubeX/pull/1343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

