### PR TITLE
fix: avoid player warnings and sync timeouts during offline playback

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -287,6 +287,10 @@ export default defineComponent({
       type: Number,
       default: 0
     },
+    localFilePlayback: {
+      type: Boolean,
+      default: false
+    },
     startTime: {
       type: Number,
       default: null
@@ -10349,11 +10353,12 @@ export default defineComponent({
     window.addEventListener('online', onlineHandler)
     window.addEventListener('offline', offlineHandler)
 
-    // Only display the offline message while buffering/the loading symbol is visible.
+    // Local files can buffer while seeking without needing a network connection.
+    // Only display the offline message for streams while buffering/the loading symbol is visible.
     // If we briefly lose the connection but it comes back before the buffer is empty,
     // the user won't notice anything so we don't need to display the message.
     const showOfflineMessage = computed(() => {
-      return isOffline.value && isBuffering.value
+      return !props.localFilePlayback && isOffline.value && isBuffering.value
     })
 
     // #endregion offline message

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -1,6 +1,7 @@
 import i18n from '../../i18n/index'
 import { showToastOnAllTabs } from '../../helpers/utils'
 import { isAppHidden } from '../../helpers/appVisibility.js'
+import { connectionEvents, getConnectionState } from '../../helpers/networkRecovery.js'
 import {
   SyncServerClient,
   SyncServerCancelledError,
@@ -58,6 +59,11 @@ let autoSyncTimer = null
 let eventSyncTimer = null
 let lifecycleSyncStarted = false
 let deviceNameRefreshId = 0
+
+function isSyncServerOffline() {
+  return getConnectionState() === 'offline' ||
+    (typeof navigator !== 'undefined' && navigator.onLine === false)
+}
 
 function clearSyncServerDeviceNames(commit) {
   deviceNameRefreshId++
@@ -819,12 +825,13 @@ const actions = {
     if (!context.rootState.settings.syncServerToken) {
       return Promise.reject(new Error('Connect to a sync server first'))
     }
+    if (isSyncServerOffline()) return Promise.resolve(null)
     if (!activeSyncPromise) {
       let syncStarted = false
       clearTimeout(eventSyncTimer)
       eventSyncTimer = null
       activeSyncPromise = withSyncLock(() => {
-        if (!context.rootState.settings.syncServerEnabled) return null
+        if (!context.rootState.settings.syncServerEnabled || isSyncServerOffline()) return null
         if (options.skipIfRecent &&
             isRecentSync(context.rootState.settings.syncServerLastSyncAt)) {
           return null
@@ -844,6 +851,24 @@ const actions = {
   async initializeSyncServer({ commit, dispatch, rootState }) {
     if (!rootState.settings.syncServerEnabled || !rootState.settings.syncServerToken) return
 
+    if (!lifecycleSyncStarted && typeof window !== 'undefined') {
+      lifecycleSyncStarted = true
+      connectionEvents.addEventListener('change', ({ detail }) => {
+        if (detail === 'offline') cancelActiveSyncClients()
+        else if (detail === 'restored' && rootState.settings.syncServerAutoSync &&
+            isSyncReasonEnabled(rootState.settings, 'automatic')) {
+          dispatch('initializeSyncServer').catch(error => {
+            console.error('Sync server reconnect sync failed', error)
+          })
+        }
+      })
+      document.addEventListener('visibilitychange', () => {
+        if (!isAppHidden()) {
+          dispatch('scheduleSyncServer', 'automatic')
+        }
+      })
+    }
+
     commit(
       'setSyncServerOtherDeviceSessions',
       getSavedOtherDeviceSessions(
@@ -851,6 +876,8 @@ const actions = {
         rootState.settings
       )
     )
+
+    if (isSyncServerOffline()) return
 
     try {
       const client = trackSyncClient(new SyncServerClient(
@@ -881,15 +908,6 @@ const actions = {
     }
 
     await dispatch('startSyncServerAutoSync')
-    if (!lifecycleSyncStarted && typeof window !== 'undefined') {
-      lifecycleSyncStarted = true
-      window.addEventListener('online', () => dispatch('scheduleSyncServer', 'automatic'))
-      document.addEventListener('visibilitychange', () => {
-        if (!isAppHidden()) {
-          dispatch('scheduleSyncServer', 'automatic')
-        }
-      })
-    }
     if (rootState.settings.syncServerAutoSync) {
       await dispatch('syncWithSyncServer', { skipIfRecent: true })
     }
@@ -913,6 +931,7 @@ const actions = {
   },
 
   async refreshSyncServerDeviceNames({ commit, dispatch, rootState }) {
+    if (isSyncServerOffline()) return
     const settings = rootState.settings
     if (!settings.syncServerToken || !settings.syncServerPrivacyKey) {
       clearSyncServerDeviceNames(commit)
@@ -965,7 +984,8 @@ const actions = {
   },
 
   scheduleSyncServer({ dispatch, rootState }, reason = 'data') {
-    if (!rootState.settings.syncServerEnabled ||
+    if (isSyncServerOffline() ||
+        !rootState.settings.syncServerEnabled ||
         !rootState.settings.syncServerAutoSync ||
         !rootState.settings.syncServerToken ||
         !isSyncReasonEnabled(rootState.settings, reason) ||

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -848,18 +848,22 @@ const actions = {
     return activeSyncPromise
   },
 
-  async initializeSyncServer({ commit, dispatch, rootState }) {
-    if (!rootState.settings.syncServerEnabled || !rootState.settings.syncServerToken) return
-
+  async initializeSyncServer({ commit, dispatch, rootState }, { skipIfRecent = true } = {}) {
     if (!lifecycleSyncStarted && typeof window !== 'undefined') {
       lifecycleSyncStarted = true
-      connectionEvents.addEventListener('change', ({ detail }) => {
+      connectionEvents.addEventListener('change', async ({ detail }) => {
         if (detail === 'offline') cancelActiveSyncClients()
-        else if (detail === 'restored' && rootState.settings.syncServerAutoSync &&
-            isSyncReasonEnabled(rootState.settings, 'automatic')) {
-          dispatch('initializeSyncServer').catch(error => {
+        else if (detail === 'restored') {
+          try {
+            // A reconnect must start a fresh sync after cancellation finishes.
+            await activeSyncPromise?.catch(() => {})
+            if (rootState.settings.syncServerAutoSync &&
+                isSyncReasonEnabled(rootState.settings, 'automatic')) {
+              await dispatch('initializeSyncServer', { skipIfRecent: false })
+            }
+          } catch (error) {
             console.error('Sync server reconnect sync failed', error)
-          })
+          }
         }
       })
       document.addEventListener('visibilitychange', () => {
@@ -868,6 +872,8 @@ const actions = {
         }
       })
     }
+
+    if (!rootState.settings.syncServerEnabled || !rootState.settings.syncServerToken) return
 
     commit(
       'setSyncServerOtherDeviceSessions',
@@ -909,7 +915,7 @@ const actions = {
 
     await dispatch('startSyncServerAutoSync')
     if (rootState.settings.syncServerAutoSync) {
-      await dispatch('syncWithSyncServer', { skipIfRecent: true })
+      await dispatch('syncWithSyncServer', { skipIfRecent })
     }
   },
 

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -94,6 +94,7 @@
           :sabr-data="sabrData"
           :legacy-formats="legacyFormats"
           :playback-source-key="playbackSourceKey"
+          :local-file-playback="localFilePlayback"
           :start-time="startTimeSeconds"
           :captions="captions"
           :caption-translations="captionTranslations"

--- a/tests/unit/player-offline-message.test.mjs
+++ b/tests/unit/player-offline-message.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import vm from 'node:vm'
+import test from 'node:test'
+import { computed, reactive, ref } from 'vue'
+
+const source = await readFile(new URL('../../src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js', import.meta.url), 'utf8')
+const start = source.indexOf('    const showOfflineMessage = computed(')
+const expression = source.slice(start, source.indexOf('\n    // #endregion offline message', start))
+
+for (const format of ['legacy', 'audio']) {
+  test(`offline warning stays hidden while seeking downloaded ${format} media`, () => {
+    const props = reactive({ localFilePlayback: true, format })
+    const isOffline = ref(true)
+    const isBuffering = ref(false)
+    const visible = vm.runInNewContext(`${expression}\nshowOfflineMessage`, { computed, props, isOffline, isBuffering })
+    assert.equal(visible.value, false)
+    isBuffering.value = true
+    assert.equal(visible.value, false, 'local seeking must not show a network warning')
+    props.localFilePlayback = false
+    assert.equal(visible.value, true, 'online streams still warn while buffering offline')
+    isOffline.value = false
+    assert.equal(visible.value, false)
+    isOffline.value = true
+    isBuffering.value = false
+    assert.equal(visible.value, false)
+  })
+}

--- a/tests/unit/sync-server-downgrade.test.mjs
+++ b/tests/unit/sync-server-downgrade.test.mjs
@@ -137,7 +137,7 @@ function fixture (overrides = {}, { encrypted = false, respond, connectionState 
       }
       if (action === 'updateChannelPlaybackSpeeds') settings.channelPlaybackSpeeds = value
       if (action === 'replaceSyncServerToken') settings.syncServerToken = value
-      if (action === 'initializeSyncServer') return store.exports.actions.initializeSyncServer(context)
+      if (action === 'initializeSyncServer') return store.exports.actions.initializeSyncServer(context, value)
       if (action === 'syncWithSyncServer') return store.exports.actions.syncWithSyncServer(context, value)
     },
   }
@@ -502,6 +502,7 @@ test('offline startup registers recovery and reconnect initializes sync', async 
   assert.equal(f.requests.length, 0)
   f.network.state = 'restored'
   f.connectionEvents.dispatchEvent(new CustomEvent('change', { detail: 'restored' }))
+  await Promise.resolve()
   assert.ok(f.dispatched.some(([action]) => action === 'initializeSyncServer'))
   for (let i = 0; i < 100 && !f.requests.length; i++) await Promise.resolve()
   assert.ok(f.requests.length > 0)
@@ -521,7 +522,68 @@ for (const settings of [{ syncServerSyncSubscriptions: false }, { syncServerAuto
     await f.actions.initializeSyncServer(f.context)
     f.network.state = 'restored'
     f.connectionEvents.dispatchEvent(new CustomEvent('change', { detail: 'restored' }))
+    await Promise.resolve()
     assert.equal(f.dispatched.some(([action]) => action === 'initializeSyncServer'), false)
     assert.equal(f.requests.length, 0)
   })
 }
+
+test('startup without an account still registers reconnect handling for a later connection', async () => {
+  const f = fixture({ syncServerToken: '' }, { encrypted: true, connectionState: 'offline', browser: true })
+  await f.actions.initializeSyncServer(f.context)
+  f.settings.syncServerToken = 'connected-token'
+  f.network.state = 'restored'
+  f.connectionEvents.dispatchEvent(new CustomEvent('change', { detail: 'restored' }))
+  for (let i = 0; i < 20; i++) await Promise.resolve()
+  assert.ok(f.dispatched.some(([action]) => action === 'initializeSyncServer'))
+})
+
+test('reconnect sync includes offline changes even when the last sync was recent', async () => {
+  const f = fixture({ syncServerLastSyncAt: Date.now() }, { encrypted: true, connectionState: 'offline', browser: true })
+  await f.actions.initializeSyncServer(f.context)
+  let options
+  const dispatch = f.context.dispatch
+  f.context.dispatch = async (action, value) => {
+    if (action === 'syncWithSyncServer') { options = value; return null }
+    return dispatch(action, value)
+  }
+  f.network.state = 'restored'
+  f.connectionEvents.dispatchEvent(new CustomEvent('change', { detail: 'restored' }))
+  for (let i = 0; i < 100 && !options; i++) await Promise.resolve()
+  assert.equal(options?.skipIfRecent, false)
+})
+
+test('disconnect cancels an active sync and reconnect waits for it to settle', async () => {
+  let releaseRequest
+  let signal
+  let started
+  const requestStarted = new Promise(resolve => { started = resolve })
+  const f = fixture({}, { encrypted: true, connectionState: 'offline', browser: true,
+    respond: (url, options) => {
+      if (signal) return
+      signal = options.signal
+      return new Promise((resolve, reject) => {
+        releaseRequest = () => reject(new DOMException('Aborted', 'AbortError'))
+        started()
+      })
+    },
+  })
+  await f.actions.initializeSyncServer(f.context)
+  f.network.state = 'online'
+  const syncing = f.actions.syncWithSyncServer(f.context)
+  await requestStarted
+  try {
+    f.network.state = 'offline'
+    f.connectionEvents.dispatchEvent(new CustomEvent('change', { detail: 'offline' }))
+    assert.equal(signal.aborted, true)
+    f.network.state = 'restored'
+    f.connectionEvents.dispatchEvent(new CustomEvent('change', { detail: 'restored' }))
+    for (let i = 0; i < 20; i++) await Promise.resolve()
+    assert.equal(f.requests.length, 1, 'reconnect must wait for the cancelled sync to settle')
+  } finally {
+    releaseRequest()
+    await syncing
+  }
+  for (let i = 0; i < 100 && f.requests.length === 1; i++) await Promise.resolve()
+  assert.ok(f.requests.length > 1, 'a fresh sync starts after cancellation settles')
+})

--- a/tests/unit/sync-server-downgrade.test.mjs
+++ b/tests/unit/sync-server-downgrade.test.mjs
@@ -10,7 +10,7 @@ import { mergeSettingEntry, resolveMergedThemeEntry } from '../../src/renderer/h
 
 import * as errors from '../../src/renderer/helpers/sync-server-errors.js'
 import * as privacy from '../../src/renderer/helpers/sync-server-privacy.js'
-import { isRecentSync } from '../../src/renderer/helpers/sync-server-scheduling.js'
+import { isRecentSync, isSyncReasonEnabled } from '../../src/renderer/helpers/sync-server-scheduling.js'
 import { createSyncServerRequestHeaders } from '../../src/renderer/helpers/sync-server-request.js'
 import { mergeSubscriptionSeenVideos } from '../../src/subscriptionSeenVideos.js'
 import { syncSubscriptionSeenVideos } from '../../src/renderer/helpers/subscription-seen-videos.js'
@@ -26,7 +26,9 @@ function withoutImports (source) {
 const helperSource = await readFile(new URL('../../src/renderer/helpers/sync-server.js', import.meta.url), 'utf8')
 const storeSource = await readFile(new URL('../../src/renderer/store/modules/sync-server.js', import.meta.url), 'utf8')
 
-function fixture (overrides = {}, { encrypted = false, respond } = {}) {
+function fixture (overrides = {}, { encrypted = false, respond, connectionState = 'online', online = true, browser = false, deferLock = false } = {}) {
+  const connectionEvents = new EventTarget()
+  const network = { state: connectionState, online }
   const requests = []
   const commits = []
   const notifications = []
@@ -56,6 +58,12 @@ function fixture (overrides = {}, { encrypted = false, respond } = {}) {
     ...privacy,
     syncSubscriptionSeenVideos,
     isRecentSync,
+    isSyncReasonEnabled,
+    getConnectionState: () => network.state,
+    navigator: { get onLine() { return network.online },
+      ...(deferLock ? { locks: { request: (name, callback) => Promise.resolve().then(callback) } } : {}) },
+    connectionEvents,
+    ...(browser ? { window: new EventTarget(), document: new EventTarget(), isAppHidden: () => false } : {}),
     crypto,
     URL,
     Headers,
@@ -129,10 +137,11 @@ function fixture (overrides = {}, { encrypted = false, respond } = {}) {
       }
       if (action === 'updateChannelPlaybackSpeeds') settings.channelPlaybackSpeeds = value
       if (action === 'replaceSyncServerToken') settings.syncServerToken = value
+      if (action === 'initializeSyncServer') return store.exports.actions.initializeSyncServer(context)
       if (action === 'syncWithSyncServer') return store.exports.actions.syncWithSyncServer(context, value)
     },
   }
-  return { settings, requests, commits, notifications, dispatched, context, actions: store.exports.actions, Client: helper.exports.SyncServerClient }
+  return { network, connectionEvents, settings, requests, commits, notifications, dispatched, context, actions: store.exports.actions, Client: helper.exports.SyncServerClient }
 }
 
 for (const [method, args, path, verb] of [
@@ -471,3 +480,48 @@ test('disabling sync clears recovery before a later manual sync succeeds', async
   await f.actions.syncWithSyncServer(f.context, { allowDataLoss: true })
   assert.equal(f.settings.syncServerAutoSync, false)
 })
+
+for (const offline of [{ connectionState: 'offline' }, { online: false }]) {
+  test(`sync skips requests while offline: ${JSON.stringify(offline)}`, async () => {
+    const f = fixture({}, { encrypted: true, ...offline })
+    await f.actions.initializeSyncServer(f.context)
+    assert.equal(f.requests.length, 0, 'startup must not contact the server offline')
+    await f.actions.syncWithSyncServer(f.context)
+    assert.equal(f.requests.length, 0)
+    assert.equal(f.commits.some(([name]) => name === 'setSyncServerError'), false)
+    f.network.state = 'online'
+    f.network.online = true
+    await f.actions.initializeSyncServer(f.context)
+    assert.ok(f.requests.length > 0, 'sync can resume once connectivity returns')
+  })
+}
+
+test('offline startup registers recovery and reconnect initializes sync', async () => {
+  const f = fixture({}, { encrypted: true, connectionState: 'offline', browser: true })
+  await f.actions.initializeSyncServer(f.context)
+  assert.equal(f.requests.length, 0)
+  f.network.state = 'restored'
+  f.connectionEvents.dispatchEvent(new CustomEvent('change', { detail: 'restored' }))
+  assert.ok(f.dispatched.some(([action]) => action === 'initializeSyncServer'))
+  for (let i = 0; i < 100 && !f.requests.length; i++) await Promise.resolve()
+  assert.ok(f.requests.length > 0)
+})
+
+test('a queued sync rechecks connectivity after acquiring its lock', async () => {
+  const f = fixture({}, { encrypted: true, deferLock: true })
+  const syncing = f.actions.syncWithSyncServer(f.context)
+  f.network.state = 'offline'
+  await syncing
+  assert.equal(f.requests.length, 0)
+})
+
+for (const settings of [{ syncServerSyncSubscriptions: false }, { syncServerAutoSync: false }]) {
+  test(`reconnect respects automatic sync preferences: ${JSON.stringify(settings)}`, async () => {
+    const f = fixture(settings, { encrypted: true, connectionState: 'offline', browser: true })
+    await f.actions.initializeSyncServer(f.context)
+    f.network.state = 'restored'
+    f.connectionEvents.dispatchEvent(new CustomEvent('change', { detail: 'restored' }))
+    assert.equal(f.dispatched.some(([action]) => action === 'initializeSyncServer'), false)
+    assert.equal(f.requests.length, 0)
+  })
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

Downloaded media briefly showed an offline warning while seeking, and sync attempts could time out after connectivity was lost. Keep local playback free of network warnings and pause sync until connectivity returns.

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Reported directly in a user task; no linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Pass the existing local-file playback state to the player. Skip sync startup, scheduled sync, and device-name requests while offline; cancel active sync clients on disconnect and resume enabled automatic sync after reconnect. Preserve the existing sync-category preferences.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Downloaded videos and audio no longer show an offline warning while seeking, and sync waits for connectivity instead of timing out while offline.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Download a video or audio file, disconnect from the internet, and open the download. Seek forward and backward. Playback should resume without the player's offline warning.
2. With automatic sync enabled, stay offline while opening the app and changing watch progress. No sync timeout toast should appear.
3. Restore connectivity. Automatic sync should resume only when it is enabled and at least one sync category is selected.
4. Turn off automatic sync, or turn off every sync category, then disconnect and reconnect. Reconnecting should not start a sync.

## Additional context
<!-- Add any other context about the pull request here. -->

Validation: full unit suite and lint passed; Android debug build and native unit tests passed. Android 8.0 with Chrome WebView 119 played and sought a local video under simulated offline connectivity with no player warning; sync startup, manual/scheduled sync, and device-name refresh made no native HTTP requests. Reconnect preferences have regression coverage.

Media omitted because an unchanged player with an absent transient warning would not explain the fix clearly.

Implemented with GPT-6 in the Codex desktop harness.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/OpenTubeX/OpenTubeX/pull/1344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

