### PR TITLE
fix: keep mobile progress and native video aligned while scrolling

### DIFF
--- a/android/app/src/androidTest/java/org/opentubex/app/NativePlaybackScreenTest.java
+++ b/android/app/src/androidTest/java/org/opentubex/app/NativePlaybackScreenTest.java
@@ -119,11 +119,49 @@ public class NativePlaybackScreenTest {
         }, (screen, controls, web, engine) -> {
             web.scrollTo(0, 120);
             assertEquals(120, web.getScrollY());
+            float expected = 180 * screen.getWidth() / 1000f - web.getScrollY();
+            assertEquals("Video must move in the scroll callback, before a later view-tree traversal", expected, frame[0].getTranslationY(), 1f);
+            assertEquals("Controls must move in the scroll callback", expected, controls.getY(), 1f);
         }, (screen, controls, web, engine) -> {
             assertEquals(120, web.getScrollY());
             float expected = 180 * screen.getWidth() / 1000f - web.getScrollY();
             assertEquals("The native video must follow Chromium scrolling without waiting for JS", expected, frame[0].getTranslationY(), 1f);
             assertEquals("Native transport buttons must scroll with the shared toolbar", expected, controls.getY(), 1f);
+        });
+    }
+
+    @Test public void miniPlayerEntersScrollingModeBeforeTheNextTraversal() {
+        View[] frame = new View[1];
+        withScreen((screen, controls, web, engine) -> {
+            screen.setFullscreen(false);
+            screen.setInlineVisible(true);
+            screen.layoutVideo(200, 200, 400, 225, 1000);
+            screen.setMiniPlayer(true, 12);
+            frame[0] = screen.getChildAt(0);
+            web.loadData("<html><body style='height:4000px'></body></html>", "text/html", "UTF-8");
+        }, (screen, controls, web, engine) -> {
+            web.scrollTo(0, 120);
+            assertEquals(120, web.getScrollY());
+            assertTrue("Momentum scrolling must raise video before Chromium paints the scrolling page",
+                screen.indexOfChild(frame[0]) > screen.indexOfChild((View) web.getParent()));
+        });
+    }
+
+    @Test public void retainedVideoAspectRatioStaysCenteredWhileDecoderSizeIsUnknown() {
+        View[] frame = new View[1];
+        withScreen((screen, controls, web, engine) -> {
+            screen.setFullscreen(false);
+            screen.setInlineVisible(true);
+            // The retained frame still has its last decoded aspect ratio when
+            // the decoder temporarily reports no size during surface changes.
+            assertEquals(0, engine.getPlayer().getVideoSize().height);
+            screen.updateAspectRatio(new androidx.media3.common.VideoSize(640, 480));
+            screen.updateAspectRatio(androidx.media3.common.VideoSize.UNKNOWN);
+            frame[0] = screen.getChildAt(0);
+            screen.layoutVideo(0, 100, 400, 225, 400);
+        }, (screen, controls, web, engine) -> {
+            float center = frame[0].getX() + frame[0].getWidth() * frame[0].getScaleX() / 2;
+            assertEquals("Retained 4:3 video must have equal side bars", screen.getWidth() / 2f, center, 1f);
         });
     }
 

--- a/android/app/src/main/java/org/opentubex/app/NativePlaybackScreen.java
+++ b/android/app/src/main/java/org/opentubex/app/NativePlaybackScreen.java
@@ -66,8 +66,9 @@ final class NativePlaybackScreen extends FrameLayout implements TextureView.Surf
     private float pageTouchY;
     private long lastPageScroll;
     private int lastWebScrollY;
+    private float videoAspectRatio;
     private final Runnable pageScrollSettled = this::requestPageScrollEnd;
-    private final android.view.ViewTreeObserver.OnScrollChangedListener pageScrollListener = this::onPageScroll;
+    private final View.OnScrollChangeListener pageScrollListener = (view, x, y, oldX, oldY) -> onPageScroll();
     private long transitionSequence;
     private long readyWebFrame = -1;
     private final java.util.Set<Runnable> pendingWebFrames = new java.util.HashSet<>();
@@ -155,7 +156,9 @@ final class NativePlaybackScreen extends FrameLayout implements TextureView.Surf
             originalParent.addOnLayoutChangeListener(originalParentLayout);
             originalParent.removeView(webOverlay);
             webOverlay.setBackgroundColor(Color.TRANSPARENT);
-            webOverlay.getViewTreeObserver().addOnScrollChangedListener(pageScrollListener);
+            // Move native layers as WebView scrolls, before the next traversal
+            // draws them against Chromium's already-scrolled page.
+            webOverlay.setOnScrollChangeListener(pageScrollListener);
             webOverlayHost = originalParent instanceof PullToRefreshLayout
                 ? ((PullToRefreshLayout) originalParent).wrapPlaybackOverlay(webOverlay)
                 : webOverlay;
@@ -525,8 +528,9 @@ final class NativePlaybackScreen extends FrameLayout implements TextureView.Surf
         }
         if (webOverlay == null || viewportWidth <= 0 || width <= 0 || height <= 0 || getWidth() <= 0) return;
         double scale = getWidth() / viewportWidth;
-        VideoSize size = engine.getPlayer().getVideoSize();
-        double ratio = size.height > 0 ? size.width * size.pixelWidthHeightRatio / size.height : width / height;
+        // Use the same ratio as the frame's measurement, including while the
+        // decoder reports an unknown size but its last frame remains visible.
+        double ratio = videoAspectRatio > 0 ? videoAspectRatio : width / height;
         double fittedWidth = Math.min(width, height * ratio);
         double fittedHeight = Math.min(height, width / ratio);
         // Keep the decoder's TextureView at a stable size. Resizing it for each
@@ -604,9 +608,10 @@ final class NativePlaybackScreen extends FrameLayout implements TextureView.Surf
         });
     }
 
-    private void updateAspectRatio(VideoSize size) {
+    void updateAspectRatio(VideoSize size) {
         if (size.width > 0 && size.height > 0) {
-            videoFrame.setAspectRatio(size.width * size.pixelWidthHeightRatio / size.height);
+            videoAspectRatio = size.width * size.pixelWidthHeightRatio / size.height;
+            videoFrame.setAspectRatio(videoAspectRatio);
             refreshVideoLayout();
         }
     }
@@ -730,7 +735,7 @@ final class NativePlaybackScreen extends FrameLayout implements TextureView.Surf
         afterWebDraw.clear();
         transitionSequence++;
         removeCallbacks(pageScrollSettled);
-        if (webOverlay != null) webOverlay.getViewTreeObserver().removeOnScrollChangedListener(pageScrollListener);
+        if (webOverlay != null) webOverlay.setOnScrollChangeListener(null);
         if (videoAnimation != null) videoAnimation.cancel();
         clearNativeButtonDown();
         engine.getControlsPlayer().removeListener(queueListener);

--- a/e2e/tests/offline/mobile-scroll-regressions.spec.mjs
+++ b/e2e/tests/offline/mobile-scroll-regressions.spec.mjs
@@ -41,14 +41,16 @@ for (const [uiScale, reducedMotion] of [[100, 'no-preference'], [125, 'no-prefer
         const nav = page.locator('.sideNav')
         if (hidden) {
           await expect(nav).toHaveClass(/scrollHidden/)
-          const geometry = await nav.evaluate(element => {
-            const rect = element.getBoundingClientRect()
-            return { top: rect.top, height: rect.height }
-          })
-          expect(Math.abs(geometry.top - visibleTop - geometry.height)).toBeLessThan(1)
+          await expect.poll(async () => {
+            const geometry = await nav.evaluate(element => {
+              const rect = element.getBoundingClientRect()
+              return { top: rect.top, height: rect.height }
+            })
+            return Math.abs(geometry.top - visibleTop - geometry.height)
+          }).toBeLessThan(1)
         } else {
           await expect(nav).not.toHaveClass(/scrollHidden/)
-          expect(Math.abs(await nav.evaluate(element => element.getBoundingClientRect().top) - visibleTop)).toBeLessThan(1)
+          await expect.poll(async () => Math.abs(await nav.evaluate(element => element.getBoundingClientRect().top) - visibleTop)).toBeLessThan(1)
         }
       }
       await expect(page.locator('.sideNav')).not.toHaveClass(/scrollHidden/)

--- a/e2e/tests/offline/mobile-scroll-regressions.spec.mjs
+++ b/e2e/tests/offline/mobile-scroll-regressions.spec.mjs
@@ -1,0 +1,57 @@
+import { test, expect, goTo, setWindowSize } from '../../helpers/app.mjs'
+
+for (const [uiScale, reducedMotion] of [[100, 'no-preference'], [125, 'no-preference'], [100, 'reduce']]) {
+  test.describe(`mobile progress at ${uiScale}% with ${reducedMotion} motion`, () => {
+    test.use({ seed: { settings: { showProgressBarToast: false, uiScale } } })
+
+    test('global progress follows navigation throughout hiding and revealing', async ({ app, page }) => {
+      await page.emulateMedia({ reducedMotion })
+      await setWindowSize(app, page, { width: 400, height: 850 })
+      await goTo(page, 'settings')
+      await page.evaluate(() => {
+        const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+        store.commit('setShowProgressBar', true)
+        store.commit('setProgressBarPercentage', 50)
+        document.querySelector('.app > .flexBox').style.minHeight = '3000px'
+        document.documentElement.style.setProperty('--safe-area-inset-bottom', '17px')
+        document.activeElement?.blur()
+        window.dispatchEvent(new Event('resize'))
+      })
+      await expect(page.locator('.progressBar')).toBeVisible()
+      const visibleTop = await page.locator('.sideNav').evaluate(nav => nav.getBoundingClientRect().top)
+      for (const [top, hidden] of [[300, true], [100, false], [400, true], [0, false]]) {
+        const maximumGap = await page.evaluate(async top => {
+          window.scrollTo(0, top)
+          let maximumGap = 0
+          const start = performance.now()
+          do {
+            await new Promise(requestAnimationFrame)
+            const nav = document.querySelector('.sideNav').getBoundingClientRect()
+            const bar = document.querySelector('.progressBar').getBoundingClientRect()
+            maximumGap = Math.max(maximumGap, Math.abs(bar.bottom - nav.top))
+          } while (performance.now() - start < 350)
+          return maximumGap
+        }, top)
+        expect(maximumGap).toBeLessThan(1)
+        if (reducedMotion === 'reduce') {
+          for (const selector of ['.sideNav', '.progressBar']) {
+            await expect(page.locator(selector)).toHaveCSS('transition-duration', '0s')
+          }
+        }
+        const nav = page.locator('.sideNav')
+        if (hidden) {
+          await expect(nav).toHaveClass(/scrollHidden/)
+          const geometry = await nav.evaluate(element => {
+            const rect = element.getBoundingClientRect()
+            return { top: rect.top, height: rect.height }
+          })
+          expect(Math.abs(geometry.top - visibleTop - geometry.height)).toBeLessThan(1)
+        } else {
+          await expect(nav).not.toHaveClass(/scrollHidden/)
+          expect(Math.abs(await nav.evaluate(element => element.getBoundingClientRect().top) - visibleTop)).toBeLessThan(1)
+        }
+      }
+      await expect(page.locator('.sideNav')).not.toHaveClass(/scrollHidden/)
+    })
+  })
+}

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -648,8 +648,31 @@
 }
 
 @media only screen and (width <= 680px) {
+  .app {
+    --mobile-nav-height: calc(60px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)));
+    --mobile-nav-reveal-transition: transform 280ms cubic-bezier(0.2, 0, 0, 1);
+    --mobile-nav-hide-transition: transform 220ms cubic-bezier(0.4, 0, 1, 1);
+  }
+
   .app:has(> .progressBar) {
     --mobile-progress-bar-space: var(--progress-bar-height);
+  }
+
+  .app > :deep(.progressBar) {
+    transform: translateY(0);
+    transition: var(--mobile-nav-reveal-transition);
+  }
+
+  .app > :deep(.sideNav.scrollHidden:not(:has(:focus-visible)) ~ .progressBar) {
+    transform: translateY(var(--mobile-nav-height));
+    transition: var(--mobile-nav-hide-transition);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .app {
+      --mobile-nav-reveal-transition: none;
+      --mobile-nav-hide-transition: none;
+    }
   }
 
   .routerView {

--- a/src/renderer/components/SideNav/SideNav.css
+++ b/src/renderer/components/SideNav/SideNav.css
@@ -295,19 +295,18 @@
     position: fixed;
     display: flex;
     margin-block-start: 0;
-    block-size: calc(60px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0)));
+    block-size: var(--mobile-nav-height);
     inline-size: 100%;
     inset-block: auto 0;
     padding-block-end: var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0));
     overflow-y: hidden;
     transform: none;
-    transition: transform 280ms cubic-bezier(0.2, 0, 0, 1);
+    transition: var(--mobile-nav-reveal-transition);
   }
 
   .sideNav.scrollHidden:not(:has(:focus-visible)) {
     transform: translateY(100%);
-    transition-duration: 220ms;
-    transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
+    transition: var(--mobile-nav-hide-transition);
     pointer-events: none;
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

Reported directly while testing the Pixel nightly app.
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description

The global progress bar stayed above the bottom navigation when it hid, native video placement lagged behind watch-page scrolling, and a retained 4:3 frame could shift left.

Share navigation/progress animation values, update native geometry and mini-player layering in the WebView scroll callback, and retain the same aspect ratio used to measure the video frame.
<!-- Please write a clear and concise description of what the pull request does. -->

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Keep Android video centered and aligned during scrolling, and move the global progress bar with the hiding bottom navigation.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Use the default System Default theme pair for screenshots and recordings: `baseTheme: 'system'`, `systemDarkTheme: 'dark'`, and `systemLightTheme: 'light'`, with the default accent colors (`mainColor: 'Red'`, `secColor: 'Blue'`). Do not substitute OpenTubeX Dark/Light (`openTubeXDark` / `openTubeXLight`) or custom themes unless the user requests them or the change specifically concerns that theme.
Capture in a fresh temporary profile. In Playwright, switch the emulated system color scheme with `await page.emulateMedia({ colorScheme: 'dark' })` and then `'light'`, keeping the app theme preferences above. Before each capture, wait for the body to have the matching `dark` or `light` class, as in `e2e/screenshots/capture.spec.mjs`.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing

1. On a narrow window or Android, start an operation that shows global progress. Scroll down and back up. The bar should remain attached to the bottom navigation throughout both animations. Repeat at 125% UI scale and with reduced motion enabled.
2. On Android, open a video and scroll the watch page. The video and controls should follow the page immediately. Minimize playback, then scroll the subscriptions feed and let it coast. The video should remain above the scrolling feed.
3. Play a 4:3 video and switch between the watch page and mini player. The picture should stay centered, including while the decoder changes surfaces.
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

## Additional context

General feed performance is not claimed fully resolved: the native timing regression is covered, but background feed updates prevented a controlled before/after scrolling comparison with the copied Pixel data.

Implemented and reviewed with GPT-6 in Codex.
<!-- Add any other context about the pull request here. -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/OpenTubeX/OpenTubeX/pull/1350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

